### PR TITLE
fix null facets in response

### DIFF
--- a/meilisearch-http/src/helpers/meilisearch.rs
+++ b/meilisearch-http/src/helpers/meilisearch.rs
@@ -333,6 +333,7 @@ pub struct SearchResult {
     pub exhaustive_nb_hits: bool,
     pub processing_time_ms: usize,
     pub query: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub facets: Option<HashMap<String, HashMap<String, usize>>>,
 }
 


### PR DESCRIPTION
remose "facet: null" in response for searches without facets