### PR TITLE
Limit query words number

### DIFF
--- a/meilisearch-core/src/lib.rs
+++ b/meilisearch-core/src/lib.rs
@@ -39,6 +39,7 @@ pub use self::update::{EnqueuedUpdateResult, ProcessedUpdateResult, UpdateStatus
 pub use meilisearch_types::{DocIndex, DocumentId, Highlight};
 pub use meilisearch_schema::Schema;
 pub use query_words_mapper::QueryWordsMapper;
+pub use query_tree::MAX_QUERY_LEN;
 
 use compact_arena::SmallArena;
 use log::{error, trace};

--- a/meilisearch-core/src/query_tree.rs
+++ b/meilisearch-core/src/query_tree.rs
@@ -16,6 +16,8 @@ use crate::{store, DocumentId, DocIndex, MResult, FstSetCow};
 use crate::automaton::{build_dfa, build_prefix_dfa, build_exact_dfa};
 use crate::QueryWordsMapper;
 
+pub const MAX_QUERY_LEN: usize = 10;
+
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub enum Operation {
     And(Vec<Operation>),
@@ -181,6 +183,7 @@ fn split_query_string<'a, A: AsRef<[u8]>>(s: &str, stop_words: &'a fst::Set<A>) 
         .tokens()
         .filter(|t| t.is_word())
         .map(|t| t.word.to_string())
+        .take(MAX_QUERY_LEN)
         .enumerate()
         .collect()
 }


### PR DESCRIPTION
This pr adds a limit to the number of words taken into account in a search query. Using query string that are too long leads to huge performance hits and ressources consumtion, that occasionally crashes the machine. The limit has been hard set to 10, and tests have been added to make sure that it is taken into account.

close #941