### PR TITLE
Fix README.md typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ For more information about features go to [our documentation](https://docs.meili
 </p>
 
 ## ✨ Features
-* Search as-you-type experience (answers < 50 milliseconds)
+* Search-as-you-type experience (answers < 50 milliseconds)
 * Full-text search
-* Typo tolerant (understands typos and miss-spelling)
+* Typo tolerant (understands typos and misspelling)
 * Faceted search and filters
-* Supports Kanji characters
-* Supports Synonym
+* Supports hanzi (Chinese characters)
+* Supports synonyms
 * Easy to install, deploy, and maintain
 * Whole documents are returned
 * Highly customizable


### PR DESCRIPTION
Just fixing some typos and such.
Kanji -> Hanzi
Kanji refers only to the Japanese versions of Chinese characters, and since we don't have a Japanese tokenization pipeline I think it could be misunderstood.