### PR TITLE
chore(ci): cache dependencies in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,23 @@ RUN     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 WORKDIR /meilisearch
 
-COPY    . .
+COPY    Cargo.lock .
+COPY    Cargo.toml .
+
+COPY    meilisearch-core/Cargo.toml meilisearch-core/
+COPY    meilisearch-error/Cargo.toml meilisearch-error/
+COPY    meilisearch-http/Cargo.toml meilisearch-http/
+COPY    meilisearch-schema/Cargo.toml meilisearch-schema/
+COPY    meilisearch-tokenizer/Cargo.toml meilisearch-tokenizer/
+COPY    meilisearch-types/Cargo.toml meilisearch-types/
 
 ENV     RUSTFLAGS="-C target-feature=-crt-static"
 
+RUN     find . -type d | xargs -I{} sh -c 'mkdir {}/src; echo "fn main() { }" > {}/src/main.rs;'
+RUN     $HOME/.cargo/bin/cargo build --release
+RUN     find . -path "*/src/main.rs" -delete
+
+COPY    . .
 RUN     $HOME/.cargo/bin/cargo build --release
 
 # Run

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,11 @@ COPY    meilisearch-types/Cargo.toml meilisearch-types/
 
 ENV     RUSTFLAGS="-C target-feature=-crt-static"
 
-RUN     find . -type d | xargs -I{} sh -c 'mkdir {}/src; echo "fn main() { }" > {}/src/main.rs;'
+# Create dummy main.rs files for each workspace member to be able to compile all the dependencies
+RUN     find . -type d -name "meilisearch-*" | xargs -I{} sh -c 'mkdir {}/src; echo "fn main() { }" > {}/src/main.rs;'
+# Use `cargo build` instead of `cargo vendor` because we need to not only download but compile dependencies too
 RUN     $HOME/.cargo/bin/cargo build --release
+# Cleanup dummy main.rs files
 RUN     find . -path "*/src/main.rs" -delete
 
 COPY    . .


### PR DESCRIPTION
Resolves https://github.com/meilisearch/MeiliSearch/issues/1317

---

1st build when no dependencies cache is present yet
```
➜ MeiliSearch (docker-deps-cache) ✔ time docker build .   
Sending build context to Docker daemon  19.76MB
Step 1/27 : FROM    alpine:3.10 AS compiler

...

Successfully built c3d6aede5ea0
docker build .  0.48s user 0.44s system 0% cpu 47:59.68 total
```

Subsequent builds
```
➜ MeiliSearch (docker-deps-cache) ✔ time docker build .
Sending build context to Docker daemon  19.76MB
Step 1/27 : FROM    alpine:3.10 AS compiler

...

Step 20/27 : RUN     $HOME/.cargo/bin/cargo build --release
 ---> Running in 60f1d353634a
   Compiling serde v1.0.119
   Compiling bitflags v1.2.1
   Compiling num-traits v0.2.14
   Compiling num-integer v0.1.44
   Compiling time v0.1.44
   Compiling meilisearch-types v0.20.0 (/meilisearch/meilisearch-types)
   Compiling meilisearch-error v0.20.0 (/meilisearch/meilisearch-error)
   Compiling meilisearch-schema v0.20.0 (/meilisearch/meilisearch-schema)
   Compiling meilisearch-core v0.20.0 (/meilisearch/meilisearch-core)
   Compiling chrono v0.4.19
   Compiling vergen v3.1.0
   Compiling meilisearch-http v0.20.0 (/meilisearch/meilisearch-http)
    Finished release [optimized + debuginfo] target(s) in 3m 56s

...

Successfully built 531ca6a33b68
docker build .  0.25s user 0.32s system 0% cpu 4:11.12 total
```