### PR TITLE
Remove unused Arc import

### DIFF
--- a/meilisearch-http/src/main.rs
+++ b/meilisearch-http/src/main.rs
@@ -7,8 +7,6 @@ use structopt::StructOpt;
 
 #[cfg(all(not(debug_assertions), feature = "analytics"))]
 use meilisearch_http::analytics;
-#[cfg(all(not(debug_assertions), feature = "analytics"))]
-use std::sync::Arc;
 
 #[cfg(target_os = "linux")]
 #[global_allocator]


### PR DESCRIPTION
This PR removes a warning introduced by #1606 which removed Sentry that was using an `Arc` but forgot to remove the scope import, we remove it here.