### PR TITLE
change health route

### DIFF
--- a/meilisearch-http/src/routes/health.rs
+++ b/meilisearch-http/src/routes/health.rs
@@ -9,5 +9,5 @@ pub fn services(cfg: &mut web::ServiceConfig) {
 
 #[get("/health")]
 async fn get_health() -> Result<HttpResponse, ResponseError> {
-    Ok(HttpResponse::NoContent().finish())
+    Ok(HttpResponse::Ok().finish())
 }

--- a/meilisearch-http/tests/health.rs
+++ b/meilisearch-http/tests/health.rs
@@ -7,5 +7,5 @@ async fn test_healthyness() {
     // Check that the server is healthy
 
     let (_response, status_code) = server.get_health().await;
-    assert_eq!(status_code, 204);
+    assert_eq!(status_code, 200);
 }


### PR DESCRIPTION
change response code from 204 to 200
to make it work with GCP healthchecks
https://cloud.google.com/load-balancing/docs/health-checks#optional-flags-hc-protocol-http

The state of this PR is not a final state, and should be improved:
- we could create a new ENV var to let the user choose the HTTP CODE (`200`, `204` ....)
- we could detect the origin/referer of the request and if it's `GCP` return `200`

fix #1144