### PR TITLE
Fix add document Content-Type

### DIFF
--- a/meilisearch-http/src/routes/indexes/documents.rs
+++ b/meilisearch-http/src/routes/indexes/documents.rs
@@ -33,9 +33,9 @@ macro_rules! guard_content_type {
     };
 }
 
+guard_content_type!(guard_ndjson, "application/x-ndjson");
+guard_content_type!(guard_csv, "text/csv");
 guard_content_type!(guard_json, "application/json");
-guard_content_type!(guard_csv, "application/csv");
-guard_content_type!(guard_ndjson, "application/ndjson");
 
 fn empty_application_type(head: &actix_web::dev::RequestHead) -> bool {
     head.headers.get("Content-Type").is_none()


### PR DESCRIPTION
change the `Content-Type` guards of the document addition routes to match the specification.
