### PR TITLE
fix Docker volume path

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ meilisearch
 #### Docker
 
 ```bash
-docker run -p 7700:7700 -v $(pwd)/data.ms:/data.ms getmeili/meilisearch
+docker run -p 7700:7700 -v "$(pwd)/data.ms:/data.ms" getmeili/meilisearch
 ```
 
 #### Try MeiliSearch in our Sandbox


### PR DESCRIPTION
essential if `$(pwd)` returns a path with spaces