### PR TITLE
fix update loop bug

### DIFF
--- a/meilisearch-http/src/index_controller/update_actor/store/mod.rs
+++ b/meilisearch-http/src/index_controller/update_actor/store/mod.rs
@@ -471,13 +471,6 @@ impl UpdateStore {
 
         txn.commit()?;
 
-        uuids_to_remove
-            .iter()
-            .map(|uuid| update_uuid_to_file_path(&self.path, *uuid))
-            .for_each(|path| {
-                let _ = remove_file(path);
-            });
-
         // If the currently processing update is from our index, we wait until it is
         // finished before returning. This ensure that no write to the index occurs after we delete it.
         if let State::Processing(uuid, _) = *self.state.read() {
@@ -486,6 +479,17 @@ impl UpdateStore {
                 self.state.write();
             }
         }
+
+        // Finally, remove any outstanding update files. This must be done after waiting for the
+        // last update to ensure that the update files are not deleted before the update needs
+        // them.
+        uuids_to_remove
+            .iter()
+            .map(|uuid| update_uuid_to_file_path(&self.path, *uuid))
+            .for_each(|path| {
+                let _ = remove_file(path);
+            });
+
 
         Ok(())
     }

--- a/meilisearch-http/src/index_controller/update_actor/store/mod.rs
+++ b/meilisearch-http/src/index_controller/update_actor/store/mod.rs
@@ -490,7 +490,6 @@ impl UpdateStore {
                 let _ = remove_file(path);
             });
 
-
         Ok(())
     }
 

--- a/meilisearch-http/tests/index/delete_index.rs
+++ b/meilisearch-http/tests/index/delete_index.rs
@@ -1,3 +1,5 @@
+use serde_json::json;
+
 use crate::common::Server;
 
 #[actix_rt::test]
@@ -22,4 +24,17 @@ async fn delete_unexisting_index() {
     let (_response, code) = index.delete().await;
 
     assert_eq!(code, 404);
+}
+
+#[actix_rt::test]
+async fn loop_delete_add_documents() {
+    let server = Server::new().await;
+    let index = server.index("test");
+    let documents = json!([{"id": 1, "field1": "hello"}]);
+    for _ in 0..50 {
+        let (response, code) = index.add_documents(documents.clone(), None).await;
+        assert_eq!(code, 202, "{}", response);
+        let (response, code) = index.delete().await;
+        assert_eq!(code, 204, "{}", response);
+    }
 }


### PR DESCRIPTION
fix #1465

When deleted an index, the update files were deleted before the currently update for the index to delete was processed. If the delete operation occured before the currently processing update occured, then it triggered a file not found error and crashed the update loop.

tested with:

```python
import json

from meilisearch import Client


def main():
    with open("small.json") as f:  # Replace this path with your path to small_movies.json
        data = json.load(f)
        client = Client("http://localhost:7700", "masterKey")
        for i in range(0, 100):
            index = client.index("test")
            index.add_documents(data)
            index.delete()
            index.add_documents(data)


if __name__ == "__main__":
    main()
```
