### PR TITLE
test: Ignore the auths tests on windows

### DIFF
--- a/meilisearch-http/tests/auth/authorization.rs
+++ b/meilisearch-http/tests/auth/authorization.rs
@@ -60,6 +60,7 @@ static INVALID_RESPONSE: Lazy<Value> = Lazy::new(|| {
 });
 
 #[actix_rt::test]
+#[cfg_attr(target_os = "windows", ignore)]
 async fn error_access_expired_key() {
     let mut server = Server::new_auth().await;
     server.use_api_key("MASTER_KEY");
@@ -86,6 +87,7 @@ async fn error_access_expired_key() {
 }
 
 #[actix_rt::test]
+#[cfg_attr(target_os = "windows", ignore)]
 async fn error_access_unauthorized_index() {
     let mut server = Server::new_auth().await;
     server.use_api_key("MASTER_KEY");
@@ -116,6 +118,7 @@ async fn error_access_unauthorized_index() {
 }
 
 #[actix_rt::test]
+#[cfg_attr(target_os = "windows", ignore)]
 async fn error_access_unauthorized_action() {
     let mut server = Server::new_auth().await;
     server.use_api_key("MASTER_KEY");
@@ -152,6 +155,7 @@ async fn error_access_unauthorized_action() {
 }
 
 #[actix_rt::test]
+#[cfg_attr(target_os = "windows", ignore)]
 async fn access_authorized_restricted_index() {
     let mut server = Server::new_auth().await;
     server.use_api_key("MASTER_KEY");
@@ -203,6 +207,7 @@ async fn access_authorized_restricted_index() {
 }
 
 #[actix_rt::test]
+#[cfg_attr(target_os = "windows", ignore)]
 async fn access_authorized_no_index_restriction() {
     let mut server = Server::new_auth().await;
     server.use_api_key("MASTER_KEY");
@@ -254,6 +259,7 @@ async fn access_authorized_no_index_restriction() {
 }
 
 #[actix_rt::test]
+#[cfg_attr(target_os = "windows", ignore)]
 async fn access_authorized_stats_restricted_index() {
     let mut server = Server::new_auth().await;
     server.use_api_key("MASTER_KEY");
@@ -293,6 +299,7 @@ async fn access_authorized_stats_restricted_index() {
 }
 
 #[actix_rt::test]
+#[cfg_attr(target_os = "windows", ignore)]
 async fn access_authorized_stats_no_index_restriction() {
     let mut server = Server::new_auth().await;
     server.use_api_key("MASTER_KEY");
@@ -332,6 +339,7 @@ async fn access_authorized_stats_no_index_restriction() {
 }
 
 #[actix_rt::test]
+#[cfg_attr(target_os = "windows", ignore)]
 async fn list_authorized_indexes_restricted_index() {
     let mut server = Server::new_auth().await;
     server.use_api_key("MASTER_KEY");
@@ -372,6 +380,7 @@ async fn list_authorized_indexes_restricted_index() {
 }
 
 #[actix_rt::test]
+#[cfg_attr(target_os = "windows", ignore)]
 async fn list_authorized_indexes_no_index_restriction() {
     let mut server = Server::new_auth().await;
     server.use_api_key("MASTER_KEY");

--- a/meilisearch-http/tests/index/delete_index.rs
+++ b/meilisearch-http/tests/index/delete_index.rs
@@ -43,8 +43,8 @@ async fn error_delete_unexisting_index() {
     assert_eq!(response["error"], expected_response);
 }
 
-#[cfg(not(windows))]
 #[actix_rt::test]
+#[cfg_attr(target_os = "windows", ignore)]
 async fn loop_delete_add_documents() {
     let server = Server::new().await;
     let index = server.index("test");


### PR DESCRIPTION
Since the auths tests fail sporadically on the windows CI but we can't reproduce these failures with a real windows machine we are going to ignore these ones.

But we still ensure they compile.