### PR TITLE
Fix search post event and disk size analytics

### DIFF
--- a/meilisearch-http/src/analytics/segment_analytics.rs
+++ b/meilisearch-http/src/analytics/segment_analytics.rs
@@ -187,7 +187,7 @@ impl Segment {
                     "kernel_version": kernel_version,
                     "cores": sys.processors().len(),
                     "ram_size": sys.total_memory(),
-                    "disk_size": sys.disks().iter().map(|disk| disk.available_space()).max(),
+                    "disk_size": sys.disks().iter().map(|disk| disk.total_space()).max(),
                     "server_provider": std::env::var("MEILI_SERVER_PROVIDER").ok(),
             })
         });

--- a/meilisearch-http/src/routes/indexes/search.rs
+++ b/meilisearch-http/src/routes/indexes/search.rs
@@ -150,7 +150,7 @@ pub async fn search_with_post(
     if let Ok(ref search_result) = search_result {
         aggregate.succeed(search_result);
     }
-    analytics.get_search(aggregate);
+    analytics.post_search(aggregate);
 
     let search_result = search_result?;
 


### PR DESCRIPTION
- Branch POST search on the post_search aggregator
- Use largest disk `total_space` instead of `available_space` 