### PR TITLE
feat(sentry): make sentry dsn customizable

### DIFF
--- a/meilisearch-http/src/option.rs
+++ b/meilisearch-http/src/option.rs
@@ -26,6 +26,17 @@ pub struct Opt {
     #[structopt(long, env = "MEILI_MASTER_KEY")]
     pub master_key: Option<String>,
 
+    /// The Sentry DSN to use for error reporting. This defaults to the MeiliSearch Sentry project.
+    /// You can disable sentry all together using the `--no-sentry` flag or `MEILI_NO_SENTRY` environment variable.
+    #[cfg(all(not(debug_assertions), feature = "sentry"))]
+    #[structopt(long, env = "SENTRY_DSN", default_value = "https://5ddfa22b95f241198be2271aaf028653@sentry.io/3060337")]
+    pub sentry_dsn: String,
+
+    /// Disable Sentry error reporting.
+    #[cfg(all(not(debug_assertions), feature = "sentry"))]
+    #[structopt(long, env = "MEILI_NO_SENTRY")]
+    pub no_sentry: bool,
+
     /// This environment variable must be set to `production` if your are running in production.
     /// If the server is running in development mode more logs will be displayed,
     /// and the master key can be avoided which implies that there is no security on the updates routes.


### PR DESCRIPTION
By removing the hardcoded value the sentry client will fall back to pulling
it from the SENTRY_DSN environment variable. The hardcoded value has been
moved to the default value of the commandline options so the default
behavior will be the same.

A `--no-sentry` and `MEILI_NO_SENTRY` option has also been introduced
that effectively disables sentry reporting.

closes #812