### PR TITLE
Fix blocking search

### DIFF
--- a/meilisearch-http/src/error.rs
+++ b/meilisearch-http/src/error.rs
@@ -11,7 +11,7 @@ use meilisearch_error::{ErrorCode, Code};
 
 #[derive(Debug)]
 pub struct ResponseError {
-    inner: Box<dyn ErrorCode>,
+    inner: Box<dyn ErrorCode + Sync + Send>,
 }
 
 impl error::Error for ResponseError {}


### PR DESCRIPTION
As pointed out by #1177, the search query were processed in the main tokio loop. This pr fixes that by offloadingn this work in a tokio blocking task.

close #1177 
