### PR TITLE
Reintroduce engine version file

### DIFF
--- a/meilisearch-lib/src/index_controller/versioning/error.rs
+++ b/meilisearch-lib/src/index_controller/versioning/error.rs
@@ -1,0 +1,16 @@
+#[derive(thiserror::Error, Debug)]
+pub enum VersionFileError {
+    #[error("Version file is missing or the previous MeiliSearch engine version was below 0.24.0. Use a dump to update Meilisearch.")]
+    MissingVersionFile,
+    #[error("Version file is corrupted and thus MeiliSearch is unable to determine the version of the database.")]
+    MalformedVersionFile,
+    #[error(
+        "Expected MeiliSearch engine version: {major}.{minor}.{patch}, current engine version: {}. To update Meilisearch use a dump.",
+        env!("CARGO_PKG_VERSION").to_string()
+    )]
+    VersionMismatch {
+        major: String,
+        minor: String,
+        patch: String,
+    },
+}

--- a/meilisearch-lib/src/index_controller/versioning/mod.rs
+++ b/meilisearch-lib/src/index_controller/versioning/mod.rs
@@ -1,0 +1,56 @@
+use std::fs;
+use std::io::ErrorKind;
+use std::path::Path;
+
+use self::error::VersionFileError;
+
+mod error;
+
+pub const VERSION_FILE_NAME: &str = "VERSION";
+
+static VERSION_MAJOR: &str = env!("CARGO_PKG_VERSION_MAJOR");
+static VERSION_MINOR: &str = env!("CARGO_PKG_VERSION_MINOR");
+static VERSION_PATCH: &str = env!("CARGO_PKG_VERSION_PATCH");
+
+// Persists the version of the current MeiliSearch binary to a VERSION file
+pub fn create_version_file(db_path: &Path) -> anyhow::Result<()> {
+    let version_path = db_path.join(VERSION_FILE_NAME);
+    fs::write(
+        version_path,
+        format!("{}.{}.{}", VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH),
+    )?;
+
+    Ok(())
+}
+
+// Ensures Meilisearch version is compatible with the database, returns an error versions mismatch.
+pub fn check_version_file(db_path: &Path) -> anyhow::Result<()> {
+    let version_path = db_path.join(VERSION_FILE_NAME);
+
+    match fs::read_to_string(&version_path) {
+        Ok(version) => {
+            let version_components = version.split('.').collect::<Vec<_>>();
+            let (major, minor, patch) = match &version_components[..] {
+                [major, minor, patch] => (major.to_string(), minor.to_string(), patch.to_string()),
+                _ => return Err(VersionFileError::MalformedVersionFile.into()),
+            };
+
+            if major != VERSION_MAJOR || minor != VERSION_MINOR {
+                return Err(VersionFileError::VersionMismatch {
+                    major,
+                    minor,
+                    patch,
+                }
+                .into());
+            }
+        }
+        Err(error) => {
+            return match error.kind() {
+                ErrorKind::NotFound => Err(VersionFileError::MissingVersionFile.into()),
+                _ => Err(error.into()),
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/meilisearch-lib/src/snapshot.rs
+++ b/meilisearch-lib/src/snapshot.rs
@@ -9,6 +9,7 @@ use tokio::time::sleep;
 use walkdir::WalkDir;
 
 use crate::compression::from_tar_gz;
+use crate::index_controller::versioning::VERSION_FILE_NAME;
 use crate::tasks::task::Job;
 use crate::tasks::TaskStore;
 
@@ -102,6 +103,7 @@ impl SnapshotJob {
         let temp_snapshot_dir = tempfile::tempdir()?;
         let temp_snapshot_path = temp_snapshot_dir.path();
 
+        self.snapshot_version_file(temp_snapshot_path)?;
         self.snapshot_meta_env(temp_snapshot_path)?;
         self.snapshot_file_store(temp_snapshot_path)?;
         self.snapshot_indexes(temp_snapshot_path)?;
@@ -129,6 +131,15 @@ impl SnapshotJob {
         }
 
         trace!("Created snapshot in {:?}.", snapshot_path);
+
+        Ok(())
+    }
+
+    fn snapshot_version_file(&self, path: &Path) -> anyhow::Result<()> {
+        let dst = path.join(VERSION_FILE_NAME);
+        let src = self.src_path.join(VERSION_FILE_NAME);
+
+        fs::copy(src, dst)?;
 
         Ok(())
     }


### PR DESCRIPTION
Right now if you boot up MeiliSearch and point it to a DB directory created with a previous version of MeiliSearch the existing indexes will be deleted. This [used to be](https://github.com/meilisearch/MeiliSearch/commit/51d7c84e7327b14f84522a1f5521f6d98c398a6f) prevented by a startup check which would compare the current engine version vs what was stored in the DB directory's version file, but this functionality seems to have been lost after a few refactorings of the code.

In order to go back to the old behavior we'll need to reintroduce the `VERSION` file that used to be present; I considered reusing the `metadata.json` file used in the dumps feature, but this seemed like the simpler and more approach. As the intent is just to restore functionality, the implementation is quite basic. I imagine that in the future we could build on this and do things like compatibility across major/minor versions and even migrating between formats.

This PR was made thanks to @mbStavola and is basically a port of his PR #1860 after a big refacto of the code #1796.

Closes #1840