### PR TITLE
Remove schema mention in error message

### DIFF
--- a/meilisearch-schema/src/error.rs
+++ b/meilisearch-schema/src/error.rs
@@ -16,7 +16,7 @@ impl fmt::Display for Error {
         use self::Error::*;
         match self {
             FieldNameNotFound(field) => write!(f, "The field {:?} doesn't exist", field),
-            PrimaryKeyAlreadyPresent => write!(f, "The schema already have an primary key. It's impossible to update it"),
+            PrimaryKeyAlreadyPresent => write!(f, "A primary key is already present. It's impossible to update it"),
             MaxFieldsLimitExceeded => write!(f, "The maximum of possible reattributed field id has been reached"),
         }
     }


### PR DESCRIPTION
We avoid mentioning the schema since MeiliSearch is schemaless for the user 🙂