### PR TITLE
fix attributes to retrieve bug

### DIFF
--- a/meilisearch-http/src/helpers/meilisearch.rs
+++ b/meilisearch-http/src/helpers/meilisearch.rs
@@ -193,9 +193,7 @@ impl<'a> SearchBuilder<'a> {
                 .index
                 .document(reader, Some(&all_attributes), doc.id)
                 .map_err(|e| Error::retrieve_document(doc.id.0, e))?
-                .ok_or(Error::internal(
-                    "Impossible to retrieve the document; Corrupted data",
-                ))?;
+                .unwrap_or_default();
 
             let mut formatted = document.iter()
                 .filter(|(key, _)| all_formatted.contains(key.as_str()))

--- a/meilisearch-http/src/routes/search.rs
+++ b/meilisearch-http/src/routes/search.rs
@@ -130,12 +130,13 @@ impl SearchQuery {
                     restricted_attributes = available_attributes.clone();
                 } else {
                     restricted_attributes = HashSet::new();
+                    search_builder.attributes_to_retrieve(HashSet::new());
                     for attr in attributes_to_retrieve {
                         if available_attributes.contains(attr) {
                             restricted_attributes.insert(attr);
                             search_builder.add_retrievable_field(attr.to_string());
                         } else {
-                            warn!("The attributes {:?} present in attributesToCrop parameter doesn't exist", attr);
+                            warn!("The attributes {:?} present in attributesToRetrieve parameter doesn't exist", attr);
                         }
                     }
                 }

--- a/meilisearch-http/tests/search.rs
+++ b/meilisearch-http/tests/search.rs
@@ -554,6 +554,16 @@ async fn search_with_attributes_to_retrieve() {
     test_post_get_search!(server, query, |response, _status_code| {
         assert_json_eq!(expected.clone(), response["hits"].clone(), ordered: false);
     });
+
+    let query = json!({
+        "q": "cherry",
+        "limit": 1,
+        "attributesToRetrieve": [],
+    });
+
+    test_post_get_search!(server, query, |response, _status_code| {
+        assert_json_eq!(json!([{}]), response["hits"].clone(), ordered: false);
+    });
 }
 
 #[actix_rt::test]


### PR DESCRIPTION
fix bug when using empty `attributeToRetrieve`