### PR TITLE
Allow payloads with no documents 

### DIFF
--- a/meilisearch-http/tests/documents/add_documents.rs
+++ b/meilisearch-http/tests/documents/add_documents.rs
@@ -710,20 +710,11 @@ async fn replace_document() {
 }
 
 #[actix_rt::test]
-async fn error_add_no_documents() {
+async fn add_no_documents() {
     let server = Server::new().await;
     let index = server.index("test");
-    let (response, code) = index.add_documents(json!([]), None).await;
-
-    let expected_response = json!({
-        "message": "The `json` payload must contain at least one document.",
-        "code": "malformed_payload",
-        "type": "invalid_request",
-        "link": "https://docs.meilisearch.com/errors#malformed_payload"
-    });
-
-    assert_eq!(response, expected_response);
-    assert_eq!(code, 400);
+    let (_response, code) = index.add_documents(json!([]), None).await;
+    assert_eq!(code, 202);
 }
 
 #[actix_rt::test]

--- a/meilisearch-lib/src/index/dump.rs
+++ b/meilisearch-lib/src/index/dump.rs
@@ -8,7 +8,7 @@ use indexmap::IndexMap;
 use milli::documents::DocumentBatchReader;
 use serde::{Deserialize, Serialize};
 
-use crate::document_formats::{read_ndjson, DocumentFormatError};
+use crate::document_formats::read_ndjson;
 use crate::index::update_handler::UpdateHandler;
 use crate::index::updates::apply_settings_to_builder;
 
@@ -130,8 +130,8 @@ impl Index {
 
         let empty = match read_ndjson(reader, &mut tmp_doc_file) {
             // if there was no document in the file it's because the index was empty
+            Ok(0) => true,
             Ok(_) => false,
-            Err(DocumentFormatError::EmptyPayload(_)) => true,
             Err(e) => return Err(e.into()),
         };
 


### PR DESCRIPTION
accept addition with 0 documents.

0 bytes payload are still refused, since they are not valid json/jsonlines/csv anyways...

close #1987
