### PR TITLE
Add EXPOSE port to Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v0.10.2
 
-- Add support for configuring the lmdb map size (#646, #647)
+  - Add support for configuring the lmdb map size (#646, #647)
+  - Add exposed port for Dockerfile (#654)
 
 ## v0.10.1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,5 @@ RUN     apk add libgcc
 COPY    --from=compiler /meilisearch/target/release/meilisearch .
 
 ENV     MEILI_HTTP_ADDR 0.0.0.0:7700
+EXPOSE  7700/tcp
 CMD     ./meilisearch


### PR DESCRIPTION
From [the docker documentation](https://docs.docker.com/engine/reference/builder/#expose):

> The EXPOSE instruction does not actually publish the port. It functions as a type of documentation between the person who builds the image and the person who runs the container, about which ports are intended to be published.

A lot of docker client seems to automatically bind exposed port to forward them.