### PR TITLE
Filter 0 in facetDistribution

### DIFF
--- a/meilisearch-http/src/helpers/meilisearch.rs
+++ b/meilisearch-http/src/helpers/meilisearch.rs
@@ -37,6 +37,7 @@ impl IndexSearchExt for Index {
             matches: false,
             facet_filters: None,
             facets: None,
+            ignore_if_zero: false,
         }
     }
 }
@@ -52,7 +53,8 @@ pub struct SearchBuilder<'a> {
     filters: Option<String>,
     matches: bool,
     facet_filters: Option<FacetFilter>,
-    facets: Option<Vec<(FieldId, String)>>
+    facets: Option<Vec<(FieldId, String)>>,
+    ignore_if_zero: bool
 }
 
 impl<'a> SearchBuilder<'a> {
@@ -99,6 +101,11 @@ impl<'a> SearchBuilder<'a> {
 
     pub fn get_matches(&mut self) -> &SearchBuilder {
         self.matches = true;
+        self
+    }
+
+    pub fn get_zero_val(&mut self) -> &SearchBuilder {
+        self.ignore_if_zero = true;
         self
     }
 
@@ -154,6 +161,7 @@ impl<'a> SearchBuilder<'a> {
 
         query_builder.set_facet_filter(self.facet_filters);
         query_builder.set_facets(self.facets);
+        query_builder.set_zero_value_discarder(self.ignore_if_zero);
 
         let start = Instant::now();
         let result = query_builder.query(reader, self.query.as_deref(), self.offset..(self.offset + self.limit));

--- a/meilisearch-http/src/routes/search.rs
+++ b/meilisearch-http/src/routes/search.rs
@@ -32,6 +32,7 @@ pub struct SearchQuery {
     matches: Option<bool>,
     facet_filters: Option<String>,
     facets_distribution: Option<String>,
+    ignore_if_zero: Option<bool>,
 }
 
 #[get("/indexes/{index_uid}/search", wrap = "Authentication::Public")]
@@ -58,6 +59,7 @@ pub struct SearchQueryPost {
     matches: Option<bool>,
     facet_filters: Option<Value>,
     facets_distribution: Option<Vec<String>>,
+    ignore_if_zero: Option<bool>,
 }
 
 impl From<SearchQueryPost> for SearchQuery {
@@ -74,6 +76,7 @@ impl From<SearchQueryPost> for SearchQuery {
             matches: other.matches,
             facet_filters: other.facet_filters.map(|f| f.to_string()),
             facets_distribution: other.facets_distribution.map(|f| format!("{:?}", f)),
+            ignore_if_zero: other.ignore_if_zero,
         }
     }
 }
@@ -223,6 +226,13 @@ impl SearchQuery {
                 search_builder.get_matches();
             }
         }
+
+        if let Some(discard_zero) = self.ignore_if_zero{
+            if discard_zero {
+                search_builder.get_zero_val();
+            }
+        }
+
         search_builder.search(&reader)
     }
 }


### PR DESCRIPTION
adding the posibility to ignore/discard facet counts if the value is 0
the param is called **ignoreIfZero** it's false if not set

I haven't updated the tests, in case you are fine with
this feature, I'll update them and refactor the code abit
default example:
![image](https://user-images.githubusercontent.com/46223652/97748263-7d7f5400-1aed-11eb-900e-09e50945ea09.png)

parameter set:
![image](https://user-images.githubusercontent.com/46223652/97748323-938d1480-1aed-11eb-8a8c-3891fdae33f3.png)

thanks