### PR TITLE
Reduce document id size from 64bits to 32bits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1624,7 +1624,6 @@ dependencies = [
  "sdset",
  "serde",
  "serde_json",
- "siphasher",
  "slice-group-by",
  "structopt",
  "tempfile",

--- a/meilisearch-core/Cargo.toml
+++ b/meilisearch-core/Cargo.toml
@@ -35,7 +35,6 @@ regex = "1.3.6"
 sdset = "0.4.0"
 serde = { version = "1.0.105", features = ["derive"] }
 serde_json = { version = "1.0.50", features = ["preserve_order"] }
-siphasher = "0.3.2"
 slice-group-by = "0.2.6"
 unicase = "2.6.0"
 zerocopy = "0.3.0"

--- a/meilisearch-core/src/database.rs
+++ b/meilisearch-core/src/database.rs
@@ -775,12 +775,12 @@ mod tests {
         assert!(document.is_none());
 
         let document: Option<IgnoredAny> = index
-            .document(&reader, None, DocumentId(7_900_334_843_754_999_545))
+            .document(&reader, None, DocumentId(0))
             .unwrap();
         assert!(document.is_some());
 
         let document: Option<IgnoredAny> = index
-            .document(&reader, None, DocumentId(8_367_468_610_878_465_872))
+            .document(&reader, None, DocumentId(1))
             .unwrap();
         assert!(document.is_some());
     }
@@ -855,12 +855,12 @@ mod tests {
         assert!(document.is_none());
 
         let document: Option<IgnoredAny> = index
-            .document(&reader, None, DocumentId(7_900_334_843_754_999_545))
+            .document(&reader, None, DocumentId(0))
             .unwrap();
         assert!(document.is_some());
 
         let document: Option<IgnoredAny> = index
-            .document(&reader, None, DocumentId(8_367_468_610_878_465_872))
+            .document(&reader, None, DocumentId(1))
             .unwrap();
         assert!(document.is_some());
 
@@ -897,7 +897,7 @@ mod tests {
 
         let reader = db.main_read_txn().unwrap();
         let document: Option<serde_json::Value> = index
-            .document(&reader, None, DocumentId(7_900_334_843_754_999_545))
+            .document(&reader, None, DocumentId(0))
             .unwrap();
 
         let new_doc1 = serde_json::json!({
@@ -908,7 +908,7 @@ mod tests {
         assert_eq!(document, Some(new_doc1));
 
         let document: Option<serde_json::Value> = index
-            .document(&reader, None, DocumentId(8_367_468_610_878_465_872))
+            .document(&reader, None, DocumentId(1))
             .unwrap();
 
         let new_doc2 = serde_json::json!({
@@ -1080,14 +1080,14 @@ mod tests {
         assert_matches!(
             iter.next(),
             Some(Document {
-                id: DocumentId(7_900_334_843_754_999_545),
+                id: DocumentId(0),
                 ..
             })
         );
         assert_matches!(
             iter.next(),
             Some(Document {
-                id: DocumentId(8_367_468_610_878_465_872),
+                id: DocumentId(1),
                 ..
             })
         );

--- a/meilisearch-core/src/lib.rs
+++ b/meilisearch-core/src/lib.rs
@@ -191,6 +191,6 @@ mod tests {
 
     #[test]
     fn docindex_mem_size() {
-        assert_eq!(mem::size_of::<DocIndex>(), 16);
+        assert_eq!(mem::size_of::<DocIndex>(), 12);
     }
 }

--- a/meilisearch-core/src/query_builder.rs
+++ b/meilisearch-core/src/query_builder.rs
@@ -228,7 +228,7 @@ mod tests {
         builder.into_inner().and_then(Set::from_bytes).unwrap()
     }
 
-    const fn doc_index(document_id: u64, word_index: u16) -> DocIndex {
+    const fn doc_index(document_id: u32, word_index: u16) -> DocIndex {
         DocIndex {
             document_id: DocumentId(document_id),
             attribute: 0,
@@ -238,7 +238,7 @@ mod tests {
         }
     }
 
-    const fn doc_char_index(document_id: u64, word_index: u16, char_index: u16) -> DocIndex {
+    const fn doc_char_index(document_id: u32, word_index: u16, char_index: u16) -> DocIndex {
         DocIndex {
             document_id: DocumentId(document_id),
             attribute: 0,

--- a/meilisearch-core/src/store/docs_words.rs
+++ b/meilisearch-core/src/store/docs_words.rs
@@ -1,4 +1,4 @@
-use super::BEU64;
+use super::BEU32;
 use crate::database::MainT;
 use crate::DocumentId;
 use heed::types::{ByteSlice, OwnedType};
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 #[derive(Copy, Clone)]
 pub struct DocsWords {
-    pub(crate) docs_words: heed::Database<OwnedType<BEU64>, ByteSlice>,
+    pub(crate) docs_words: heed::Database<OwnedType<BEU32>, ByteSlice>,
 }
 
 impl DocsWords {
@@ -17,13 +17,13 @@ impl DocsWords {
         document_id: DocumentId,
         words: &fst::Set,
     ) -> ZResult<()> {
-        let document_id = BEU64::new(document_id.0);
+        let document_id = BEU32::new(document_id.0);
         let bytes = words.as_fst().as_bytes();
         self.docs_words.put(writer, &document_id, bytes)
     }
 
     pub fn del_doc_words(self, writer: &mut heed::RwTxn<MainT>, document_id: DocumentId) -> ZResult<bool> {
-        let document_id = BEU64::new(document_id.0);
+        let document_id = BEU32::new(document_id.0);
         self.docs_words.delete(writer, &document_id)
     }
 
@@ -36,7 +36,7 @@ impl DocsWords {
         reader: &heed::RoTxn<MainT>,
         document_id: DocumentId,
     ) -> ZResult<Option<fst::Set>> {
-        let document_id = BEU64::new(document_id.0);
+        let document_id = BEU32::new(document_id.0);
         match self.docs_words.get(reader, &document_id)? {
             Some(bytes) => {
                 let len = bytes.len();

--- a/meilisearch-core/src/store/documents_ids.rs
+++ b/meilisearch-core/src/store/documents_ids.rs
@@ -26,16 +26,16 @@ impl<'a> BytesDecode<'a> for DocumentsIds {
 
 pub struct DiscoverIds<'a> {
     ids_iter: std::slice::Iter<'a, DocumentId>,
-    left_id: Option<u64>,
-    right_id: Option<u64>,
-    available_range: std::ops::Range<u64>,
+    left_id: Option<u32>,
+    right_id: Option<u32>,
+    available_range: std::ops::Range<u32>,
 }
 
 impl DiscoverIds<'_> {
     pub fn new(ids: &Set<DocumentId>) -> DiscoverIds {
         let mut ids_iter = ids.iter();
         let right_id = ids_iter.next().map(|id| id.0);
-        let available_range = 0..right_id.unwrap_or(u64::max_value());
+        let available_range = 0..right_id.unwrap_or(u32::max_value());
         DiscoverIds { ids_iter, left_id: None, right_id, available_range }
     }
 }
@@ -49,7 +49,7 @@ impl Iterator for DiscoverIds<'_> {
                 // The available range gives us a new id, we return it.
                 Some(id) => return Some(DocumentId(id)),
                 // The available range is exhausted, we need to find the next one.
-                None if self.available_range.end == u64::max_value() => return None,
+                None if self.available_range.end == u32::max_value() => return None,
                 None => loop {
                     self.left_id = self.right_id.take();
                     self.right_id = self.ids_iter.next().map(|id| id.0);
@@ -61,9 +61,9 @@ impl Iterator for DiscoverIds<'_> {
                             break;
                         },
                         // The last used id has been reached, we can use all ids
-                        // until u64 MAX
+                        // until u32 MAX
                         (Some(l), None) => {
-                            self.available_range = l.saturating_add(1)..u64::max_value();
+                            self.available_range = l.saturating_add(1)..u32::max_value();
                             break;
                         },
                         _ => (),

--- a/meilisearch-core/src/store/documents_ids.rs
+++ b/meilisearch-core/src/store/documents_ids.rs
@@ -1,0 +1,75 @@
+use std::borrow::Cow;
+
+use heed::{BytesDecode, BytesEncode};
+use sdset::Set;
+
+use crate::DocumentId;
+use super::cow_set::CowSet;
+
+pub struct DocumentsIds;
+
+impl BytesEncode<'_> for DocumentsIds {
+    type EItem = Set<DocumentId>;
+
+    fn bytes_encode(item: &Self::EItem) -> Option<Cow<[u8]>> {
+        CowSet::bytes_encode(item)
+    }
+}
+
+impl<'a> BytesDecode<'a> for DocumentsIds {
+    type DItem = Cow<'a, Set<DocumentId>>;
+
+    fn bytes_decode(bytes: &'a [u8]) -> Option<Self::DItem> {
+        CowSet::bytes_decode(bytes)
+    }
+}
+
+pub struct DiscoverIds<'a> {
+    ids_iter: std::slice::Iter<'a, DocumentId>,
+    left_id: Option<u64>,
+    right_id: Option<u64>,
+    available_range: std::ops::Range<u64>,
+}
+
+impl DiscoverIds<'_> {
+    pub fn new(ids: &Set<DocumentId>) -> DiscoverIds {
+        let mut ids_iter = ids.iter();
+        let right_id = ids_iter.next().map(|id| id.0);
+        let available_range = 0..right_id.unwrap_or(u64::max_value());
+        DiscoverIds { ids_iter, left_id: None, right_id, available_range }
+    }
+}
+
+impl Iterator for DiscoverIds<'_> {
+    type Item = DocumentId;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            match self.available_range.next() {
+                // The available range gives us a new id, we return it.
+                Some(id) => return Some(DocumentId(id)),
+                // The available range is exhausted, we need to find the next one.
+                None if self.available_range.end == u64::max_value() => return None,
+                None => loop {
+                    self.left_id = self.right_id.take();
+                    self.right_id = self.ids_iter.next().map(|id| id.0);
+                    match (self.left_id, self.right_id) {
+                        // We found a gap in the used ids, we can yield all ids
+                        // until the end of the gap
+                        (Some(l), Some(r)) => if l.saturating_add(1) != r {
+                            self.available_range = (l + 1)..r;
+                            break;
+                        },
+                        // The last used id has been reached, we can use all ids
+                        // until u64 MAX
+                        (Some(l), None) => {
+                            self.available_range = l.saturating_add(1)..u64::max_value();
+                            break;
+                        },
+                        _ => (),
+                    }
+                },
+            }
+        }
+    }
+}

--- a/meilisearch-core/src/store/main.rs
+++ b/meilisearch-core/src/store/main.rs
@@ -14,7 +14,7 @@ use crate::RankedMap;
 use crate::settings::RankingRule;
 use super::{CowSet, DocumentsIds};
 
-const ATTRIBUTES_FOR_FACETING: &str = "attributes-for-faceting";
+const ATTRIBUTES_FOR_FACETING_KEY: &str = "attributes-for-faceting";
 const CREATED_AT_KEY: &str = "created-at";
 const CUSTOMS_KEY: &str = "customs";
 const DISTINCT_ATTRIBUTE_KEY: &str = "distinct-attribute";
@@ -277,15 +277,15 @@ impl Main {
     }
 
     pub fn attributes_for_faceting<'txn>(&self, reader: &'txn heed::RoTxn<MainT>) -> ZResult<Option<Cow<'txn, Set<FieldId>>>> {
-        self.main.get::<_, Str, CowSet<FieldId>>(reader, ATTRIBUTES_FOR_FACETING)
+        self.main.get::<_, Str, CowSet<FieldId>>(reader, ATTRIBUTES_FOR_FACETING_KEY)
     }
 
     pub fn put_attributes_for_faceting(self, writer: &mut heed::RwTxn<MainT>, attributes: &Set<FieldId>) -> ZResult<()> {
-        self.main.put::<_, Str, CowSet<FieldId>>(writer, ATTRIBUTES_FOR_FACETING, attributes)
+        self.main.put::<_, Str, CowSet<FieldId>>(writer, ATTRIBUTES_FOR_FACETING_KEY, attributes)
     }
 
     pub fn delete_attributes_for_faceting(self, writer: &mut heed::RwTxn<MainT>) -> ZResult<bool> {
-        self.main.delete::<_, Str>(writer, ATTRIBUTES_FOR_FACETING)
+        self.main.delete::<_, Str>(writer, ATTRIBUTES_FOR_FACETING_KEY)
     }
 
     pub fn ranking_rules(&self, reader: &heed::RoTxn<MainT>) -> ZResult<Option<Vec<RankingRule>>> {

--- a/meilisearch-core/src/store/main.rs
+++ b/meilisearch-core/src/store/main.rs
@@ -153,7 +153,7 @@ impl Main {
 
     pub fn user_to_internal_id(self, reader: &heed::RoTxn<MainT>, userid: &str) -> ZResult<Option<DocumentId>> {
         let user_ids = self.user_ids(reader)?;
-        Ok(user_ids.get(userid).map(DocumentId))
+        Ok(user_ids.get(userid).map(|id| DocumentId(id as u32)))
     }
 
     pub fn put_words_fst(self, writer: &mut heed::RwTxn<MainT>, fst: &fst::Set) -> ZResult<()> {

--- a/meilisearch-core/src/store/main.rs
+++ b/meilisearch-core/src/store/main.rs
@@ -85,8 +85,34 @@ impl Main {
         }
     }
 
+    pub fn merge_internal_ids(self, writer: &mut heed::RwTxn<MainT>, new_ids: &sdset::Set<DocumentId>) -> ZResult<()> {
+        use sdset::SetOperation;
+
+        // We do an union of the old and new internal ids.
+        let internal_ids = self.internal_ids(writer)?;
+        let internal_ids = sdset::duo::Union::new(&new_ids, &internal_ids).into_set_buf();
+        self.put_internal_ids(writer, &internal_ids)
+    }
+
     pub fn put_user_ids(self, writer: &mut heed::RwTxn<MainT>, ids: &fst::Map) -> ZResult<()> {
         self.main.put::<_, Str, ByteSlice>(writer, USER_IDS_KEY, ids.as_fst().as_bytes())
+    }
+
+    pub fn merge_user_ids(self, writer: &mut heed::RwTxn<MainT>, new_ids: &fst::Map) -> ZResult<()> {
+        use fst::{Streamer, IntoStreamer};
+
+        let user_ids = self.user_ids(writer)?;
+
+        // Do an union of the old and the new set of user ids.
+        let mut op = user_ids.op().add(new_ids.into_stream()).r#union();
+        let mut build = fst::MapBuilder::memory();
+        while let Some((userid, values)) = op.next() {
+            build.insert(userid, values[0].value).unwrap();
+        }
+        let user_ids = build.into_inner().unwrap();
+
+        // TODO prefer using self.put_user_ids
+        self.main.put::<_, Str, ByteSlice>(writer, USER_IDS_KEY, user_ids.as_slice())
     }
 
     pub fn user_ids(self, reader: &heed::RoTxn<MainT>) -> ZResult<fst::Map> {

--- a/meilisearch-core/src/store/main.rs
+++ b/meilisearch-core/src/store/main.rs
@@ -107,15 +107,15 @@ impl Main {
         self.main.put::<_, Str, ByteSlice>(writer, EXTERNAL_DOCIDS_KEY, ids.as_fst().as_bytes())
     }
 
-    pub fn merge_external_docids(self, writer: &mut heed::RwTxn<MainT>, new_ids: &fst::Map) -> ZResult<()> {
+    pub fn merge_external_docids(self, writer: &mut heed::RwTxn<MainT>, new_docids: &fst::Map) -> ZResult<()> {
         use fst::{Streamer, IntoStreamer};
 
-        // Do an union of the old and the new set of user ids.
+        // Do an union of the old and the new set of external docids.
         let external_docids = self.external_docids(writer)?;
-        let mut op = external_docids.op().add(new_ids.into_stream()).r#union();
+        let mut op = external_docids.op().add(new_docids.into_stream()).r#union();
         let mut build = fst::MapBuilder::memory();
-        while let Some((userid, values)) = op.next() {
-            build.insert(userid, values[0].value).unwrap();
+        while let Some((docid, values)) = op.next() {
+            build.insert(docid, values[0].value).unwrap();
         }
         let external_docids = build.into_inner().unwrap();
 
@@ -126,12 +126,12 @@ impl Main {
     pub fn remove_external_docids(self, writer: &mut heed::RwTxn<MainT>, ids: &fst::Map) -> ZResult<()> {
         use fst::{Streamer, IntoStreamer};
 
-        // Do an union of the old and the new set of user ids.
+        // Do an union of the old and the new set of external docids.
         let external_docids = self.external_docids(writer)?;
         let mut op = external_docids.op().add(ids.into_stream()).difference();
         let mut build = fst::MapBuilder::memory();
-        while let Some((userid, values)) = op.next() {
-            build.insert(userid, values[0].value).unwrap();
+        while let Some((docid, values)) = op.next() {
+            build.insert(docid, values[0].value).unwrap();
         }
         let external_docids = build.into_inner().unwrap();
 

--- a/meilisearch-core/src/store/mod.rs
+++ b/meilisearch-core/src/store/mod.rs
@@ -1,15 +1,16 @@
 mod cow_set;
 mod docs_words;
-mod prefix_documents_cache;
-mod prefix_postings_lists_cache;
+mod documents_ids;
 mod documents_fields;
 mod documents_fields_counts;
+mod facets;
 mod main;
 mod postings_lists;
+mod prefix_documents_cache;
+mod prefix_postings_lists_cache;
 mod synonyms;
 mod updates;
 mod updates_results;
-mod facets;
 
 pub use self::docs_words::DocsWords;
 pub use self::facets::Facets;

--- a/meilisearch-core/src/store/mod.rs
+++ b/meilisearch-core/src/store/mod.rs
@@ -12,16 +12,16 @@ mod synonyms;
 mod updates;
 mod updates_results;
 
+pub use self::cow_set::CowSet;
 pub use self::docs_words::DocsWords;
-pub use self::facets::Facets;
-pub use self::prefix_documents_cache::PrefixDocumentsCache;
-pub use self::prefix_postings_lists_cache::PrefixPostingsListsCache;
 pub use self::documents_fields::{DocumentFieldsIter, DocumentsFields};
-pub use self::documents_fields_counts::{
-    DocumentFieldsCountsIter, DocumentsFieldsCounts, DocumentsIdsIter,
-};
+pub use self::documents_fields_counts::{DocumentFieldsCountsIter, DocumentsFieldsCounts, DocumentsIdsIter};
+pub use self::documents_ids::{DocumentsIds, DiscoverIds};
+pub use self::facets::Facets;
 pub use self::main::Main;
 pub use self::postings_lists::PostingsLists;
+pub use self::prefix_documents_cache::PrefixDocumentsCache;
+pub use self::prefix_postings_lists_cache::PrefixPostingsListsCache;
 pub use self::synonyms::Synonyms;
 pub use self::updates::Updates;
 pub use self::updates_results::UpdatesResults;

--- a/meilisearch-core/src/store/prefix_documents_cache.rs
+++ b/meilisearch-core/src/store/prefix_documents_cache.rs
@@ -4,7 +4,7 @@ use heed::types::{OwnedType, CowSlice};
 use heed::Result as ZResult;
 use zerocopy::{AsBytes, FromBytes};
 
-use super::BEU64;
+use super::{BEU64, BEU32};
 use crate::{DocumentId, Highlight};
 use crate::database::MainT;
 
@@ -13,15 +13,15 @@ use crate::database::MainT;
 pub struct PrefixKey {
     prefix: [u8; 4],
     index: BEU64,
-    docid: BEU64,
+    docid: BEU32,
 }
 
 impl PrefixKey {
-    pub fn new(prefix: [u8; 4], index: u64, docid: u64) -> PrefixKey {
+    pub fn new(prefix: [u8; 4], index: u64, docid: u32) -> PrefixKey {
         PrefixKey {
             prefix,
             index: BEU64::new(index),
-            docid: BEU64::new(docid),
+            docid: BEU32::new(docid),
         }
     }
 }
@@ -54,7 +54,7 @@ impl PrefixDocumentsCache {
         prefix: [u8; 4],
     ) -> ZResult<PrefixDocumentsIter<'txn>> {
         let start = PrefixKey::new(prefix, 0, 0);
-        let end = PrefixKey::new(prefix, u64::max_value(), u64::max_value());
+        let end = PrefixKey::new(prefix, u64::max_value(), u32::max_value());
         let iter = self.prefix_documents_cache.range(reader, &(start..=end))?;
         Ok(PrefixDocumentsIter { iter })
     }

--- a/meilisearch-core/src/update/clear_all.rs
+++ b/meilisearch-core/src/update/clear_all.rs
@@ -7,6 +7,8 @@ pub fn apply_clear_all(
     index: &store::Index,
 ) -> MResult<()> {
     index.main.put_words_fst(writer, &fst::Set::default())?;
+    index.main.put_user_ids(writer, &fst::Map::default())?;
+    index.main.put_internal_ids(writer, &sdset::SetBuf::default())?;
     index.main.put_ranked_map(writer, &RankedMap::default())?;
     index.main.put_number_of_documents(writer, |_| 0)?;
     index.documents_fields.clear(writer)?;

--- a/meilisearch-core/src/update/clear_all.rs
+++ b/meilisearch-core/src/update/clear_all.rs
@@ -7,8 +7,8 @@ pub fn apply_clear_all(
     index: &store::Index,
 ) -> MResult<()> {
     index.main.put_words_fst(writer, &fst::Set::default())?;
-    index.main.put_user_ids(writer, &fst::Map::default())?;
-    index.main.put_internal_ids(writer, &sdset::SetBuf::default())?;
+    index.main.put_external_docids(writer, &fst::Map::default())?;
+    index.main.put_internal_docids(writer, &sdset::SetBuf::default())?;
     index.main.put_ranked_map(writer, &RankedMap::default())?;
     index.main.put_number_of_documents(writer, |_| 0)?;
     index.documents_fields.clear(writer)?;

--- a/meilisearch-core/src/update/documents_addition.rs
+++ b/meilisearch-core/src/update/documents_addition.rs
@@ -190,9 +190,9 @@ pub fn apply_addition<'a, 'b>(
         documents_additions.insert(document_id, document);
     }
 
-    // 2. remove the documents posting lists
+    // 2. remove the documents postings lists
     let number_of_inserted_documents = documents_additions.len();
-    let documents_ids = documents_additions.iter().map(|(id, _)| *id).collect();
+    let documents_ids = new_user_ids.iter().map(|(userid, _)| userid.clone()).collect();
     apply_documents_deletion(writer, index, documents_ids)?;
 
     let mut ranked_map = match index.main.ranked_map(writer)? {

--- a/meilisearch-core/src/update/documents_addition.rs
+++ b/meilisearch-core/src/update/documents_addition.rs
@@ -242,7 +242,7 @@ pub fn apply_addition<'a, 'b>(
 
     index.main.put_schema(writer, &schema)?;
 
-    let new_user_ids = fst::Map::from_iter(new_user_ids)?;
+    let new_user_ids = fst::Map::from_iter(new_user_ids.iter().map(|(u, i)| (u, *i as u64)))?;
     let new_internal_ids = sdset::SetBuf::from_dirty(new_internal_ids);
     index.main.merge_user_ids(writer, &new_user_ids)?;
     index.main.merge_internal_ids(writer, &new_internal_ids)?;

--- a/meilisearch-core/src/update/documents_deletion.rs
+++ b/meilisearch-core/src/update/documents_deletion.rs
@@ -31,7 +31,7 @@ impl DocumentsDeletion {
         }
     }
 
-    pub fn delete_document_by_user_id(&mut self, document_id: String) {
+    pub fn delete_document_by_external_docid(&mut self, document_id: String) {
         self.documents.push(document_id);
     }
 
@@ -73,19 +73,19 @@ pub fn apply_documents_deletion(
     deletion: Vec<String>,
 ) -> MResult<()>
 {
-    let (user_ids, internal_ids) = {
-        let new_user_ids = SetBuf::from_dirty(deletion);
-        let mut internal_ids = Vec::new();
+    let (external_docids, internal_docids) = {
+        let new_external_docids = SetBuf::from_dirty(deletion);
+        let mut internal_docids = Vec::new();
 
-        let user_ids = index.main.user_ids(writer)?;
-        for userid in new_user_ids.as_slice() {
+        let user_ids = index.main.external_docids(writer)?;
+        for userid in new_external_docids.as_slice() {
             if let Some(id) = user_ids.get(userid) {
-                internal_ids.push(DocumentId(id as u32));
+                internal_docids.push(DocumentId(id as u32));
             }
         }
 
-        let new_user_ids = fst::Map::from_iter(new_user_ids.into_iter().map(|k| (k, 0))).unwrap();
-        (new_user_ids, SetBuf::from_dirty(internal_ids))
+        let new_external_docids = fst::Map::from_iter(new_external_docids.into_iter().map(|k| (k, 0))).unwrap();
+        (new_external_docids, SetBuf::from_dirty(internal_docids))
     };
 
     let schema = match index.main.schema(writer)? {
@@ -100,7 +100,7 @@ pub fn apply_documents_deletion(
 
     // facet filters deletion
     if let Some(attributes_for_facetting) = index.main.attributes_for_faceting(writer)? {
-        let facet_map = facets::facet_map_from_docids(writer, &index, &internal_ids, &attributes_for_facetting)?;
+        let facet_map = facets::facet_map_from_docids(writer, &index, &internal_docids, &attributes_for_facetting)?;
         index.facets.remove(writer, facet_map)?;
     }
 
@@ -108,7 +108,7 @@ pub fn apply_documents_deletion(
     let ranked_fields = schema.ranked();
 
     let mut words_document_ids = HashMap::new();
-    for id in internal_ids.iter().cloned() {
+    for id in internal_docids.iter().cloned() {
         // remove all the ranked attributes from the ranked_map
         for ranked_attr in ranked_fields {
             ranked_map.remove(id, *ranked_attr);
@@ -179,8 +179,8 @@ pub fn apply_documents_deletion(
     index.main.put_number_of_documents(writer, |old| old - deleted_documents_len)?;
 
     // We apply the changes to the user and internal ids
-    index.main.remove_user_ids(writer, &user_ids)?;
-    index.main.remove_internal_ids(writer, &internal_ids)?;
+    index.main.remove_external_docids(writer, &external_docids)?;
+    index.main.remove_internal_docids(writer, &internal_docids)?;
 
     compute_short_prefixes(writer, index)?;
 

--- a/meilisearch-core/src/update/documents_deletion.rs
+++ b/meilisearch-core/src/update/documents_deletion.rs
@@ -71,7 +71,10 @@ pub fn apply_documents_deletion(
     writer: &mut heed::RwTxn<MainT>,
     index: &store::Index,
     deletion: Vec<DocumentId>,
-) -> MResult<()> {
+) -> MResult<()>
+{
+    unimplemented!("When we delete documents we must ask for user ids instead of internal ones");
+
     let schema = match index.main.schema(writer)? {
         Some(schema) => schema,
         None => return Err(Error::SchemaMissing),

--- a/meilisearch-core/src/update/documents_deletion.rs
+++ b/meilisearch-core/src/update/documents_deletion.rs
@@ -80,7 +80,7 @@ pub fn apply_documents_deletion(
         let user_ids = index.main.user_ids(writer)?;
         for userid in new_user_ids.as_slice() {
             if let Some(id) = user_ids.get(userid) {
-                internal_ids.push(DocumentId(id));
+                internal_ids.push(DocumentId(id as u32));
             }
         }
 

--- a/meilisearch-core/src/update/helpers.rs
+++ b/meilisearch-core/src/update/helpers.rs
@@ -105,7 +105,7 @@ pub fn discover_document_id(
 {
     if userid.chars().all(|x| x.is_ascii_alphanumeric() || x == '-' || x == '_') {
         match user_ids.get(userid) {
-            Some(internal_id) => Ok(DocumentId(internal_id)),
+            Some(id) => Ok(DocumentId(id as u32)),
             None => {
                 let internal_id = available_ids.next().expect("no more ids available");
                 Ok(internal_id)

--- a/meilisearch-core/src/update/mod.rs
+++ b/meilisearch-core/src/update/mod.rs
@@ -9,7 +9,7 @@ pub use self::clear_all::{apply_clear_all, push_clear_all};
 pub use self::customs_update::{apply_customs_update, push_customs_update};
 pub use self::documents_addition::{apply_documents_addition, apply_documents_partial_addition, DocumentsAddition};
 pub use self::documents_deletion::{apply_documents_deletion, DocumentsDeletion};
-pub use self::helpers::{index_value, value_to_string, value_to_number, compute_document_id, extract_document_id};
+pub use self::helpers::{index_value, value_to_string, value_to_number, discover_document_id, extract_document_id};
 pub use self::settings_update::{apply_settings_update, push_settings_update};
 
 use std::cmp;

--- a/meilisearch-core/src/update/mod.rs
+++ b/meilisearch-core/src/update/mod.rs
@@ -24,7 +24,7 @@ use sdset::Set;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::{store, DocumentId, MResult};
+use crate::{store, MResult};
 use crate::database::{MainT, UpdateT};
 use crate::settings::SettingsUpdate;
 
@@ -63,7 +63,7 @@ impl Update {
         }
     }
 
-    fn documents_deletion(data: Vec<DocumentId>) -> Update {
+    fn documents_deletion(data: Vec<String>) -> Update {
         Update {
             data: UpdateData::DocumentsDeletion(data),
             enqueued_at: Utc::now(),
@@ -84,7 +84,7 @@ pub enum UpdateData {
     Customs(Vec<u8>),
     DocumentsAddition(Vec<IndexMap<String, Value>>),
     DocumentsPartial(Vec<IndexMap<String, Value>>),
-    DocumentsDeletion(Vec<DocumentId>),
+    DocumentsDeletion(Vec<String>),
     Settings(SettingsUpdate)
 }
 

--- a/meilisearch-http/src/error.rs
+++ b/meilisearch-http/src/error.rs
@@ -22,7 +22,7 @@ pub enum ResponseError {
     NotFound(String),
     OpenIndex(String),
     FilterParsing(String),
-    RetrieveDocument(u64, String),
+    RetrieveDocument(u32, String),
     SearchDocuments(String),
     PayloadTooLarge,
     UnsupportedMediaType,
@@ -116,7 +116,7 @@ impl ResponseError {
         ResponseError::Maintenance
     }
 
-    pub fn retrieve_document(doc_id: u64, err: impl fmt::Display) -> ResponseError {
+    pub fn retrieve_document(doc_id: u32, err: impl fmt::Display) -> ResponseError {
         ResponseError::RetrieveDocument(doc_id, err.to_string())
     }
 

--- a/meilisearch-http/src/routes/document.rs
+++ b/meilisearch-http/src/routes/document.rs
@@ -44,7 +44,7 @@ async fn get_document(
         .ok_or(ResponseError::index_not_found(&path.index_uid))?;
 
     let reader = data.db.main_read_txn()?;
-    let internal_id = index.main.user_to_internal_id(&reader, &path.document_id)?;
+    let internal_id = index.main.external_to_internal_docid(&reader, &path.document_id)?;
 
     let internal_id = match internal_id {
         Some(internal_id) => internal_id,
@@ -74,7 +74,7 @@ async fn delete_document(
     let mut update_writer = data.db.update_write_txn()?;
 
     let mut documents_deletion = index.documents_deletion();
-    documents_deletion.delete_document_by_user_id(path.document_id.clone());
+    documents_deletion.delete_document_by_external_docid(path.document_id.clone());
 
     let update_id = documents_deletion.finalize(&mut update_writer)?;
 
@@ -242,7 +242,7 @@ async fn delete_documents(
 
     for document_id in body.into_inner() {
         let document_id = update::value_to_string(&document_id);
-        documents_deletion.delete_document_by_user_id(document_id);
+        documents_deletion.delete_document_by_external_docid(document_id);
     }
 
     let update_id = documents_deletion.finalize(&mut writer)?;

--- a/meilisearch-http/src/routes/document.rs
+++ b/meilisearch-http/src/routes/document.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeSet, HashSet};
 use actix_web::{web, HttpResponse};
 use actix_web_macros::{delete, get, post, put};
 use indexmap::IndexMap;
-use meilisearch_core::{update, Error};
+use meilisearch_core::update;
 use serde::Deserialize;
 use serde_json::Value;
 
@@ -43,11 +43,16 @@ async fn get_document(
         .open_index(&path.index_uid)
         .ok_or(ResponseError::index_not_found(&path.index_uid))?;
 
-    let document_id = update::compute_document_id(&path.document_id).map_err(Error::Serializer)?;
     let reader = data.db.main_read_txn()?;
+    let internal_id = index.main.user_to_internal_id(&reader, &path.document_id)?;
+
+    let internal_id = match internal_id {
+        Some(internal_id) => internal_id,
+        None => return Err(ResponseError::document_not_found(&path.document_id)),
+    };
 
     let response: Document = index
-        .document(&reader, None, document_id)?
+        .document(&reader, None, internal_id)?
         .ok_or(ResponseError::document_not_found(&path.document_id))?;
 
     Ok(HttpResponse::Ok().json(response))
@@ -66,12 +71,10 @@ async fn delete_document(
         .open_index(&path.index_uid)
         .ok_or(ResponseError::index_not_found(&path.index_uid))?;
 
-    let document_id = update::compute_document_id(&path.document_id).map_err(Error::Serializer)?;
-
     let mut update_writer = data.db.update_write_txn()?;
 
     let mut documents_deletion = index.documents_deletion();
-    documents_deletion.delete_document_by_id(document_id);
+    documents_deletion.delete_document_by_user_id(path.document_id.clone());
 
     let update_id = documents_deletion.finalize(&mut update_writer)?;
 
@@ -239,8 +242,7 @@ async fn delete_documents(
 
     for document_id in body.into_inner() {
         let document_id = update::value_to_string(&document_id);
-        let document_id = update::compute_document_id(&document_id).map_err(Error::Serializer)?;
-        documents_deletion.delete_document_by_id(document_id);
+        documents_deletion.delete_document_by_user_id(document_id);
     }
 
     let update_id = documents_deletion.finalize(&mut writer)?;

--- a/meilisearch-http/src/routes/document.rs
+++ b/meilisearch-http/src/routes/document.rs
@@ -44,12 +44,9 @@ async fn get_document(
         .ok_or(ResponseError::index_not_found(&path.index_uid))?;
 
     let reader = data.db.main_read_txn()?;
-    let internal_id = index.main.external_to_internal_docid(&reader, &path.document_id)?;
-
-    let internal_id = match internal_id {
-        Some(internal_id) => internal_id,
-        None => return Err(ResponseError::document_not_found(&path.document_id)),
-    };
+    let internal_id = index.main
+        .external_to_internal_docid(&reader, &path.document_id)?
+        .ok_or(ResponseError::document_not_found(&path.document_id))?;
 
     let response: Document = index
         .document(&reader, None, internal_id)?

--- a/meilisearch-types/src/lib.rs
+++ b/meilisearch-types/src/lib.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "zerocopy", derive(AsBytes, FromBytes))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[repr(C)]
-pub struct DocumentId(pub u64);
+pub struct DocumentId(pub u32);
 
 /// This structure represent the position of a word
 /// in a document and its attributes.


### PR DESCRIPTION
This is another step towards improving the performances and disk space usage of MeiliSearch.