### PR TITLE
Use self hosted GitHub runner

### DIFF
--- a/.github/workflows/publish-docker-latest.yml
+++ b/.github/workflows/publish-docker-latest.yml
@@ -7,7 +7,7 @@ name: Publish latest image to Docker Hub
 
 jobs:
   docker-latest:
-    runs-on: self-hosted
+    runs-on: docker
     steps:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/publish-docker-tag.yml
+++ b/.github/workflows/publish-docker-tag.yml
@@ -8,7 +8,7 @@ name: Publish tagged image to Docker Hub
 
 jobs:
   docker-tag:
-    runs-on: self-hosted
+    runs-on: docker
     steps:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1


### PR DESCRIPTION
Checked with @tpayet, we have created a self hosted github runner to save time when pushing the docker images.