### PR TITLE
Remove COMMIT_SHA and COMMIT_DATE build arg from the Docker CIs

### DIFF
--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -26,7 +26,7 @@ jobs:
     - uses: hecrj/setup-rust-action@master
       with:
         rust-version: stable
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Build
       run: cargo build --release --locked
     - name: Upload binaries to release
@@ -41,7 +41,7 @@ jobs:
     name: Publish for ARMv8
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v1.0.0
+      - uses: actions/checkout@v2
       - uses: uraimo/run-on-arch-action@v1.0.7
         id: runcmd
         with:

--- a/.github/workflows/publish-deb-brew-pkg.yml
+++ b/.github/workflows/publish-deb-brew-pkg.yml
@@ -14,7 +14,7 @@ jobs:
         rust-version: stable
     - name: Install cargo-deb
       run: cargo install cargo-deb
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Build deb package
       run: cargo deb -p meilisearch-http -o target/debian/meilisearch.deb
     - name: Upload debian pkg to release

--- a/.github/workflows/publish-docker-latest.yml
+++ b/.github/workflows/publish-docker-latest.yml
@@ -13,9 +13,6 @@ jobs:
       - name: Check if current release is latest
         run: echo "##[set-output name=is_latest;]$(sh .github/is-latest-release.sh)"
         id: release
-      - name: Set COMMIT_DATE env variable
-        run: |
-          echo "COMMIT_DATE=$( git log --pretty=format:'%ad' -n1 --date=short )" >> $GITHUB_ENV
       - name: Publish to Registry
         if: steps.release.outputs.is_latest == 'true'
         uses: elgohr/Publish-Docker-Github-Action@master
@@ -23,4 +20,3 @@ jobs:
           name: getmeili/meilisearch
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          buildargs: COMMIT_SHA,COMMIT_DATE

--- a/.github/workflows/publish-docker-tag.yml
+++ b/.github/workflows/publish-docker-tag.yml
@@ -10,10 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v1
-      - name: Set COMMIT_DATE env variable
-        run: |
-          echo "COMMIT_DATE=$( git log --pretty=format:'%ad' -n1 --date=short )" >> $GITHUB_ENV
+      - uses: actions/checkout@v2
       - name: Publish to Registry
         uses: elgohr/Publish-Docker-Github-Action@master
         env:
@@ -23,4 +20,3 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           tag_names: true
-          buildargs: COMMIT_SHA,COMMIT_DATE


### PR DESCRIPTION
Since @irevoire add the `.git` folder in the Dockerfile, no need to compute `COMMIT_SHA` and `COMMIT_DATE` in the CI.
Can you confirm @irevoire?

Also, update some CIs using `checkout@v1` to `checkout@v2`