### PR TITLE
Add support of nested null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,4 +3,4 @@
   - Add the number of hits in search result (#541)
   - Add support for aligned crop in search result (#543)
   - Sanitize the content displayed in the web interface (#539)
-  - Add support of nested null and boolean values
+  - Add support of nested null and boolean values (#571 and #568)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,4 +3,4 @@
   - Add the number of hits in search result (#541)
   - Add support for aligned crop in search result (#543)
   - Sanitize the content displayed in the web interface (#539)
-  - Add support of nested null values
+  - Add support of nested null and boolean values

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
   - Add the number of hits in search result (#541)
   - Add support for aligned crop in search result (#543)
   - Sanitize the content displayed in the web interface (#539)
+  - Add support of nested null values

--- a/meilisearch-core/src/serde/convert_to_string.rs
+++ b/meilisearch-core/src/serde/convert_to_string.rs
@@ -88,7 +88,7 @@ impl ser::Serializer for ConvertToString {
     }
 
     fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
-        Err(SerializerError::UnserializableType { type_name: "()" })
+        Ok("".to_string())
     }
 
     fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {

--- a/meilisearch-core/src/serde/convert_to_string.rs
+++ b/meilisearch-core/src/serde/convert_to_string.rs
@@ -88,7 +88,7 @@ impl ser::Serializer for ConvertToString {
     }
 
     fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
-        Ok("".to_string())
+        Ok(String::new())
     }
 
     fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {

--- a/meilisearch-http/tests/documents_add.rs
+++ b/meilisearch-http/tests/documents_add.rs
@@ -79,7 +79,7 @@ fn check_add_documents_with_nested_boolean() {
 
 // Test issue https://github.com/meilisearch/MeiliSearch/issues/571
 #[test]
-fn check_add_documents_with_nested_sequence() {
+fn check_add_documents_with_nested_null() {
     let mut server = common::Server::with_uid("tasks");
 
     // 1 - Create the index with no primary_key
@@ -91,7 +91,12 @@ fn check_add_documents_with_nested_sequence() {
 
     // 2 - Add a document that contains a null in a nested object
 
-    let body = serde_json::from_str("[{\"id\":0,\"foo\":{\"bar\":null}}]").unwrap();
+    let body = json!([{ 
+        "id": 0, 
+        "foo": { 
+            "bar": null
+        } 
+    }]);
 
     let url = "/indexes/tasks/documents";
     let (response, status_code) = server.post_request(&url, body);

--- a/meilisearch-http/tests/documents_add.rs
+++ b/meilisearch-http/tests/documents_add.rs
@@ -76,3 +76,33 @@ fn check_add_documents_with_nested_boolean() {
     assert_eq!(status_code, 200);
     assert_eq!(response["status"], "processed");
 }
+
+// Test issue https://github.com/meilisearch/MeiliSearch/issues/571
+#[test]
+fn check_add_documents_with_nested_sequence() {
+    let mut server = common::Server::with_uid("tasks");
+
+    // 1 - Create the index with no primary_key
+
+    let body = json!({ "uid": "tasks" });
+    let (response, status_code) = server.create_index(body);
+    assert_eq!(status_code, 201);
+    assert_eq!(response["primaryKey"], json!(null));
+
+    // 2 - Add a document that contains a null in a nested object
+
+    let body = serde_json::from_str("[{\"id\":0,\"foo\":{\"bar\":null}}]").unwrap();
+
+    let url = "/indexes/tasks/documents";
+    let (response, status_code) = server.post_request(&url, body);
+    eprintln!("{:#?}", response);
+    assert_eq!(status_code, 202);
+    let update_id = response["updateId"].as_u64().unwrap();
+    server.wait_update_id(update_id);
+
+    // 3 - Check update sucess
+
+    let (response, status_code) = server.get_update_status(update_id);
+    assert_eq!(status_code, 200);
+    assert_eq!(response["status"], "processed");
+}


### PR DESCRIPTION
Hi,

Issue: https://github.com/meilisearch/MeiliSearch/issues/571

The test below seems to hang, so please do not merge it yet. This problem is caused with the JSON below:

```json
[{"id":0,"foo":{"bar":null}}]
```

What should Meili do? Simply ignore the value or stringify it?

@Kerollmops Wil the function `fn serialize_unit(self) -> Result<Self::Ok, Self::Error>` from `convert_to_string.rs` or `convert_to_number.rs` be called in this case?