### PR TITLE
Support nested-seq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,4 +3,4 @@
   - Add the number of hits in search result (#541)
   - Add support for aligned crop in search result (#543)
   - Sanitize the content displayed in the web interface (#539)
-  - Add support of nested null and boolean values (#571 and #568)
+  - Add support of nested null, boolean and seq values (#571 and #568, #574)

--- a/meilisearch-http/tests/documents_add.rs
+++ b/meilisearch-http/tests/documents_add.rs
@@ -129,7 +129,7 @@ fn check_add_documents_with_nested_sequence() {
     let body = json!([{ 
         "id": 0, 
         "foo": { 
-            "bar": [123],
+            "bar": [123,456],
             "fez": [{
                 "id": 255,
                 "baz": "leesz",
@@ -137,6 +137,22 @@ fn check_add_documents_with_nested_sequence() {
                     "fax": [234]
                 },
                 "sas": []
+            }],
+            "foz": [{
+                "id": 255,
+                "baz": "leesz",
+                "fuzz": {
+                    "fax": [234]
+                },
+                "sas": []
+            },
+            {
+                "id": 256,
+                "baz": "loss",
+                "fuzz": {
+                    "fax": [235]
+                },
+                "sas": [321, 321]
             }]
         }
     }]);

--- a/meilisearch-http/tests/documents_add.rs
+++ b/meilisearch-http/tests/documents_add.rs
@@ -135,7 +135,8 @@ fn check_add_documents_with_nested_sequence() {
                 "baz": "leesz",
                 "fuzz": {
                     "fax": [234]
-                }
+                },
+                "sas": []
             }]
         }
     }]);

--- a/meilisearch-http/tests/documents_add.rs
+++ b/meilisearch-http/tests/documents_add.rs
@@ -30,7 +30,7 @@ fn check_add_documents_with_primary_key_param() {
     let update_id = response["updateId"].as_u64().unwrap();
     server.wait_update_id(update_id);
 
-    // 3 - Check update sucess
+    // 3 - Check update success
 
     let (response, status_code) = server.get_update_status(update_id);
     assert_eq!(status_code, 200);
@@ -70,7 +70,7 @@ fn check_add_documents_with_nested_boolean() {
     let update_id = response["updateId"].as_u64().unwrap();
     server.wait_update_id(update_id);
 
-    // 3 - Check update sucess
+    // 3 - Check update success
 
     let (response, status_code) = server.get_update_status(update_id);
     assert_eq!(status_code, 200);
@@ -105,9 +105,56 @@ fn check_add_documents_with_nested_null() {
     let update_id = response["updateId"].as_u64().unwrap();
     server.wait_update_id(update_id);
 
-    // 3 - Check update sucess
+    // 3 - Check update success
 
     let (response, status_code) = server.get_update_status(update_id);
     assert_eq!(status_code, 200);
     assert_eq!(response["status"], "processed");
+}
+
+// Test issue https://github.com/meilisearch/MeiliSearch/issues/574
+#[test]
+fn check_add_documents_with_nested_sequence() {
+    let mut server = common::Server::with_uid("tasks");
+
+    // 1 - Create the index with no primary_key
+
+    let body = json!({ "uid": "tasks" });
+    let (response, status_code) = server.create_index(body);
+    assert_eq!(status_code, 201);
+    assert_eq!(response["primaryKey"], json!(null));
+
+    // 2 - Add a document that contains a seq in a nested object
+
+    let body = json!([{ 
+        "id": 0, 
+        "foo": { 
+            "bar": [123],
+            "fez": [{
+                "id": 255,
+                "baz": "leesz",
+                "fuzz": {
+                    "fax": [234]
+                }
+            }]
+        }
+    }]);
+
+    let url = "/indexes/tasks/documents";
+    let (response, status_code) = server.post_request(&url, body.clone());
+    eprintln!("{:#?}", response);
+    assert_eq!(status_code, 202);
+    let update_id = response["updateId"].as_u64().unwrap();
+    server.wait_update_id(update_id);
+
+    // 3 - Check update success
+
+    let (response, status_code) = server.get_update_status(update_id);
+    assert_eq!(status_code, 200);
+    assert_eq!(response["status"], "processed");
+
+    let url = "/indexes/tasks/search?q=leesz";
+    let (response, status_code) = server.get_request(&url);
+    assert_eq!(status_code, 200);
+    assert_eq!(response["hits"], body);
 }


### PR DESCRIPTION
Hi,

In this PR the support of nested sequences is added, so you are allowed to index a JSON like this:

```json
[{
    "id": 0,
    "foo": {
        "bar": [
            123
        ],
        "fez": [{
            "id": 255,
            "baz": "leesz",
            "fuzz": {
                "fax": [234]
            },
            "sas": []
        }]
    }
}]
```

Basically it adds the struct `SeqConvertToString` and implements `ser::SerializeSeq` to serialize the sequence, recursively, by using the struct `ConvertToString`.

Issue: #574 