### PR TITLE
Use a personal access token to publish release binaries

### DIFF
--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Upload binaries to release
       uses: svenstaro/upload-release-action@v1-release
       with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        repo_token: ${{ secrets.PUBLISH_TOKEN }}
         file: target/release/${{ matrix.artifact_name }}
         asset_name: ${{ matrix.asset_name }}
         tag: ${{ github.ref }}
@@ -57,7 +57,7 @@ jobs:
       - name: Upload the binary to release
         uses: svenstaro/upload-release-action@v1-release
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          repo_token: ${{ secrets.PUBLISH_TOKEN }}
           file: target/release/meilisearch
           asset_name: meilisearch-linux-armv7
           tag: ${{ github.ref }}
@@ -81,7 +81,7 @@ jobs:
       - name: Upload the binary to release
         uses: svenstaro/upload-release-action@v1-release
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          repo_token: ${{ secrets.PUBLISH_TOKEN }}
           file: target/release/meilisearch
           asset_name: meilisearch-linux-armv8
           tag: ${{ github.ref }}


### PR DESCRIPTION
This PR fixes the errors encountered when release compilation for some platform took more than 1 hour and the default `GITHUB_TOKEN` expires. We are forced to use a personal access token to bypass this short expiration time.

https://github.community/t5/GitHub-Actions/error-Bad-credentials/m-p/37721#M3057