### PR TITLE
Extract actual Content-Type from the header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1629,6 +1629,7 @@ dependencies = [
  "arc-swap",
  "async-stream",
  "async-trait",
+ "bstr",
  "byte-unit",
  "bytes",
  "cargo_toml",

--- a/meilisearch-http/Cargo.toml
+++ b/meilisearch-http/Cargo.toml
@@ -28,9 +28,10 @@ actix-web-static-files = { git = "https://github.com/MarinPostma/actix-web-stati
 # TODO: specifying this dependency so semver doesn't bump to next beta
 actix-tls = "=3.0.0-beta.5"
 anyhow = { version = "1.0.43", features = ["backtrace"] }
+arc-swap = "1.3.2"
 async-stream = "0.3.2"
 async-trait = "0.1.51"
-arc-swap = "1.3.2"
+bstr = "0.2.17"
 byte-unit = { version = "4.0.12", default-features = false, features = ["std"] }
 bytes = "1.1.0"
 chrono = { version = "0.4.19", features = ["serde"] }
@@ -46,13 +47,15 @@ http = "0.2.4"
 indexmap = { version = "1.7.0", features = ["serde-1"] }
 itertools = "0.10.1"
 log = "0.4.14"
-meilisearch-lib = { path = "../meilisearch-lib" }
 meilisearch-error = { path = "../meilisearch-error" }
+meilisearch-lib = { path = "../meilisearch-lib" }
 meilisearch-tokenizer = { git = "https://github.com/meilisearch/tokenizer.git", tag = "v0.2.5" }
 mime = "0.3.16"
 num_cpus = "1.13.0"
+obkv = "0.2.0"
 once_cell = "1.8.0"
 parking_lot = "0.11.2"
+pin-project = "1.0.8"
 platform-dirs = "0.3.0"
 rand = "0.8.4"
 rayon = "1.5.1"
@@ -65,16 +68,14 @@ sha2 = "0.9.6"
 siphasher = "0.3.7"
 slice-group-by = "0.2.6"
 structopt = "0.3.23"
+sysinfo = "0.20.2"
 tar = "0.4.37"
 tempfile = "3.2.0"
 thiserror = "1.0.28"
 tokio = { version = "1.11.0", features = ["full"] }
+tokio-stream = "0.1.7"
 uuid = { version = "0.8.2", features = ["serde"] }
 walkdir = "2.3.2"
-obkv = "0.2.0"
-pin-project = "1.0.8"
-sysinfo = "0.20.2"
-tokio-stream = "0.1.7"
 
 [dev-dependencies]
 actix-rt = "2.2.0"

--- a/meilisearch-http/src/routes/indexes/documents.rs
+++ b/meilisearch-http/src/routes/indexes/documents.rs
@@ -1,6 +1,9 @@
 use actix_web::error::PayloadError;
+use actix_web::http::header::CONTENT_TYPE;
+use actix_web::http::HeaderMap;
 use actix_web::web::Bytes;
 use actix_web::{web, HttpRequest, HttpResponse};
+use bstr::ByteSlice;
 use futures::{Stream, StreamExt};
 use log::debug;
 use meilisearch_error::ResponseError;
@@ -144,9 +147,7 @@ pub async fn add_documents(
     );
 
     let task = document_addition(
-        req.headers()
-            .get("Content-type")
-            .map(|s| s.to_str().unwrap_or("unkown")),
+        extract_content_type(req.headers()),
         meilisearch,
         index_uid,
         params.primary_key,
@@ -176,9 +177,7 @@ pub async fn update_documents(
     );
 
     let task = document_addition(
-        req.headers()
-            .get("Content-type")
-            .map(|s| s.to_str().unwrap_or("unkown")),
+        extract_content_type(req.headers()),
         meilisearch,
         index_uid,
         params.into_inner().primary_key,
@@ -191,7 +190,7 @@ pub async fn update_documents(
 }
 
 async fn document_addition(
-    content_type: Option<&str>,
+    content_type: Option<String>,
     meilisearch: GuardedData<Private, MeiliSearch>,
     index_uid: String,
     primary_key: Option<String>,
@@ -205,7 +204,8 @@ async fn document_addition(
             "text/csv".to_string(),
         ]
     });
-    let format = match content_type {
+
+    let format = match content_type.as_ref().map(AsRef::as_ref) {
         Some("application/json") => DocumentAdditionFormat::Json,
         Some("application/x-ndjson") => DocumentAdditionFormat::Ndjson,
         Some("text/csv") => DocumentAdditionFormat::Csv,
@@ -273,4 +273,24 @@ pub async fn clear_all_documents(
 
     debug!("returns: {:?}", task);
     Ok(HttpResponse::Accepted().json(task))
+}
+
+/// Returns the Content-Type header value without the charset=utf-8 or anything,
+/// only the value that is before the first semicolon (;).
+///
+/// Here is the composition of an HTTP Content-Type header
+/// <https://datatracker.ietf.org/doc/html/rfc7231#section-3.1.1.1>.
+fn extract_content_type(headers: &HeaderMap) -> Option<String> {
+    match headers.get(CONTENT_TYPE) {
+        Some(value) => match value.to_str() {
+            Ok(content) => Some(
+                content
+                    .split_once(";")
+                    .map_or(content, |(ct, _)| ct.trim())
+                    .to_string(),
+            ),
+            Err(_) => Some(format!("{}", value.as_bytes().as_bstr())), // convenient bytes display
+        },
+        None => None,
+    }
 }

--- a/meilisearch-http/src/routes/indexes/documents.rs
+++ b/meilisearch-http/src/routes/indexes/documents.rs
@@ -1,7 +1,7 @@
 use actix_web::error::PayloadError;
 use actix_web::http::header::CONTENT_TYPE;
-use actix_web::http::HeaderMap;
 use actix_web::web::Bytes;
+use actix_web::HttpMessage;
 use actix_web::{web, HttpRequest, HttpResponse};
 use bstr::ByteSlice;
 use futures::{Stream, StreamExt};
@@ -10,6 +10,7 @@ use meilisearch_error::ResponseError;
 use meilisearch_lib::index_controller::{DocumentAdditionFormat, Update};
 use meilisearch_lib::milli::update::IndexDocumentsMethod;
 use meilisearch_lib::MeiliSearch;
+use mime::Mime;
 use once_cell::sync::Lazy;
 use serde::Deserialize;
 use serde_json::Value;
@@ -24,6 +25,14 @@ use crate::task::SummarizedTaskView;
 const DEFAULT_RETRIEVE_DOCUMENTS_OFFSET: usize = 0;
 const DEFAULT_RETRIEVE_DOCUMENTS_LIMIT: usize = 20;
 
+static ACCEPTED_CONTENT_TYPE: Lazy<Vec<String>> = Lazy::new(|| {
+    vec![
+        "application/json".to_string(),
+        "application/x-ndjson".to_string(),
+        "text/csv".to_string(),
+    ]
+});
+
 /// This is required because Payload is not Sync nor Send
 fn payload_to_stream(mut payload: Payload) -> impl Stream<Item = Result<Bytes, PayloadError>> {
     let (snd, recv) = mpsc::channel(1);
@@ -33,6 +42,24 @@ fn payload_to_stream(mut payload: Payload) -> impl Stream<Item = Result<Bytes, P
         }
     });
     tokio_stream::wrappers::ReceiverStream::new(recv)
+}
+
+/// Extracts the mime type from the content type and return
+/// a meilisearch error if anyhthing bad happen.
+fn extract_mime_type(req: &HttpRequest) -> Result<Option<Mime>, MeilisearchHttpError> {
+    match req.mime_type() {
+        Ok(Some(mime)) => Ok(Some(mime)),
+        Ok(None) => Ok(None),
+        Err(_) => match req.headers().get(CONTENT_TYPE) {
+            Some(content_type) => Err(MeilisearchHttpError::InvalidContentType(
+                content_type.as_bytes().as_bstr().to_string(),
+                ACCEPTED_CONTENT_TYPE.clone(),
+            )),
+            None => Err(MeilisearchHttpError::MissingContentType(
+                ACCEPTED_CONTENT_TYPE.clone(),
+            )),
+        },
+    }
 }
 
 #[derive(Deserialize)]
@@ -147,7 +174,7 @@ pub async fn add_documents(
     );
 
     let task = document_addition(
-        extract_content_type(req.headers()),
+        extract_mime_type(&req)?,
         meilisearch,
         index_uid,
         params.primary_key,
@@ -177,7 +204,7 @@ pub async fn update_documents(
     );
 
     let task = document_addition(
-        extract_content_type(req.headers()),
+        extract_mime_type(&req)?,
         meilisearch,
         index_uid,
         params.into_inner().primary_key,
@@ -190,28 +217,23 @@ pub async fn update_documents(
 }
 
 async fn document_addition(
-    content_type: Option<String>,
+    mime_type: Option<Mime>,
     meilisearch: GuardedData<Private, MeiliSearch>,
     index_uid: String,
     primary_key: Option<String>,
     body: Payload,
     method: IndexDocumentsMethod,
 ) -> Result<SummarizedTaskView, ResponseError> {
-    static ACCEPTED_CONTENT_TYPE: Lazy<Vec<String>> = Lazy::new(|| {
-        vec![
-            "application/json".to_string(),
-            "application/x-ndjson".to_string(),
-            "text/csv".to_string(),
-        ]
-    });
-
-    let format = match content_type.as_ref().map(AsRef::as_ref) {
-        Some("application/json") => DocumentAdditionFormat::Json,
-        Some("application/x-ndjson") => DocumentAdditionFormat::Ndjson,
-        Some("text/csv") => DocumentAdditionFormat::Csv,
-        Some(other) => {
+    let format = match mime_type
+        .as_ref()
+        .map(|m| (m.type_().as_str(), m.subtype().as_str()))
+    {
+        Some(("application", "json")) => DocumentAdditionFormat::Json,
+        Some(("application", "x-ndjson")) => DocumentAdditionFormat::Ndjson,
+        Some(("text", "csv")) => DocumentAdditionFormat::Csv,
+        Some((type_, subtype)) => {
             return Err(MeilisearchHttpError::InvalidContentType(
-                other.to_string(),
+                format!("{}/{}", type_, subtype),
                 ACCEPTED_CONTENT_TYPE.clone(),
             )
             .into())
@@ -273,24 +295,4 @@ pub async fn clear_all_documents(
 
     debug!("returns: {:?}", task);
     Ok(HttpResponse::Accepted().json(task))
-}
-
-/// Returns the Content-Type header value without the charset=utf-8 or anything,
-/// only the value that is before the first semicolon (;).
-///
-/// Here is the composition of an HTTP Content-Type header
-/// <https://datatracker.ietf.org/doc/html/rfc7231#section-3.1.1.1>.
-fn extract_content_type(headers: &HeaderMap) -> Option<String> {
-    match headers.get(CONTENT_TYPE) {
-        Some(value) => match value.to_str() {
-            Ok(content) => Some(
-                content
-                    .split_once(";")
-                    .map_or(content, |(ct, _)| ct.trim())
-                    .to_string(),
-            ),
-            Err(_) => Some(format!("{}", value.as_bytes().as_bstr())), // convenient bytes display
-        },
-        None => None,
-    }
 }


### PR DESCRIPTION
This PR should fix #1866 by extracting the actual Content-Type from the header and ignoring everything that follows the first semicolon (`;`) which, most of the time, means ignoring the `charset=utf-8`. We use [the `mime_type` method](https://docs.rs/actix-web/3.3.2/actix_web/trait.HttpMessage.html#method.mime_type) to do so.