### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Now that your MeiliSearch server is up and running, you can learn more about how
 - Accepts query time search config like the [searchable attributes](https://github.com/meilisearch/MeiliSearch/blob/3ea5aa18a209b6973b921542d46a79e1c753c163/meilisearch-core/src/query_builder.rs#L331-L336)
 - Supports [runtime incremental indexing](https://github.com/meilisearch/MeiliSearch/blob/3ea5aa18a209b6973b921542d46a79e1c753c163/meilisearch-core/src/store/mod.rs#L143-L212)
 
-## Performances
+## Performance
 
 When processing a dataset composed of 5M books, each with their own titles and authors, MeiliSearch is able to carry out more than 553 req/sec with an average response time of 21 ms on an Intel i7-7700 (8) @ 4.2GHz.
 


### PR DESCRIPTION
Non-plural would be more usual in English. I assume "performances" was a typo.