### PR TITLE
Use serdeval for validating json format.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1666,7 +1666,6 @@ dependencies = [
  "num_cpus",
  "obkv",
  "once_cell",
- "oxidized-json-checker",
  "parking_lot",
  "paste",
  "pin-project",
@@ -1679,6 +1678,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_url_params",
+ "serdeval",
  "sha-1 0.9.6",
  "sha2",
  "siphasher",
@@ -1968,12 +1968,6 @@ checksum = "f100fcfb41e5385e0991f74981732049f9b896821542a219420491046baafdc2"
 dependencies = [
  "num-traits",
 ]
-
-[[package]]
-name = "oxidized-json-checker"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938464aebf563f48ab86d1cfc0e2df952985c0b814d3108f41d1b85e7f5b0dac"
 
 [[package]]
 name = "page_size"
@@ -2781,6 +2775,15 @@ dependencies = [
  "form_urlencoded",
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serdeval"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94023adfd3d548a8bd9a1f09c09f44eaab7080c7a9ab20314bb65154bee62bd0"
+dependencies = [
  "serde",
 ]
 

--- a/meilisearch-http/Cargo.toml
+++ b/meilisearch-http/Cargo.toml
@@ -55,7 +55,6 @@ milli = { git = "https://github.com/meilisearch/milli.git", tag = "v0.8.0" }
 mime = "0.3.16"
 num_cpus = "1.13.0"
 once_cell = "1.5.2"
-oxidized-json-checker = "0.3.2"
 parking_lot = "0.11.1"
 rand = "0.7.3"
 rayon = "1.5.0"
@@ -77,6 +76,7 @@ obkv = "0.2.0"
 pin-project = "1.0.7"
 whoami = { version = "1.1.2", optional = true }
 reqwest = { version = "0.11.3", features = ["json", "rustls-tls"], default-features = false, optional = true }
+serdeval = "0.1.0"
 
 [dependencies.sentry]
 default-features = false


### PR DESCRIPTION
uses [serdeval](https://github.com/MarinPostma/serdeval) to validate that the json payload is valid json, and in the correct format.

fix #1535
