### PR TITLE
Add openssl-dev pkg as dependencies in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM    alpine:3.10 AS compiler
 RUN     apk update --quiet
 RUN     apk add curl
 RUN     apk add build-base
+RUN     apk add openssl-dev
 
 RUN     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 


### PR DESCRIPTION
Since Actix or Sentry the Docker image can not be built.

Should I add in the GitHub actions a test wether we can build or not the Docker image when anyone makes a pull request?