### PR TITLE
Hotfix: Log but don't panic when vergen can't retrieve commit information

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1617,14 +1617,14 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "meilisearch-error"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "actix-http",
 ]
 
 [[package]]
 name = "meilisearch-http"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "actix-cors",
  "actix-http",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3388,9 +3388,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vergen"
-version = "5.1.13"
+version = "5.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "542f37b4798c879409865dde7908e746d836f77839c3a6bea5c8b4e4dcf6620b"
+checksum = "265455aab08c55a1ab13f07c8d5e25c7d46900f4484dd7cbd682e77171f93f3c"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",

--- a/meilisearch-error/Cargo.toml
+++ b/meilisearch-error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "meilisearch-error"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["marin <postma.marin@protonmail.com>"]
 edition = "2018"
 

--- a/meilisearch-http/Cargo.toml
+++ b/meilisearch-http/Cargo.toml
@@ -4,7 +4,7 @@ description = "MeiliSearch HTTP server"
 edition = "2018"
 license = "MIT"
 name = "meilisearch-http"
-version = "0.21.0"
+version = "0.21.1"
 
 [[bin]]
 name = "meilisearch"

--- a/meilisearch-http/Cargo.toml
+++ b/meilisearch-http/Cargo.toml
@@ -18,7 +18,7 @@ hex = { version = "0.4.3", optional = true }
 reqwest = { version = "0.11.3", features = ["blocking", "rustls-tls"], default-features = false, optional = true }
 sha-1 = { version = "0.9.4", optional = true }
 tempfile = { version = "3.1.0", optional = true }
-vergen = { version = "5.1.13", default-features = false, features = ["build", "git"] }
+vergen = { version = "5.1.15", default-features = false, features = ["git"] }
 zip = { version = "0.5.12", optional = true }
 
 [dependencies]

--- a/meilisearch-http/build.rs
+++ b/meilisearch-http/build.rs
@@ -1,7 +1,9 @@
 use vergen::{vergen, Config};
 
 fn main() {
-    vergen(Config::default()).unwrap();
+    if let Err(e) = vergen(Config::default()) {
+        println!("cargo:warning=vergen: {}", e);
+    }
 
     #[cfg(feature = "mini-dashboard")]
     mini_dashboard::setup_mini_dashboard().expect("Could not load the mini-dashboard assets");

--- a/meilisearch-http/src/main.rs
+++ b/meilisearch-http/src/main.rs
@@ -104,14 +104,8 @@ async fn run_http(data: Data, opt: Opt) -> Result<(), Box<dyn std::error::Error>
 }
 
 pub fn print_launch_resume(opt: &Opt, data: &Data) {
-    let commit_sha = match option_env!("COMMIT_SHA") {
-        Some("") | None => env!("VERGEN_GIT_SHA"),
-        Some(commit_sha) => commit_sha,
-    };
-    let commit_date = match option_env!("COMMIT_DATE") {
-        Some("") | None => env!("VERGEN_GIT_COMMIT_TIMESTAMP"),
-        Some(commit_date) => commit_date,
-    };
+    let commit_sha = option_env!("VERGEN_GIT_SHA").unwrap_or("unknown");
+    let commit_date = option_env!("VERGEN_GIT_COMMIT_TIMESTAMP").unwrap_or("unknown");
 
     let ascii_name = r#"
 888b     d888          d8b 888 d8b  .d8888b.                                    888

--- a/meilisearch-http/src/routes/mod.rs
+++ b/meilisearch-http/src/routes/mod.rs
@@ -245,14 +245,8 @@ struct VersionResponse {
 }
 
 async fn get_version(_data: GuardedData<Private, Data>) -> HttpResponse {
-    let commit_sha = match option_env!("COMMIT_SHA") {
-        Some("") | None => env!("VERGEN_GIT_SHA"),
-        Some(commit_sha) => commit_sha,
-    };
-    let commit_date = match option_env!("COMMIT_DATE") {
-        Some("") | None => env!("VERGEN_GIT_COMMIT_TIMESTAMP"),
-        Some(commit_date) => commit_date,
-    };
+    let commit_sha = option_env!("VERGEN_GIT_SHA").unwrap_or("unknown");
+    let commit_date = option_env!("VERGEN_GIT_COMMIT_TIMESTAMP").unwrap_or("unknown");
 
     HttpResponse::Ok().json(VersionResponse {
         commit_sha: commit_sha.to_string(),


### PR DESCRIPTION
This pull request fixes an issue we discovered when we tried to publish meilisearch v0.21 on brew, brew uses the tarball downloaded from github directly which doesn't contain the `.git` folder.

We use the `.git` folder with [vergen](https://docs.rs/vergen) to retrieve the commit and datetime information. Unfortunately, we were unwrapping the vergen result and it was crashing when the git folder was missing.

We no more panic when vergen can't find the `.git` folder and just log out a potential error returned by [the git2 library](https://docs.rs/git2). We then just check that the env variables are available at compile-time and replace it with "unknown" if not.

### When the `.git` folder is available

```
xh localhost:7700/version
HTTP/1.1 200 OK
Content-Type: application/json
Date: Thu, 26 Aug 2021 13:44:23 GMT
Transfer-Encoding: chunked

{
    "commitSha": "81a76eab69944de8a8d5006345b5aec7b02acf50",
    "commitDate": "2021-08-26T13:41:30+00:00",
    "pkgVersion": "0.21.0"
}
```

### When the `.git` folder is unavailable

```bash
cp -R meilisearch meilisearch-cpy
cd meilisearch-cpy
rm -rf .git
cargo clean
cargo run --release
   <snip>
   Compiling meilisearch-http v0.21.0 (/Users/clementrenault/Documents/meilisearch-cpy/meilisearch-http)
warning: vergen: could not find repository from '/Users/clementrenault/Documents/meilisearch-cpy/meilisearch-http'; class=Repository (6); code=NotFound (-3)
```

```
xh localhost:7700/version
HTTP/1.1 200 OK
Content-Type: application/json
Date: Thu, 26 Aug 2021 13:46:33 GMT
Transfer-Encoding: chunked

{
    "commitSha": "unknown",
    "commitDate": "unknown",
    "pkgVersion": "0.21.0"
}
```