### PR TITLE
fix snapshot

### DIFF
--- a/meilisearch-http/tests/snapshot/mod.rs
+++ b/meilisearch-http/tests/snapshot/mod.rs
@@ -50,11 +50,11 @@ async fn perform_snapshot() {
         }))
         .await;
 
-    index.wait_task(0).await;
-
     index.load_test_set().await;
 
     server.index("test1").create(Some("prim")).await;
+
+    index.wait_task(2).await;
 
     sleep(Duration::from_secs(2)).await;
 

--- a/meilisearch-lib/src/snapshot.rs
+++ b/meilisearch-lib/src/snapshot.rs
@@ -1,3 +1,4 @@
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -139,12 +140,10 @@ impl SnapshotJob {
         // FIXME(marin): We may copy more files than necessary, if new files are added while we are
         // performing the snapshop. We need a way to filter them out.
 
+        let dst = path.join("updates");
+        fs::create_dir_all(&dst)?;
         let options = CopyOptions::default();
-        dir::copy(
-            self.src_path.join("updates/updates_files/"),
-            path.join("updates/updates_files/"),
-            &options,
-        )?;
+        dir::copy(self.src_path.join("updates/updates_files"), dst, &options)?;
 
         Ok(())
     }


### PR DESCRIPTION
fix snapshot test introduced by using dir::copy. Resolved by creating the destination directory before copying.

needs to be merged after #1951 