### PR TITLE
Bug(FS): Consider empty pre-created directory as unexisting DB

### DIFF
--- a/meilisearch-lib/src/index_controller/mod.rs
+++ b/meilisearch-lib/src/index_controller/mod.rs
@@ -167,7 +167,11 @@ impl IndexControllerBuilder {
 
         let db_exists = db_path.as_ref().exists();
         if db_exists {
-            versioning::check_version_file(db_path.as_ref())?;
+            // Directory could be pre-created without any database in.
+            let db_is_empty = db_path.as_ref().read_dir()?.next().is_none();
+            if !db_is_empty {
+                versioning::check_version_file(db_path.as_ref())?;
+            }
         }
 
         if let Some(ref path) = self.import_snapshot {


### PR DESCRIPTION
When the database directory was pre-created we were considering that DB is invalid, we are now accepting to create a database in it.
