### PR TITLE
Revert 944

### DIFF
--- a/meilisearch-core/src/bucket_sort.rs
+++ b/meilisearch-core/src/bucket_sort.rs
@@ -100,17 +100,17 @@ where
     debug!("found {} documents", docids.len());
     debug!("number of postings {:?}", queries.len());
 
-    if let Some(f) = facet_count_docids {
-        // hardcoded value, until approximation optimization
-        result.exhaustive_facets_count = Some(true);
-        result.facets = Some(facet_count(f, &docids));
-    }
-
     if let Some(facets_docids) = facets_docids {
         let intersection = sdset::duo::OpBuilder::new(docids.as_ref(), facets_docids.as_set())
             .intersection()
             .into_set_buf();
         docids = Cow::Owned(intersection);
+    }
+
+    if let Some(f) = facet_count_docids {
+        // hardcoded value, until approximation optimization
+        result.exhaustive_facets_count = Some(true);
+        result.facets = Some(facet_count(f, &docids));
     }
 
     let before = Instant::now();
@@ -243,17 +243,17 @@ where
     debug!("found {} documents", docids.len());
     debug!("number of postings {:?}", queries.len());
 
-    if let Some(f) = facet_count_docids {
-        // hardcoded value, until approximation optimization
-        result.exhaustive_facets_count = Some(true);
-        result.facets = Some(facet_count(f, &docids));
-    }
-
     if let Some(facets_docids) = facets_docids {
         let intersection = OpBuilder::new(docids.as_ref(), facets_docids.as_set())
             .intersection()
             .into_set_buf();
         docids = Cow::Owned(intersection);
+    }
+
+    if let Some(f) = facet_count_docids {
+        // hardcoded value, until approximation optimization
+        result.exhaustive_facets_count = Some(true);
+        result.facets = Some(facet_count(f, &docids));
     }
 
     let before = Instant::now();

--- a/meilisearch-http/tests/search.rs
+++ b/meilisearch-http/tests/search.rs
@@ -1466,6 +1466,7 @@ async fn test_facet_count() {
     server.update_all_settings(body).await;
     // same as before, but now facets are set:
     test_post_get_search!(server, query, |response, _status_code|{
+        println!("{}", response);
         assert!(response.get("exhaustiveFacetsCount").is_some());
         assert_eq!(response.get("facetsDistribution").unwrap().as_object().unwrap().values().count(), 1);
         // assert that case is preserved
@@ -1694,38 +1695,4 @@ async fn update_documents_with_facet_distribution() {
     server.add_or_update_multiple_documents(update2).await;
     let (response2, _) = server.search_post(search).await;
     assert_json_eq!(expected_facet_distribution, response2["facetsDistribution"].clone());
-}
-
-#[actix_rt::test]
-async fn test_facet_count_with_facet_filter() {
-    let mut server = common::Server::test_server().await;
-    let body = json!({
-        "attributesForFaceting": ["gender"]
-    });
-    server.update_all_settings(body).await;
-    let query = json!({
-        "q": "a",
-        "facetsDistribution": ["gender"],
-        "facetFilters": ["gender:male"],
-    });
-
-    test_post_get_search!(server, query, |response, _status_code|{
-        assert!(response.get("exhaustiveFacetsCount").is_some());
-        let facets_distribution = response.get("facetsDistribution").unwrap().as_object();
-        assert_eq!(facets_distribution.unwrap()["gender"]["male"], 37);
-        assert_eq!(facets_distribution.unwrap()["gender"]["female"], 39);
-    });
-    // facet distribution should remain the same when facet filter changes
-    let query = json!({
-        "q": "a",
-        "facetsDistribution": ["gender"],
-        "facetFilters": [["gender:male", "gender:female"]],
-    });
-
-    test_post_get_search!(server, query, |response, _status_code|{
-        assert!(response.get("exhaustiveFacetsCount").is_some());
-        let facets_distribution = response.get("facetsDistribution").unwrap().as_object();
-        assert_eq!(facets_distribution.unwrap()["gender"]["male"], 37);
-        assert_eq!(facets_distribution.unwrap()["gender"]["female"], 39);
-    });
 }


### PR DESCRIPTION
revert #944 
@bidoubiwa  @curquiza @eskombro, this was a misunderstanding from our side. Doing this would in fact be an error, and would prevent us to do this: https://github.com/meilisearch/MeiliSearch/issues/945#issuecomment-685526678, which is what we are really after. We are resetting this to its default behaviour before it goes in prodution. Sorry for the confusion.