### PR TITLE
refactor task names

### DIFF
--- a/meilisearch-http/src/task.rs
+++ b/meilisearch-http/src/task.rs
@@ -124,11 +124,11 @@ impl From<Task> for TaskResponse {
                 TaskType::SettingsUpdate,
                 Some(TaskDetails::Settings { settings }),
             ),
-            TaskContent::CreateIndex { primary_key } => (
+            TaskContent::IndexCreation { primary_key } => (
                 TaskType::IndexCreation,
                 Some(TaskDetails::IndexInfo { primary_key }),
             ),
-            TaskContent::UpdateIndex { primary_key } => (
+            TaskContent::IndexUpdate { primary_key } => (
                 TaskType::IndexUpdate,
                 Some(TaskDetails::IndexInfo { primary_key }),
             ),

--- a/meilisearch-lib/src/index_controller/mod.rs
+++ b/meilisearch-lib/src/index_controller/mod.rs
@@ -28,7 +28,7 @@ use crate::index::{
 use crate::options::IndexerOpts;
 use crate::tasks::create_task_store;
 use crate::tasks::error::TaskError;
-use crate::tasks::task::{DocumentDeletion, Task, TaskContent, TaskEvent, TaskId};
+use crate::tasks::task::{DocumentDeletion, Task, TaskContent, TaskId};
 use crate::tasks::task_store::TaskFilter;
 use crate::tasks::TaskStore;
 use error::Result;
@@ -364,8 +364,8 @@ where
                 }
             }
             Update::DeleteIndex => TaskContent::IndexDeletion,
-            Update::CreateIndex { primary_key } => TaskContent::CreateIndex { primary_key },
-            Update::UpdateIndex { primary_key } => TaskContent::UpdateIndex { primary_key },
+            Update::CreateIndex { primary_key } => TaskContent::IndexCreation { primary_key },
+            Update::UpdateIndex { primary_key } => TaskContent::IndexUpdate { primary_key },
         };
 
         let task = self.task_store.register(uid, content).await?;

--- a/meilisearch-lib/src/index_resolver/mod.rs
+++ b/meilisearch-lib/src/index_resolver/mod.rs
@@ -201,7 +201,7 @@ where
 
                 Ok(TaskResult::Other)
             }
-            TaskContent::CreateIndex { primary_key } => {
+            TaskContent::IndexCreation { primary_key } => {
                 let index = self.create_index(index_uid, task.id).await?;
 
                 if let Some(primary_key) = primary_key {
@@ -211,7 +211,7 @@ where
 
                 Ok(TaskResult::Other)
             }
-            TaskContent::UpdateIndex { primary_key } => {
+            TaskContent::IndexUpdate { primary_key } => {
                 let index = self.get_index(index_uid.into_inner()).await?;
 
                 if let Some(primary_key) = primary_key {

--- a/meilisearch-lib/src/tasks/task.rs
+++ b/meilisearch-lib/src/tasks/task.rs
@@ -4,7 +4,10 @@ use milli::update::{DocumentAdditionResult, IndexDocumentsMethod};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::{index::{Settings, Unchecked}, index_resolver::IndexUid};
+use crate::{
+    index::{Settings, Unchecked},
+    index_resolver::IndexUid,
+};
 
 use super::batch::BatchId;
 
@@ -12,17 +15,13 @@ pub type TaskId = u64;
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum TaskResult {
-    DocumentAddition {
-        number_of_documents: usize,
-    },
-    DocumentDeletion {
-        number_of_documents: u64,
-    },
+    DocumentAddition { number_of_documents: usize },
+    DocumentDeletion { number_of_documents: u64 },
     Other,
 }
 
 impl From<DocumentAdditionResult> for TaskResult {
-    fn from(other : DocumentAdditionResult) -> Self {
+    fn from(other: DocumentAdditionResult) -> Self {
         Self::DocumentAddition {
             number_of_documents: other.nb_documents,
         }
@@ -76,10 +75,10 @@ pub enum TaskContent {
         is_deletion: bool,
     },
     IndexDeletion,
-    CreateIndex {
+    IndexCreation {
         primary_key: Option<String>,
     },
-    UpdateIndex {
+    IndexUpdate {
         primary_key: Option<String>,
     },
 }
@@ -160,9 +159,13 @@ mod test {
             let n = g.choose(&[1, 2, 3]).unwrap();
             match n {
                 1 => Self::Other,
-                2 => Self::DocumentAddition { number_of_documents: usize::arbitrary(g) },
-                3 => Self::DocumentDeletion { number_of_documents: u64::arbitrary(g) },
-                _ => unreachable!()
+                2 => Self::DocumentAddition {
+                    number_of_documents: usize::arbitrary(g),
+                },
+                3 => Self::DocumentDeletion {
+                    number_of_documents: u64::arbitrary(g),
+                },
+                _ => unreachable!(),
             }
         }
     }


### PR DESCRIPTION
Rename task content types for more consistency across codebase
