### PR TITLE
chore(http): do not require auth on /health endpoint

### DIFF
--- a/meilisearch-http/src/routes/health.rs
+++ b/meilisearch-http/src/routes/health.rs
@@ -10,7 +10,7 @@ pub fn services(cfg: &mut web::ServiceConfig) {
     cfg.service(get_health).service(change_healthyness);
 }
 
-#[get("/health", wrap = "Authentication::Private")]
+#[get("/health")]
 async fn get_health(data: web::Data<Data>) -> Result<HttpResponse, ResponseError> {
     let reader = data.db.main_read_txn()?;
     if let Ok(Some(_)) = data.db.get_health(&reader) {


### PR DESCRIPTION
This makes it easier to determine the health of the server using http.

closes #822