### PR TITLE
chore(ci): Enable rust_backtrace in the ci

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,6 +11,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
 
 jobs:
   tests:


### PR DESCRIPTION
This should help us to understand unreproducible panics that happens in the CI all the time