### PR TITLE
Add publish action to gemfury for apt pkg

### DIFF
--- a/.github/workflows/publish-deb-pkg.yml
+++ b/.github/workflows/publish-deb-pkg.yml
@@ -1,4 +1,4 @@
-name: Publish debian package to GitHub release
+name: Publish deb pkg to GitHub release & apt repository
 
 on:
   push:
@@ -26,3 +26,5 @@ jobs:
         file: target/debian/meilisearch.deb
         asset_name: meilisearch.deb
         tag: ${{ github.ref }}
+    - name: Upload debian pkg to apt repository
+      run: curl -F package=@target/debian/meilisearch.deb https://${{ secrets.GEMFURY_PUSH_TOKEN }}@push.fury.io/meilisearch/

--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ For more [details about those features, go to our documentation](https://docs.me
 docker run -it -p 7700:7700 --rm getmeili/MeiliSearch
 ```
 
+#### Installation using APT
+
+```bash
+echo "deb [trusted=yes] https://apt.fury.io/meilisearch/ /" > /etc/apt/sources.list.d/fury.list
+apt update && apt install meilisearch-http
+meilisearch
+```
+
 #### Download the binary
 
 ```bash


### PR DESCRIPTION
Upload the .deb package on gemfury apt repository.

Usage to install on debian-based OS:
```bash
$ echo "deb [trusted=yes] https://apt.fury.io/meilisearch/ /" > /etc/apt/sources.list.d/fury.list
$ apt update && apt install meilisearch-http
$ meilisearch
Server is listening on: http://127.0.0.1:7700
```

I wonder if I should add this usage in the README.md but it may add some complexity.
@Kerollmops Shoud we have an INSTALL.md file somewhere at the root of the project or in the misc/ directory?

PS: When merging this PR, you should add the GEMFURY_PUSH_TOKEN secrets in the repository settings