### PR TITLE
Fix web interface when using api key

### DIFF
--- a/meilisearch-http/public/interface.html
+++ b/meilisearch-http/public/interface.html
@@ -203,7 +203,6 @@
                 apiKeyContainer.appendChild(columnNode);
 
                 apiKey.addEventListener('input', function(e) {
-                    console.log("addEventListener");
                     localStorage.setItem('apiKey', apiKey.value);
                     refreshIndexList();
                 }, false);

--- a/meilisearch-http/public/interface.html
+++ b/meilisearch-http/public/interface.html
@@ -201,6 +201,16 @@
                 columnNode.classList.add('column', 'is-4');
                 columnNode.appendChild(fieldNode);
                 apiKeyContainer.appendChild(columnNode);
+
+                apiKey.addEventListener('input', function(e) {
+                    console.log("addEventListener");
+                    localStorage.setItem('apiKey', apiKey.value);
+                    refreshIndexList();
+                }, false);
+
+                if (!apiKey.value) {
+                  apiKey.value = localStorage.getItem('apiKey');
+                }
             }
         }
         
@@ -340,15 +350,6 @@
         };
         lastRequest.send(null);
     }
-
-    if (!apiKey.value) {
-        apiKey.value = localStorage.getItem('apiKey');
-    }
-
-    apiKey.addEventListener('input', function(e) {
-        localStorage.setItem('apiKey', apiKey.value);
-        refreshIndexList();
-    }, false);
 
     let baseUrl = window.location.origin;
     setApiKeyField();


### PR DESCRIPTION
closes #1339 

The `apiKey` variable in the localstorage is not updated each time the input with id `apiKey` changes as it should be [because the element gets removed](https://github.com/meilisearch/MeiliSearch/blob/94c0858c276743e8b2f4c8c97880070a198341bf/meilisearch-http/public/interface.html#L178) when it gets the response of the query in `setApiKeyField` checking whether there is an apiKey needed or not.

Since the element with id `apiKey` has been removed, [the event listener](https://github.com/meilisearch/MeiliSearch/blob/94c0858c276743e8b2f4c8c97880070a198341bf/meilisearch-http/public/interface.html#L348) is removed too and the apiKey won't be updated anymore.

Adding the eventlistener and checking for the variable in the localstorage when re-creating the input fixes this.