### PR TITLE
Create tests for error codes

### DIFF
--- a/meilisearch-core/src/error.rs
+++ b/meilisearch-core/src/error.rs
@@ -41,7 +41,7 @@ impl ErrorCode for Error {
             FacetError(_) => Code::Facet,
             FilterParseError(_) => Code::Filter,
             IndexAlreadyExists => Code::IndexAlreadyExists,
-            MissingPrimaryKey => Code::InvalidState,
+            MissingPrimaryKey => Code::MissingPrimaryKey,
             MissingDocumentId => Code::MissingDocumentId,
             MaxFieldsLimitExceeded => Code::MaxFieldsLimitExceeded,
             Schema(s) =>  s.error_code(),

--- a/meilisearch-error/src/lib.rs
+++ b/meilisearch-error/src/lib.rs
@@ -102,7 +102,7 @@ impl Code {
             PrimaryKeyAlreadyPresent => ErrCode::invalid("primary_key_already_present", StatusCode::BAD_REQUEST),
 
             // invalid document
-            MaxFieldsLimitExceeded => ErrCode::invalid("max_field_limit_exceeded", StatusCode::BAD_REQUEST),
+            MaxFieldsLimitExceeded => ErrCode::invalid("max_fields_limit_exceeded", StatusCode::BAD_REQUEST),
             MissingDocumentId => ErrCode::invalid("missing_document_id", StatusCode::BAD_REQUEST),
 
             // error related to facets

--- a/meilisearch-error/src/lib.rs
+++ b/meilisearch-error/src/lib.rs
@@ -87,10 +87,11 @@ impl Code {
         match self {
             // index related errors
             // create index is thrown on internal error while creating an index.
-            CreateIndex => ErrCode::invalid("index_creation_failed", StatusCode::BAD_REQUEST),
+            CreateIndex => ErrCode::internal("index_creation_failed", StatusCode::BAD_REQUEST),
             IndexAlreadyExists => ErrCode::invalid("index_already_exists", StatusCode::BAD_REQUEST),
             // thrown when requesting an unexisting index
-            IndexNotFound => ErrCode::invalid("index_not_found", StatusCode::NOT_FOUND), InvalidIndexUid => ErrCode::invalid("invalid_index_uid", StatusCode::BAD_REQUEST),
+            IndexNotFound => ErrCode::invalid("index_not_found", StatusCode::NOT_FOUND),
+            InvalidIndexUid => ErrCode::invalid("invalid_index_uid", StatusCode::BAD_REQUEST),
             OpenIndex => ErrCode::internal("index_not_accessible", StatusCode::INTERNAL_SERVER_ERROR),
 
             // invalid state error

--- a/meilisearch-error/src/lib.rs
+++ b/meilisearch-error/src/lib.rs
@@ -97,7 +97,7 @@ impl Code {
             // invalid state error
             InvalidState => ErrCode::internal("invalid_state", StatusCode::INTERNAL_SERVER_ERROR),
             // thrown when no primary key has been set
-            MissingPrimaryKey => ErrCode::internal("missing_primary_key", StatusCode::INTERNAL_SERVER_ERROR),
+            MissingPrimaryKey => ErrCode::invalid("missing_primary_key", StatusCode::BAD_REQUEST),
             // error thrown when trying to set an already existing primary key
             PrimaryKeyAlreadyPresent => ErrCode::invalid("primary_key_already_present", StatusCode::BAD_REQUEST),
 

--- a/meilisearch-http/src/routes/document.rs
+++ b/meilisearch-http/src/routes/document.rs
@@ -156,7 +156,7 @@ async fn update_multiple_documents(
     let mut schema = index
         .main
         .schema(&reader)?
-        .ok_or(Error::internal("Impossible to retrieve the schema"))?;
+        .ok_or(meilisearch_core::Error::SchemaMissing)?;
 
     if schema.primary_key().is_none() {
         let id = match &params.primary_key {
@@ -164,7 +164,7 @@ async fn update_multiple_documents(
             None => body
                 .first()
                 .and_then(find_primary_key)
-                .ok_or(Error::bad_request("Could not infer a primary key"))?,
+                .ok_or(meilisearch_core::Error::MissingPrimaryKey)?
         };
 
         schema

--- a/meilisearch-http/tests/errors.rs
+++ b/meilisearch-http/tests/errors.rs
@@ -92,7 +92,7 @@ async fn max_field_limit_exceeded_error() {
     }
     let docs = json!([doc]);
     assert_error_async!(
-        "max_field_limit_exceeded",
+        "max_fields_limit_exceeded",
         "invalid_request_error",
         server,
         server.add_or_replace_multiple_documents_sync(docs).await);
@@ -179,4 +179,18 @@ async fn payload_too_large_error() {
         "invalid_request_error",
         StatusCode::PAYLOAD_TOO_LARGE,
         server.create_index(json!(bigvec)).await);
+}
+
+#[actix_rt::test]
+async fn missing_primary_key_error() {
+    let mut server = common::Server::with_uid("test");
+    server.create_index(json!({"uid": "test"})).await;
+    let document = json!([{
+        "content": "test"
+    }]);
+    assert_error!(
+        "missing_primary_key",
+        "invalid_request_error",
+        StatusCode::BAD_REQUEST,
+        server.add_or_replace_multiple_documents_sync(document).await);
 }

--- a/meilisearch-http/tests/index.rs
+++ b/meilisearch-http/tests/index.rs
@@ -658,9 +658,8 @@ async fn check_add_documents_without_primary_key() {
 
     let (response, status_code) = server.add_or_replace_multiple_documents_sync(body).await;
 
-    let message = response["message"].as_str().unwrap();
     assert_eq!(response.as_object().unwrap().len(), 4);
-    assert_eq!(message, "Could not infer a primary key");
+    assert_eq!(response["errorCode"], "missing_primary_key");
     assert_eq!(status_code, 400);
 }
 


### PR DESCRIPTION
- create tests for error codes
-  fix primary key error that returned internal error instead of the correct error
- bits of documentation for error
- change a bunch of error type, for better accuracy, @curquiza, @eskombro, @bidoubiwa  you may want to take a look at `meilisearch-error/src/lib.rs`
- fix #836 