### PR TITLE
Update telemetry link

### DIFF
--- a/meilisearch-http/src/main.rs
+++ b/meilisearch-http/src/main.rs
@@ -145,7 +145,7 @@ pub fn print_launch_resume(opt: &Opt, data: &Data) {
                 "
 Thank you for using MeiliSearch!
 
-We collect anonymized analytics to improve our product and your experience. To learn more, including how to turn off analytics, visit our dedicated documentation page: https://docs.meilisearch.com/reference/features/configuration.html#disable-analytics
+We collect anonymized analytics to improve our product and your experience. To learn more, including how to turn off analytics, visit our dedicated documentation page: https://docs.meilisearch.com/learn/what_is_meilisearch/telemetry.html
 
 Anonymous telemetry:   \"Enabled\""
             );


### PR DESCRIPTION
Here is the page the user will have: https://dev.docs.meilisearch.com/learn/what_is_meilisearch/telemetry.html
instead of: https://docs.meilisearch.com/reference/features/configuration.html#disable-analytics