### PR TITLE
Rename fields_frequency into fields_distribution (and fieldsFrequency into fieldsDistribution)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   - Fix NormalizePath middleware to make the dashboard accessible (#695)
   - Update sentry features to remove openssl (#702)
   - Add SSL support (#669)
+  - Rename fieldsFrequency into fieldsDistribution in stats (#719)
 
 ## v0.10.1
 

--- a/meilisearch-core/src/store/main.rs
+++ b/meilisearch-core/src/store/main.rs
@@ -19,7 +19,7 @@ const CREATED_AT_KEY: &str = "created-at";
 const CUSTOMS_KEY: &str = "customs";
 const DISTINCT_ATTRIBUTE_KEY: &str = "distinct-attribute";
 const EXTERNAL_DOCIDS_KEY: &str = "external-docids";
-const FIELDS_FREQUENCY_KEY: &str = "fields-frequency";
+const FIELDS_DISTRIBUTION_KEY: &str = "fields-distribution";
 const INTERNAL_DOCIDS_KEY: &str = "internal-docids";
 const NAME_KEY: &str = "name";
 const NUMBER_OF_DOCUMENTS_KEY: &str = "number-of-documents";
@@ -232,19 +232,19 @@ impl Main {
         }
     }
 
-    pub fn put_fields_frequency(
+    pub fn put_fields_distribution(
         self,
         writer: &mut heed::RwTxn<MainT>,
-        fields_frequency: &FreqsMap,
+        fields_distribution: &FreqsMap,
     ) -> ZResult<()> {
         self.main
-            .put::<_, Str, SerdeFreqsMap>(writer, FIELDS_FREQUENCY_KEY, fields_frequency)
+            .put::<_, Str, SerdeFreqsMap>(writer, FIELDS_DISTRIBUTION_KEY, fields_distribution)
     }
 
-    pub fn fields_frequency(&self, reader: &heed::RoTxn<MainT>) -> ZResult<Option<FreqsMap>> {
+    pub fn fields_distribution(&self, reader: &heed::RoTxn<MainT>) -> ZResult<Option<FreqsMap>> {
         match self
             .main
-            .get::<_, Str, SerdeFreqsMap>(reader, FIELDS_FREQUENCY_KEY)?
+            .get::<_, Str, SerdeFreqsMap>(reader, FIELDS_DISTRIBUTION_KEY)?
         {
             Some(freqs) => Ok(Some(freqs)),
             None => Ok(None),

--- a/meilisearch-http/src/data.rs
+++ b/meilisearch-http/src/data.rs
@@ -107,23 +107,23 @@ impl DataInner {
             .all_documents_fields_counts(&writer)?;
 
         // count fields frequencies
-        let mut fields_frequency = HashMap::<_, usize>::new();
+        let mut fields_distribution = HashMap::<_, usize>::new();
         for result in all_documents_fields {
             let (_, attr, _) = result?;
             if let Some(field_id) = schema.indexed_pos_to_field_id(attr) {
-                *fields_frequency.entry(field_id).or_default() += 1;
+                *fields_distribution.entry(field_id).or_default() += 1;
             }
         }
 
         // convert attributes to their names
-        let frequency: HashMap<_, _> = fields_frequency
+        let distribution: HashMap<_, _> = fields_distribution
             .into_iter()
             .filter_map(|(a, c)| schema.name(a).map(|name| (name.to_string(), c)))
             .collect();
 
         index
             .main
-            .put_fields_frequency(writer, &frequency)
+            .put_fields_distribution(writer, &distribution)
             .map_err(MError::Zlmdb)
     }
 }

--- a/meilisearch-http/src/routes/stats.rs
+++ b/meilisearch-http/src/routes/stats.rs
@@ -28,7 +28,7 @@ pub fn services(cfg: &mut web::ServiceConfig) {
 struct IndexStatsResponse {
     number_of_documents: u64,
     is_indexing: bool,
-    fields_frequency: HashMap<String, usize>,
+    fields_distribution: HashMap<String, usize>,
 }
 
 #[get("/indexes/{index_uid}/stats", wrap = "Authentication::Private")]
@@ -45,7 +45,7 @@ async fn index_stats(
 
     let number_of_documents = index.main.number_of_documents(&reader)?;
 
-    let fields_frequency = index.main.fields_frequency(&reader)?.unwrap_or_default();
+    let fields_distribution = index.main.fields_distribution(&reader)?.unwrap_or_default();
 
     let update_reader = data.db.update_read_txn()?;
 
@@ -58,7 +58,7 @@ async fn index_stats(
     Ok(HttpResponse::Ok().json(IndexStatsResponse {
         number_of_documents,
         is_indexing,
-        fields_frequency,
+        fields_distribution,
     }))
 }
 
@@ -84,7 +84,7 @@ async fn get_stats(data: web::Data<Data>) -> Result<HttpResponse, ResponseError>
             Some(index) => {
                 let number_of_documents = index.main.number_of_documents(&reader)?;
 
-                let fields_frequency = index.main.fields_frequency(&reader)?.unwrap_or_default();
+                let fields_distribution = index.main.fields_distribution(&reader)?.unwrap_or_default();
 
                 let is_indexing = data.is_indexing(&update_reader, &index_uid)?.ok_or(
                     ResponseError::internal("Impossible to know if the database is indexing"),
@@ -93,7 +93,7 @@ async fn get_stats(data: web::Data<Data>) -> Result<HttpResponse, ResponseError>
                 let response = IndexStatsResponse {
                     number_of_documents,
                     is_indexing,
-                    fields_frequency,
+                    fields_distribution,
                 };
                 index_list.insert(index_uid, response);
             }


### PR DESCRIPTION
The field returned in the `/stats` and `/indexes/:index_uid/stats` routes have been renamed to `fieldsDistribution`, instead of `fieldsFrequency`, as discussed with the core team (and the integrations team). This term was chosen for consistency with other naming in MeiliSearch, specially those chosen for the faceted filtering search (cf  #716).

All the corresponding references to fields frequency have been updated in the code for consistency and coherence

Closes #713 