### PR TITLE
fix synonyms normalization

### DIFF
--- a/meilisearch-http/tests/settings.rs
+++ b/meilisearch-http/tests/settings.rs
@@ -171,6 +171,8 @@ async fn write_all_and_update() {
         "synonyms": {
             "road": ["street", "avenue"],
             "street": ["avenue"],
+            "HP": ["Harry Potter"],
+            "Harry Potter": ["HP"]
         },
         "attributesForFaceting": ["title"],
     });
@@ -208,6 +210,8 @@ async fn write_all_and_update() {
         "synonyms": {
             "road": ["street", "avenue"],
             "street": ["avenue"],
+            "hp": ["harry potter"],
+            "harry potter": ["hp"]
         },
         "attributesForFaceting": ["title"],
     });


### PR DESCRIPTION
Synonyms needs to be indexed in ascendant order,
and the new normalization step for synonyms potentially changes this order
which break the indexation process
because "Harry Potter" > "HP"  but "harry potter" < "hp"