### PR TITLE
Construct a Set using the from_dirty method

### DIFF
--- a/meilisearch-core/src/query_tree.rs
+++ b/meilisearch-core/src/query_tree.rs
@@ -531,7 +531,7 @@ pub fn traverse_query_tree<'o, 'txn>(
                     let docids = SetBuf::new(docids).unwrap();
                     debug!("{:2$}docids construction took {:.02?}", "", before.elapsed(), depth * 2);
 
-                    let matches = Cow::Owned(SetBuf::new(matches).unwrap());
+                    let matches = Cow::Owned(SetBuf::from_dirty(matches));
                     let key = PostingsKey { query, input: vec![], distance: 0, is_exact: true };
                     postings.insert(key, matches);
 


### PR DESCRIPTION
This commit fixes #566 by ensuring that the slice of matches is ordered and deduplicated.

I think this bug was affecting all double words (i.e. "lala", "kiki", "chouchou") who matches something in the documents when half split (i.e. "la", "ki", "chou").

@piccaso I would be glad if you test this PR before I merge it in master :)