### PR TITLE
Bump Milli to improve geosearch errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1757,8 +1757,8 @@ dependencies = [
 
 [[package]]
 name = "milli"
-version = "0.17.0"
-source = "git+https://github.com/meilisearch/milli.git?tag=v0.17.0#22551d0941bee1a9cdcf7d5bfc4ca46517dd25f3"
+version = "0.17.1"
+source = "git+https://github.com/meilisearch/milli.git?tag=v0.17.1#31c18f095396d45e67ace32038dda7d0fbc9a4e4"
 dependencies = [
  "bimap",
  "bincode",

--- a/meilisearch-lib/Cargo.toml
+++ b/meilisearch-lib/Cargo.toml
@@ -31,7 +31,7 @@ log = "0.4.14"
 meilisearch-error = { path = "../meilisearch-error" }
 meilisearch-tokenizer = { git = "https://github.com/meilisearch/tokenizer.git", tag = "v0.2.5" }
 memmap = "0.7.0"
-milli = { git = "https://github.com/meilisearch/milli.git", tag = "v0.17.0"}
+milli = { git = "https://github.com/meilisearch/milli.git", tag = "v0.17.1"}
 mime = "0.3.16"
 num_cpus = "1.13.0"
 once_cell = "1.8.0"


### PR DESCRIPTION
closes #1734 

@curquiza, your two examples still don't work because a filter must be composed of multiples operations; look at my screenshot to see what works and what doesn't.
Is this ok? :thinking: 

@gmourier,
What do you think?

![image](https://user-images.githubusercontent.com/7032172/135846911-588f652d-16db-4d88-89fd-148640bac0f7.png)


And here is a screenshot with all the new errors that have been implemented

![image](https://user-images.githubusercontent.com/7032172/135854851-da469fef-0dd0-4ff1-b15e-89934ed8fb6f.png)