### PR TITLE
Ignore the snapshots and dumps in the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 /*.mdb
 /query-history.txt
 /data.ms
+/snapshots
+/dumps


### PR DESCRIPTION
I think we never want to push these directories, putting these in our default `.gitignore`  should improve our dev experience