### PR TITLE
Use tikv-jemallocator instead of jemallocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1351,27 +1351,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
-name = "jemalloc-sys"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45"
-dependencies = [
- "cc",
- "fs_extra",
- "libc",
-]
-
-[[package]]
-name = "jemallocator"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69"
-dependencies = [
- "jemalloc-sys",
- "libc",
-]
-
-[[package]]
 name = "jieba-rs"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1583,7 +1562,6 @@ dependencies = [
  "http",
  "indexmap",
  "itertools",
- "jemallocator",
  "log",
  "main_error",
  "meilisearch-error",
@@ -1617,6 +1595,7 @@ dependencies = [
  "tempdir",
  "tempfile",
  "thiserror",
+ "tikv-jemallocator",
  "tokio",
  "urlencoding",
  "uuid",
@@ -2851,6 +2830,27 @@ dependencies = [
  "proc-macro2 1.0.29",
  "quote 1.0.9",
  "syn 1.0.76",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.4.2+5.2.1-patched.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5844e429d797c62945a566f8da4e24c7fe3fbd5d6617fd8bf7a0b7dc1ee0f22e"
+dependencies = [
+ "cc",
+ "fs_extra",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c14a5a604eb8715bc5785018a37d00739b180bcf609916ddf4393d33d49ccdf"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/meilisearch-http/Cargo.toml
+++ b/meilisearch-http/Cargo.toml
@@ -100,7 +100,7 @@ analytics = ["whoami", "reqwest"]
 default = ["analytics", "mini-dashboard"]
 
 [target.'cfg(target_os = "linux")'.dependencies]
-jemallocator = "0.3.2"
+tikv-jemallocator = "0.4.1"
 
 [package.metadata.mini-dashboard]
 assets-url = "https://github.com/meilisearch/mini-dashboard/releases/download/v0.1.4/build.zip"

--- a/meilisearch-http/src/main.rs
+++ b/meilisearch-http/src/main.rs
@@ -10,7 +10,7 @@ use meilisearch_http::analytics;
 
 #[cfg(target_os = "linux")]
 #[global_allocator]
-static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 #[actix_web::main]
 async fn main() -> Result<(), MainError> {


### PR DESCRIPTION
`jemallocator` has been abandoned for nearly two years, and `rustc`
itself moved to use `tikv-jemallocator` instead:
https://github.com/rust-lang/rust/commit/3965773ae7743e051070b4eed3c6e02e9df3b25c

Let's switch to a better maintained version.