### PR TITLE
Add '@' char as a tokenizer separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.10.1 (unreleased)
+
+  - Add '@' character as tokenizer separator (#607)
+
 ## v0.10
 
   - Refined filtering (#592)

--- a/meilisearch-tokenizer/src/lib.rs
+++ b/meilisearch-tokenizer/src/lib.rs
@@ -54,7 +54,7 @@ fn classify_separator(c: char) -> Option<SeparatorCategory> {
         c if c.is_whitespace() => Some(Soft), // whitespaces
         c if deunicode_char(c) == Some("'") => Some(Soft), // quotes
         c if deunicode_char(c) == Some("\"") => Some(Soft), // double quotes
-        '-' | '_' | '\'' | ':' | '/' | '\\' => Some(Soft),
+        '-' | '_' | '\'' | ':' | '/' | '\\' | '@' => Some(Soft),
         '.' | ';' | ',' | '!' | '?' | '(' | ')' => Some(Hard),
         _ => None,
     }


### PR DESCRIPTION
When we are indexing email adresses, users should be able to search through the domain name.
This is not possible currently because we are not splitting on `@`.

I've not come up with other common usage of the `@`, if you have any in mind we might consider classifying it as a `Soft` separator, a `Hard` separator or not a separator at all.