### PR TITLE
Make sure that we do not use jemalloc on macos

### DIFF
--- a/meilisearch-http/Cargo.toml
+++ b/meilisearch-http/Cargo.toml
@@ -82,5 +82,5 @@ branch = "master"
 [build-dependencies]
 vergen = "3.1.0"
 
-[target.'cfg(unix)'.dependencies]
+[target.'cfg(target_os = "linux")'.dependencies]
 jemallocator = "0.3.2"


### PR DESCRIPTION
We were wrongly compiling jemalloc on macOS even though we did use it only on Linux.

Fixes #1136.