### PR TITLE
fix: cors error since v0.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,14 +40,16 @@ dependencies = [
 
 [[package]]
 name = "actix-cors"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3e5c769e4d332bfad27f11b8139b5818c4bbddb02c385b8f16344d93ff1a8eb"
+checksum = "aaf0c4345c9663a2822d42602391418fd5766f269109ec6bf1784b056a9356a7"
 dependencies = [
- "actix-service",
  "actix-web",
  "derive_more",
  "futures-util",
+ "log",
+ "once_cell",
+ "tinyvec 1.0.1",
 ]
 
 [[package]]
@@ -1898,8 +1900,7 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 [[package]]
 name = "pest"
 version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+source = "git+https://github.com/pest-parser/pest.git?rev=51fd1d49f1041f7839975664ef71fe15c7dcaf67#51fd1d49f1041f7839975664ef71fe15c7dcaf67"
 dependencies = [
  "ucd-trie",
 ]
@@ -1907,7 +1908,8 @@ dependencies = [
 [[package]]
 name = "pest"
 version = "2.1.3"
-source = "git+https://github.com/pest-parser/pest.git?rev=51fd1d49f1041f7839975664ef71fe15c7dcaf67#51fd1d49f1041f7839975664ef71fe15c7dcaf67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
 dependencies = [
  "ucd-trie",
 ]

--- a/meilisearch-http/Cargo.toml
+++ b/meilisearch-http/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 default = ["sentry"]
 
 [dependencies]
-actix-cors = "0.4.1"
+actix-cors = "0.5"
 actix-http = "2"
 actix-rt = "1"
 actix-service = "1.0.6"

--- a/meilisearch-http/src/main.rs
+++ b/meilisearch-http/src/main.rs
@@ -83,11 +83,10 @@ async fn main() -> Result<(), MainError> {
     let http_server = HttpServer::new(move || {
         create_app(&data)
             .wrap(
-                Cors::new()
-                    .send_wildcard()
+                Cors::default()
+                    .allow_any_origin()
                     .allowed_headers(vec!["content-type", "x-meili-api-key"])
                     .max_age(86_400) // 24h
-                    .finish(),
             )
             .wrap(middleware::Logger::default())
             .wrap(middleware::Compress::default())


### PR DESCRIPTION
fix #1021

How to test it simply:
run meilisearch from master, and run the HTML below on navigator:
```html
<!DOCTYPE html>
<html>
<head>
  <meta charset='utf-8'>
  <meta http-equiv='X-UA-Compatible' content='IE=edge'>
</head>
<body>
    Indexes:
    <div id="indexes"></div>
</body>
</html>
<script>
    httpRequest = new XMLHttpRequest();
    httpRequest.open('GET', 'http://127.0.0.1:7700/test/search', true);
    httpRequest.send();
</script>
```

retry with fixing branch
