### PR TITLE
Remove email address from the message at the launch

### DIFF
--- a/meilisearch-http/src/main.rs
+++ b/meilisearch-http/src/main.rs
@@ -144,6 +144,6 @@ Anonymous telemetry:\t\"Enabled\""
     eprintln!();
     eprintln!("Documentation:\t\thttps://docs.meilisearch.com");
     eprintln!("Source code:\t\thttps://github.com/meilisearch/meilisearch");
-    eprintln!("Contact:\t\thttps://docs.meilisearch.com/resources/contact.html or bonjour@meilisearch.com");
+    eprintln!("Contact:\t\thttps://docs.meilisearch.com/resources/contact.html");
     eprintln!();
 }


### PR DESCRIPTION
I suggest removing this email address from the message at the launch since it can encourage people to think this is an email address for support. Is it something we want @meilisearch/devrel-team since we mostly redirect them to the forum or the slack?