### PR TITLE
Bug(auth): Parse YMD date

### DIFF
--- a/meilisearch-auth/src/key.rs
+++ b/meilisearch-auth/src/key.rs
@@ -1,7 +1,7 @@
 use crate::action::Action;
 use crate::error::{AuthControllerError, Result};
 use crate::store::{KeyId, KEY_ID_LENGTH};
-use chrono::{DateTime, NaiveDateTime, Utc};
+use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 use serde_json::{from_value, Value};
@@ -142,8 +142,8 @@ fn parse_expiration_date(value: &Value) -> Result<Option<DateTime<Utc>>> {
                     .map(|naive| DateTime::from_utc(naive, Utc))
             })
             .or_else(|_| {
-                NaiveDateTime::parse_from_str(string, "%Y-%m-%d")
-                    .map(|naive| DateTime::from_utc(naive, Utc))
+                NaiveDate::parse_from_str(string, "%Y-%m-%d")
+                    .map(|naive| DateTime::from_utc(naive.and_hms(0, 0, 0), Utc))
             })
             .map_err(|_| AuthControllerError::InvalidApiKeyExpiresAt(value.clone()))
             // check if the key is already expired.

--- a/meilisearch-http/tests/auth/api_keys.rs
+++ b/meilisearch-http/tests/auth/api_keys.rs
@@ -63,6 +63,65 @@ async fn add_valid_api_key() {
 }
 
 #[actix_rt::test]
+async fn add_valid_api_key_expired_at() {
+    let mut server = Server::new_auth().await;
+    server.use_api_key("MASTER_KEY");
+
+    let content = json!({
+        "description": "Indexing API key",
+        "indexes": ["products"],
+        "actions": [
+            "search",
+            "documents.add",
+            "documents.get",
+            "documents.delete",
+            "indexes.create",
+            "indexes.get",
+            "indexes.update",
+            "indexes.delete",
+            "tasks.get",
+            "settings.get",
+            "settings.update",
+            "stats.get",
+            "dumps.create",
+            "dumps.get"
+        ],
+        "expiresAt": "2050-11-13"
+    });
+
+    let (response, code) = server.add_api_key(content).await;
+    assert!(response["key"].is_string(), "{:?}", response);
+    assert!(response["expiresAt"].is_string());
+    assert!(response["createdAt"].is_string());
+    assert!(response["updatedAt"].is_string());
+
+    let expected_response = json!({
+        "description": "Indexing API key",
+        "indexes": ["products"],
+        "actions": [
+            "search",
+            "documents.add",
+            "documents.get",
+            "documents.delete",
+            "indexes.create",
+            "indexes.get",
+            "indexes.update",
+            "indexes.delete",
+            "tasks.get",
+            "settings.get",
+            "settings.update",
+            "stats.get",
+            "dumps.create",
+            "dumps.get"
+        ],
+        "expiresAt": "2050-11-13T00:00:00Z"
+    });
+
+    assert_json_include!(actual: response, expected: expected_response);
+    assert_eq!(code, 201);
+}
+
+#[actix_rt::test]
 async fn add_valid_api_key_no_description() {
     let mut server = Server::new_auth().await;
     server.use_api_key("MASTER_KEY");


### PR DESCRIPTION
Use NaiveDate to parse YMD date instead of NaiveDatetime

fix #2017
