### PR TITLE
Added tini process manager and entrypoint decl.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,12 @@ RUN     $HOME/.cargo/bin/cargo build --release
 # Run
 FROM    alpine:3.10
 
-RUN     apk update --quiet
-RUN     apk add libgcc
+RUN     apk add -q --no-cache libgcc tini
 
 COPY    --from=compiler /meilisearch/target/release/meilisearch .
 
 ENV     MEILI_HTTP_ADDR 0.0.0.0:7700
 EXPOSE  7700/tcp
+
+ENTRYPOINT ["tini", "--"]
 CMD     ./meilisearch


### PR DESCRIPTION
The main process in the Dockerfile `CMD` and images generated from it is not passing through linux signals correctly so shutdown is not correctly instigated when the container is stopped.

This introduces the `tini` init process manager to the `entrypoint` decl. which addresses this. 

More info about this can be found here.

https://github.com/krallin/tini

It would also be possible to use a feature of the docker runtime command to introduce this behaviour, but this would be less portable, for example:

```
docker run -it --rm --init \
    -p 7700:7700 \
    -v $(pwd)/data.ms:/data.ms \
    getmeili/meilisearch
```
