### PR TITLE
Import `.git` to the docker build image to fix vergen

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 target
 Dockerfile
 .dockerignore
-.git
 .gitignore

--- a/meilisearch-http/src/main.rs
+++ b/meilisearch-http/src/main.rs
@@ -108,8 +108,8 @@ pub fn print_launch_resume(opt: &Opt, data: &Data) {
         Some("") | None => env!("VERGEN_GIT_SHA"),
         Some(commit_sha) => commit_sha,
     };
-    let commit_date = match dbg!(option_env!("COMMIT_DATE")) {
-        Some("") | None => dbg!(env!("VERGEN_GIT_COMMIT_TIMESTAMP")),
+    let commit_date = match option_env!("COMMIT_DATE") {
+        Some("") | None => env!("VERGEN_GIT_COMMIT_TIMESTAMP"),
         Some(commit_date) => commit_date,
     };
 


### PR DESCRIPTION
I observed a small difference in the size of the build image, but I think we can allow it:
![image](https://user-images.githubusercontent.com/7032172/127369567-d03f9a41-3ad5-4933-888e-a3777df8c6cf.png)

I was not able to see any difference in build time, though.