### PR TITLE
Update mini-dashboard version to v0.1.5

### DIFF
--- a/meilisearch-http/Cargo.toml
+++ b/meilisearch-http/Cargo.toml
@@ -98,5 +98,5 @@ default = ["analytics", "mini-dashboard"]
 tikv-jemallocator = "0.4.1"
 
 [package.metadata.mini-dashboard]
-assets-url = "https://github.com/meilisearch/mini-dashboard/releases/download/v0.1.4/build.zip"
-sha1 = "750e8a8e56cfa61fbf9ead14b08a5f17ad3f3d37"
+assets-url = "https://github.com/meilisearch/mini-dashboard/releases/download/v0.1.5/build.zip"
+sha1 = "1d955ea91b7691bd6fc207cb39866b82210783f0"


### PR DESCRIPTION
Update the mini-dashboard with its latest version (v0.1.5)

Check with @mdubus, replaces https://github.com/meilisearch/MeiliSearch/pull/1903

Fixes #1898 