### PR TITLE
fix(dump): Fix the import of dump from the v24 and before

### DIFF
--- a/meilisearch-auth/src/dump.rs
+++ b/meilisearch-auth/src/dump.rs
@@ -29,6 +29,10 @@ impl AuthController {
 
         let keys_file_path = src.as_ref().join(KEYS_PATH);
 
+        if !keys_file_path.exists() {
+            return Ok(());
+        }
+
         let mut reader = BufReader::new(File::open(&keys_file_path)?).lines();
         while let Some(key) = reader.next().transpose()? {
             let key = serde_json::from_str(&key)?;


### PR DESCRIPTION
When trying to import [this dump](https://files.slack.com/files-pri/TD4JJU04D-F02UK3ZP2KA/download/dumps-steam.dump) we were getting this error:
```
Error: Internal error: No such file or directory (os error 2)
```

It’s because in any dump made from before the v25 we had no `key_file_store`.