### PR TITLE
Trigger CodeCoverage manually instead of on each PR

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,7 +1,6 @@
 ---
 on:
-  pull_request:
-    types: [review_requested, ready_for_review]
+  workflow_dispatch:
 
 name: Execute code coverage
 


### PR DESCRIPTION
Since no one is using it now on the PRs, we would rather get a state of the code coverage once (triggered manually) rather than on each PR.