### PR TITLE
Bump heed to 0.8.0 and handle abort errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1234,9 +1234,9 @@ dependencies = [
 
 [[package]]
 name = "heed"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d432af60d4dada5bc2d391b98ed258a16e659a4b5ec88b0c90e148062ed1a5c"
+checksum = "fd7882b766b4be1b90d8ce5ce4c7aca2539b43176a708dbc8e79576dbbdbba93"
 dependencies = [
  "byteorder",
  "heed-traits",

--- a/meilisearch-core/Cargo.toml
+++ b/meilisearch-core/Cargo.toml
@@ -18,7 +18,7 @@ either = "1.5.3"
 env_logger = "0.7.1"
 fst = "0.4.4"
 hashbrown = { version = "0.7.1", features = ["serde"] }
-heed = "0.7.0"
+heed = "0.8.0"
 indexmap = { version = "1.3.2", features = ["serde-1"] }
 intervaltree = "0.2.5"
 itertools = "0.9.0"

--- a/meilisearch-core/src/database.rs
+++ b/meilisearch-core/src/database.rs
@@ -104,7 +104,7 @@ fn update_awaiter(
             };
 
             // do not keep the reader for too long
-            update_reader.abort();
+            break_try!(update_reader.abort(), "aborting update transaction failed");
 
             // instantiate a transaction to touch to the main env
             let result = env.typed_write_txn::<MainT>();
@@ -118,7 +118,7 @@ fn update_awaiter(
             if status.error.is_none() {
                 break_try!(main_writer.commit(), "commit nested transaction failed");
             } else {
-                main_writer.abort()
+                break_try!(main_writer.abort(), "abborting nested transaction failed");
             }
 
             // now that the update has been processed we can instantiate
@@ -178,7 +178,7 @@ impl Database {
             must_open.push(index_uid.to_owned());
         }
 
-        reader.abort();
+        reader.abort()?;
 
         // open the previously aggregated indexes
         let mut indexes = HashMap::new();

--- a/meilisearch-http/Cargo.toml
+++ b/meilisearch-http/Cargo.toml
@@ -29,7 +29,7 @@ chrono = { version = "0.4.11", features = ["serde"] }
 crossbeam-channel = "0.4.2"
 env_logger = "0.7.1"
 futures = "0.3.4"
-heed = "0.7.0"
+heed = "0.8.0"
 http = "0.1.19"
 indexmap = { version = "1.3.2", features = ["serde-1"] }
 log = "0.4.8"


### PR DESCRIPTION
This new heed version contains a fix on read transaction abortion.