### PR TITLE
Update documents_delete tests to use the test dataset

### DIFF
--- a/meilisearch-http/tests/documents_delete.rs
+++ b/meilisearch-http/tests/documents_delete.rs
@@ -2,30 +2,28 @@ mod common;
 
 #[actix_rt::test]
 async fn delete() {
-    let mut server = common::Server::with_uid("movies");
-    server.populate_movies().await;
+    let mut server = common::Server::test_server().await;
 
-    let (_response, status_code) = server.get_document(419704).await;
+    let (_response, status_code) = server.get_document(50).await;
     assert_eq!(status_code, 200);
 
-    server.delete_document(419704).await;
+    server.delete_document(50).await;
 
-    let (_response, status_code) = server.get_document(419704).await;
+    let (_response, status_code) = server.get_document(50).await;
     assert_eq!(status_code, 404);
 }
 
 // Resolve the issue https://github.com/meilisearch/MeiliSearch/issues/493
 #[actix_rt::test]
 async fn delete_batch() {
-    let mut server = common::Server::with_uid("movies");
-    server.populate_movies().await;
+    let mut server = common::Server::test_server().await;
 
-    let (_response, status_code) = server.get_document(419704).await;
+    let (_response, status_code) = server.get_document(50).await;
     assert_eq!(status_code, 200);
 
-    let body = serde_json::json!([419704, 512200, 181812]);
+    let body = serde_json::json!([50, 55, 60]);
     server.delete_multiple_documents(body).await;
 
-    let (_response, status_code) = server.get_document(419704).await;
+    let (_response, status_code) = server.get_document(50).await;
     assert_eq!(status_code, 404);
 }


### PR DESCRIPTION
As requested by @MarinPostma, creating a separate pull request for updating the Documents Delete test to use the Test Dataset.

Let me know whether this is the expectation for addressing #655.

Also please let me know whether it's okay for me to create individual PRs like this for every test file.

Thanks in advance.