### PR TITLE
return 404 when getting a task on an unexisting index

### DIFF
--- a/meilisearch-lib/src/index_controller/dump_actor/loaders/v1.rs
+++ b/meilisearch-lib/src/index_controller/dump_actor/loaders/v1.rs
@@ -38,7 +38,8 @@ impl MetadataV1 {
         let uuid_store = HeedUuidStore::new(&dst)?;
         for index in self.indexes {
             let uuid = Uuid::new_v4();
-            uuid_store.insert(index.uid.clone(), uuid)?;
+            // Since we don't know when the index was created, we assume it's from 0
+            uuid_store.insert(index.uid.clone(), uuid, 0)?;
             let src = src.as_ref().join(index.uid);
             load_index(
                 &src,

--- a/meilisearch-lib/src/index_controller/index_resolver/uuid_store.rs
+++ b/meilisearch-lib/src/index_controller/index_resolver/uuid_store.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::fs::create_dir_all;
 use std::path::{Path, PathBuf};
 
-use heed::types::{ByteSlice, SerdeBincode, Str};
+use heed::types::{SerdeBincode, Str};
 use heed::{CompactionOption, Database, Env, EnvOpenOptions};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -96,7 +96,7 @@ impl HeedUuidStore {
         Ok(entries)
     }
 
-    fn insert(&self, name: String, uuid: Uuid, task_id: TaskId) -> Result<()> {
+    pub(crate) fn insert(&self, name: String, uuid: Uuid, task_id: TaskId) -> Result<()> {
         let env = self.env.clone();
         let db = self.db;
         let mut txn = env.write_txn()?;

--- a/meilisearch-lib/src/index_controller/mod.rs
+++ b/meilisearch-lib/src/index_controller/mod.rs
@@ -27,10 +27,10 @@ use crate::index::{
 use crate::index_controller::index_resolver::create_index_resolver;
 //use crate::index_controller::snapshot::SnapshotService;
 use crate::options::IndexerOpts;
+use crate::tasks::create_task_store;
 use crate::tasks::task::{DocumentDeletion, Task, TaskContent, TaskId};
 use crate::tasks::task_store::TaskFilter;
 use crate::tasks::TaskStore;
-use crate::tasks::create_task_store;
 use error::Result;
 
 // use self::dump_actor::load_dump;
@@ -368,18 +368,43 @@ where
         Ok(task)
     }
 
+    pub async fn get_index_task(&self, index_uid: String, task_id: TaskId) -> Result<Task> {
+    //    let mut filter = TaskFilter::default();
+    //    filter.filter_index(params.index_uid);
+    //    let task: TaskResponse = meilisearch
+    //        .get_task(params.task_id, Some(filter))
+    //        .await?
+    //        .into();
+        todo!()
+    }
+
     pub async fn list_tasks(
         &self,
         filter: Option<TaskFilter>,
         limit: Option<usize>,
         offset: Option<TaskId>,
     ) -> Result<Vec<Task>> {
-        let tasks = self
-            .task_store
-            .list_tasks(filter, limit, offset)
-            .await?;
+        let tasks = self.task_store.list_tasks(filter, limit, offset).await?;
 
         Ok(tasks)
+    }
+
+    pub async fn list_index_task(
+        &self,
+        index_uid: String,
+        limit: Option<usize>,
+        offset: Option<usize>,
+    ) -> Result<Vec<Task>> {
+    //let mut filter = TaskFilter::default();
+    //filter.filter_index(index_uid.into_inner());
+    //let tasks: TaskListResponse = meilisearch
+    //    .list_tasks(Some(filter), None, None)
+    //    .await?
+    //    .into_iter()
+    //    .map(TaskResponse::from)
+    //    .collect::<Vec<_>>()
+    //    .into();
+        todo!()
     }
 
     pub async fn list_indexes(&self) -> Result<Vec<IndexMetadata>> {

--- a/meilisearch-lib/src/tasks/task_store/mod.rs
+++ b/meilisearch-lib/src/tasks/task_store/mod.rs
@@ -147,6 +147,7 @@ impl TaskStore {
         filter: Option<TaskFilter>,
         limit: Option<usize>,
         offset: Option<TaskId>,
+        _until: Option<TaskId>,
     ) -> Result<Vec<Task>> {
         let store = self.store.clone();
 
@@ -221,10 +222,11 @@ pub mod test {
             &self,
             filter: Option<TaskFilter>,
             limit: Option<usize>,
-            offset: Option<TaskId>,
+            from: Option<TaskId>,
+            until: Option<TaskId>,
         ) -> Result<Vec<Task>> {
             match self {
-                Self::Real(s) => s.list_tasks(filter, limit, offset).await,
+                Self::Real(s) => s.list_tasks(filter, limit, from, until).await,
                 Self::Mock(_m) => todo!(),
             }
         }


### PR DESCRIPTION
When getting a task from `/indexex/uid/tasks`, a 404 is now returned to the user if the index hasn't been created.

When the index is created, the task id that lead to it's creation is ascociated to it, so only tasks that have a higher `task_id` than the creation `task_id` are returned to the the user. This solves the issue when a user deletes an index and then re-creates one with the same name. Now older tasks are not returned.

The older tasks are still available from the `/tasks` route.
