### PR TITLE
Set the indexes info in the create_index function

### DIFF
--- a/meilisearch-core/src/database.rs
+++ b/meilisearch-core/src/database.rs
@@ -236,8 +236,12 @@ impl Database {
                 let (sender, receiver) = crossbeam_channel::bounded(100);
                 let index = store::create(&self.env, &self.update_env, name, sender)?;
 
-                let mut writer = self.env.write_txn()?;
+                let mut writer = self.env.typed_write_txn::<MainT>()?;
                 self.indexes_store.put(&mut writer, name, &())?;
+
+                index.main.put_name(&mut writer, name)?;
+                index.main.put_created_at(&mut writer)?;
+                index.main.put_updated_at(&mut writer)?;
 
                 let env_clone = self.env.clone();
                 let update_env_clone = self.update_env.clone();

--- a/meilisearch-http/src/routes/index.rs
+++ b/meilisearch-http/src/routes/index.rs
@@ -57,13 +57,13 @@ pub async fn list_indexes(ctx: Context<Data>) -> SResult<Response> {
                     .map_err(ResponseError::internal)?
                     .ok_or(ResponseError::internal("'updated_at' date not found"))?;
 
-                let index_reponse = IndexResponse {
+                let index_response = IndexResponse {
                     name,
                     uid: index_uid,
                     created_at,
                     updated_at,
                 };
-                response_body.push(index_reponse);
+                response_body.push(index_response);
             }
             None => error!(
                 "Index {} is referenced in the indexes list but cannot be found",
@@ -170,14 +170,6 @@ pub async fn create_index(mut ctx: Context<Data>) -> SResult<Response> {
     created_index
         .main
         .put_name(&mut writer, &body.name)
-        .map_err(ResponseError::internal)?;
-    created_index
-        .main
-        .put_created_at(&mut writer)
-        .map_err(ResponseError::internal)?;
-    created_index
-        .main
-        .put_updated_at(&mut writer)
         .map_err(ResponseError::internal)?;
 
     let schema: Option<Schema> = body.schema.clone().map(Into::into);


### PR DESCRIPTION
Adding essential data like the name, the creation, and update date at creation time allows us to open an index created using the `from_file` example with the HTTP server.