### PR TITLE
Docker command updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ For more [details about those features, go to our documentation](https://docs.me
 #### Run it using Docker
 
 ```bash
-docker run -it -p 7700:7700 --rm getmeili/MeiliSearch
+docker run -it -p 7700:7700 --rm getmeili/meilisearch
 ```
 
 #### Download the binary


### PR DESCRIPTION
Docker does not allow Uppercase letters, throws this error 

`docker: invalid reference format: repository name must be lowercase.`