### PR TITLE
Remove not maintained csv movies dataset

### DIFF
--- a/datasets/movies/README.md
+++ b/datasets/movies/README.md
@@ -1,1 +1,1 @@
-_datas in movies.csv are from https://www.themoviedb.org/_
+_datas in movies.json are from https://www.themoviedb.org/_


### PR DESCRIPTION
Remove `movies.csv` from the dataset folder as it is not updated and not usable with MeiliSearch without converting it to json.