### PR TITLE
fix tide cors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,4 @@
   - Publish an ARMv7 and ARMv8 binaries on releases (#540 and #581)
   - Fixed a bug where the result of the update status after the first update was empty (#542)
   - Fixed a bug where stop words were not handled correctly (#594)
+  - Fix CORS issues (#602)

--- a/meilisearch-http/src/main.rs
+++ b/meilisearch-http/src/main.rs
@@ -4,7 +4,8 @@ use async_std::task;
 use log::info;
 use main_error::MainError;
 use structopt::StructOpt;
-use tide::middleware::{Cors, RequestLogger};
+use tide::middleware::{Cors, RequestLogger, Origin};
+use http::header::HeaderValue;
 
 use meilisearch_http::data::Data;
 use meilisearch_http::option::Opt;
@@ -51,7 +52,10 @@ pub fn main() -> Result<(), MainError> {
 
     let mut app = tide::with_state(data);
 
-    app.middleware(Cors::new());
+    app.middleware(Cors::new()
+        .allow_methods(HeaderValue::from_static("GET, POST, PUT, DELETE, OPTIONS"))
+        .allow_headers(HeaderValue::from_static("X-Meili-API-Key"))
+        .allow_origin(Origin::from("*")));
     app.middleware(RequestLogger::new());
 
     routes::load_routes(&mut app);


### PR DESCRIPTION
Override default cors options by static one. Add allow headers.