### PR TITLE
Make the engine index booleans

### DIFF
--- a/meilisearch-core/src/serde/convert_to_string.rs
+++ b/meilisearch-core/src/serde/convert_to_string.rs
@@ -16,10 +16,8 @@ impl ser::Serializer for ConvertToString {
     type SerializeStruct = StructConvertToString;
     type SerializeStructVariant = ser::Impossible<Self::Ok, Self::Error>;
 
-    fn serialize_bool(self, _value: bool) -> Result<Self::Ok, Self::Error> {
-        Err(SerializerError::UnserializableType {
-            type_name: "boolean",
-        })
+    fn serialize_bool(self, value: bool) -> Result<Self::Ok, Self::Error> {
+        Ok(value.to_string())
     }
 
     fn serialize_char(self, value: char) -> Result<Self::Ok, Self::Error> {

--- a/meilisearch-http/tests/documents_add.rs
+++ b/meilisearch-http/tests/documents_add.rs
@@ -36,3 +36,43 @@ fn check_add_documents_with_primary_key_param() {
     assert_eq!(status_code, 200);
     assert_eq!(response["status"], "processed");
 }
+
+// Test issue https://github.com/meilisearch/MeiliSearch/issues/568
+#[test]
+fn check_add_documents_with_nested_boolean() {
+    let mut server = common::Server::with_uid("tasks");
+
+    // 1 - Create the index with no primary_key
+
+    let body = json!({ "uid": "tasks" });
+    let (response, status_code) = server.create_index(body);
+    assert_eq!(status_code, 201);
+    assert_eq!(response["primaryKey"], json!(null));
+
+    // 2 - Add a document that contains a boolean in a nested object
+
+    let body = json!([{
+        "id": 12161,
+        "created_at": "2019-04-10T14:57:57.522Z",
+        "foo": {
+            "bar": {
+                "id": 121,
+                "crash": false
+            },
+            "id": 45912
+        }
+    }]);
+
+    let url = "/indexes/tasks/documents";
+    let (response, status_code) = server.post_request(&url, body);
+    eprintln!("{:#?}", response);
+    assert_eq!(status_code, 202);
+    let update_id = response["updateId"].as_u64().unwrap();
+    server.wait_update_id(update_id);
+
+    // 3 - Check update sucess
+
+    let (response, status_code) = server.get_update_status(update_id);
+    assert_eq!(status_code, 200);
+    assert_eq!(response["status"], "processed");
+}


### PR DESCRIPTION
Hey @ppamorim,

I would be glad if you can test this PR before I merge it on master :)
The engine will now see boolean values like real text "true" and "false".

Fixes #568.