### PR TITLE
Update action workflow for docker tagged image

### DIFF
--- a/.github/workflows/publish-docker-tag.yml
+++ b/.github/workflows/publish-docker-tag.yml
@@ -17,4 +17,4 @@ jobs:
           name: getmeili/meilisearch
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          tags: true
+          tag_names: true


### PR DESCRIPTION
On the latest release, the github actions didnt tag the latest image with currrent tag because we used the wrong syntax. https://github.com/marketplace/actions/publish-docker#tag_names
Here is the correction