### PR TITLE
bug(http): fix task duration

### DIFF
--- a/meilisearch-http/src/task.rs
+++ b/meilisearch-http/src/task.rs
@@ -224,12 +224,12 @@ impl From<Task> for TaskView {
             _ => unreachable!("A task must always have a creation event."),
         };
 
-        let duration = finished_at.map(|ts| (ts - enqueued_at));
-
         let started_at = events.iter().find_map(|e| match e {
             TaskEvent::Processing(ts) => Some(*ts),
             _ => None,
         });
+
+        let duration = finished_at.zip(started_at).map(|(tf, ts)| (tf - ts));
 
         Self {
             uid: id,


### PR DESCRIPTION
@gmourier found that the duration in the task view was not computed correctly, this pr fixes it.

@curquiza, I let you decide if we need to make a hotfix out of this or wait for the next release. This is not breaking.
