### PR TITLE
Fix clippy warnings

### DIFF
--- a/meilisearch-core/src/database.rs
+++ b/meilisearch-core/src/database.rs
@@ -182,7 +182,7 @@ fn version_guard(path: &Path, create: bool) -> MResult<()> {
             let version = re
                 .captures_iter(&version)
                 .next()
-                .ok_or(Error::VersionMismatch("bad VERSION file".to_string()))?;
+                .ok_or_else(|| Error::VersionMismatch("bad VERSION file".to_string()))?;
             // the first is always the complete match, safe to unwrap because we have a match
             let version_major = version.get(1).unwrap().as_str();
             let version_minor = version.get(2).unwrap().as_str();
@@ -205,7 +205,7 @@ fn version_guard(path: &Path, create: bool) -> MResult<()> {
                     } else {
                         // when no version file is found and we were not told to create one, this
                         // means that the version is inferior to the one this feature was added in.
-                        return Err(Error::VersionMismatch(format!("<0.12.0")));
+                        return Err(Error::VersionMismatch("<0.12.0".to_string()));
                     }
                 }
                 _ => return Err(error.into())


### PR DESCRIPTION
Good day!

Since `cargo clippy` showed two warnings like the following, I've fixed them. This is a small PR.

```sh
warning: use of `ok_or` followed by a function call
   --> meilisearch-core/src/database.rs:185:18
    |
185 |                 .ok_or(Error::VersionMismatch("bad VERSION file".to_string()))?;
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `ok_or_else(|| Error::VersionMismatch("bad VERSION file".to_string()))`
    |
    = note: `#[warn(clippy::or_fun_call)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#or_fun_call

warning: useless use of `format!`
   --> meilisearch-core/src/database.rs:208:59
    |
208 |                         return Err(Error::VersionMismatch(format!("<0.12.0")));
    |                                                           ^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `"<0.12.0".to_string()`
    |
    = note: `#[warn(clippy::useless_format)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_format

warning: 2 warnings emitted
```