### PR TITLE
Fix csv content-type error message

### DIFF
--- a/meilisearch-http/src/routes/indexes/documents.rs
+++ b/meilisearch-http/src/routes/indexes/documents.rs
@@ -181,7 +181,7 @@ async fn document_addition(
         vec![
             "application/json".to_string(),
             "application/x-ndjson".to_string(),
-            "application/csv".to_string(),
+            "text/csv".to_string(),
         ]
     });
     let format = match content_type {

--- a/meilisearch-http/tests/documents/add_documents.rs
+++ b/meilisearch-http/tests/documents/add_documents.rs
@@ -124,7 +124,7 @@ async fn add_documents_test_bad_content_types() {
     assert_eq!(
         response["message"],
         json!(
-            r#"The Content-Type "text/plain" is invalid. Accepted values for the Content-Type header are: "application/json", "application/x-ndjson", "application/csv""#
+            r#"The Content-Type "text/plain" is invalid. Accepted values for the Content-Type header are: "application/json", "application/x-ndjson", "text/csv""#
         )
     );
 
@@ -142,7 +142,7 @@ async fn add_documents_test_bad_content_types() {
     assert_eq!(
         response["message"],
         json!(
-            r#"The Content-Type "text/plain" is invalid. Accepted values for the Content-Type header are: "application/json", "application/x-ndjson", "application/csv""#
+            r#"The Content-Type "text/plain" is invalid. Accepted values for the Content-Type header are: "application/json", "application/x-ndjson", "text/csv""#
         )
     );
 }


### PR DESCRIPTION
Fixes #1805

I was not sure if the `application/csv` [here](https://github.com/meilisearch/MeiliSearch/blob/23f11e355d300a572030117ed7860ffbcf2d027c/meilisearch-http/tests/content_type.rs#L29) should also be changed? I'm thinking yes, but `applicaiton/csv` is a bad type.