### PR TITLE
Optimize build size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,5 @@ members = [
 ]
 resolver = "2"
 
-[build]
-rustflags = "-C link-args=-s"
-
 [patch.crates-io]
 pest = { git = "https://github.com/pest-parser/pest.git", rev = "51fd1d49f1041f7839975664ef71fe15c7dcaf67" }


### PR DESCRIPTION
Remove debug symbols from the release build, and strip the binaries.

We used to need to debug symbols for sentry, but since it was removed with #1616, we don't need them anymore.

Shrinks the binary size from ~300MB to ~50MB on linux.