### PR TITLE
Revert "Merge #1001"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 ## v0.16.0
 
-  - Fix settings bug that caused setting to be overwitten (#1001)
   - Automatically create index on document push if index doesn't exist (#914)
   - Sort displayedAttributes and facetDistribution (#946)
 

--- a/meilisearch-core/src/facets.rs
+++ b/meilisearch-core/src/facets.rs
@@ -246,7 +246,7 @@ mod test {
     #[test]
     fn test_facet_key() {
         let mut schema = Schema::new();
-        let id = schema.register_field("hello").unwrap();
+        let id = schema.insert_and_index("hello").unwrap();
         let facet_list = [schema.id("hello").unwrap()];
         assert_eq!(
             FacetKey::from_str("hello:12", &schema, &facet_list).unwrap(),
@@ -287,7 +287,7 @@ mod test {
     fn test_parse_facet_array() {
         use either::Either::{Left, Right};
         let mut schema = Schema::new();
-        let _id = schema.register_field("hello").unwrap();
+        let _id = schema.insert_and_index("hello").unwrap();
         let facet_list = [schema.id("hello").unwrap()];
         assert_eq!(
             FacetFilter::from_str("[[\"hello:12\"]]", &schema, &facet_list).unwrap(),

--- a/meilisearch-core/src/serde/deserializer.rs
+++ b/meilisearch-core/src/serde/deserializer.rs
@@ -55,7 +55,6 @@ pub struct Deserializer<'a> {
     pub documents_fields: DocumentsFields,
     pub schema: &'a Schema,
     pub fields: Option<&'a HashSet<FieldId>>,
-    pub displayed: bool,
 }
 
 impl<'de, 'a, 'b> de::Deserializer<'de> for &'b mut Deserializer<'a> {
@@ -94,9 +93,7 @@ impl<'de, 'a, 'b> de::Deserializer<'de> for &'b mut Deserializer<'a> {
                 };
 
                 let is_displayed = self.schema.is_displayed(attr);
-                // Check if displayed fields were requested, if yes, return only displayed fields,
-                // else return all fields
-                if !self.displayed || (is_displayed && self.fields.map_or(true, |f| f.contains(&attr))) {
+                if is_displayed && self.fields.map_or(true, |f| f.contains(&attr)) {
                     if let Some(attribute_name) = self.schema.name(attr) {
                         let cursor = Cursor::new(value.to_owned());
                         let ioread = SerdeJsonIoRead::new(cursor);

--- a/meilisearch-core/src/store/mod.rs
+++ b/meilisearch-core/src/store/mod.rs
@@ -243,7 +243,6 @@ impl Index {
             documents_fields: self.documents_fields,
             schema: &schema,
             fields: attributes.as_ref(),
-            displayed: true,
         };
 
         Ok(Option::<T>::deserialize(&mut deserializer)?)

--- a/meilisearch-core/src/update/documents_addition.rs
+++ b/meilisearch-core/src/update/documents_addition.rs
@@ -197,7 +197,6 @@ pub fn apply_addition<'a, 'b>(
                 documents_fields: index.documents_fields,
                 schema: &schema,
                 fields: None,
-                displayed: false,
             };
 
             let old_document = Option::<HashMap<String, Value>>::deserialize(&mut deserializer)?;
@@ -229,7 +228,7 @@ pub fn apply_addition<'a, 'b>(
     for (document_id, document) in &documents_additions {
         // For each key-value pair in the document.
         for (attribute, value) in document {
-            let field_id = schema.register_field(&attribute)?;
+            let field_id = schema.insert_and_index(&attribute)?;
             index_document(
                 writer,
                 index.documents_fields,

--- a/meilisearch-http/tests/search.rs
+++ b/meilisearch-http/tests/search.rs
@@ -1780,7 +1780,7 @@ async fn update_documents_with_facet_distribution() {
     let settings = json!({
         "attributesForFaceting": ["genre"],
         "displayedAttributes": ["genre"],
-        "searchableAttributes": ["genre", "type"]
+        "searchableAttributes": ["genre"]
     });
     server.update_all_settings(settings).await;
     let update1 = json!([

--- a/meilisearch-http/tests/settings.rs
+++ b/meilisearch-http/tests/settings.rs
@@ -1,5 +1,5 @@
 use assert_json_diff::assert_json_eq;
-use serde_json::{json, Value};
+use serde_json::json;
 use std::convert::Into;
 mod common;
 
@@ -486,7 +486,15 @@ async fn test_displayed_attributes_field() {
         ],
         "distinctAttribute": "id",
         "searchableAttributes": [
-            "*"
+            "id",
+            "name",
+            "color",
+            "gender",
+            "email",
+            "phone",
+            "address",
+            "registered",
+            "about"
         ],
         "displayedAttributes": [
             "age",
@@ -512,72 +520,4 @@ async fn test_displayed_attributes_field() {
     let (response, _status_code) = server.get_all_settings().await;
 
     assert_json_eq!(body, response, ordered: true);
-}
-
-#[actix_rt::test]
-async fn push_documents_after_updating_settings_should_not_change_settings() {
-    let mut server = common::Server::with_uid("test");
-
-    let index_body = json!({
-        "uid": "test",
-        "primaryKey": "id",
-    });
-
-    let settings_body = json!({
-        "rankingRules": [
-            "typo",
-            "words",
-            "proximity",
-            "attribute",
-            "wordsPosition",
-            "exactness",
-            "desc(registered)",
-            "desc(age)",
-        ],
-        "distinctAttribute": "id",
-        "searchableAttributes": [
-            "id",
-            "name",
-            "color",
-            "gender",
-            "email",
-            "phone",
-            "address",
-            "registered",
-            "about"
-        ],
-        "displayedAttributes": [
-            "name",
-            "gender",
-            "email",
-            "registered",
-            "age",
-        ],
-        "stopWords": [
-            "ad",
-            "in",
-            "ut",
-        ],
-        "synonyms": {
-            "road": ["street", "avenue"],
-            "street": ["avenue"],
-        },
-        "attributesForFaceting": ["name", "color"],
-    });
-
-    let dataset = include_bytes!("assets/test_set.json");
-
-    let documents_body: Value = serde_json::from_slice(dataset).unwrap();
-
-    server.create_index(index_body).await;
-
-    server.update_all_settings(settings_body.clone()).await;
-
-    server.add_or_replace_multiple_documents(documents_body).await;
-
-    // === check if settings are the same ====
-
-    let (response, _status_code) = server.get_all_settings().await;
-
-    assert_json_eq!(settings_body, response, ordered: false);
 }


### PR DESCRIPTION
This reverts commit 690eab4a253bf25d6e457953182a86fb5ba8ee8b, reversing
changes made to 086020e543d422237121949656d43358a7f93ff0.

After arbitrage with @curquiza and @eskombro, this fix would introduce a relevancy bug that cannot be circumvented, whereas the previous bug was only a setting bug with a workaround. we need to discuss this issue further to provide a fix that meets our expectations.

related to #1050 

This will be merged directly in the release branche, as a hotfix