### PR TITLE
feat(analytics): log if analytics are enabled

### DIFF
--- a/meilisearch-http/src/main.rs
+++ b/meilisearch-http/src/main.rs
@@ -129,6 +129,15 @@ pub fn print_launch_resume(opt: &Opt, data: &Data) {
         }
     );
 
+    eprintln!(
+        "Amplitude Analytics:\t{:?}",
+        if !opt.no_analytics {
+            "Enabled"
+        } else {
+            "Disabled"
+        }
+    );
+
     eprintln!();
 
     if data.api_keys.master.is_some() {


### PR DESCRIPTION
Simply adds a line if analytics are enabled or not.

```bash
888b     d888          d8b 888 d8b  .d8888b.                                    888
8888b   d8888          Y8P 888 Y8P d88P  Y88b                                   888
88888b.d88888              888     Y88b.                                        888
888Y88888P888  .d88b.  888 888 888  "Y888b.    .d88b.   8888b.  888d888 .d8888b 88888b.
888 Y888P 888 d8P  Y8b 888 888 888     "Y88b. d8P  Y8b     "88b 888P"  d88P"    888 "88b
888  Y8P  888 88888888 888 888 888       "888 88888888 .d888888 888    888      888  888
888   "   888 Y8b.     888 888 888 Y88b  d88P Y8b.     888  888 888    Y88b.    888  888
888       888  "Y8888  888 888 888  "Y8888P"   "Y8888  "Y888888 888     "Y8888P 888  888

Database path:          "./data.ms"
Server listening on:    "127.0.0.1:7700"
Environment:            "development"
Commit SHA:             "92d9283d1a3e1dbcf1c111c22b7e3b30557f5635"
Build date:             "2020-07-01T15:54:13.492144799+00:00"
Package version:        "0.12.0"
Amplitude Analytics:    "Enabled"

No master key found; The server will accept unidentified requests. If you need some protection in development mode, please export a key: export MEILI_MASTER_KEY=xxx

Documentation:          https://docs.meilisearch.com
Source code:            https://github.com/meilisearch/meilisearch
Contact:                https://docs.meilisearch.com/resources/contact.html or bonjour@meilisearch.com

[2020-07-01T15:55:08Z INFO  actix_server::builder] Starting 8 workers
[2020-07-01T15:55:08Z INFO  actix_server::builder] Starting "actix-web-service-127.0.0.1:7700" service on 127.0.0.1:7700
```