### PR TITLE
Sentry was never sending anything

### DIFF
--- a/meilisearch-http/src/main.rs
+++ b/meilisearch-http/src/main.rs
@@ -49,12 +49,12 @@ async fn main() -> Result<(), MainError> {
                     release: sentry::release_name!(),
                     dsn: Some(SENTRY_DSN.parse()?),
                     before_send: Some(Arc::new(|event| {
-                        event
-                            .message
-                            .as_ref()
-                            .map(|msg| msg.to_lowercase().contains("no space left on device"))
-                            .unwrap_or(false)
-                            .then(|| event)
+                        if matches!(event.message, Some(ref msg) if msg.to_lowercase().contains("no space left on device"))
+                        {
+                            None
+                        } else {
+                            Some(event)
+                        }
                     })),
                     ..Default::default()
                 });


### PR DESCRIPTION
@Kerollmops noticed that we had no log of this release in sentry, and it look like I badly tested my code after ignoring the “No space left on device” errors.

Now it should be fixed.