### PR TITLE
Fix for 'Update Status after the first update comes up to be empty (#542)'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,4 @@
   - Add support of nested null, boolean and seq values (#571 and #568, #574)
   - Fixed the core benchmark (#576)
   - Publish an ARMv7 and ARMv8 binaries on releases (#540 and #581)
-  - First update does not appear before being processed (#542)
+  - Fixing the bug where the result of the update status after the first update was empty (#542)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,4 @@
   - Add support of nested null, boolean and seq values (#571 and #568, #574)
   - Fixed the core benchmark (#576)
   - Publish an ARMv7 and ARMv8 binaries on releases (#540 and #581)
-  - Fixing the bug where the result of the update status after the first update was empty (#542)
+  - Fixing a bug where the result of the update status after the first update was empty (#542)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
   - Add support of nested null, boolean and seq values (#571 and #568, #574)
   - Fixed the core benchmark (#576)
   - Publish an ARMv7 and ARMv8 binaries on releases (#540 and #581)
+  - First update does not appear before being processed (#542)

--- a/meilisearch-core/src/store/mod.rs
+++ b/meilisearch-core/src/store/mod.rs
@@ -334,14 +334,14 @@ impl Index {
             for id in 0..=last_id {
                 if let Some(update) = self.update_status(reader, id)? {
                     updates.push(update);
-                    last_update_result_id = id;
+                    last_update_result_id = id + 1;
                 }
             }
         }
 
         // retrieve all enqueued updates
         if let Some((last_id, _)) = self.updates.last_update(reader)? {
-            for id in last_update_result_id + 1..=last_id {
+            for id in last_update_result_id..=last_id {
                 if let Some(update) = self.update_status(reader, id)? {
                     updates.push(update);
                 }

--- a/meilisearch-http/tests/index.rs
+++ b/meilisearch-http/tests/index.rs
@@ -660,7 +660,7 @@ fn check_add_documents_without_primary_key() {
 }
 
 #[test]
-fn check_first_update_should_bring_up_enqueued_status_before_processing(){
+fn check_first_update_should_bring_up_processed_status_after_first_docs_addition(){
     let mut server = common::Server::with_uid("movies");
 
     let body = json!({


### PR DESCRIPTION
Hi @Kerollmops,

This PR fixes the issue #542 First update does not appear before being processed.

Cheers,
Sai