### PR TITLE
Add new error types for document additions

### DIFF
--- a/meilisearch-error/src/lib.rs
+++ b/meilisearch-error/src/lib.rs
@@ -84,6 +84,7 @@ pub enum Code {
     DumpAlreadyInProgress,
     DumpProcessFailed,
 
+    InvalidContentType,
     MissingContentType,
     MalformedPayload,
 }
@@ -158,7 +159,8 @@ impl Code {
                 ErrCode::internal("dump_process_failed", StatusCode::INTERNAL_SERVER_ERROR)
             }
             MissingContentType => ErrCode::invalid("missing_content_type", StatusCode::UNSUPPORTED_MEDIA_TYPE),
-            MalformedPayload => ErrCode::invalid("malformed_payload", StatusCode::BAD_REQUEST)
+            MalformedPayload => ErrCode::invalid("malformed_payload", StatusCode::BAD_REQUEST),
+            InvalidContentType => ErrCode::invalid("invalid_content_type", StatusCode::UNSUPPORTED_MEDIA_TYPE),
         }
     }
 

--- a/meilisearch-error/src/lib.rs
+++ b/meilisearch-error/src/lib.rs
@@ -85,6 +85,7 @@ pub enum Code {
     DumpProcessFailed,
 
     MissingContentType,
+    MalformedPayload,
 }
 
 impl Code {
@@ -157,6 +158,7 @@ impl Code {
                 ErrCode::internal("dump_process_failed", StatusCode::INTERNAL_SERVER_ERROR)
             }
             MissingContentType => ErrCode::invalid("missing_content_type", StatusCode::UNSUPPORTED_MEDIA_TYPE),
+            MalformedPayload => ErrCode::invalid("malformed_payload", StatusCode::BAD_REQUEST)
         }
     }
 

--- a/meilisearch-error/src/lib.rs
+++ b/meilisearch-error/src/lib.rs
@@ -87,6 +87,7 @@ pub enum Code {
     InvalidContentType,
     MissingContentType,
     MalformedPayload,
+    MissingPayload,
 }
 
 impl Code {
@@ -158,9 +159,14 @@ impl Code {
             DumpProcessFailed => {
                 ErrCode::internal("dump_process_failed", StatusCode::INTERNAL_SERVER_ERROR)
             }
-            MissingContentType => ErrCode::invalid("missing_content_type", StatusCode::UNSUPPORTED_MEDIA_TYPE),
+            MissingContentType => {
+                ErrCode::invalid("missing_content_type", StatusCode::UNSUPPORTED_MEDIA_TYPE)
+            }
             MalformedPayload => ErrCode::invalid("malformed_payload", StatusCode::BAD_REQUEST),
-            InvalidContentType => ErrCode::invalid("invalid_content_type", StatusCode::UNSUPPORTED_MEDIA_TYPE),
+            InvalidContentType => {
+                ErrCode::invalid("invalid_content_type", StatusCode::UNSUPPORTED_MEDIA_TYPE)
+            }
+            MissingPayload => ErrCode::invalid("missing_payload", StatusCode::BAD_REQUEST),
         }
     }
 

--- a/meilisearch-error/src/lib.rs
+++ b/meilisearch-error/src/lib.rs
@@ -83,6 +83,8 @@ pub enum Code {
 
     DumpAlreadyInProgress,
     DumpProcessFailed,
+
+    MissingContentType,
 }
 
 impl Code {
@@ -154,6 +156,7 @@ impl Code {
             DumpProcessFailed => {
                 ErrCode::internal("dump_process_failed", StatusCode::INTERNAL_SERVER_ERROR)
             }
+            MissingContentType => ErrCode::invalid("missing_content_type", StatusCode::UNSUPPORTED_MEDIA_TYPE),
         }
     }
 

--- a/meilisearch-http/src/error.rs
+++ b/meilisearch-http/src/error.rs
@@ -9,6 +9,20 @@ use aweb::error::{JsonPayloadError, QueryPayloadError};
 use meilisearch_error::{Code, ErrorCode};
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug, thiserror::Error)]
+pub enum MeilisearchHttpError {
+    #[error("A Content-Type header is missing. Accepted values for the Content-Type header are: \"application/json\", \"application/x-ndjson\", \"test/csv\"")]
+    MissingContentType,
+}
+
+impl ErrorCode for MeilisearchHttpError {
+    fn error_code(&self) -> Code {
+        match self {
+            MeilisearchHttpError::MissingContentType => Code::MissingContentType,
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ResponseError {

--- a/meilisearch-http/src/error.rs
+++ b/meilisearch-http/src/error.rs
@@ -11,9 +11,9 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, thiserror::Error)]
 pub enum MeilisearchHttpError {
-    #[error("A Content-Type header is missing. Accepted values for the Content-Type header are: \"application/json\", \"application/x-ndjson\", \"test/csv\"")]
+    #[error("A Content-Type header is missing. Accepted values for the Content-Type header are: \"application/json\", \"application/x-ndjson\", \"text/csv\"")]
     MissingContentType,
-    #[error("The Content-Type \"{0}\" is invalid. Accepted values for the Content-Type header are: \"application/json\", \"application/x-ndjson\", \"test/csv\"")]
+    #[error("The Content-Type \"{0}\" is invalid. Accepted values for the Content-Type header are: \"application/json\", \"application/x-ndjson\", \"text/csv\"")]
     InvalidContentType(String),
 }
 

--- a/meilisearch-http/src/error.rs
+++ b/meilisearch-http/src/error.rs
@@ -13,12 +13,15 @@ use serde::{Deserialize, Serialize};
 pub enum MeilisearchHttpError {
     #[error("A Content-Type header is missing. Accepted values for the Content-Type header are: \"application/json\", \"application/x-ndjson\", \"test/csv\"")]
     MissingContentType,
+    #[error("The Content-Type \"{0}\" is invalid. Accepted values for the Content-Type header are: \"application/json\", \"application/x-ndjson\", \"test/csv\"")]
+    InvalidContentType(String),
 }
 
 impl ErrorCode for MeilisearchHttpError {
     fn error_code(&self) -> Code {
         match self {
             MeilisearchHttpError::MissingContentType => Code::MissingContentType,
+            MeilisearchHttpError::InvalidContentType(_) => Code::InvalidContentType,
         }
     }
 }

--- a/meilisearch-http/src/routes/indexes/documents.rs
+++ b/meilisearch-http/src/routes/indexes/documents.rs
@@ -10,7 +10,7 @@ use serde::Deserialize;
 use serde_json::Value;
 use tokio::sync::mpsc;
 
-use crate::error::ResponseError;
+use crate::error::{MeilisearchHttpError, ResponseError};
 use crate::extractors::authentication::{policies::*, GuardedData};
 use crate::extractors::payload::Payload;
 use crate::routes::IndexParam;
@@ -66,7 +66,7 @@ pub fn configure(cfg: &mut web::ServiceConfig) {
             .route(
                 web::post()
                     .guard(empty_application_type)
-                    .to(HttpResponse::UnsupportedMediaType),
+                    .to(missing_content_type_error),
             )
             .route(web::post().guard(guard_json).to(add_documents_json))
             .route(web::post().guard(guard_ndjson).to(add_documents_ndjson))
@@ -76,7 +76,7 @@ pub fn configure(cfg: &mut web::ServiceConfig) {
             .route(
                 web::put()
                     .guard(empty_application_type)
-                    .to(HttpResponse::UnsupportedMediaType),
+                    .to(missing_content_type_error),
             )
             .route(web::put().guard(guard_json).to(update_documents_json))
             .route(web::put().guard(guard_ndjson).to(update_documents_ndjson))
@@ -91,6 +91,10 @@ pub fn configure(cfg: &mut web::ServiceConfig) {
             .route(web::get().to(get_document))
             .route(web::delete().to(delete_document)),
     );
+}
+
+async fn missing_content_type_error() -> Result<HttpResponse, ResponseError> {
+    Err(MeilisearchHttpError::MissingContentType.into())
 }
 
 pub async fn get_document(

--- a/meilisearch-http/src/routes/indexes/documents.rs
+++ b/meilisearch-http/src/routes/indexes/documents.rs
@@ -133,13 +133,16 @@ pub async fn add_documents(
 ) -> Result<HttpResponse, ResponseError> {
     debug!("called with params: {:?}", params);
     document_addition(
-        req.headers().get("Content-type").map(|s| s.to_str().unwrap_or("unkown")),
+        req.headers()
+            .get("Content-type")
+            .map(|s| s.to_str().unwrap_or("unkown")),
         meilisearch,
         path.into_inner().index_uid,
         params.into_inner().primary_key,
         body,
-        IndexDocumentsMethod::ReplaceDocuments)
-        .await
+        IndexDocumentsMethod::ReplaceDocuments,
+    )
+    .await
 }
 
 pub async fn update_documents(
@@ -151,13 +154,16 @@ pub async fn update_documents(
 ) -> Result<HttpResponse, ResponseError> {
     debug!("called with params: {:?}", params);
     document_addition(
-        req.headers().get("Content-type").map(|s| s.to_str().unwrap_or("unkown")),
+        req.headers()
+            .get("Content-type")
+            .map(|s| s.to_str().unwrap_or("unkown")),
         meilisearch,
         path.into_inner().index_uid,
         params.into_inner().primary_key,
         body,
-        IndexDocumentsMethod::UpdateDocuments)
-        .await
+        IndexDocumentsMethod::UpdateDocuments,
+    )
+    .await
 }
 
 /// Route used when the payload type is "application/json"
@@ -174,7 +180,9 @@ async fn document_addition(
         Some("application/json") => DocumentAdditionFormat::Json,
         Some("application/x-ndjson") => DocumentAdditionFormat::Ndjson,
         Some("text/csv") => DocumentAdditionFormat::Csv,
-        Some(other) => return Err(MeilisearchHttpError::InvalidContentType(other.to_string()).into()),
+        Some(other) => {
+            return Err(MeilisearchHttpError::InvalidContentType(other.to_string()).into())
+        }
         None => return Err(MeilisearchHttpError::MissingContentType.into()),
     };
 
@@ -185,9 +193,7 @@ async fn document_addition(
         format,
     };
 
-    let update_status = meilisearch
-        .register_update(index_uid, update, true)
-        .await?;
+    let update_status = meilisearch.register_update(index_uid, update, true).await?;
 
     debug!("returns: {:?}", update_status);
     Ok(HttpResponse::Accepted().json(serde_json::json!({ "updateId": update_status.id() })))

--- a/meilisearch-http/src/routes/mod.rs
+++ b/meilisearch-http/src/routes/mod.rs
@@ -361,10 +361,8 @@ mod test {
 
             indexes::documents::clear_all_documents,
             indexes::documents::delete_documents,
-            indexes::documents::update_documents_json,
-            indexes::documents::update_documents_csv,
-            indexes::documents::add_documents_json,
-            indexes::documents::add_documents_csv,
+            indexes::documents::update_documents,
+            indexes::documents::add_documents,
             indexes::documents::delete_document,
 
             indexes::updates::get_all_updates_status,

--- a/meilisearch-lib/src/document_formats.rs
+++ b/meilisearch-lib/src/document_formats.rs
@@ -2,6 +2,7 @@ use std::fmt;
 use std::io::{self, Read, Result as IoResult, Seek, Write};
 
 use csv::{Reader as CsvReader, StringRecordsIntoIter};
+use meilisearch_error::{Code, ErrorCode};
 use milli::documents::DocumentBatchBuilder;
 use serde_json::{Deserializer, Map, Value};
 
@@ -33,6 +34,15 @@ pub enum DocumentFormatError {
         Box<dyn std::error::Error + Send + Sync + 'static>,
         PayloadType,
     ),
+}
+
+impl ErrorCode for DocumentFormatError {
+    fn error_code(&self) -> Code {
+        match self {
+            DocumentFormatError::Internal(_) => Code::Internal,
+            DocumentFormatError::MalformedPayload(_, _) => Code::MalformedPayload,
+        }
+    }
 }
 
 internal_error!(DocumentFormatError: milli::documents::Error, io::Error);

--- a/meilisearch-lib/src/index_controller/mod.rs
+++ b/meilisearch-lib/src/index_controller/mod.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::fmt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
@@ -73,6 +74,16 @@ pub enum DocumentAdditionFormat {
     Json,
     Csv,
     Ndjson,
+}
+
+impl fmt::Display for DocumentAdditionFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DocumentAdditionFormat::Json => write!(f, "json"),
+            DocumentAdditionFormat::Ndjson => write!(f, "ndjson"),
+            DocumentAdditionFormat::Csv => write!(f, "csv"),
+        }
+    }
 }
 
 #[derive(Serialize, Debug)]

--- a/meilisearch-lib/src/index_controller/updates/error.rs
+++ b/meilisearch-lib/src/index_controller/updates/error.rs
@@ -5,7 +5,7 @@ use meilisearch_error::{Code, ErrorCode};
 
 use crate::{
     document_formats::DocumentFormatError,
-    index_controller::update_file_store::UpdateFileStoreError,
+    index_controller::{update_file_store::UpdateFileStoreError, DocumentAdditionFormat},
 };
 
 pub type Result<T> = std::result::Result<T, UpdateLoopError>;
@@ -26,6 +26,8 @@ pub enum UpdateLoopError {
     // TODO: The reference to actix has to go.
     #[error("{0}")]
     PayloadError(#[from] actix_web::error::PayloadError),
+    #[error("A {0} payload is missing.")]
+    MissingPayload(DocumentAdditionFormat),
 }
 
 impl<T> From<tokio::sync::mpsc::error::SendError<T>> for UpdateLoopError
@@ -63,6 +65,7 @@ impl ErrorCode for UpdateLoopError {
                 actix_web::error::PayloadError::Overflow => Code::PayloadTooLarge,
                 _ => Code::Internal,
             },
+            Self::MissingPayload(_) => Code::MissingPayload,
         }
     }
 }

--- a/meilisearch-lib/src/index_controller/updates/error.rs
+++ b/meilisearch-lib/src/index_controller/updates/error.rs
@@ -22,9 +22,7 @@ pub enum UpdateLoopError {
     )]
     FatalUpdateStoreError,
     #[error("{0}")]
-    InvalidPayload(#[from] DocumentFormatError),
-    #[error("{0}")]
-    MalformedPayload(Box<dyn Error + Send + Sync + 'static>),
+    DocumentFormatError(#[from] DocumentFormatError),
     // TODO: The reference to actix has to go.
     #[error("{0}")]
     PayloadError(#[from] actix_web::error::PayloadError),
@@ -60,8 +58,7 @@ impl ErrorCode for UpdateLoopError {
             Self::Internal(_) => Code::Internal,
             //Self::IndexActor(e) => e.error_code(),
             Self::FatalUpdateStoreError => Code::Internal,
-            Self::InvalidPayload(_) => Code::BadRequest,
-            Self::MalformedPayload(_) => Code::BadRequest,
+            Self::DocumentFormatError(error) => error.error_code(),
             Self::PayloadError(error) => match error {
                 actix_web::error::PayloadError::Overflow => Code::PayloadTooLarge,
                 _ => Code::Internal,


### PR DESCRIPTION
Adds the missing errors for the documents routes, as specified.

close #1691
close #1690
