### PR TITLE
Fixes the stop words and words fst generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,5 @@
   - Add support of nested null, boolean and seq values (#571 and #568, #574)
   - Fixed the core benchmark (#576)
   - Publish an ARMv7 and ARMv8 binaries on releases (#540 and #581)
-  - Fixing a bug where the result of the update status after the first update was empty (#542)
+  - Fixed a bug where the result of the update status after the first update was empty (#542)
+  - Fixed a bug where stop words were not handled correctly (#594)

--- a/meilisearch-http/tests/settings_stop_words.rs
+++ b/meilisearch-http/tests/settings_stop_words.rs
@@ -6,11 +6,7 @@ mod common;
 #[test]
 fn update_stop_words() {
     let mut server = common::Server::with_uid("movies");
-    let body = json!({
-        "uid": "movies",
-        "primaryKey": "id",
-    });
-    server.create_index(body);
+    server.populate_movies();
 
     // 1 - Get stop words
 
@@ -35,4 +31,33 @@ fn update_stop_words() {
 
     let (response, _status_code) = server.get_stop_words();
     assert_eq!(response.as_array().unwrap().is_empty(), true);
+}
+
+#[test]
+fn add_documents_and_stop_words() {
+    let mut server = common::Server::with_uid("movies");
+    server.populate_movies();
+
+    // 2 - Update stop words
+
+    let body = json!(["the", "of"]);
+    server.update_stop_words(body.clone());
+
+    // 3 - Search for a document with stop words
+
+    let (response, _status_code) = server.search("q=the%20mask");
+    assert!(!response["hits"].as_array().unwrap().is_empty());
+
+    // 4 - Search for documents with *only* stop words
+
+    let (response, _status_code) = server.search("q=the%20of");
+    assert!(response["hits"].as_array().unwrap().is_empty());
+
+    // 5 - Delete all stop words
+
+    // server.delete_stop_words();
+
+    // // 6 - Search for a document with one stop word
+
+    // assert!(!response["hits"].as_array().unwrap().is_empty());
 }


### PR DESCRIPTION
This pull request fixes a bug where the fst of stop words was accidentaly written in place of the words fst, making the engine only care about stop words and ignoring any other legitimate words.

It also adds a test to ensure the bug is catched next time.

Fixes #586.