### PR TITLE
Optimize document transform

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1763,13 +1763,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
-name = "memmap"
-version = "0.7.0"
+name = "memmap2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
+checksum = "4647a11b578fead29cdbb34d4adef8dd3dc35b876c9c6d5240d83f205abfe96e"
 dependencies = [
  "libc",
- "winapi",
 ]
 
 [[package]]
@@ -1783,8 +1782,8 @@ dependencies = [
 
 [[package]]
 name = "milli"
-version = "0.17.2"
-source = "git+https://github.com/meilisearch/milli.git?tag=v0.17.3#1e8acaa20b323a198229ad8ede96d045072e45c8"
+version = "0.19.0"
+source = "git+https://github.com/meilisearch/milli.git?tag=v0.19.0#d7943fe22553b8205b86c32a0f2656d9e42de351"
 dependencies = [
  "bimap",
  "bincode",
@@ -1793,6 +1792,7 @@ dependencies = [
  "chrono",
  "concat-arrays",
  "crossbeam-channel",
+ "csv",
  "either",
  "flate2",
  "fst",
@@ -1807,7 +1807,7 @@ dependencies = [
  "log",
  "logging_timer",
  "meilisearch-tokenizer",
- "memmap",
+ "memmap2",
  "obkv",
  "once_cell",
  "ordered-float",

--- a/meilisearch-lib/Cargo.toml
+++ b/meilisearch-lib/Cargo.toml
@@ -30,7 +30,7 @@ lazy_static = "1.4.0"
 log = "0.4.14"
 meilisearch-error = { path = "../meilisearch-error" }
 meilisearch-tokenizer = { git = "https://github.com/meilisearch/tokenizer.git", tag = "v0.2.5" }
-milli = { git = "https://github.com/meilisearch/milli.git", tag = "v0.17.3" }
+milli = { git = "https://github.com/meilisearch/milli.git", tag = "v0.19.0" }
 mime = "0.3.16"
 num_cpus = "1.13.0"
 once_cell = "1.8.0"

--- a/meilisearch-lib/src/index_controller/update_file_store.rs
+++ b/meilisearch-lib/src/index_controller/update_file_store.rs
@@ -149,7 +149,7 @@ impl UpdateFileStore {
         // for jsonl for example...)
         while let Some((index, document)) = document_reader.next_document_with_index()? {
             for (field_id, content) in document.iter() {
-                if let Some(field_name) = index.get_by_left(&field_id) {
+                if let Some(field_name) = index.name(field_id) {
                     let content = serde_json::from_slice(content)?;
                     document_buffer.insert(field_name.to_string(), content);
                 }

--- a/meilisearch-lib/src/lib.rs
+++ b/meilisearch-lib/src/lib.rs
@@ -11,7 +11,7 @@ pub use index_controller::MeiliSearch;
 pub use milli;
 
 mod compression;
-mod document_formats;
+pub mod document_formats;
 
 use walkdir::WalkDir;
 


### PR DESCRIPTION
integrate the optimization from https://github.com/meilisearch/milli/pull/402.

optimize payload read, by reading it to RAM first instead of streaming it. This means that the payload must fit into RAM, which should not be a problem.

Add BufWriter to the obkv writer to improve write speed.

I have measured a gain of 40-45% in speed after these optimizations.
