### PR TITLE
Revert "Merge #1037"

### DIFF
--- a/meilisearch-core/src/store/synonyms.rs
+++ b/meilisearch-core/src/store/synonyms.rs
@@ -12,14 +12,18 @@ pub struct Synonyms {
 }
 
 impl Synonyms {
-    pub(crate) fn put_synonyms<A>(self, writer: &mut heed::RwTxn<MainT>, word: &[u8], synonyms: &fst::Set<A>) -> ZResult<()>
+    pub fn put_synonyms<A>(self, writer: &mut heed::RwTxn<MainT>, word: &[u8], synonyms: &fst::Set<A>) -> ZResult<()>
     where A: AsRef<[u8]>,
     {
         let bytes = synonyms.as_fst().as_bytes();
         self.synonyms.put(writer, word, bytes)
     }
 
-    pub(crate) fn clear(self, writer: &mut heed::RwTxn<MainT>) -> ZResult<()> {
+    pub fn del_synonyms(self, writer: &mut heed::RwTxn<MainT>, word: &[u8]) -> ZResult<bool> {
+        self.synonyms.delete(writer, word)
+    }
+
+    pub fn clear(self, writer: &mut heed::RwTxn<MainT>) -> ZResult<()> {
         self.synonyms.clear(writer)
     }
 

--- a/meilisearch-core/src/update/settings_update.rs
+++ b/meilisearch-core/src/update/settings_update.rs
@@ -126,7 +126,7 @@ pub fn apply_settings_update(
     }
 
     match settings.synonyms {
-        UpdateState::Update(synonyms) => apply_synonyms_update(writer, index, canonicalize_synonyms(synonyms))? ,
+        UpdateState::Update(synonyms) => apply_synonyms_update(writer, index, synonyms)?,
         UpdateState::Clear => apply_synonyms_update(writer, index, BTreeMap::new())?,
         UpdateState::Nothing => (),
     }
@@ -136,18 +136,6 @@ pub fn apply_settings_update(
     }
 
     Ok(())
-}
-
-fn canonicalize_synonyms(synonyms: BTreeMap<String, Vec<String>>) -> BTreeMap<String, Vec<String>> {
-    let mut canonicalized = BTreeMap::new();
-    for (key, values) in synonyms {
-        let deunicoded = deunicode::deunicode(&key);
-        canonicalized
-            .entry(deunicoded)
-            .or_insert_with(Vec::new)
-            .extend_from_slice(&values);
-    }
-    canonicalized
 }
 
 fn apply_attributes_for_faceting_update(


### PR DESCRIPTION
This reverts commit 257f9fb2b2b69045bff01a093e6ce15440af1bed, reversing
changes made to 9bae7a35bf98ee79370be422292fd71f5e884015.

The reason fo this is that de-unicoding is not always desirable (for example is the case of CJK documents). This cannot be handled correctly for now, and will necessitate work on the tokenizer.