### PR TITLE
Update CI for new workflow

### DIFF
--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -1,9 +1,8 @@
-name: Publish binaries to GitHub release
-
 on:
-  push:
-    tags:
-      - '*'
+  release:
+    types: [published]
+
+name: Publish binaries to release
 
 jobs:
   publish:

--- a/.github/workflows/publish-deb-brew-pkg.yml
+++ b/.github/workflows/publish-deb-brew-pkg.yml
@@ -2,7 +2,7 @@ name: Publish deb pkg to GitHub release & APT repository & Homebrew
 
 on:
   release:
-    types: [published]
+    types: [released]
 
 jobs:
   debian:

--- a/.github/workflows/publish-docker-latest.yml
+++ b/.github/workflows/publish-docker-latest.yml
@@ -1,7 +1,7 @@
 ---
 on:
   release:
-    types: [published]
+    types: [released]
 
 name: Publish latest image to Docker Hub
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,11 @@
 on:
   push:
     branches:
-      - staging
+      - release-v*
       - trying
+      - staging
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+' # this only concerns tags on stable
 
 name: Test binaries with cargo test
 
@@ -14,7 +17,6 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-
     steps:
     - uses: actions/checkout@v1
     - uses: actions-rs/toolchain@v1
@@ -32,6 +34,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: clippy
+
   build-image:
     name: Test the build of Docker image
     runs-on: ubuntu-latest
@@ -39,3 +42,52 @@ jobs:
     - uses: actions/checkout@v1
     - run: docker build . --file Dockerfile -t meilisearch
       name: Docker build
+
+  ## A push occurred on a release branch, a prerelease is created and assets are generated
+  prerelease:
+    name: create prerelease
+    needs: [check, build-image]
+    if: ${{ contains(github.ref, 'release-') && github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Get version number
+        id: version-number
+        run: echo "##[set-output name=number;]$(echo ${{ github.ref }} | sed 's/.*\(v.*\)/\1/')"
+      - name: Get commit count
+        id: commit-count
+        run: echo "##[set-output name=count;]$(git rev-list remotes/origin/master..remotes/origin/release-${{ steps.version-number.outputs.number }} --count)"
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.PUBLISH_TOKEN }} # Personal Access Token
+        with:
+          tag_name: ${{ steps.version-number.outputs.number }}rc${{ steps.commit-count.outputs.count }}
+          release_name: Pre-release ${{ steps.version-number.outputs.number }}-rc${{ steps.commit-count.outputs.count }}
+          prerelease: true
+
+  ## If a tag is pushed, a release is created for this tag, and assets will be generated
+  release:
+    name: create release
+    needs: [check, build-image]
+    if:  ${{ contains(github.ref, 'tags/v') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Get version number
+        id: version-number
+        run: echo "##[set-output name=number;]$(echo ${{ github.ref }} | sed 's/.*\(v.*\)/\1/')" 
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.PUBLISH_TOKEN }} # PAT
+        with:
+          tag_name: ${{ steps.version-number.outputs.number }}
+          release_name: Meilisearch ${{ steps.version-number.outputs.number }}
+          prerelease: false


### PR DESCRIPTION
This pr implements the necessary automation for our new release workflow.

## Pre-releases

whenever something is pushed to a branch `release-v*`, tests are triggered. If all test pass, the current reference is checked to see if it's a release branch. If it's a release branch, a pre-release is created for this branch and assets are automatically generated for this branch. The prerelease has the tag `vx.x.xrcn` where `x.x.x` is the version extracteds from the branch name, and n is the number of commits since the branch was forked from master. (starting from rc0).

## Releases

Whenever something is pushed to stable and tagged `vx.x.x` where `x.x.x` is the version, tests are run and a release is generated containing the assets, and binaries are published to docker, brew, apt, etc.