### PR TITLE
Separate the update and main databases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -636,7 +636,7 @@ dependencies = [
 
 [[package]]
 name = "heed"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -944,7 +944,7 @@ dependencies = [
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fst 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashbrown 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "heed 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "heed 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "levenshtein_automata 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -975,7 +975,7 @@ dependencies = [
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "heed 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "heed 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "isahc 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2582,7 +2582,7 @@ dependencies = [
 "checksum h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
 "checksum hashbrown 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8e6073d0ca812575946eb5f35ff68dbe519907b25c42530389ff946dc84c6ead"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
-"checksum heed 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b021df76de18f82f716fa6c858fd6bf39aec2c651852055563b5aba51debca81"
+"checksum heed 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df6c88807a125a2722484f62fa9c9615d85b0779a06467626db1279c32e287ba"
 "checksum hermit-abi 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "307c3c9f937f38e3534b1d6447ecf090cafcc9744e4a6360e8b037b2cf5af120"
 "checksum http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)" = "d7e06e336150b178206af098a055e3621e8336027e2b4d126bda0bc64824baaf"
 "checksum http-body 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d"

--- a/meilisearch-core/Cargo.toml
+++ b/meilisearch-core/Cargo.toml
@@ -14,7 +14,7 @@ deunicode = "1.0.0"
 env_logger = "0.7.0"
 fst = { version = "0.3.5", default-features = false }
 hashbrown = { version = "0.6.0", features = ["serde"] }
-heed = "0.5.0"
+heed = "0.6.0"
 levenshtein_automata = { version = "0.1.1", features = ["fst_automaton"] }
 log = "0.4.8"
 meilisearch-schema = { path = "../meilisearch-schema", version = "0.8.0" }

--- a/meilisearch-core/src/automaton/mod.rs
+++ b/meilisearch-core/src/automaton/mod.rs
@@ -8,6 +8,7 @@ use fst::{IntoStreamer, Streamer};
 use levenshtein_automata::DFA;
 use meilisearch_tokenizer::{is_cjk, split_query_string};
 
+use crate::database::MainT;
 use crate::error::MResult;
 use crate::store;
 
@@ -23,7 +24,7 @@ pub struct AutomatonProducer {
 
 impl AutomatonProducer {
     pub fn new(
-        reader: &heed::RoTxn,
+        reader: &heed::RoTxn<MainT>,
         query: &str,
         main_store: store::Main,
         postings_list_store: store::PostingsLists,
@@ -131,7 +132,7 @@ pub fn normalize_str(string: &str) -> String {
 }
 
 fn split_best_frequency<'a>(
-    reader: &heed::RoTxn,
+    reader: &heed::RoTxn<MainT>,
     word: &'a str,
     postings_lists_store: store::PostingsLists,
 ) -> MResult<Option<(&'a str, &'a str)>> {
@@ -159,7 +160,7 @@ fn split_best_frequency<'a>(
 }
 
 fn generate_automatons(
-    reader: &heed::RoTxn,
+    reader: &heed::RoTxn<MainT>,
     query: &str,
     main_store: store::Main,
     postings_lists_store: store::PostingsLists,

--- a/meilisearch-core/src/lib.rs
+++ b/meilisearch-core/src/lib.rs
@@ -18,7 +18,7 @@ pub mod serde;
 pub mod store;
 mod update;
 
-pub use self::database::{BoxUpdateFn, Database};
+pub use self::database::{BoxUpdateFn, Database, MainT, UpdateT};
 pub use self::error::{Error, MResult};
 pub use self::number::{Number, ParseNumberError};
 pub use self::ranked_map::RankedMap;

--- a/meilisearch-core/src/serde/deserializer.rs
+++ b/meilisearch-core/src/serde/deserializer.rs
@@ -8,6 +8,7 @@ use serde_json::de::IoRead as SerdeJsonIoRead;
 use serde_json::Deserializer as SerdeJsonDeserializer;
 use serde_json::Error as SerdeJsonError;
 
+use crate::database::MainT;
 use crate::store::DocumentsFields;
 use crate::DocumentId;
 
@@ -50,7 +51,7 @@ impl From<heed::Error> for DeserializerError {
 
 pub struct Deserializer<'a> {
     pub document_id: DocumentId,
-    pub reader: &'a heed::RoTxn,
+    pub reader: &'a heed::RoTxn<MainT>,
     pub documents_fields: DocumentsFields,
     pub schema: &'a Schema,
     pub attributes: Option<&'a HashSet<SchemaAttr>>,

--- a/meilisearch-core/src/serde/serializer.rs
+++ b/meilisearch-core/src/serde/serializer.rs
@@ -1,6 +1,7 @@
 use meilisearch_schema::{Schema, SchemaAttr, SchemaProps};
 use serde::ser;
 
+use crate::database::MainT;
 use crate::raw_indexer::RawIndexer;
 use crate::store::{DocumentsFields, DocumentsFieldsCounts};
 use crate::{DocumentId, RankedMap};
@@ -8,7 +9,7 @@ use crate::{DocumentId, RankedMap};
 use super::{ConvertToNumber, ConvertToString, Indexer, SerializerError};
 
 pub struct Serializer<'a, 'b> {
-    pub txn: &'a mut heed::RwTxn<'b>,
+    pub txn: &'a mut heed::RwTxn<'b, MainT>,
     pub schema: &'a Schema,
     pub document_store: DocumentsFields,
     pub document_fields_counts: DocumentsFieldsCounts,
@@ -191,7 +192,7 @@ impl<'a, 'b> ser::Serializer for Serializer<'a, 'b> {
 }
 
 pub struct MapSerializer<'a, 'b> {
-    txn: &'a mut heed::RwTxn<'b>,
+    txn: &'a mut heed::RwTxn<'b, MainT>,
     schema: &'a Schema,
     document_id: DocumentId,
     document_store: DocumentsFields,
@@ -254,7 +255,7 @@ impl<'a, 'b> ser::SerializeMap for MapSerializer<'a, 'b> {
 }
 
 pub struct StructSerializer<'a, 'b> {
-    txn: &'a mut heed::RwTxn<'b>,
+    txn: &'a mut heed::RwTxn<'b, MainT>,
     schema: &'a Schema,
     document_id: DocumentId,
     document_store: DocumentsFields,
@@ -297,7 +298,7 @@ impl<'a, 'b> ser::SerializeStruct for StructSerializer<'a, 'b> {
 }
 
 pub fn serialize_value<T: ?Sized>(
-    txn: &mut heed::RwTxn,
+    txn: &mut heed::RwTxn<MainT>,
     attribute: SchemaAttr,
     props: SchemaProps,
     document_id: DocumentId,

--- a/meilisearch-core/src/store/docs_words.rs
+++ b/meilisearch-core/src/store/docs_words.rs
@@ -1,4 +1,5 @@
 use super::BEU64;
+use crate::database::MainT;
 use crate::DocumentId;
 use heed::types::{ByteSlice, OwnedType};
 use heed::Result as ZResult;
@@ -12,7 +13,7 @@ pub struct DocsWords {
 impl DocsWords {
     pub fn put_doc_words(
         self,
-        writer: &mut heed::RwTxn,
+        writer: &mut heed::RwTxn<MainT>,
         document_id: DocumentId,
         words: &fst::Set,
     ) -> ZResult<()> {
@@ -21,18 +22,18 @@ impl DocsWords {
         self.docs_words.put(writer, &document_id, bytes)
     }
 
-    pub fn del_doc_words(self, writer: &mut heed::RwTxn, document_id: DocumentId) -> ZResult<bool> {
+    pub fn del_doc_words(self, writer: &mut heed::RwTxn<MainT>, document_id: DocumentId) -> ZResult<bool> {
         let document_id = BEU64::new(document_id.0);
         self.docs_words.delete(writer, &document_id)
     }
 
-    pub fn clear(self, writer: &mut heed::RwTxn) -> ZResult<()> {
+    pub fn clear(self, writer: &mut heed::RwTxn<MainT>) -> ZResult<()> {
         self.docs_words.clear(writer)
     }
 
     pub fn doc_words(
         self,
-        reader: &heed::RoTxn,
+        reader: &heed::RoTxn<MainT>,
         document_id: DocumentId,
     ) -> ZResult<Option<fst::Set>> {
         let document_id = BEU64::new(document_id.0);

--- a/meilisearch-core/src/store/documents_fields.rs
+++ b/meilisearch-core/src/store/documents_fields.rs
@@ -1,4 +1,5 @@
 use heed::types::{ByteSlice, OwnedType};
+use crate::database::MainT;
 use heed::Result as ZResult;
 use meilisearch_schema::SchemaAttr;
 
@@ -13,7 +14,7 @@ pub struct DocumentsFields {
 impl DocumentsFields {
     pub fn put_document_field(
         self,
-        writer: &mut heed::RwTxn,
+        writer: &mut heed::RwTxn<MainT>,
         document_id: DocumentId,
         attribute: SchemaAttr,
         value: &[u8],
@@ -24,7 +25,7 @@ impl DocumentsFields {
 
     pub fn del_all_document_fields(
         self,
-        writer: &mut heed::RwTxn,
+        writer: &mut heed::RwTxn<MainT>,
         document_id: DocumentId,
     ) -> ZResult<usize> {
         let start = DocumentAttrKey::new(document_id, SchemaAttr::min());
@@ -32,13 +33,13 @@ impl DocumentsFields {
         self.documents_fields.delete_range(writer, &(start..=end))
     }
 
-    pub fn clear(self, writer: &mut heed::RwTxn) -> ZResult<()> {
+    pub fn clear(self, writer: &mut heed::RwTxn<MainT>) -> ZResult<()> {
         self.documents_fields.clear(writer)
     }
 
     pub fn document_attribute<'txn>(
         self,
-        reader: &'txn heed::RoTxn,
+        reader: &'txn heed::RoTxn<MainT>,
         document_id: DocumentId,
         attribute: SchemaAttr,
     ) -> ZResult<Option<&'txn [u8]>> {
@@ -48,7 +49,7 @@ impl DocumentsFields {
 
     pub fn document_fields<'txn>(
         self,
-        reader: &'txn heed::RoTxn,
+        reader: &'txn heed::RoTxn<MainT>,
         document_id: DocumentId,
     ) -> ZResult<DocumentFieldsIter<'txn>> {
         let start = DocumentAttrKey::new(document_id, SchemaAttr::min());

--- a/meilisearch-core/src/store/documents_fields_counts.rs
+++ b/meilisearch-core/src/store/documents_fields_counts.rs
@@ -1,4 +1,5 @@
 use super::DocumentAttrKey;
+use crate::database::MainT;
 use crate::DocumentId;
 use heed::types::OwnedType;
 use heed::Result as ZResult;
@@ -12,7 +13,7 @@ pub struct DocumentsFieldsCounts {
 impl DocumentsFieldsCounts {
     pub fn put_document_field_count(
         self,
-        writer: &mut heed::RwTxn,
+        writer: &mut heed::RwTxn<MainT>,
         document_id: DocumentId,
         attribute: SchemaAttr,
         value: u64,
@@ -23,7 +24,7 @@ impl DocumentsFieldsCounts {
 
     pub fn del_all_document_fields_counts(
         self,
-        writer: &mut heed::RwTxn,
+        writer: &mut heed::RwTxn<MainT>,
         document_id: DocumentId,
     ) -> ZResult<usize> {
         let start = DocumentAttrKey::new(document_id, SchemaAttr::min());
@@ -32,13 +33,13 @@ impl DocumentsFieldsCounts {
             .delete_range(writer, &(start..=end))
     }
 
-    pub fn clear(self, writer: &mut heed::RwTxn) -> ZResult<()> {
+    pub fn clear(self, writer: &mut heed::RwTxn<MainT>) -> ZResult<()> {
         self.documents_fields_counts.clear(writer)
     }
 
     pub fn document_field_count(
         self,
-        reader: &heed::RoTxn,
+        reader: &heed::RoTxn<MainT>,
         document_id: DocumentId,
         attribute: SchemaAttr,
     ) -> ZResult<Option<u64>> {
@@ -51,7 +52,7 @@ impl DocumentsFieldsCounts {
 
     pub fn document_fields_counts<'txn>(
         self,
-        reader: &'txn heed::RoTxn,
+        reader: &'txn heed::RoTxn<MainT>,
         document_id: DocumentId,
     ) -> ZResult<DocumentFieldsCountsIter<'txn>> {
         let start = DocumentAttrKey::new(document_id, SchemaAttr::min());
@@ -60,7 +61,7 @@ impl DocumentsFieldsCounts {
         Ok(DocumentFieldsCountsIter { iter })
     }
 
-    pub fn documents_ids<'txn>(self, reader: &'txn heed::RoTxn) -> ZResult<DocumentsIdsIter<'txn>> {
+    pub fn documents_ids<'txn>(self, reader: &'txn heed::RoTxn<MainT>) -> ZResult<DocumentsIdsIter<'txn>> {
         let iter = self.documents_fields_counts.iter(reader)?;
         Ok(DocumentsIdsIter {
             last_seen_id: None,
@@ -70,7 +71,7 @@ impl DocumentsFieldsCounts {
 
     pub fn all_documents_fields_counts<'txn>(
         self,
-        reader: &'txn heed::RoTxn,
+        reader: &'txn heed::RoTxn<MainT>,
     ) -> ZResult<AllDocumentsFieldsCountsIter<'txn>> {
         let iter = self.documents_fields_counts.iter(reader)?;
         Ok(AllDocumentsFieldsCountsIter { iter })

--- a/meilisearch-core/src/store/main.rs
+++ b/meilisearch-core/src/store/main.rs
@@ -1,3 +1,4 @@
+use crate::database::MainT;
 use crate::RankedMap;
 use chrono::{DateTime, Utc};
 use heed::types::{ByteSlice, OwnedType, SerdeBincode, Str};
@@ -28,46 +29,46 @@ pub struct Main {
 }
 
 impl Main {
-    pub fn clear(self, writer: &mut heed::RwTxn) -> ZResult<()> {
+    pub fn clear(self, writer: &mut heed::RwTxn<MainT>) -> ZResult<()> {
         self.main.clear(writer)
     }
 
-    pub fn put_name(self, writer: &mut heed::RwTxn, name: &str) -> ZResult<()> {
-        self.main.put::<Str, Str>(writer, NAME_KEY, name)
+    pub fn put_name(self, writer: &mut heed::RwTxn<MainT>, name: &str) -> ZResult<()> {
+        self.main.put::<_, Str, Str>(writer, NAME_KEY, name)
     }
 
-    pub fn name(self, reader: &heed::RoTxn) -> ZResult<Option<String>> {
+    pub fn name(self, reader: &heed::RoTxn<MainT>) -> ZResult<Option<String>> {
         Ok(self
             .main
-            .get::<Str, Str>(reader, NAME_KEY)?
+            .get::<_, Str, Str>(reader, NAME_KEY)?
             .map(|name| name.to_owned()))
     }
 
-    pub fn put_created_at(self, writer: &mut heed::RwTxn) -> ZResult<()> {
+    pub fn put_created_at(self, writer: &mut heed::RwTxn<MainT>) -> ZResult<()> {
         self.main
-            .put::<Str, SerdeDatetime>(writer, CREATED_AT_KEY, &Utc::now())
+            .put::<_, Str, SerdeDatetime>(writer, CREATED_AT_KEY, &Utc::now())
     }
 
-    pub fn created_at(self, reader: &heed::RoTxn) -> ZResult<Option<DateTime<Utc>>> {
-        self.main.get::<Str, SerdeDatetime>(reader, CREATED_AT_KEY)
+    pub fn created_at(self, reader: &heed::RoTxn<MainT>) -> ZResult<Option<DateTime<Utc>>> {
+        self.main.get::<_, Str, SerdeDatetime>(reader, CREATED_AT_KEY)
     }
 
-    pub fn put_updated_at(self, writer: &mut heed::RwTxn) -> ZResult<()> {
+    pub fn put_updated_at(self, writer: &mut heed::RwTxn<MainT>) -> ZResult<()> {
         self.main
-            .put::<Str, SerdeDatetime>(writer, UPDATED_AT_KEY, &Utc::now())
+            .put::<_, Str, SerdeDatetime>(writer, UPDATED_AT_KEY, &Utc::now())
     }
 
-    pub fn updated_at(self, reader: &heed::RoTxn) -> ZResult<Option<DateTime<Utc>>> {
-        self.main.get::<Str, SerdeDatetime>(reader, UPDATED_AT_KEY)
+    pub fn updated_at(self, reader: &heed::RoTxn<MainT>) -> ZResult<Option<DateTime<Utc>>> {
+        self.main.get::<_, Str, SerdeDatetime>(reader, UPDATED_AT_KEY)
     }
 
-    pub fn put_words_fst(self, writer: &mut heed::RwTxn, fst: &fst::Set) -> ZResult<()> {
+    pub fn put_words_fst(self, writer: &mut heed::RwTxn<MainT>, fst: &fst::Set) -> ZResult<()> {
         let bytes = fst.as_fst().as_bytes();
-        self.main.put::<Str, ByteSlice>(writer, WORDS_KEY, bytes)
+        self.main.put::<_, Str, ByteSlice>(writer, WORDS_KEY, bytes)
     }
 
-    pub fn words_fst(self, reader: &heed::RoTxn) -> ZResult<Option<fst::Set>> {
-        match self.main.get::<Str, ByteSlice>(reader, WORDS_KEY)? {
+    pub fn words_fst(self, reader: &heed::RoTxn<MainT>) -> ZResult<Option<fst::Set>> {
+        match self.main.get::<_, Str, ByteSlice>(reader, WORDS_KEY)? {
             Some(bytes) => {
                 let len = bytes.len();
                 let bytes = Arc::new(bytes.to_owned());
@@ -78,33 +79,33 @@ impl Main {
         }
     }
 
-    pub fn put_schema(self, writer: &mut heed::RwTxn, schema: &Schema) -> ZResult<()> {
+    pub fn put_schema(self, writer: &mut heed::RwTxn<MainT>, schema: &Schema) -> ZResult<()> {
         self.main
-            .put::<Str, SerdeBincode<Schema>>(writer, SCHEMA_KEY, schema)
+            .put::<_, Str, SerdeBincode<Schema>>(writer, SCHEMA_KEY, schema)
     }
 
-    pub fn schema(self, reader: &heed::RoTxn) -> ZResult<Option<Schema>> {
+    pub fn schema(self, reader: &heed::RoTxn<MainT>) -> ZResult<Option<Schema>> {
         self.main
-            .get::<Str, SerdeBincode<Schema>>(reader, SCHEMA_KEY)
+            .get::<_, Str, SerdeBincode<Schema>>(reader, SCHEMA_KEY)
     }
 
-    pub fn put_ranked_map(self, writer: &mut heed::RwTxn, ranked_map: &RankedMap) -> ZResult<()> {
+    pub fn put_ranked_map(self, writer: &mut heed::RwTxn<MainT>, ranked_map: &RankedMap) -> ZResult<()> {
         self.main
-            .put::<Str, SerdeBincode<RankedMap>>(writer, RANKED_MAP_KEY, &ranked_map)
+            .put::<_, Str, SerdeBincode<RankedMap>>(writer, RANKED_MAP_KEY, &ranked_map)
     }
 
-    pub fn ranked_map(self, reader: &heed::RoTxn) -> ZResult<Option<RankedMap>> {
+    pub fn ranked_map(self, reader: &heed::RoTxn<MainT>) -> ZResult<Option<RankedMap>> {
         self.main
-            .get::<Str, SerdeBincode<RankedMap>>(reader, RANKED_MAP_KEY)
+            .get::<_, Str, SerdeBincode<RankedMap>>(reader, RANKED_MAP_KEY)
     }
 
-    pub fn put_synonyms_fst(self, writer: &mut heed::RwTxn, fst: &fst::Set) -> ZResult<()> {
+    pub fn put_synonyms_fst(self, writer: &mut heed::RwTxn<MainT>, fst: &fst::Set) -> ZResult<()> {
         let bytes = fst.as_fst().as_bytes();
-        self.main.put::<Str, ByteSlice>(writer, SYNONYMS_KEY, bytes)
+        self.main.put::<_, Str, ByteSlice>(writer, SYNONYMS_KEY, bytes)
     }
 
-    pub fn synonyms_fst(self, reader: &heed::RoTxn) -> ZResult<Option<fst::Set>> {
-        match self.main.get::<Str, ByteSlice>(reader, SYNONYMS_KEY)? {
+    pub fn synonyms_fst(self, reader: &heed::RoTxn<MainT>) -> ZResult<Option<fst::Set>> {
+        match self.main.get::<_, Str, ByteSlice>(reader, SYNONYMS_KEY)? {
             Some(bytes) => {
                 let len = bytes.len();
                 let bytes = Arc::new(bytes.to_owned());
@@ -115,14 +116,14 @@ impl Main {
         }
     }
 
-    pub fn put_stop_words_fst(self, writer: &mut heed::RwTxn, fst: &fst::Set) -> ZResult<()> {
+    pub fn put_stop_words_fst(self, writer: &mut heed::RwTxn<MainT>, fst: &fst::Set) -> ZResult<()> {
         let bytes = fst.as_fst().as_bytes();
         self.main
-            .put::<Str, ByteSlice>(writer, STOP_WORDS_KEY, bytes)
+            .put::<_, Str, ByteSlice>(writer, STOP_WORDS_KEY, bytes)
     }
 
-    pub fn stop_words_fst(self, reader: &heed::RoTxn) -> ZResult<Option<fst::Set>> {
-        match self.main.get::<Str, ByteSlice>(reader, STOP_WORDS_KEY)? {
+    pub fn stop_words_fst(self, reader: &heed::RoTxn<MainT>) -> ZResult<Option<fst::Set>> {
+        match self.main.get::<_, Str, ByteSlice>(reader, STOP_WORDS_KEY)? {
             Some(bytes) => {
                 let len = bytes.len();
                 let bytes = Arc::new(bytes.to_owned());
@@ -133,20 +134,20 @@ impl Main {
         }
     }
 
-    pub fn put_number_of_documents<F>(self, writer: &mut heed::RwTxn, f: F) -> ZResult<u64>
+    pub fn put_number_of_documents<F>(self, writer: &mut heed::RwTxn<MainT>, f: F) -> ZResult<u64>
     where
         F: Fn(u64) -> u64,
     {
-        let new = self.number_of_documents(writer).map(f)?;
+        let new = self.number_of_documents(&*writer).map(f)?;
         self.main
-            .put::<Str, OwnedType<u64>>(writer, NUMBER_OF_DOCUMENTS_KEY, &new)?;
+            .put::<_, Str, OwnedType<u64>>(writer, NUMBER_OF_DOCUMENTS_KEY, &new)?;
         Ok(new)
     }
 
-    pub fn number_of_documents(self, reader: &heed::RoTxn) -> ZResult<u64> {
+    pub fn number_of_documents(self, reader: &heed::RoTxn<MainT>) -> ZResult<u64> {
         match self
             .main
-            .get::<Str, OwnedType<u64>>(reader, NUMBER_OF_DOCUMENTS_KEY)?
+            .get::<_, Str, OwnedType<u64>>(reader, NUMBER_OF_DOCUMENTS_KEY)?
         {
             Some(value) => Ok(value),
             None => Ok(0),
@@ -155,29 +156,29 @@ impl Main {
 
     pub fn put_fields_frequency(
         self,
-        writer: &mut heed::RwTxn,
+        writer: &mut heed::RwTxn<MainT>,
         fields_frequency: &FreqsMap,
     ) -> ZResult<()> {
         self.main
-            .put::<Str, SerdeFreqsMap>(writer, FIELDS_FREQUENCY_KEY, fields_frequency)
+            .put::<_, Str, SerdeFreqsMap>(writer, FIELDS_FREQUENCY_KEY, fields_frequency)
     }
 
-    pub fn fields_frequency(&self, reader: &heed::RoTxn) -> ZResult<Option<FreqsMap>> {
+    pub fn fields_frequency(&self, reader: &heed::RoTxn<MainT>) -> ZResult<Option<FreqsMap>> {
         match self
             .main
-            .get::<Str, SerdeFreqsMap>(reader, FIELDS_FREQUENCY_KEY)?
+            .get::<_, Str, SerdeFreqsMap>(reader, FIELDS_FREQUENCY_KEY)?
         {
             Some(freqs) => Ok(Some(freqs)),
             None => Ok(None),
         }
     }
 
-    pub fn put_customs(self, writer: &mut heed::RwTxn, customs: &[u8]) -> ZResult<()> {
+    pub fn put_customs(self, writer: &mut heed::RwTxn<MainT>, customs: &[u8]) -> ZResult<()> {
         self.main
-            .put::<Str, ByteSlice>(writer, CUSTOMS_KEY, customs)
+            .put::<_, Str, ByteSlice>(writer, CUSTOMS_KEY, customs)
     }
 
-    pub fn customs<'txn>(self, reader: &'txn heed::RoTxn) -> ZResult<Option<&'txn [u8]>> {
-        self.main.get::<Str, ByteSlice>(reader, CUSTOMS_KEY)
+    pub fn customs<'txn>(self, reader: &'txn heed::RoTxn<MainT>) -> ZResult<Option<&'txn [u8]>> {
+        self.main.get::<_, Str, ByteSlice>(reader, CUSTOMS_KEY)
     }
 }

--- a/meilisearch-core/src/store/postings_lists.rs
+++ b/meilisearch-core/src/store/postings_lists.rs
@@ -1,4 +1,5 @@
 use crate::DocIndex;
+use crate::database::MainT;
 use heed::types::{ByteSlice, CowSlice};
 use heed::Result as ZResult;
 use sdset::{Set, SetBuf};
@@ -12,24 +13,24 @@ pub struct PostingsLists {
 impl PostingsLists {
     pub fn put_postings_list(
         self,
-        writer: &mut heed::RwTxn,
+        writer: &mut heed::RwTxn<MainT>,
         word: &[u8],
         words_indexes: &Set<DocIndex>,
     ) -> ZResult<()> {
         self.postings_lists.put(writer, word, words_indexes)
     }
 
-    pub fn del_postings_list(self, writer: &mut heed::RwTxn, word: &[u8]) -> ZResult<bool> {
+    pub fn del_postings_list(self, writer: &mut heed::RwTxn<MainT>, word: &[u8]) -> ZResult<bool> {
         self.postings_lists.delete(writer, word)
     }
 
-    pub fn clear(self, writer: &mut heed::RwTxn) -> ZResult<()> {
+    pub fn clear(self, writer: &mut heed::RwTxn<MainT>) -> ZResult<()> {
         self.postings_lists.clear(writer)
     }
 
     pub fn postings_list<'txn>(
         self,
-        reader: &'txn heed::RoTxn,
+        reader: &'txn heed::RoTxn<MainT>,
         word: &[u8],
     ) -> ZResult<Option<Cow<'txn, Set<DocIndex>>>> {
         match self.postings_lists.get(reader, word)? {

--- a/meilisearch-core/src/store/synonyms.rs
+++ b/meilisearch-core/src/store/synonyms.rs
@@ -1,4 +1,5 @@
 use heed::types::ByteSlice;
+use crate::database::MainT;
 use heed::Result as ZResult;
 use std::sync::Arc;
 
@@ -10,7 +11,7 @@ pub struct Synonyms {
 impl Synonyms {
     pub fn put_synonyms(
         self,
-        writer: &mut heed::RwTxn,
+        writer: &mut heed::RwTxn<MainT>,
         word: &[u8],
         synonyms: &fst::Set,
     ) -> ZResult<()> {
@@ -18,15 +19,15 @@ impl Synonyms {
         self.synonyms.put(writer, word, bytes)
     }
 
-    pub fn del_synonyms(self, writer: &mut heed::RwTxn, word: &[u8]) -> ZResult<bool> {
+    pub fn del_synonyms(self, writer: &mut heed::RwTxn<MainT>, word: &[u8]) -> ZResult<bool> {
         self.synonyms.delete(writer, word)
     }
 
-    pub fn clear(self, writer: &mut heed::RwTxn) -> ZResult<()> {
+    pub fn clear(self, writer: &mut heed::RwTxn<MainT>) -> ZResult<()> {
         self.synonyms.clear(writer)
     }
 
-    pub fn synonyms(self, reader: &heed::RoTxn, word: &[u8]) -> ZResult<Option<fst::Set>> {
+    pub fn synonyms(self, reader: &heed::RoTxn<MainT>, word: &[u8]) -> ZResult<Option<fst::Set>> {
         match self.synonyms.get(reader, word)? {
             Some(bytes) => {
                 let len = bytes.len();

--- a/meilisearch-core/src/store/updates_results.rs
+++ b/meilisearch-core/src/store/updates_results.rs
@@ -1,4 +1,5 @@
 use super::BEU64;
+use crate::database::UpdateT;
 use crate::update::ProcessedUpdateResult;
 use heed::types::{OwnedType, SerdeJson};
 use heed::Result as ZResult;
@@ -9,9 +10,9 @@ pub struct UpdatesResults {
 }
 
 impl UpdatesResults {
-    pub fn last_update_id(
+    pub fn last_update(
         self,
-        reader: &heed::RoTxn,
+        reader: &heed::RoTxn<UpdateT>,
     ) -> ZResult<Option<(u64, ProcessedUpdateResult)>> {
         match self.updates_results.last(reader)? {
             Some((key, data)) => Ok(Some((key.get(), data))),
@@ -21,7 +22,7 @@ impl UpdatesResults {
 
     pub fn put_update_result(
         self,
-        writer: &mut heed::RwTxn,
+        writer: &mut heed::RwTxn<UpdateT>,
         update_id: u64,
         update_result: &ProcessedUpdateResult,
     ) -> ZResult<()> {
@@ -31,14 +32,14 @@ impl UpdatesResults {
 
     pub fn update_result(
         self,
-        reader: &heed::RoTxn,
+        reader: &heed::RoTxn<UpdateT>,
         update_id: u64,
     ) -> ZResult<Option<ProcessedUpdateResult>> {
         let update_id = BEU64::new(update_id);
         self.updates_results.get(reader, &update_id)
     }
 
-    pub fn clear(self, writer: &mut heed::RwTxn) -> ZResult<()> {
+    pub fn clear(self, writer: &mut heed::RwTxn<UpdateT>) -> ZResult<()> {
         self.updates_results.clear(writer)
     }
 }

--- a/meilisearch-core/src/update/clear_all.rs
+++ b/meilisearch-core/src/update/clear_all.rs
@@ -1,8 +1,9 @@
+use crate::database::{MainT, UpdateT};
 use crate::update::{next_update_id, Update};
 use crate::{store, MResult, RankedMap};
 
 pub fn apply_clear_all(
-    writer: &mut heed::RwTxn,
+    writer: &mut heed::RwTxn<MainT>,
     main_store: store::Main,
     documents_fields_store: store::DocumentsFields,
     documents_fields_counts_store: store::DocumentsFieldsCounts,
@@ -21,7 +22,7 @@ pub fn apply_clear_all(
 }
 
 pub fn push_clear_all(
-    writer: &mut heed::RwTxn,
+    writer: &mut heed::RwTxn<UpdateT>,
     updates_store: store::Updates,
     updates_results_store: store::UpdatesResults,
 ) -> MResult<u64> {

--- a/meilisearch-core/src/update/customs_update.rs
+++ b/meilisearch-core/src/update/customs_update.rs
@@ -1,9 +1,11 @@
-use crate::store;
-use crate::update::{next_update_id, Update};
 use heed::Result as ZResult;
 
+use crate::database::{MainT, UpdateT};
+use crate::store;
+use crate::update::{next_update_id, Update};
+
 pub fn apply_customs_update(
-    writer: &mut heed::RwTxn,
+    writer: &mut heed::RwTxn<MainT>,
     main_store: store::Main,
     customs: &[u8],
 ) -> ZResult<()> {
@@ -11,7 +13,7 @@ pub fn apply_customs_update(
 }
 
 pub fn push_customs_update(
-    writer: &mut heed::RwTxn,
+    writer: &mut heed::RwTxn<UpdateT>,
     updates_store: store::Updates,
     updates_results_store: store::UpdatesResults,
     customs: Vec<u8>,

--- a/meilisearch-core/src/update/documents_addition.rs
+++ b/meilisearch-core/src/update/documents_addition.rs
@@ -4,6 +4,7 @@ use fst::{set::OpBuilder, SetBuilder};
 use sdset::{duo::Union, SetOperation};
 use serde::{Deserialize, Serialize};
 
+use crate::database::{MainT, UpdateT};
 use crate::database::{UpdateEvent, UpdateEventsEmitter};
 use crate::raw_indexer::RawIndexer;
 use crate::serde::{extract_document_id, serialize_value, Deserializer, Serializer};
@@ -52,7 +53,7 @@ impl<D> DocumentsAddition<D> {
         self.documents.push(document);
     }
 
-    pub fn finalize(self, writer: &mut heed::RwTxn) -> MResult<u64>
+    pub fn finalize(self, writer: &mut heed::RwTxn<UpdateT>) -> MResult<u64>
     where
         D: serde::Serialize,
     {
@@ -75,7 +76,7 @@ impl<D> Extend<D> for DocumentsAddition<D> {
 }
 
 pub fn push_documents_addition<D: serde::Serialize>(
-    writer: &mut heed::RwTxn,
+    writer: &mut heed::RwTxn<UpdateT>,
     updates_store: store::Updates,
     updates_results_store: store::UpdatesResults,
     addition: Vec<D>,
@@ -102,7 +103,7 @@ pub fn push_documents_addition<D: serde::Serialize>(
 }
 
 pub fn apply_documents_addition<'a, 'b>(
-    writer: &'a mut heed::RwTxn<'b>,
+    writer: &'a mut heed::RwTxn<'b, MainT>,
     main_store: store::Main,
     documents_fields_store: store::DocumentsFields,
     documents_fields_counts_store: store::DocumentsFieldsCounts,
@@ -181,7 +182,7 @@ pub fn apply_documents_addition<'a, 'b>(
 }
 
 pub fn apply_documents_partial_addition<'a, 'b>(
-    writer: &'a mut heed::RwTxn<'b>,
+    writer: &'a mut heed::RwTxn<'b, MainT>,
     main_store: store::Main,
     documents_fields_store: store::DocumentsFields,
     documents_fields_counts_store: store::DocumentsFieldsCounts,
@@ -277,7 +278,7 @@ pub fn apply_documents_partial_addition<'a, 'b>(
 }
 
 pub fn reindex_all_documents(
-    writer: &mut heed::RwTxn,
+    writer: &mut heed::RwTxn<MainT>,
     main_store: store::Main,
     documents_fields_store: store::DocumentsFields,
     documents_fields_counts_store: store::DocumentsFieldsCounts,
@@ -354,7 +355,7 @@ pub fn reindex_all_documents(
 }
 
 pub fn write_documents_addition_index(
-    writer: &mut heed::RwTxn,
+    writer: &mut heed::RwTxn<MainT>,
     main_store: store::Main,
     postings_lists_store: store::PostingsLists,
     docs_words_store: store::DocsWords,

--- a/meilisearch-core/src/update/documents_deletion.rs
+++ b/meilisearch-core/src/update/documents_deletion.rs
@@ -4,6 +4,7 @@ use fst::{SetBuilder, Streamer};
 use meilisearch_schema::Schema;
 use sdset::{duo::DifferenceByKey, SetBuf, SetOperation};
 
+use crate::database::{MainT, UpdateT};
 use crate::database::{UpdateEvent, UpdateEventsEmitter};
 use crate::serde::extract_document_id;
 use crate::store;
@@ -50,7 +51,7 @@ impl DocumentsDeletion {
         Ok(())
     }
 
-    pub fn finalize(self, writer: &mut heed::RwTxn) -> MResult<u64> {
+    pub fn finalize(self, writer: &mut heed::RwTxn<UpdateT>) -> MResult<u64> {
         let _ = self.updates_notifier.send(UpdateEvent::NewUpdate);
         let update_id = push_documents_deletion(
             writer,
@@ -69,7 +70,7 @@ impl Extend<DocumentId> for DocumentsDeletion {
 }
 
 pub fn push_documents_deletion(
-    writer: &mut heed::RwTxn,
+    writer: &mut heed::RwTxn<UpdateT>,
     updates_store: store::Updates,
     updates_results_store: store::UpdatesResults,
     deletion: Vec<DocumentId>,
@@ -83,7 +84,7 @@ pub fn push_documents_deletion(
 }
 
 pub fn apply_documents_deletion(
-    writer: &mut heed::RwTxn,
+    writer: &mut heed::RwTxn<MainT>,
     main_store: store::Main,
     documents_fields_store: store::DocumentsFields,
     documents_fields_counts_store: store::DocumentsFieldsCounts,

--- a/meilisearch-core/src/update/schema_update.rs
+++ b/meilisearch-core/src/update/schema_update.rs
@@ -1,11 +1,12 @@
 use meilisearch_schema::{Diff, Schema};
 
+use crate::database::{MainT, UpdateT};
 use crate::update::documents_addition::reindex_all_documents;
 use crate::update::{next_update_id, Update};
 use crate::{error::UnsupportedOperation, store, MResult};
 
 pub fn apply_schema_update(
-    writer: &mut heed::RwTxn,
+    writer: &mut heed::RwTxn<MainT>,
     new_schema: &Schema,
     main_store: store::Main,
     documents_fields_store: store::DocumentsFields,
@@ -61,7 +62,7 @@ pub fn apply_schema_update(
 }
 
 pub fn push_schema_update(
-    writer: &mut heed::RwTxn,
+    writer: &mut heed::RwTxn<UpdateT>,
     updates_store: store::Updates,
     updates_results_store: store::UpdatesResults,
     schema: Schema,

--- a/meilisearch-core/src/update/stop_words_addition.rs
+++ b/meilisearch-core/src/update/stop_words_addition.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeSet;
 
 use fst::{set::OpBuilder, SetBuilder};
 
+use crate::database::{MainT, UpdateT};
 use crate::automaton::normalize_str;
 use crate::database::{UpdateEvent, UpdateEventsEmitter};
 use crate::update::{next_update_id, Update};
@@ -33,7 +34,7 @@ impl StopWordsAddition {
         self.stop_words.insert(stop_word);
     }
 
-    pub fn finalize(self, writer: &mut heed::RwTxn) -> MResult<u64> {
+    pub fn finalize(self, writer: &mut heed::RwTxn<UpdateT>) -> MResult<u64> {
         let _ = self.updates_notifier.send(UpdateEvent::NewUpdate);
         let update_id = push_stop_words_addition(
             writer,
@@ -46,7 +47,7 @@ impl StopWordsAddition {
 }
 
 pub fn push_stop_words_addition(
-    writer: &mut heed::RwTxn,
+    writer: &mut heed::RwTxn<UpdateT>,
     updates_store: store::Updates,
     updates_results_store: store::UpdatesResults,
     addition: BTreeSet<String>,
@@ -60,7 +61,7 @@ pub fn push_stop_words_addition(
 }
 
 pub fn apply_stop_words_addition(
-    writer: &mut heed::RwTxn,
+    writer: &mut heed::RwTxn<MainT>,
     main_store: store::Main,
     postings_lists_store: store::PostingsLists,
     addition: BTreeSet<String>,

--- a/meilisearch-core/src/update/stop_words_deletion.rs
+++ b/meilisearch-core/src/update/stop_words_deletion.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeSet;
 
 use fst::{set::OpBuilder, SetBuilder};
 
+use crate::database::{MainT, UpdateT};
 use crate::automaton::normalize_str;
 use crate::database::{UpdateEvent, UpdateEventsEmitter};
 use crate::update::documents_addition::reindex_all_documents;
@@ -34,7 +35,7 @@ impl StopWordsDeletion {
         self.stop_words.insert(stop_word);
     }
 
-    pub fn finalize(self, writer: &mut heed::RwTxn) -> MResult<u64> {
+    pub fn finalize(self, writer: &mut heed::RwTxn<UpdateT>) -> MResult<u64> {
         let _ = self.updates_notifier.send(UpdateEvent::NewUpdate);
         let update_id = push_stop_words_deletion(
             writer,
@@ -47,7 +48,7 @@ impl StopWordsDeletion {
 }
 
 pub fn push_stop_words_deletion(
-    writer: &mut heed::RwTxn,
+    writer: &mut heed::RwTxn<UpdateT>,
     updates_store: store::Updates,
     updates_results_store: store::UpdatesResults,
     deletion: BTreeSet<String>,
@@ -61,7 +62,7 @@ pub fn push_stop_words_deletion(
 }
 
 pub fn apply_stop_words_deletion(
-    writer: &mut heed::RwTxn,
+    writer: &mut heed::RwTxn<MainT>,
     main_store: store::Main,
     documents_fields_store: store::DocumentsFields,
     documents_fields_counts_store: store::DocumentsFieldsCounts,

--- a/meilisearch-core/src/update/synonyms_addition.rs
+++ b/meilisearch-core/src/update/synonyms_addition.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeMap;
 use fst::{set::OpBuilder, SetBuilder};
 use sdset::SetBuf;
 
+use crate::database::{MainT, UpdateT};
 use crate::automaton::normalize_str;
 use crate::database::{UpdateEvent, UpdateEventsEmitter};
 use crate::update::{next_update_id, Update};
@@ -43,7 +44,7 @@ impl SynonymsAddition {
             .extend(alternatives);
     }
 
-    pub fn finalize(self, writer: &mut heed::RwTxn) -> MResult<u64> {
+    pub fn finalize(self, writer: &mut heed::RwTxn<UpdateT>) -> MResult<u64> {
         let _ = self.updates_notifier.send(UpdateEvent::NewUpdate);
         let update_id = push_synonyms_addition(
             writer,
@@ -56,7 +57,7 @@ impl SynonymsAddition {
 }
 
 pub fn push_synonyms_addition(
-    writer: &mut heed::RwTxn,
+    writer: &mut heed::RwTxn<UpdateT>,
     updates_store: store::Updates,
     updates_results_store: store::UpdatesResults,
     addition: BTreeMap<String, Vec<String>>,
@@ -70,7 +71,7 @@ pub fn push_synonyms_addition(
 }
 
 pub fn apply_synonyms_addition(
-    writer: &mut heed::RwTxn,
+    writer: &mut heed::RwTxn<MainT>,
     main_store: store::Main,
     synonyms_store: store::Synonyms,
     addition: BTreeMap<String, Vec<String>>,

--- a/meilisearch-core/src/update/synonyms_deletion.rs
+++ b/meilisearch-core/src/update/synonyms_deletion.rs
@@ -4,6 +4,7 @@ use std::iter::FromIterator;
 use fst::{set::OpBuilder, SetBuilder};
 use sdset::SetBuf;
 
+use crate::database::{MainT, UpdateT};
 use crate::automaton::normalize_str;
 use crate::database::{UpdateEvent, UpdateEventsEmitter};
 use crate::update::{next_update_id, Update};
@@ -50,7 +51,7 @@ impl SynonymsDeletion {
         }
     }
 
-    pub fn finalize(self, writer: &mut heed::RwTxn) -> MResult<u64> {
+    pub fn finalize(self, writer: &mut heed::RwTxn<UpdateT>) -> MResult<u64> {
         let _ = self.updates_notifier.send(UpdateEvent::NewUpdate);
         let update_id = push_synonyms_deletion(
             writer,
@@ -63,7 +64,7 @@ impl SynonymsDeletion {
 }
 
 pub fn push_synonyms_deletion(
-    writer: &mut heed::RwTxn,
+    writer: &mut heed::RwTxn<UpdateT>,
     updates_store: store::Updates,
     updates_results_store: store::UpdatesResults,
     deletion: BTreeMap<String, Option<Vec<String>>>,
@@ -77,7 +78,7 @@ pub fn push_synonyms_deletion(
 }
 
 pub fn apply_synonyms_deletion(
-    writer: &mut heed::RwTxn,
+    writer: &mut heed::RwTxn<MainT>,
     main_store: store::Main,
     synonyms_store: store::Synonyms,
     deletion: BTreeMap<String, Option<Vec<String>>>,

--- a/meilisearch-http/Cargo.toml
+++ b/meilisearch-http/Cargo.toml
@@ -16,7 +16,7 @@ bincode = "1.2.0"
 chrono = { version = "0.4.9", features = ["serde"] }
 crossbeam-channel = "0.4.0"
 env_logger = "0.7.1"
-heed = "0.5.0"
+heed = "0.6.0"
 http = "0.1.19"
 indexmap = { version = "1.3.0", features = ["serde-1"] }
 isahc = "0.7.6"

--- a/meilisearch-http/src/helpers/meilisearch.rs
+++ b/meilisearch-http/src/helpers/meilisearch.rs
@@ -4,6 +4,7 @@ use log::error;
 use meilisearch_core::criterion::*;
 use meilisearch_core::Highlight;
 use meilisearch_core::{Index, RankedMap};
+use meilisearch_core::MainT;
 use meilisearch_schema::{Schema, SchemaAttr};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -157,7 +158,7 @@ impl<'a> SearchBuilder<'a> {
         self
     }
 
-    pub fn search(&self, reader: &heed::RoTxn) -> Result<SearchResult, Error> {
+    pub fn search(&self, reader: &heed::RoTxn<MainT>) -> Result<SearchResult, Error> {
         let schema = self.index.main.schema(reader);
         let schema = schema.map_err(|e| Error::Internal(e.to_string()))?;
         let schema = match schema {
@@ -285,7 +286,7 @@ impl<'a> SearchBuilder<'a> {
 
     pub fn get_criteria(
         &self,
-        reader: &heed::RoTxn,
+        reader: &heed::RoTxn<MainT>,
         ranked_map: &'a RankedMap,
         schema: &Schema,
     ) -> Result<Option<Criteria<'a>>, Error> {

--- a/meilisearch-http/src/helpers/tide.rs
+++ b/meilisearch-http/src/helpers/tide.rs
@@ -29,14 +29,13 @@ impl ContextExt for Context<Data> {
         let request_index: Option<String> = None; //self.param::<String>("index").ok();
 
         let db = &self.state().db;
-        let env = &db.env;
-        let reader = env.read_txn().map_err(ResponseError::internal)?;
+        let reader = db.main_read_txn().map_err(ResponseError::internal)?;
 
         let token_key = format!("{}{}", TOKEN_PREFIX_KEY, user_api_key);
 
         let token_config = db
             .common_store()
-            .get::<Str, SerdeBincode<Token>>(&reader, &token_key)
+            .get::<_, Str, SerdeBincode<Token>>(&reader, &token_key)
             .map_err(ResponseError::internal)?
             .ok_or(ResponseError::invalid_token(format!(
                 "Api key does not exist: {}",

--- a/meilisearch-http/src/routes/health.rs
+++ b/meilisearch-http/src/routes/health.rs
@@ -11,12 +11,11 @@ const UNHEALTHY_KEY: &str = "_is_unhealthy";
 
 pub async fn get_health(ctx: Context<Data>) -> SResult<()> {
     let db = &ctx.state().db;
-    let env = &db.env;
-    let reader = env.read_txn().map_err(ResponseError::internal)?;
+    let reader = db.main_read_txn().map_err(ResponseError::internal)?;
 
     let common_store = ctx.state().db.common_store();
 
-    if let Ok(Some(_)) = common_store.get::<Str, Unit>(&reader, UNHEALTHY_KEY) {
+    if let Ok(Some(_)) = common_store.get::<_, Str, Unit>(&reader, UNHEALTHY_KEY) {
         return Err(ResponseError::Maintenance);
     }
 
@@ -27,11 +26,10 @@ pub async fn set_healthy(ctx: Context<Data>) -> SResult<()> {
     ctx.is_allowed(Admin)?;
 
     let db = &ctx.state().db;
-    let env = &db.env;
-    let mut writer = env.write_txn().map_err(ResponseError::internal)?;
+    let mut writer = db.main_write_txn().map_err(ResponseError::internal)?;
 
     let common_store = ctx.state().db.common_store();
-    match common_store.delete::<Str>(&mut writer, UNHEALTHY_KEY) {
+    match common_store.delete::<_, Str>(&mut writer, UNHEALTHY_KEY) {
         Ok(_) => (),
         Err(e) => return Err(ResponseError::internal(e)),
     }
@@ -47,12 +45,11 @@ pub async fn set_unhealthy(ctx: Context<Data>) -> SResult<()> {
     ctx.is_allowed(Admin)?;
 
     let db = &ctx.state().db;
-    let env = &db.env;
-    let mut writer = env.write_txn().map_err(ResponseError::internal)?;
+    let mut writer = db.main_write_txn().map_err(ResponseError::internal)?;
 
     let common_store = ctx.state().db.common_store();
 
-    if let Err(e) = common_store.put::<Str, Unit>(&mut writer, UNHEALTHY_KEY, &()) {
+    if let Err(e) = common_store.put::<_, Str, Unit>(&mut writer, UNHEALTHY_KEY, &()) {
         return Err(ResponseError::internal(e));
     }
 

--- a/meilisearch-http/src/routes/search.rs
+++ b/meilisearch-http/src/routes/search.rs
@@ -33,8 +33,8 @@ pub async fn search_with_url_query(ctx: Context<Data>) -> SResult<Response> {
     // ctx.is_allowed(DocumentsRead)?;
 
     let index = ctx.index()?;
-    let env = &ctx.state().db.env;
-    let reader = env.read_txn().map_err(ResponseError::internal)?;
+    let db = &ctx.state().db;
+    let reader = db.main_read_txn().map_err(ResponseError::internal)?;
 
     let schema = index
         .main
@@ -210,9 +210,7 @@ pub async fn search_multi_index(mut ctx: Context<Data>) -> SResult<Response> {
                 }
             }
 
-            let env = &db.env;
-            let reader = env.read_txn().map_err(ResponseError::internal)?;
-
+            let reader = db.main_read_txn().map_err(ResponseError::internal)?;
             let response = search_builder
                 .search(&reader)
                 .map_err(ResponseError::internal)?;

--- a/meilisearch-http/src/routes/setting.rs
+++ b/meilisearch-http/src/routes/setting.rs
@@ -34,8 +34,8 @@ pub async fn get(ctx: Context<Data>) -> SResult<Response> {
     ctx.is_allowed(SettingsRead)?;
     let index = ctx.index()?;
 
-    let env = &ctx.state().db.env;
-    let reader = env.read_txn().map_err(ResponseError::internal)?;
+    let db = &ctx.state().db;
+    let reader = db.main_read_txn().map_err(ResponseError::internal)?;
 
     let settings = match index.main.customs(&reader).unwrap() {
         Some(bytes) => bincode::deserialize(bytes).unwrap(),
@@ -52,10 +52,11 @@ pub async fn update(mut ctx: Context<Data>) -> SResult<Response> {
 
     let index = ctx.index()?;
 
-    let env = &ctx.state().db.env;
-    let mut writer = env.write_txn().map_err(ResponseError::internal)?;
+    let db = &ctx.state().db;
+    let reader = db.main_write_txn().map_err(ResponseError::internal)?;
+    let mut writer = db.update_write_txn().map_err(ResponseError::internal)?;
 
-    let mut current_settings = match index.main.customs(&writer).unwrap() {
+    let mut current_settings = match index.main.customs(&reader).unwrap() {
         Some(bytes) => bincode::deserialize(bytes).unwrap(),
         None => SettingBody::default(),
     };

--- a/meilisearch-http/src/routes/stats.rs
+++ b/meilisearch-http/src/routes/stats.rs
@@ -26,8 +26,9 @@ pub async fn index_stat(ctx: Context<Data>) -> SResult<Response> {
     let index_uid = ctx.url_param("index")?;
     let index = ctx.index()?;
 
-    let env = &ctx.state().db.env;
-    let reader = env.read_txn().map_err(ResponseError::internal)?;
+    let db = &ctx.state().db;
+    let reader = db.main_read_txn().map_err(ResponseError::internal)?;
+    let update_reader = db.update_read_txn().map_err(ResponseError::internal)?;
 
     let number_of_documents = index
         .main
@@ -42,7 +43,7 @@ pub async fn index_stat(ctx: Context<Data>) -> SResult<Response> {
 
     let is_indexing = ctx
         .state()
-        .is_indexing(&reader, &index_uid)
+        .is_indexing(&update_reader, &index_uid)
         .map_err(ResponseError::internal)?
         .ok_or(ResponseError::internal("'is_indexing' date not found"))?;
 
@@ -68,8 +69,8 @@ pub async fn get_stats(ctx: Context<Data>) -> SResult<Response> {
     let mut index_list = HashMap::new();
 
     let db = &ctx.state().db;
-    let env = &db.env;
-    let reader = env.read_txn().map_err(ResponseError::internal)?;
+    let reader = db.main_read_txn().map_err(ResponseError::internal)?;
+    let update_reader = db.update_read_txn().map_err(ResponseError::internal)?;
 
     let indexes_set = ctx.state().db.indexes_uids();
     for index_uid in indexes_set {
@@ -90,7 +91,7 @@ pub async fn get_stats(ctx: Context<Data>) -> SResult<Response> {
 
                 let is_indexing = ctx
                     .state()
-                    .is_indexing(&reader, &index_uid)
+                    .is_indexing(&update_reader, &index_uid)
                     .map_err(ResponseError::internal)?
                     .ok_or(ResponseError::internal("'is_indexing' date not found"))?;
 

--- a/meilisearch-http/src/routes/stop_words.rs
+++ b/meilisearch-http/src/routes/stop_words.rs
@@ -12,8 +12,8 @@ pub async fn list(ctx: Context<Data>) -> SResult<Response> {
     ctx.is_allowed(SettingsRead)?;
     let index = ctx.index()?;
 
-    let env = &ctx.state().db.env;
-    let reader = env.read_txn().map_err(ResponseError::internal)?;
+    let db = &ctx.state().db;
+    let reader = db.main_read_txn().map_err(ResponseError::internal)?;
 
     let stop_words_fst = index
         .main
@@ -35,8 +35,8 @@ pub async fn add(mut ctx: Context<Data>) -> SResult<Response> {
 
     let data: Vec<String> = ctx.body_json().await.map_err(ResponseError::bad_request)?;
 
-    let env = &ctx.state().db.env;
-    let mut writer = env.write_txn().map_err(ResponseError::internal)?;
+    let db = &ctx.state().db;
+    let mut writer = db.update_write_txn().map_err(ResponseError::internal)?;
 
     let mut stop_words_addition = index.stop_words_addition();
     for stop_word in data {
@@ -61,8 +61,8 @@ pub async fn delete(mut ctx: Context<Data>) -> SResult<Response> {
 
     let data: Vec<String> = ctx.body_json().await.map_err(ResponseError::bad_request)?;
 
-    let env = &ctx.state().db.env;
-    let mut writer = env.write_txn().map_err(ResponseError::internal)?;
+    let db = &ctx.state().db;
+    let mut writer = db.update_write_txn().map_err(ResponseError::internal)?;
 
     let mut stop_words_deletion = index.stop_words_deletion();
     for stop_word in data {


### PR DESCRIPTION
We will be able to handle multiple indexes updates at the same time as we are consuming them.

We used the heed typed transaction to make it safe (https://github.com/Kerollmops/heed/pull/27).