### PR TITLE
feat(error): Update the error message when you have no version file

### DIFF
--- a/meilisearch-lib/src/index_controller/versioning/error.rs
+++ b/meilisearch-lib/src/index_controller/versioning/error.rs
@@ -1,6 +1,9 @@
 #[derive(thiserror::Error, Debug)]
 pub enum VersionFileError {
-    #[error("Version file is missing or the previous MeiliSearch engine version was below 0.24.0. Use a dump to update MeiliSearch.")]
+    #[error(
+        "MeilSearch (v{}) failed to infer the version of the database. Please consider using a dump to load your data.",
+        env!("CARGO_PKG_VERSION").to_string()
+    )]
     MissingVersionFile,
     #[error("Version file is corrupted and thus MeiliSearch is unable to determine the version of the database.")]
     MalformedVersionFile,


### PR DESCRIPTION
Following this [issue](https://github.com/meilisearch/meilisearch-kubernetes/issues/95) we decided to change the error message from:
```
Version file is missing or the previous MeiliSearch engine version was below 0.24.0. Use a dump to update MeiliSearch.
```
to
```
Version file is missing or the previous MeiliSearch engine version was below 0.25.0. Use a dump to update MeiliSearch.
```