### PR TITLE
Add deploy on Platform.sh option to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,9 @@ Create a MeiliSearch instance in [MeiliSearch Sandbox](https://sandbox.meilisear
 
 #### Deploy on Platform.sh
 
-<p align="center">
 <a href="https://console.platform.sh/projects/create-project?template=https://raw.githubusercontent.com/platformsh/template-builder/master/templates/meilisearch/.platform.template.yaml&utm_content=meilisearch&utm_source=github&utm_medium=button&utm_campaign=deploy_on_platform">
     <img src="https://platform.sh/images/deploy/lg-blue.svg" alt="Deploy on Platform.sh" width="180px" />
 </a>
-</p>
 
 #### APT (Debian & Ubuntu)
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ Create a MeiliSearch instance in [MeiliSearch Sandbox](https://sandbox.meilisear
 
 [![DigitalOcean Marketplace](assets/do-btn-blue.svg)](https://marketplace.digitalocean.com/apps/meilisearch?action=deploy&refcode=7c67bd97e101)
 
+#### Deploy on Platform.sh
+
+<p align="center">
+<a href="https://console.platform.sh/projects/create-project?template=https://raw.githubusercontent.com/platformsh/template-builder/master/templates/meilisearch/.platform.template.yaml&utm_content=meilisearch&utm_source=github&utm_medium=button&utm_campaign=deploy_on_platform">
+    <img src="https://platform.sh/images/deploy/lg-blue.svg" alt="Deploy on Platform.sh" width="180px" />
+</a>
+</p>
+
 #### APT (Debian & Ubuntu)
 
 ```bash


### PR DESCRIPTION
We have had a lot of success using Meilisearch on our public documentation, and I've put together the "movies" demo to quickly show it off. Included in our template README is instructions for modifying the template deployment to make it production ready. 

All the best.

As per CONTRIBUTING, related to https://github.com/meilisearch/MeiliSearch/issues/1086

closes https://github.com/meilisearch/MeiliSearch/issues/1086