### PR TITLE
Update release process for stable releases

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,4 +1,4 @@
-# GitHub actions workflow for MeiliDB
+# GitHub Actions Workflow for MeiliSearch
 
 > **Note:**
 
@@ -6,12 +6,14 @@
 
 ## Workflow
 
-- On each pull request, we are triggering `cargo test`.
-- On each tag, we are building:
-    - the tagged docker image
+- On each pull request, we trigger `cargo test`.
+- On each tag, we build:
+    - the tagged Docker image and publish it to Docker Hub
     - the binaries for MacOS, Ubuntu, and Windows
-    - the debian package
-- On each stable release, we are build the latest docker image.
+    - the Debian package
+- On each stable release (`v*.*.*` tag):
+    - we build the `latest` Docker image and publish it to Docker Hub
+    - we publish the binary to Hombrew and Gemfury
 
 ## Problems
 

--- a/.github/workflows/publish-deb-brew-pkg.yml
+++ b/.github/workflows/publish-deb-brew-pkg.yml
@@ -1,9 +1,8 @@
-name: Publish deb pkg to GitHub release & apt repository & Homebrew
+name: Publish deb pkg to GitHub release & APT repository & Homebrew
 
 on:
-  push:
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+  release:
+    types: [published]
 
 jobs:
   debian:
@@ -32,7 +31,8 @@ jobs:
     name: Bump Homebrew formula
     runs-on: ubuntu-latest
     steps:
-      - uses: mislav/bump-homebrew-formula-action@v1
+      - name: Create PR to Homebrew
+        uses: mislav/bump-homebrew-formula-action@v1
         with:
           formula-name: meilisearch
         env:

--- a/.github/workflows/publish-docker-latest.yml
+++ b/.github/workflows/publish-docker-latest.yml
@@ -1,8 +1,7 @@
 ---
 on:
-  push:
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+  release:
+    types: [published]
 
 name: Publish latest image to Docker Hub
 
@@ -10,8 +9,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+      - name: Check if current release is latest
+        run: echo "##[set-output name=is_latest;]$(sh .github/is-latest-release.sh)"
+        id: release
       - name: Publish to Registry
+        if: steps.release.outputs.is_latest == 'true'
         uses: elgohr/Publish-Docker-Github-Action@master
         with:
           name: getmeili/meilisearch


### PR DESCRIPTION
- Fix: the script `download-latest.sh` checks what is the latest tag based on release tags only (and not on all the tags as it was done before)
- The CI to publish the latest docker image runs only for releases (not for pre-releases, not for draft-releases and not for a simple tag) and checks the release is indeed the latest
  Ex: previous tag -> `v0.10.1`
        new tag -> `v0.8.12`
        The new tag should not be the latest: the CI will not run for the release `v0.8.2`
- The CI to publish to Brew and APT runs only for releases (not for pre-releases, not for draft-releases and not for a simple tag)

I'm not sure I put the script `is-latest-release.sh` at the right place.
Maybe we can create a `scripts/` folder at the root of MeiliSearch repository to put all the scripts, included `download-latest.sh`.