### PR TITLE
chore(all): fix rust edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,3 @@ members = [
     "meilisearch-lib",
     "meilisearch-auth",
 ]
-edition = "2021"

--- a/meilisearch-auth/Cargo.toml
+++ b/meilisearch-auth/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "meilisearch-auth"
 version = "0.25.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 enum-iterator = "0.7.0"

--- a/meilisearch-error/Cargo.toml
+++ b/meilisearch-error/Cargo.toml
@@ -2,7 +2,7 @@
 name = "meilisearch-error"
 version = "0.25.0"
 authors = ["marin <postma.marin@protonmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 actix-http = "=3.0.0-beta.10"

--- a/meilisearch-http/Cargo.toml
+++ b/meilisearch-http/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Quentin de Quelen <quentin@dequelen.me>", "Clément Renault <clement@meilisearch.com>"]
 description = "MeiliSearch HTTP server"
-edition = "2018"
+edition = "2021"
 license = "MIT"
 name = "meilisearch-http"
 version = "0.25.0"

--- a/meilisearch-lib/Cargo.toml
+++ b/meilisearch-lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "meilisearch-lib"
 version = "0.25.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/meilisearch-lib/src/index_controller/dump_actor/mod.rs
+++ b/meilisearch-lib/src/index_controller/dump_actor/mod.rs
@@ -298,6 +298,7 @@ impl DumpJob {
             .await?;
 
         let dump_path = tokio::task::spawn_blocking(move || -> Result<PathBuf> {
+            let _ = &self;
             // for now we simply copy the updates/updates_files
             // FIXME: We may copy more files than necessary, if new files are added while we are
             // performing the dump. We need a way to filter them out.


### PR DESCRIPTION
I hadn't correctly set the rust edition in my previous pr, and cargo was returning a warning. This time I followed this guide: https://doc.rust-lang.org/edition-guide/editions/transitioning-an-existing-project-to-a-new-edition.html
