### PR TITLE
Fix atomic snapshot creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1734,6 +1734,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "ureq",
+ "uuid",
  "vergen",
  "walkdir",
  "whoami",

--- a/meilisearch-http/Cargo.toml
+++ b/meilisearch-http/Cargo.toml
@@ -51,6 +51,7 @@ tar = "0.4.30"
 tempfile = "3.1.0"
 tokio = { version = "0.2", features = ["macros"] }
 ureq = { version = "2.0.0", features = ["tls"], default-features = false }
+uuid = "0.8"
 walkdir = "2.3.1"
 whoami = "1.0.3"
 

--- a/meilisearch-http/src/helpers/compression.rs
+++ b/meilisearch-http/src/helpers/compression.rs
@@ -1,19 +1,27 @@
 use flate2::Compression;
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
-use std::fs::{create_dir_all, File};
+use std::fs::{create_dir_all, rename, File};
 use std::path::Path;
 use tar::{Builder, Archive};
+use uuid::Uuid;
 
 use crate::error::Error;
 
 pub fn to_tar_gz(src: &Path, dest: &Path) -> Result<(), Error> {
-    let f = File::create(dest)?;
+    let file_name = format!(".{}", Uuid::new_v4().to_urn());
+    let p = dest.with_file_name(file_name);
+    let tmp_dest = p.as_path();
+
+    let f = File::create(tmp_dest)?;
     let gz_encoder = GzEncoder::new(f, Compression::default());
     let mut tar_encoder = Builder::new(gz_encoder);
     tar_encoder.append_dir_all(".", src)?;
     let gz_encoder = tar_encoder.into_inner()?;
     gz_encoder.finish()?;
+
+    rename(tmp_dest, dest)?;
+
     Ok(())
 }
 


### PR DESCRIPTION
Compress gzip files to a temporary file first and then do an atomic rename.

In our setup we have an indexer which does snapshoting for the instances serving the requests. Since currently the snapshoting mechanism is replacing the file in place therefore the indexer could not share the snapshot with a live instance. 

With this small patch we first create a new temporary file in the same directory as the snapshot dir and then we do an atomic rename therefore the snapshot path would always contain a valid snapshot.
After applying this change it would be enough to simply restart the serving instances to pick up the new snapshot from a shared storage without worrying them to die because of an incomplete snapshot.