### PR TITLE
Ignore existing primary key

### DIFF
--- a/meilisearch-http/src/routes/document.rs
+++ b/meilisearch-http/src/routes/document.rs
@@ -175,7 +175,6 @@ async fn update_multiple_documents(
             .ok_or(meilisearch_core::Error::SchemaMissing)?;
 
         match (params.into_inner().primary_key, schema.primary_key()) {
-            (Some(_), Some(_)) => return Err(meilisearch_schema::Error::PrimaryKeyAlreadyPresent)?,
             (Some(key), None) => document_addition.set_primary_key(key),
             (None, None) => {
                 let key = body
@@ -184,7 +183,7 @@ async fn update_multiple_documents(
                     .ok_or(meilisearch_core::Error::MissingPrimaryKey)?;
                 document_addition.set_primary_key(key);
             }
-            (None, Some(_)) => ()
+            _ => ()
         }
 
         for document in body.into_inner() {


### PR DESCRIPTION
fixing bug in #1176 made it an hard error to try to re-set the primary key on a document addition. This PR makes Meilisearch ignore a primary key passed as an argument to a document addition. This has been decided after a discussion with @curquiza, in order to make the bug fix non breaking.

Turns out it was a good catch too, since contrary to what I thought the error was not caught asynchronously, thank you @curquiza 