### PR TITLE
Close multiples issues on HTTP behavior

### DIFF
--- a/meilisearch-core/src/serde/indexer.rs
+++ b/meilisearch-core/src/serde/indexer.rs
@@ -24,9 +24,7 @@ impl<'a> ser::Serializer for Indexer<'a> {
     type SerializeStructVariant = ser::Impossible<Self::Ok, Self::Error>;
 
     fn serialize_bool(self, _value: bool) -> Result<Self::Ok, Self::Error> {
-        Err(SerializerError::UnindexableType {
-            type_name: "boolean",
-        })
+        Ok(None)
     }
 
     fn serialize_char(self, value: char) -> Result<Self::Ok, Self::Error> {
@@ -96,9 +94,7 @@ impl<'a> ser::Serializer for Indexer<'a> {
     }
 
     fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
-        Err(SerializerError::UnindexableType {
-            type_name: "Option",
-        })
+        Ok(None)
     }
 
     fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error>
@@ -113,13 +109,11 @@ impl<'a> ser::Serializer for Indexer<'a> {
     }
 
     fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
-        Err(SerializerError::UnindexableType { type_name: "()" })
+        Ok(None)
     }
 
     fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
-        Err(SerializerError::UnindexableType {
-            type_name: "unit struct",
-        })
+        Ok(None)
     }
 
     fn serialize_unit_variant(
@@ -128,9 +122,7 @@ impl<'a> ser::Serializer for Indexer<'a> {
         _variant_index: u32,
         _variant: &'static str,
     ) -> Result<Self::Ok, Self::Error> {
-        Err(SerializerError::UnindexableType {
-            type_name: "unit variant",
-        })
+        Ok(None)
     }
 
     fn serialize_newtype_struct<T: ?Sized>(
@@ -219,9 +211,14 @@ impl<'a> ser::Serializer for Indexer<'a> {
         _name: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeStruct, Self::Error> {
-        Err(SerializerError::UnindexableType {
-            type_name: "struct",
-        })
+        let indexer = StructIndexer {
+            attribute: self.attribute,
+            document_id: self.document_id,
+            indexer: self.indexer,
+            texts: Vec::new(),
+        };
+
+        Ok(indexer)
     }
 
     fn serialize_struct_variant(

--- a/meilisearch-core/src/update/stop_words_deletion.rs
+++ b/meilisearch-core/src/update/stop_words_deletion.rs
@@ -101,14 +101,18 @@ pub fn apply_stop_words_deletion(
 
     // now that we have setup the stop words
     // lets reindex everything...
-    reindex_all_documents(
-        writer,
-        main_store,
-        documents_fields_store,
-        documents_fields_counts_store,
-        postings_lists_store,
-        docs_words_store,
-    )?;
+    if let Ok(number) = main_store.number_of_documents(writer) {
+        if number > 0 {
+            reindex_all_documents(
+                writer,
+                main_store,
+                documents_fields_store,
+                documents_fields_counts_store,
+                postings_lists_store,
+                docs_words_store,
+            )?;
+        }
+    }
 
     Ok(())
 }

--- a/meilisearch-http/src/error.rs
+++ b/meilisearch-http/src/error.rs
@@ -79,7 +79,7 @@ impl IntoResponse for ResponseError {
                 error(err, StatusCode::BAD_REQUEST)
             }
             ResponseError::InvalidToken(err) => {
-                error(format!("Invalid Token: {}", err), StatusCode::FORBIDDEN)
+                error(format!("Invalid API key: {}", err), StatusCode::FORBIDDEN)
             }
             ResponseError::NotFound(err) => error(err, StatusCode::NOT_FOUND),
             ResponseError::IndexNotFound(index) => {

--- a/meilisearch-http/src/helpers/meilisearch.rs
+++ b/meilisearch-http/src/helpers/meilisearch.rs
@@ -243,7 +243,14 @@ impl<'a> SearchBuilder<'a> {
                 .map_err(|e| Error::RetrieveDocument(doc.id.0, e.to_string()))?
                 .ok_or(Error::DocumentNotFound(doc.id.0))?;
 
-            let mut formatted = document.clone();
+            let has_attributes_to_highlight = self.attributes_to_highlight.is_some();
+            let has_attributes_to_crop = self.attributes_to_crop.is_some();
+
+            let mut formatted = if has_attributes_to_highlight || has_attributes_to_crop {
+                document.clone()
+            } else {
+                IndexMap::new()
+            };
             let mut matches = doc.highlights.clone();
 
             // Crops fields if needed
@@ -494,7 +501,7 @@ fn calculate_highlights(
     matches: &MatchesInfos,
     attributes_to_highlight: &HashSet<String>,
 ) -> IndexMap<String, Value> {
-    let mut highlight_result = IndexMap::new();
+    let mut highlight_result = document.clone();
 
     for (attribute, matches) in matches.iter() {
         if attributes_to_highlight.contains(attribute) {

--- a/meilisearch-http/src/helpers/meilisearch.rs
+++ b/meilisearch-http/src/helpers/meilisearch.rs
@@ -1,4 +1,4 @@
-use crate::routes::setting::{RankingOrdering, SettingBody};
+use crate::routes::setting::{RankingOrdering, Setting};
 use indexmap::IndexMap;
 use log::{error, warn};
 use meilisearch_core::criterion::*;
@@ -299,7 +299,7 @@ impl<'a> SearchBuilder<'a> {
     ) -> Result<Option<Criteria<'a>>, Error> {
         let current_settings = match self.index.main.customs(reader).unwrap() {
             Some(bytes) => bincode::deserialize(bytes).unwrap(),
-            None => SettingBody::default(),
+            None => Setting::default(),
         };
 
         let ranking_rules = &current_settings.ranking_rules;

--- a/meilisearch-http/src/helpers/tide.rs
+++ b/meilisearch-http/src/helpers/tide.rs
@@ -66,7 +66,7 @@ impl ContextExt for Context<Data> {
         }
 
         if !token_config.acl.contains(&acl) {
-            return Err(ResponseError::invalid_token("token do not have this ACL"));
+            return Err(ResponseError::invalid_token("no permission"));
         }
 
         Ok(())

--- a/meilisearch-http/src/routes/index.rs
+++ b/meilisearch-http/src/routes/index.rs
@@ -390,19 +390,10 @@ pub async fn get_all_updates_status(ctx: Context<Data>) -> SResult<Response> {
 
 pub async fn delete_index(ctx: Context<Data>) -> SResult<StatusCode> {
     ctx.is_allowed(IndexesWrite)?;
+    let _ = ctx.index()?;
     let index_uid = ctx.url_param("index")?;
-
-    let found = ctx
-        .state()
-        .db
-        .delete_index(&index_uid)
-        .map_err(ResponseError::internal)?;
-
-    if found {
-        Ok(StatusCode::NO_CONTENT)
-    } else {
-        Ok(StatusCode::NOT_FOUND)
-    }
+    ctx.state().db.delete_index(&index_uid).map_err(ResponseError::internal)?;
+    Ok(StatusCode::NO_CONTENT)
 }
 
 pub fn index_update_callback(index_uid: &str, data: &Data, status: ProcessedUpdateResult) {


### PR DESCRIPTION
closes #377 
A valid message is now returned if there is no index.
<img width="1920" alt="Capture d’écran 2019-12-12 à 14 04 45" src="https://user-images.githubusercontent.com/6064892/70714648-dc2abc00-1ce8-11ea-967a-ad3c30a1e254.png">

closes #372 
A stop word addition without schema is now processed.
<img width="1920" alt="Capture d’écran 2019-12-12 à 15 34 02" src="https://user-images.githubusercontent.com/6064892/70720844-dd61e600-1cf4-11ea-81fa-d0860b4e4dac.png">

closes #316 
The response for API Keys is now more clear.
<img width="1920" alt="Capture d’écran 2019-12-12 à 15 50 05" src="https://user-images.githubusercontent.com/6064892/70722444-9cb79c00-1cf7-11ea-86f7-859c0ca01ba8.png">

Closes #325 
Return formatted section on search only if it's requested.
<img width="1920" alt="Capture d’écran 2019-12-12 à 16 22 33" src="https://user-images.githubusercontent.com/6064892/70724904-c1157780-1cfb-11ea-9ef1-934e04f77edf.png">
<img width="1920" alt="Capture d’écran 2019-12-12 à 16 22 24" src="https://user-images.githubusercontent.com/6064892/70724906-c1ae0e00-1cfb-11ea-99f0-391045c8561b.png">

Closes #369 
This doesn't unwrap anymore

touch #397

closes #402 
Check settings, there are all to null
<img width="1920" alt="Capture d’écran 2019-12-13 à 10 17 13" src="https://user-images.githubusercontent.com/6064892/70788749-dc32c680-1d91-11ea-91f8-f4cbdea65728.png">
Push new settings
<img width="1920" alt="Capture d’écran 2019-12-13 à 10 17 30" src="https://user-images.githubusercontent.com/6064892/70788747-dc32c680-1d91-11ea-9b24-cc6c817f2151.png">
Check settings, they have the right values
<img width="1920" alt="Capture d’écran 2019-12-13 à 10 17 35" src="https://user-images.githubusercontent.com/6064892/70788746-db9a3000-1d91-11ea-9deb-d3d55c627dc5.png">
Remove settings
<img width="1920" alt="Capture d’écran 2019-12-13 à 10 17 48" src="https://user-images.githubusercontent.com/6064892/70788750-dccb5d00-1d91-11ea-8519-00f8c773a818.png">
Check settings, there are all to null
<img width="1920" alt="Capture d’écran 2019-12-13 à 10 17 57" src="https://user-images.githubusercontent.com/6064892/70788752-dd63f380-1d91-11ea-9703-0af25cd33422.png">

