### PR TITLE
Fixes the content overflow in the web interface in chrome.

### DIFF
--- a/meilisearch-http/public/interface.html
+++ b/meilisearch-http/public/interface.html
@@ -79,6 +79,7 @@
         box-sizing: border-box;
         padding-left: 10px;
         color: rgba(0,0,0,.9);
+        overflow-wrap: break-word;
       }
     </style>
   </head>


### PR DESCRIPTION
Fixes #609,
After the css changes:
### Firefox
![firefox](https://user-images.githubusercontent.com/12899161/79960545-31908a00-848e-11ea-9f04-66d1615b63f0.png)
### Chrome
![chrome](https://user-images.githubusercontent.com/12899161/79960556-35241100-848e-11ea-9e1a-23a68b56c2c2.png)

The difference [according to MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap) may be because of

> ### overflow-wrap
> ### break-word
>   The same as the anywhere value, with normally unbreakable words allowed to be broken at arbitrary points **if there are no otherwise acceptable break points in the line** ... .