### PR TITLE
enables debug without sentry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## v0.10.2
 
+  - Disable sentry in debug (#681)
   - Add support for facet count (#676)
   - Add support for faceted search (#631)
   - Add support for configuring the lmdb map size (#646, #647)

--- a/meilisearch-http/src/main.rs
+++ b/meilisearch-http/src/main.rs
@@ -20,13 +20,13 @@ static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 async fn main() -> Result<(), MainError> {
     let opt = Opt::from_args();
 
-    #[cfg(feature = "sentry")]
+    #[cfg(all(not(debug_assertions), feature = "sentry"))]
     let _sentry = sentry::init((
-        "https://5ddfa22b95f241198be2271aaf028653@sentry.io/3060337",
-        sentry::ClientOptions {
-            release: sentry::release_name!(),
-            ..Default::default()
-        },
+            "https://5ddfa22b95f241198be2271aaf028653@sentry.io/3060337",
+            sentry::ClientOptions {
+                release: sentry::release_name!(),
+                ..Default::default()
+            },
     ));
 
     match opt.env.as_ref() {
@@ -38,7 +38,7 @@ async fn main() -> Result<(), MainError> {
                 );
             }
 
-            #[cfg(feature = "sentry")]
+            #[cfg(all(not(debug_assertions), feature = "sentry"))]
             if !opt.no_analytics {
                 sentry::integrations::panic::register_panic_handler();
                 sentry::integrations::env_logger::init(None, Default::default());


### PR DESCRIPTION
enables building meili in debug without sentry by default. 
- workaround tokio bug
- probably better stats if debug build are not taken into account by sentry