### PR TITLE
Integrate the new `milli` release as `MeiliSearch` dependency

### DIFF
--- a/meilisearch-lib/Cargo.toml
+++ b/meilisearch-lib/Cargo.toml
@@ -30,7 +30,7 @@ lazy_static = "1.4.0"
 log = "0.4.14"
 meilisearch-error = { path = "../meilisearch-error" }
 meilisearch-tokenizer = { git = "https://github.com/meilisearch/tokenizer.git", tag = "v0.2.5" }
-milli = { git = "https://github.com/meilisearch/milli.git", tag = "v0.17.3" }
+milli = { git = "https://github.com/meilisearch/milli.git", tag = "v0.18.0" }
 mime = "0.3.16"
 num_cpus = "1.13.0"
 once_cell = "1.8.0"


### PR DESCRIPTION
Fix issue #1687: Replacing `pest` with `nom`