### PR TITLE
Add a link to join the cloud-hosted beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ meilisearch
 docker run -p 7700:7700 -v "$(pwd)/data.ms:/data.ms" getmeili/meilisearch
 ```
 
+#### Announcing a cloud-hosted MeiliSearch
+
+Join the closed beta by filling out this [form](https://meilisearch.typeform.com/to/FtnzvZfh).
+
 #### Try MeiliSearch in our Sandbox
 
 Create a MeiliSearch instance in [MeiliSearch Sandbox](https://sandbox.meilisearch.com/). This instance is free, and will be active for 48 hours.


### PR DESCRIPTION
The product team would like to add a link to communicate and invite users to fill out the form to test the closed beta of our cloud solution.

We have done the same thing on the documentation side https://github.com/meilisearch/documentation/pull/1148. 😇