### PR TITLE
Increasing payload default size

### DIFF
--- a/meilisearch-http/src/option.rs
+++ b/meilisearch-http/src/option.rs
@@ -57,7 +57,7 @@ pub struct Opt {
     pub max_udb_size: usize,
 
     /// The maximum size, in bytes, of accepted JSON payloads
-    #[structopt(long, env = "MEILI_HTTP_PAYLOAD_SIZE_LIMIT", default_value = "10485760")] // 10MB
+    #[structopt(long, env = "MEILI_HTTP_PAYLOAD_SIZE_LIMIT", default_value = "104857600")] // 100MB
     pub http_payload_size_limit: usize,
 
     /// Read server certificates from CERTFILE.

--- a/meilisearch-http/tests/common.rs
+++ b/meilisearch-http/tests/common.rs
@@ -57,7 +57,7 @@ impl Server {
             no_analytics: true,
             max_mdb_size: default_db_options.main_map_size,
             max_udb_size: default_db_options.update_map_size,
-            http_payload_size_limit: 10000000,
+            http_payload_size_limit: 100000000,
             ..Opt::default()
         };
 

--- a/meilisearch-http/tests/errors.rs
+++ b/meilisearch-http/tests/errors.rs
@@ -177,7 +177,7 @@ async fn document_not_found_error() {
 #[actix_rt::test]
 async fn payload_too_large_error() {
     let mut server = common::Server::with_uid("test");
-    let bigvec = vec![0u64; 10_000_000]; // 80mb
+    let bigvec = vec![0u64; 100_000_000]; // 800mb
     assert_error!(
         "payload_too_large",
         "invalid_request_error",


### PR DESCRIPTION
References issue #1137

Increasing the default payload size from 10mb to 100mb.