### PR TITLE
Index already exist code

### DIFF
--- a/meilisearch-error/src/lib.rs
+++ b/meilisearch-error/src/lib.rs
@@ -28,8 +28,8 @@ pub trait ErrorCode: std::error::Error {
 
 enum ErrorType {
     InternalError,
-    InvalidRequest,
-    Authentication,
+    InvalidRequestError,
+    AuthenticationError,
 }
 
 impl fmt::Display for ErrorType {
@@ -38,8 +38,8 @@ impl fmt::Display for ErrorType {
 
         match self {
             InternalError => write!(f, "internal_error"),
-            InvalidRequest => write!(f, "invalid_request"),
-            Authentication => write!(f, "authentication"),
+            InvalidRequestError => write!(f, "invalid_request_error"),
+            AuthenticationError => write!(f, "authentication_error"),
         }
     }
 }
@@ -152,7 +152,7 @@ impl ErrCode {
         ErrCode {
             status_code,
             error_name,
-            error_type: ErrorType::Authentication,
+            error_type: ErrorType::AuthenticationError,
         }
     }
 
@@ -168,7 +168,7 @@ impl ErrCode {
         ErrCode {
             status_code,
             error_name,
-            error_type: ErrorType::InvalidRequest,
+            error_type: ErrorType::InvalidRequestError,
         }
     }
 }

--- a/meilisearch-error/src/lib.rs
+++ b/meilisearch-error/src/lib.rs
@@ -87,7 +87,7 @@ impl Code {
         match self {
             // index related errors
             CreateIndex => ErrCode::invalid("create_index", StatusCode::BAD_REQUEST),
-            IndexAlreadyExists => ErrCode::invalid("existing_index", StatusCode::BAD_REQUEST),
+            IndexAlreadyExists => ErrCode::invalid("index_already_exists", StatusCode::BAD_REQUEST),
             IndexNotFound => ErrCode::invalid("index_not_found", StatusCode::NOT_FOUND), InvalidIndexUid => ErrCode::invalid("invalid_index_uid", StatusCode::BAD_REQUEST),
             OpenIndex => ErrCode::internal("open_index", StatusCode::INTERNAL_SERVER_ERROR),
 

--- a/meilisearch-http/src/routes/index.rs
+++ b/meilisearch-http/src/routes/index.rs
@@ -178,7 +178,10 @@ async fn create_index(
     let created_index = data
         .db
         .create_index(&uid)
-        .map_err(Error::create_index)?;
+        .map_err(|e| match e {
+            meilisearch_core::Error::IndexAlreadyExists => e.into(),
+            _ => ResponseError::from(Error::create_index(e))
+        })?;
 
     let index_response = data.db.main_write::<_, _, ResponseError>(|mut writer| {
         let name = body.name.as_ref().unwrap_or(&uid);

--- a/meilisearch-http/tests/index.rs
+++ b/meilisearch-http/tests/index.rs
@@ -54,7 +54,7 @@ async fn create_index_with_uid() {
         "uid": "movies",
     });
 
-    let (res1_value, status_code) = server.create_index(body).await;
+    let (res1_value, status_code) = server.create_index(body.clone()).await;
 
     assert_eq!(status_code, 201);
     assert_eq!(res1_value.as_object().unwrap().len(), 5);
@@ -66,6 +66,13 @@ async fn create_index_with_uid() {
     assert_eq!(r1_uid, "movies");
     assert!(r1_created_at.len() > 1);
     assert!(r1_updated_at.len() > 1);
+
+    // 1.5 verify that error is thrown when trying to create the same index
+
+    let (response, status_code) = server.create_index(body).await;
+
+    assert_eq!(status_code, 400);
+    assert_eq!(response["errorCode"].as_str().unwrap(), "index_already_exists");
 
     // 2 - Check the list of indexes
 


### PR DESCRIPTION
- rename `existing_index` code to `index_already_exists`
- report special code for `index_already_exists`
- change error types according to https://github.com/meilisearch/MeiliSearch/issues/683#issuecomment-635946532