### PR TITLE
Fix of `release-v0.25.0` branch into `main`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ WORKDIR /meilisearch
 COPY    Cargo.lock .
 COPY    Cargo.toml .
 
+COPY    meilisearch-auth/Cargo.toml meilisearch-auth/
 COPY    meilisearch-error/Cargo.toml meilisearch-error/
 COPY    meilisearch-http/Cargo.toml meilisearch-http/
 COPY    meilisearch-lib/Cargo.toml meilisearch-lib/

--- a/download-latest.sh
+++ b/download-latest.sh
@@ -80,7 +80,7 @@ get_latest() {
     fi
 
     releases=$(cat "$temp_file" | \
-        grep -E "tag_name|draft|prerelease" \
+        grep -E '"tag_name":|"draft":|"prerelease":' \
         | tr -d ',"' | cut -d ':' -f2 | tr -d ' ')
         # Returns a list of [tag_name draft_boolean prerelease_boolean ...]
         # Ex: v0.10.1 false false v0.9.1-rc.1 false true v0.9.0 false false...


### PR DESCRIPTION
The fixes in #1976 should be on main to be taken into account by 
```
curl -L https://install.meilisearch.com | sh
```