### PR TITLE
Add heroku one-click deploy

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: ./target/release/meilisearch --http-addr=0.0.0.0:$PORT

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ curl -L https://install.meilisearch.com | sh
 ./meilisearch
 ```
 
+#### Run it on heroku
+
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/meilisearch/MeiliSearch)
+
 #### Compile and run it from sources
 
 If you have the Rust toolchain already installed, you can compile from the source

--- a/app.json
+++ b/app.json
@@ -1,0 +1,16 @@
+{
+  "name": "MeiliSearch",
+  "description": "Ultra relevant, instant and typo-tolerant full-text search API",
+  "keywords": [
+    "search-engine",
+    "instant search",
+    "search API"
+  ],
+  "website": "https://docs.meilisearch.com/",
+  "repository": "https://github.com/meilisearch/MeiliSearch",
+  "buildpacks": [
+    {
+      "url": "https://github.com/emk/heroku-buildpack-rust"
+    }
+  ]
+}


### PR DESCRIPTION
The link won't be working until the merge on master is done.

You can try the button by replacing the url https://heroku.com/deploy?template=https://github.com/meilisearch/MeiliSearch by https://heroku.com/deploy?template=https://github.com/tpayet/MeiliSearch/tree/feat/heroku-button which point to my working branch with the required files. 

The compilation when the button is triggered can take up to 23 minutes. I do not really know why but I suspect the Rust buildpack is installing Rust and its stuff (clippy, fmt) on each build.

The next step would be to have a buildpack containing MeiliSearch.