### PR TITLE
Remove call to map_size

### DIFF
--- a/meilisearch-core/src/database.rs
+++ b/meilisearch-core/src/database.rs
@@ -142,13 +142,11 @@ impl Database {
 
         fs::create_dir_all(&main_path)?;
         let env = heed::EnvOpenOptions::new()
-            .map_size(100 * 1024 * 1024 * 1024) // 100GB
             .max_dbs(3000)
             .open(main_path)?;
 
         fs::create_dir_all(&update_path)?;
         let update_env = heed::EnvOpenOptions::new()
-            .map_size(100 * 1024 * 1024 * 1024) // 100GB
             .max_dbs(3000)
             .open(update_path)?;
 


### PR DESCRIPTION
Fixes #643 

This removes the call to `map_size`, which seemingly makes the database autogrow instead of preallocate the 2x 100Gb on Windows Server machines.

This change has _not_ been tested on large scale databases or with production usage patterns.