### PR TITLE
Make exec binary for M1 mac available for download

### DIFF
--- a/download-latest.sh
+++ b/download-latest.sh
@@ -140,10 +140,10 @@ get_os() {
 get_archi() {
     architecture=$(uname -m)
     case "$architecture" in
-    'x86_64' | 'amd64')
+    'x86_64' | 'amd64' | 'arm64')
         archi='amd64'
         ;;
-    'aarch64' | 'arm64')
+    'aarch64')
         archi='armv8'
         ;;
     *)

--- a/download-latest.sh
+++ b/download-latest.sh
@@ -140,7 +140,7 @@ get_os() {
 get_archi() {
     architecture=$(uname -m)
     case "$architecture" in
-    'x86_64' | 'amd64')
+    'x86_64' | 'amd64' | 'arm64')
         archi='amd64'
         ;;
     'aarch64')
@@ -188,7 +188,7 @@ case "$os" in
 		BINARY_NAME='meilisearch.exe'
 
         ;;
-	*) 
+	*)
 		release_file="meilisearch-$os-$archi"
 		BINARY_NAME='meilisearch'
 

--- a/download-latest.sh
+++ b/download-latest.sh
@@ -140,7 +140,7 @@ get_os() {
 get_archi() {
     architecture=$(uname -m)
     case "$architecture" in
-    'x86_64' | 'amd64' | 'arm64')
+    'x86_64' | 'amd64')
         archi='amd64'
         ;;
     'aarch64' | 'arm64')

--- a/download-latest.sh
+++ b/download-latest.sh
@@ -143,7 +143,7 @@ get_archi() {
     'x86_64' | 'amd64' | 'arm64')
         archi='amd64'
         ;;
-    'aarch64')
+    'aarch64' | 'arm64')
         archi='armv8'
         ;;
     *)


### PR DESCRIPTION
## Why

fix: https://github.com/meilisearch/MeiliSearch/issues/1661

Now, Do not supported getting exec file for m1 mac on using`download-latest.sh`.


## What

Download x86 binary when run `download-latest.sh` on m1 mac, because it can execute binary targeting x86.

## Proof

I verified like this.
I got executable binary on M1 mac 💡 

```sh
:) % arch
arm64

:) % ./download-latest.sh
Downloading MeiliSearch binary v0.21.1 for macos, architecture amd64...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   631  100   631    0     0   2035      0 --:--:-- --:--:-- --:--:--  2035
100 43.5M  100 43.5M    0     0  7826k      0  0:00:05  0:00:05 --:--:-- 9123k
MeiliSearch binary successfully downloaded as 'meilisearch' file.

Run it:
    $ ./meilisearch
Usage:
    $ ./meilisearch --help

:) % file ./meilisearch
./meilisearch: Mach-O 64-bit executable x86_64

:) % ./meilisearch --help # this is execuable
meilisearch-http 0.21.1
...
...
```