### PR TITLE
bug(lib): ignore primary if already set on document addition

### DIFF
--- a/meilisearch-http/tests/documents/add_documents.rs
+++ b/meilisearch-http/tests/documents/add_documents.rs
@@ -1032,3 +1032,26 @@ async fn error_primary_key_inference() {
 
     assert_eq!(response["error"], expected_error);
 }
+
+#[actix_rt::test]
+async fn add_documents_with_primary_key_twice() {
+    let server = Server::new().await;
+    let index = server.index("test");
+
+    let documents = json!([
+        {
+            "title": "11",
+            "desc": "foobar"
+        }
+    ]);
+
+    index.add_documents(documents.clone(), Some("title")).await;
+    index.wait_task(0).await;
+    let (response, _code) = index.get_task(0).await;
+    assert_eq!(response["status"], "succeeded");
+
+    index.add_documents(documents, Some("title")).await;
+    index.wait_task(1).await;
+    let (response, _code) = index.get_task(1).await;
+    assert_eq!(response["status"], "succeeded");
+}

--- a/meilisearch-lib/src/index/updates.rs
+++ b/meilisearch-lib/src/index/updates.rs
@@ -237,7 +237,9 @@ impl Index {
         let mut txn = self.write_txn()?;
 
         if let Some(primary_key) = primary_key {
-            self.update_primary_key_txn(&mut txn, primary_key)?;
+            if self.primary_key(&txn)?.is_none() {
+                self.update_primary_key_txn(&mut txn, primary_key)?;
+            }
         }
 
         let indexing_callback = |indexing_step| debug!("update: {:?}", indexing_step);


### PR DESCRIPTION
Ignore the primary key if it is already set on documents updates. Add a test for verify behaviour.

close #2002
