### PR TITLE
Support boolean for the no-analytics flag

### DIFF
--- a/meilisearch-http/Cargo.toml
+++ b/meilisearch-http/Cargo.toml
@@ -67,7 +67,7 @@ serde_json = { version = "1.0.67", features = ["preserve_order"] }
 sha2 = "0.9.6"
 siphasher = "0.3.7"
 slice-group-by = "0.2.6"
-structopt = "0.3.23"
+structopt = "0.3.25"
 sysinfo = "0.20.2"
 tar = "0.4.37"
 tempfile = "3.2.0"

--- a/meilisearch-http/src/main.rs
+++ b/meilisearch-http/src/main.rs
@@ -50,7 +50,7 @@ async fn main() -> anyhow::Result<()> {
     let auth_controller = AuthController::new(&opt.db_path, &opt.master_key)?;
 
     #[cfg(all(not(debug_assertions), feature = "analytics"))]
-    let (analytics, user) = if !opt.no_analytics {
+    let (analytics, user) = if opt.analytics() {
         analytics::SegmentAnalytics::new(&opt, &meilisearch).await
     } else {
         analytics::MockAnalytics::new(&opt)
@@ -125,9 +125,7 @@ pub fn print_launch_resume(opt: &Opt, user: &str) {
 
     #[cfg(all(not(debug_assertions), feature = "analytics"))]
     {
-        if opt.no_analytics {
-            eprintln!("Anonymous telemetry:\t\"Disabled\"");
-        } else {
+        if opt.analytics() {
             eprintln!(
                 "
 Thank you for using MeiliSearch!
@@ -136,6 +134,8 @@ We collect anonymized analytics to improve our product and your experience. To l
 
 Anonymous telemetry:\t\"Enabled\""
             );
+        } else {
+            eprintln!("Anonymous telemetry:\t\"Disabled\"");
         }
     }
 

--- a/meilisearch-http/src/option.rs
+++ b/meilisearch-http/src/option.rs
@@ -38,7 +38,7 @@ pub struct Opt {
     /// Do not send analytics to Meili.
     #[cfg(all(not(debug_assertions), feature = "analytics"))]
     #[structopt(long, env = "MEILI_NO_ANALYTICS")]
-    pub no_analytics: bool,
+    pub no_analytics: Option<Option<bool>>,
 
     /// The maximum size, in bytes, of the main lmdb database directory
     #[structopt(long, env = "MEILI_MAX_INDEX_SIZE", default_value = "100 GiB")]
@@ -129,6 +129,16 @@ pub struct Opt {
 }
 
 impl Opt {
+    /// Wether analytics should be enabled or not.
+    #[cfg(all(not(debug_assertions), feature = "analytics"))]
+    pub fn analytics(&self) -> bool {
+        match self.no_analytics {
+            None => true,
+            Some(None) => false,
+            Some(Some(disabled)) => !disabled,
+        }
+    }
+
     pub fn get_ssl_config(&self) -> anyhow::Result<Option<rustls::ServerConfig>> {
         if let (Some(cert_path), Some(key_path)) = (&self.ssl_cert_path, &self.ssl_key_path) {
             let client_auth = match &self.ssl_auth_path {

--- a/meilisearch-http/tests/common/server.rs
+++ b/meilisearch-http/tests/common/server.rs
@@ -98,7 +98,7 @@ pub fn default_settings(dir: impl AsRef<Path>) -> Opt {
         master_key: None,
         env: "development".to_owned(),
         #[cfg(all(not(debug_assertions), feature = "analytics"))]
-        no_analytics: true,
+        no_analytics: Some(Some(true)),
         max_index_size: Byte::from_unit(4.0, ByteUnit::GiB).unwrap(),
         max_task_db_size: Byte::from_unit(4.0, ByteUnit::GiB).unwrap(),
         http_payload_size_limit: Byte::from_unit(10.0, ByteUnit::MiB).unwrap(),


### PR DESCRIPTION
This PR fixes an issue with the `no-analytics` flag that was ignoring the value passed to it, therefore a `no-analytics false` was just understood as a `no-analytics` and was effectively disabling the analytics instead of enabling them. I found [a closed issue about this exact behavior on the structopt repository](https://github.com/TeXitoi/structopt/issues/468) and applied it here.

I don't think we should update the documentation as it must have worked like this from the start of this project. I tested it on my machine and it is working great now. Thank you @nicolasvienot for this issue report.

Fixes #1983.