### PR TITLE
feat(auth): Tenant token

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ dependencies = [
  "actix-tls",
  "actix-utils",
  "ahash 0.7.6",
- "base64",
+ "base64 0.13.0",
  "bitflags",
  "brotli",
  "bytes",
@@ -385,6 +385,12 @@ dependencies = [
  "object",
  "rustc-demangle",
 ]
+
+[[package]]
+name = "base64"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "base64"
@@ -1521,6 +1527,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afabcc15e437a6484fc4f12d0fd63068fe457bf93f1c148d3d9649c60b103f32"
+dependencies = [
+ "base64 0.12.3",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "language-tags"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1714,6 +1734,7 @@ dependencies = [
  "http",
  "indexmap",
  "itertools",
+ "jsonwebtoken",
  "log",
  "maplit",
  "meilisearch-auth",
@@ -2038,6 +2059,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2181,6 +2213,17 @@ name = "pdqselect"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec91767ecc0a0bbe558ce8c9da33c068066c57ecc8bb8477ef8c1ad3ef77c27"
+
+[[package]]
+name = "pem"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd56cbd21fea48d0c440b41cd69c589faacade08c992d9a54e471b79d0fd13eb"
+dependencies = [
+ "base64 0.13.0",
+ "once_cell",
+ "regex",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -2542,7 +2585,7 @@ version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f242f1488a539a79bac6dbe7c8609ae43b7914b7736210f239a37cccb32525"
 dependencies = [
- "base64",
+ "base64 0.13.0",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2640,7 +2683,7 @@ version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
 dependencies = [
- "base64",
+ "base64 0.13.0",
  "log",
  "ring",
  "sct 0.6.1",
@@ -2665,7 +2708,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
 dependencies = [
- "base64",
+ "base64 0.13.0",
 ]
 
 [[package]]
@@ -2845,6 +2888,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "simple_asn1"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692ca13de57ce0613a363c8c2f1de925adebc81b04c923ac60c5488bb44abe4b"
+dependencies = [
+ "chrono",
+ "num-bigint",
+ "num-traits",
 ]
 
 [[package]]

--- a/meilisearch-http/Cargo.toml
+++ b/meilisearch-http/Cargo.toml
@@ -44,6 +44,7 @@ heed = { git = "https://github.com/Kerollmops/heed", tag = "v0.12.1" }
 http = "0.2.4"
 indexmap = { version = "1.7.0", features = ["serde-1"] }
 itertools = "0.10.1"
+jsonwebtoken = "7"
 log = "0.4.14"
 meilisearch-auth = { path = "../meilisearch-auth" }
 meilisearch-error = { path = "../meilisearch-error" }

--- a/meilisearch-http/src/analytics/segment_analytics.rs
+++ b/meilisearch-http/src/analytics/segment_analytics.rs
@@ -8,6 +8,7 @@ use actix_web::http::header::USER_AGENT;
 use actix_web::HttpRequest;
 use chrono::{DateTime, Utc};
 use http::header::CONTENT_TYPE;
+use meilisearch_auth::SearchRules;
 use meilisearch_lib::index::{SearchQuery, SearchResult};
 use meilisearch_lib::index_controller::Stats;
 use meilisearch_lib::MeiliSearch;
@@ -260,7 +261,7 @@ impl Segment {
     }
 
     async fn tick(&mut self, meilisearch: MeiliSearch) {
-        if let Ok(stats) = meilisearch.get_all_stats(&None).await {
+        if let Ok(stats) = meilisearch.get_all_stats(&SearchRules::default()).await {
             let _ = self
                 .batcher
                 .push(Identify {

--- a/meilisearch-http/src/extractors/authentication/mod.rs
+++ b/meilisearch-http/src/extractors/authentication/mod.rs
@@ -50,19 +50,23 @@ impl<P: Policy + 'static, D: 'static + Clone> FromRequest for GuardedData<P, D> 
                     Some("Bearer") => {
                         // TODO: find a less hardcoded way?
                         let index = req.match_info().get("index_uid");
-                        let token = type_token.next().unwrap_or("unknown");
-                        match P::authenticate(auth, token, index) {
-                            Some(filters) => match req.app_data::<D>().cloned() {
-                                Some(data) => ok(Self {
-                                    data,
-                                    filters,
-                                    _marker: PhantomData,
-                                }),
-                                None => err(AuthenticationError::IrretrievableState.into()),
+                        match type_token.next() {
+                            Some(token) => match P::authenticate(auth, token, index) {
+                                Some(filters) => match req.app_data::<D>().cloned() {
+                                    Some(data) => ok(Self {
+                                        data,
+                                        filters,
+                                        _marker: PhantomData,
+                                    }),
+                                    None => err(AuthenticationError::IrretrievableState.into()),
+                                },
+                                None => {
+                                    let token = token.to_string();
+                                    err(AuthenticationError::InvalidToken(token).into())
+                                }
                             },
                             None => {
-                                let token = token.to_string();
-                                err(AuthenticationError::InvalidToken(token).into())
+                                err(AuthenticationError::InvalidToken("unknown".to_string()).into())
                             }
                         }
                     }
@@ -90,10 +94,21 @@ pub trait Policy {
 }
 
 pub mod policies {
+    use chrono::Utc;
+    use jsonwebtoken::{dangerous_insecure_decode, decode, Algorithm, DecodingKey, Validation};
+    use once_cell::sync::Lazy;
+    use serde::{Deserialize, Serialize};
+
     use crate::extractors::authentication::Policy;
-    use meilisearch_auth::{Action, AuthController, AuthFilter};
+    use meilisearch_auth::{Action, AuthController, AuthFilter, SearchRules};
     // reexport actions in policies in order to be used in routes configuration.
     pub use meilisearch_auth::actions;
+
+    pub static TENANT_TOKEN_VALIDATION: Lazy<Validation> = Lazy::new(|| Validation {
+        validate_exp: false,
+        algorithms: vec![Algorithm::HS256, Algorithm::HS384, Algorithm::HS512],
+        ..Default::default()
+    });
 
     pub struct MasterPolicy;
 
@@ -126,15 +141,81 @@ pub mod policies {
                 return Some(AuthFilter::default());
             }
 
-            // authenticate if token is allowed.
-            if let Some(action) = Action::from_repr(A) {
-                let index = index.map(|i| i.as_bytes());
+            // Tenant token
+            if let Some(filters) = ActionPolicy::<A>::authenticate_tenant_token(&auth, token, index)
+            {
+                return Some(filters);
+            } else if let Some(action) = Action::from_repr(A) {
+                // API key
                 if let Ok(true) = auth.authenticate(token.as_bytes(), action, index) {
-                    return auth.get_key_filters(token).ok();
+                    return auth.get_key_filters(token, None).ok();
                 }
             }
 
             None
         }
+    }
+
+    impl<const A: u8> ActionPolicy<A> {
+        fn authenticate_tenant_token(
+            auth: &AuthController,
+            token: &str,
+            index: Option<&str>,
+        ) -> Option<AuthFilter> {
+            // Only search action can be accessed by a tenant token.
+            if A != actions::SEARCH {
+                return None;
+            }
+
+            // get token fields without validating it.
+            let Claims {
+                search_rules,
+                exp,
+                api_key_prefix,
+            } = dangerous_insecure_decode::<Claims>(token).ok()?.claims;
+
+            // Check index access if an index restriction is provided.
+            if let Some(index) = index {
+                if !search_rules.is_index_authorized(index) {
+                    return None;
+                }
+            }
+
+            // Check if token is expired.
+            if let Some(exp) = exp {
+                if Utc::now().timestamp() > exp {
+                    return None;
+                }
+            }
+
+            // check if parent key is authorized to do the action.
+            if auth
+                .is_key_authorized(api_key_prefix.as_bytes(), Action::Search, index)
+                .ok()?
+            {
+                // Check if tenant token is valid.
+                let key = auth.generate_key(&api_key_prefix)?;
+                decode::<Claims>(
+                    token,
+                    &DecodingKey::from_secret(key.as_bytes()),
+                    &TENANT_TOKEN_VALIDATION,
+                )
+                .ok()?;
+
+                return auth
+                    .get_key_filters(api_key_prefix, Some(search_rules))
+                    .ok();
+            }
+
+            None
+        }
+    }
+
+    #[derive(Debug, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct Claims {
+        search_rules: SearchRules,
+        exp: Option<i64>,
+        api_key_prefix: String,
     }
 }

--- a/meilisearch-http/src/routes/mod.rs
+++ b/meilisearch-http/src/routes/mod.rs
@@ -127,9 +127,9 @@ pub async fn running() -> HttpResponse {
 async fn get_stats(
     meilisearch: GuardedData<ActionPolicy<{ actions::STATS_GET }>, MeiliSearch>,
 ) -> Result<HttpResponse, ResponseError> {
-    let filters = meilisearch.filters();
+    let search_rules = &meilisearch.filters().search_rules;
 
-    let response = meilisearch.get_all_stats(&filters.indexes).await?;
+    let response = meilisearch.get_all_stats(search_rules).await?;
 
     debug!("returns: {:?}", response);
     Ok(HttpResponse::Ok().json(response))

--- a/meilisearch-http/src/routes/tasks.rs
+++ b/meilisearch-http/src/routes/tasks.rs
@@ -25,13 +25,16 @@ async fn get_tasks(
         Some(&req),
     );
 
-    let filters = meilisearch.filters().indexes.as_ref().map(|indexes| {
+    let search_rules = &meilisearch.filters().search_rules;
+    let filters = if search_rules.is_index_authorized("*") {
+        None
+    } else {
         let mut filters = TaskFilter::default();
-        for index in indexes {
-            filters.filter_index(index.to_string());
+        for (index, _policy) in search_rules.clone() {
+            filters.filter_index(index);
         }
-        filters
-    });
+        Some(filters)
+    };
 
     let tasks: TaskListView = meilisearch
         .list_tasks(filters, None, None)
@@ -56,13 +59,16 @@ async fn get_task(
         Some(&req),
     );
 
-    let filters = meilisearch.filters().indexes.as_ref().map(|indexes| {
+    let search_rules = &meilisearch.filters().search_rules;
+    let filters = if search_rules.is_index_authorized("*") {
+        None
+    } else {
         let mut filters = TaskFilter::default();
-        for index in indexes {
-            filters.filter_index(index.to_string());
+        for (index, _policy) in search_rules.clone() {
+            filters.filter_index(index);
         }
-        filters
-    });
+        Some(filters)
+    };
 
     let task: TaskView = meilisearch
         .get_task(task_id.into_inner(), filters)

--- a/meilisearch-http/tests/auth/authorization.rs
+++ b/meilisearch-http/tests/auth/authorization.rs
@@ -5,7 +5,7 @@ use once_cell::sync::Lazy;
 use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet};
 
-static AUTHORIZATIONS: Lazy<HashMap<(&'static str, &'static str), HashSet<&'static str>>> =
+pub static AUTHORIZATIONS: Lazy<HashMap<(&'static str, &'static str), HashSet<&'static str>>> =
     Lazy::new(|| {
         hashmap! {
             ("POST",    "/indexes/products/search") =>                         hashset!{"search", "*"},
@@ -49,7 +49,7 @@ static AUTHORIZATIONS: Lazy<HashMap<(&'static str, &'static str), HashSet<&'stat
         }
     });
 
-static ALL_ACTIONS: Lazy<HashSet<&'static str>> = Lazy::new(|| {
+pub static ALL_ACTIONS: Lazy<HashSet<&'static str>> = Lazy::new(|| {
     AUTHORIZATIONS
         .values()
         .cloned()

--- a/meilisearch-http/tests/auth/mod.rs
+++ b/meilisearch-http/tests/auth/mod.rs
@@ -1,6 +1,7 @@
 mod api_keys;
 mod authorization;
 mod payload;
+mod tenant_token;
 
 use crate::common::Server;
 use actix_web::http::StatusCode;

--- a/meilisearch-http/tests/auth/tenant_token.rs
+++ b/meilisearch-http/tests/auth/tenant_token.rs
@@ -1,0 +1,574 @@
+use crate::common::Server;
+use chrono::{Duration, Utc};
+use maplit::hashmap;
+use once_cell::sync::Lazy;
+use serde_json::{json, Value};
+use std::collections::HashMap;
+
+use super::authorization::{ALL_ACTIONS, AUTHORIZATIONS};
+
+fn generate_tenant_token(parent_key: impl AsRef<str>, mut body: HashMap<&str, Value>) -> String {
+    use jsonwebtoken::{encode, EncodingKey, Header};
+
+    let key_id = &parent_key.as_ref()[..8];
+    body.insert("apiKeyPrefix", json!(key_id));
+    encode(
+        &Header::default(),
+        &body,
+        &EncodingKey::from_secret(parent_key.as_ref().as_bytes()),
+    )
+    .unwrap()
+}
+
+static DOCUMENTS: Lazy<Value> = Lazy::new(|| {
+    json!([
+        {
+            "title": "Shazam!",
+            "id": "287947",
+            "color": ["green", "blue"]
+        },
+        {
+            "title": "Captain Marvel",
+            "id": "299537",
+            "color": ["yellow", "blue"]
+        },
+        {
+            "title": "Escape Room",
+            "id": "522681",
+            "color": ["yellow", "red"]
+        },
+        {
+            "title": "How to Train Your Dragon: The Hidden World",
+            "id": "166428",
+            "color": ["green", "red"]
+        },
+        {
+            "title": "Glass",
+            "id": "450465",
+            "color": ["blue", "red"]
+        }
+    ])
+});
+
+static INVALID_RESPONSE: Lazy<Value> = Lazy::new(|| {
+    json!({"message": "The provided API key is invalid.",
+        "code": "invalid_api_key",
+        "type": "auth",
+        "link": "https://docs.meilisearch.com/errors#invalid_api_key"
+    })
+});
+
+static ACCEPTED_KEYS: Lazy<Vec<Value>> = Lazy::new(|| {
+    vec![
+        json!({
+            "indexes": ["*"],
+            "actions": ["*"],
+            "expiresAt": Utc::now() + Duration::days(1)
+        }),
+        json!({
+            "indexes": ["*"],
+            "actions": ["search"],
+            "expiresAt": Utc::now() + Duration::days(1)
+        }),
+        json!({
+            "indexes": ["sales"],
+            "actions": ["*"],
+            "expiresAt": Utc::now() + Duration::days(1)
+        }),
+        json!({
+            "indexes": ["sales"],
+            "actions": ["search"],
+            "expiresAt": Utc::now() + Duration::days(1)
+        }),
+    ]
+});
+
+static REFUSED_KEYS: Lazy<Vec<Value>> = Lazy::new(|| {
+    vec![
+        // no search action
+        json!({
+            "indexes": ["*"],
+            "actions": ALL_ACTIONS.iter().cloned().filter(|a| *a != "search" && *a != "*").collect::<Vec<_>>(),
+            "expiresAt": Utc::now() + Duration::days(1)
+        }),
+        json!({
+            "indexes": ["sales"],
+            "actions": ALL_ACTIONS.iter().cloned().filter(|a| *a != "search" && *a != "*").collect::<Vec<_>>(),
+            "expiresAt": Utc::now() + Duration::days(1)
+        }),
+        // bad index
+        json!({
+            "indexes": ["products"],
+            "actions": ["*"],
+            "expiresAt": Utc::now() + Duration::days(1)
+        }),
+        json!({
+            "indexes": ["products"],
+            "actions": ["search"],
+            "expiresAt": Utc::now() + Duration::days(1)
+        }),
+    ]
+});
+
+macro_rules! compute_autorized_search {
+    ($tenant_tokens:expr, $filter:expr, $expected_count:expr) => {
+        let mut server = Server::new_auth().await;
+        server.use_api_key("MASTER_KEY");
+        let index = server.index("sales");
+        let documents = DOCUMENTS.clone();
+        index.add_documents(documents, None).await;
+        index.wait_task(0).await;
+        index
+            .update_settings(json!({"filterableAttributes": ["color"]}))
+            .await;
+        index.wait_task(1).await;
+        drop(index);
+
+        for key_content in ACCEPTED_KEYS.iter() {
+            server.use_api_key("MASTER_KEY");
+            let (response, code) = server.add_api_key(key_content.clone()).await;
+            assert_eq!(code, 201);
+            let key = response["key"].as_str().unwrap();
+
+            for tenant_token in $tenant_tokens.iter() {
+                let web_token = generate_tenant_token(&key, tenant_token.clone());
+                server.use_api_key(&web_token);
+                let index = server.index("sales");
+                index
+                    .search(json!({ "filter": $filter }), |response, code| {
+                        assert_eq!(
+                            code, 200,
+                            "{} using tenant_token: {:?} generated with parent_key: {:?}",
+                            response, tenant_token, key_content
+                        );
+                        assert_eq!(
+                            response["hits"].as_array().unwrap().len(),
+                            $expected_count,
+                            "{} using tenant_token: {:?} generated with parent_key: {:?}",
+                            response,
+                            tenant_token,
+                            key_content
+                        );
+                    })
+                    .await;
+            }
+        }
+    };
+}
+
+macro_rules! compute_forbidden_search {
+    ($tenant_tokens:expr, $parent_keys:expr) => {
+        let mut server = Server::new_auth().await;
+        server.use_api_key("MASTER_KEY");
+        let index = server.index("sales");
+        let documents = DOCUMENTS.clone();
+        index.add_documents(documents, None).await;
+        index.wait_task(0).await;
+        drop(index);
+
+        for key_content in $parent_keys.iter() {
+            server.use_api_key("MASTER_KEY");
+            let (response, code) = server.add_api_key(key_content.clone()).await;
+            assert_eq!(code, 201, "{:?}", response);
+            let key = response["key"].as_str().unwrap();
+
+            for tenant_token in $tenant_tokens.iter() {
+                let web_token = generate_tenant_token(&key, tenant_token.clone());
+                server.use_api_key(&web_token);
+                let index = server.index("sales");
+                index
+                    .search(json!({}), |response, code| {
+                        assert_eq!(
+                            response,
+                            INVALID_RESPONSE.clone(),
+                            "{} using tenant_token: {:?} generated with parent_key: {:?}",
+                            response,
+                            tenant_token,
+                            key_content
+                        );
+                        assert_eq!(
+                            code, 403,
+                            "{} using tenant_token: {:?} generated with parent_key: {:?}",
+                            response, tenant_token, key_content
+                        );
+                    })
+                    .await;
+            }
+        }
+    };
+}
+
+#[actix_rt::test]
+#[cfg_attr(target_os = "windows", ignore)]
+async fn search_authorized_simple_token() {
+    let tenant_tokens = vec![
+        hashmap! {
+            "searchRules" => json!({"*": {}}),
+            "exp" => json!((Utc::now() + Duration::hours(1)).timestamp())
+        },
+        hashmap! {
+            "searchRules" => json!(["*"]),
+            "exp" => json!((Utc::now() + Duration::hours(1)).timestamp())
+        },
+        hashmap! {
+            "searchRules" => json!({"sales": {}}),
+            "exp" => json!((Utc::now() + Duration::hours(1)).timestamp())
+        },
+        hashmap! {
+            "searchRules" => json!(["sales"]),
+            "exp" => json!((Utc::now() + Duration::hours(1)).timestamp())
+        },
+        hashmap! {
+            "searchRules" => json!({"*": {}}),
+            "exp" => Value::Null
+        },
+        hashmap! {
+            "searchRules" => json!({"*": Value::Null}),
+            "exp" => Value::Null
+        },
+        hashmap! {
+            "searchRules" => json!(["*"]),
+            "exp" => Value::Null
+        },
+        hashmap! {
+            "searchRules" => json!({"sales": {}}),
+            "exp" => Value::Null
+        },
+        hashmap! {
+            "searchRules" => json!({"sales": Value::Null}),
+            "exp" => Value::Null
+        },
+        hashmap! {
+            "searchRules" => json!(["sales"]),
+            "exp" => Value::Null
+        },
+    ];
+
+    compute_autorized_search!(tenant_tokens, {}, 5);
+}
+
+#[actix_rt::test]
+#[cfg_attr(target_os = "windows", ignore)]
+async fn search_authorized_filter_token() {
+    let tenant_tokens = vec![
+        hashmap! {
+            "searchRules" => json!({"*": {"filter": "color = blue"}}),
+            "exp" => json!((Utc::now() + Duration::hours(1)).timestamp())
+        },
+        hashmap! {
+            "searchRules" => json!({"sales": {"filter": "color = blue"}}),
+            "exp" => json!((Utc::now() + Duration::hours(1)).timestamp())
+        },
+        hashmap! {
+            "searchRules" => json!({"*": {"filter": ["color = blue"]}}),
+            "exp" => json!((Utc::now() + Duration::hours(1)).timestamp())
+        },
+        hashmap! {
+            "searchRules" => json!({"sales": {"filter": ["color = blue"]}}),
+            "exp" => json!((Utc::now() + Duration::hours(1)).timestamp())
+        },
+        // filter on sales should override filters on *
+        hashmap! {
+            "searchRules" => json!({
+                "*": {"filter": "color = green"},
+                "sales": {"filter": "color = blue"}
+            }),
+            "exp" => json!((Utc::now() + Duration::hours(1)).timestamp())
+        },
+        hashmap! {
+            "searchRules" => json!({
+                "*": {},
+                "sales": {"filter": "color = blue"}
+            }),
+            "exp" => json!((Utc::now() + Duration::hours(1)).timestamp())
+        },
+        hashmap! {
+            "searchRules" => json!({
+                "*": {"filter": "color = green"},
+                "sales": {"filter": ["color = blue"]}
+            }),
+            "exp" => json!((Utc::now() + Duration::hours(1)).timestamp())
+        },
+        hashmap! {
+            "searchRules" => json!({
+                "*": {},
+                "sales": {"filter": ["color = blue"]}
+            }),
+            "exp" => json!((Utc::now() + Duration::hours(1)).timestamp())
+        },
+    ];
+
+    compute_autorized_search!(tenant_tokens, {}, 3);
+}
+
+#[actix_rt::test]
+#[cfg_attr(target_os = "windows", ignore)]
+async fn filter_search_authorized_filter_token() {
+    let tenant_tokens = vec![
+        hashmap! {
+            "searchRules" => json!({"*": {"filter": "color = blue"}}),
+            "exp" => json!((Utc::now() + Duration::hours(1)).timestamp())
+        },
+        hashmap! {
+            "searchRules" => json!({"sales": {"filter": "color = blue"}}),
+            "exp" => json!((Utc::now() + Duration::hours(1)).timestamp())
+        },
+        hashmap! {
+            "searchRules" => json!({"*": {"filter": ["color = blue"]}}),
+            "exp" => json!((Utc::now() + Duration::hours(1)).timestamp())
+        },
+        hashmap! {
+            "searchRules" => json!({"sales": {"filter": ["color = blue"]}}),
+            "exp" => json!((Utc::now() + Duration::hours(1)).timestamp())
+        },
+        // filter on sales should override filters on *
+        hashmap! {
+            "searchRules" => json!({
+                "*": {"filter": "color = green"},
+                "sales": {"filter": "color = blue"}
+            }),
+            "exp" => json!((Utc::now() + Duration::hours(1)).timestamp())
+        },
+        hashmap! {
+            "searchRules" => json!({
+                "*": {},
+                "sales": {"filter": "color = blue"}
+            }),
+            "exp" => json!((Utc::now() + Duration::hours(1)).timestamp())
+        },
+        hashmap! {
+            "searchRules" => json!({
+                "*": {"filter": "color = green"},
+                "sales": {"filter": ["color = blue"]}
+            }),
+            "exp" => json!((Utc::now() + Duration::hours(1)).timestamp())
+        },
+        hashmap! {
+            "searchRules" => json!({
+                "*": {},
+                "sales": {"filter": ["color = blue"]}
+            }),
+            "exp" => json!((Utc::now() + Duration::hours(1)).timestamp())
+        },
+    ];
+
+    compute_autorized_search!(tenant_tokens, "color = yellow", 1);
+}
+
+#[actix_rt::test]
+#[cfg_attr(target_os = "windows", ignore)]
+async fn error_search_token_forbidden_parent_key() {
+    let tenant_tokens = vec![
+        hashmap! {
+            "searchRules" => json!({"*": {}}),
+            "exp" => json!((Utc::now() + Duration::hours(1)).timestamp())
+        },
+        hashmap! {
+            "searchRules" => json!({"*": Value::Null}),
+            "exp" => json!((Utc::now() + Duration::hours(1)).timestamp())
+        },
+        hashmap! {
+            "searchRules" => json!(["*"]),
+            "exp" => json!((Utc::now() + Duration::hours(1)).timestamp())
+        },
+        hashmap! {
+            "searchRules" => json!({"sales": {}}),
+            "exp" => json!((Utc::now() + Duration::hours(1)).timestamp())
+        },
+        hashmap! {
+            "searchRules" => json!({"sales": Value::Null}),
+            "exp" => json!((Utc::now() + Duration::hours(1)).timestamp())
+        },
+        hashmap! {
+            "searchRules" => json!(["sales"]),
+            "exp" => json!((Utc::now() + Duration::hours(1)).timestamp())
+        },
+    ];
+
+    compute_forbidden_search!(tenant_tokens, REFUSED_KEYS);
+}
+
+#[actix_rt::test]
+#[cfg_attr(target_os = "windows", ignore)]
+async fn error_search_forbidden_token() {
+    let tenant_tokens = vec![
+        // bad index
+        hashmap! {
+            "searchRules" => json!({"products": {}}),
+            "exp" => json!((Utc::now() + Duration::hours(1)).timestamp())
+        },
+        hashmap! {
+            "searchRules" => json!(["products"]),
+            "exp" => json!((Utc::now() + Duration::hours(1)).timestamp())
+        },
+        hashmap! {
+            "searchRules" => json!({"products": {}}),
+            "exp" => Value::Null
+        },
+        hashmap! {
+            "searchRules" => json!({"products": Value::Null}),
+            "exp" => Value::Null
+        },
+        hashmap! {
+            "searchRules" => json!(["products"]),
+            "exp" => Value::Null
+        },
+        // expired token
+        hashmap! {
+            "searchRules" => json!({"*": {}}),
+            "exp" => json!((Utc::now() - Duration::hours(1)).timestamp())
+        },
+        hashmap! {
+            "searchRules" => json!({"*": Value::Null}),
+            "exp" => json!((Utc::now() - Duration::hours(1)).timestamp())
+        },
+        hashmap! {
+            "searchRules" => json!(["*"]),
+            "exp" => json!((Utc::now() - Duration::hours(1)).timestamp())
+        },
+        hashmap! {
+            "searchRules" => json!({"sales": {}}),
+            "exp" => json!((Utc::now() - Duration::hours(1)).timestamp())
+        },
+        hashmap! {
+            "searchRules" => json!({"sales": Value::Null}),
+            "exp" => json!((Utc::now() - Duration::hours(1)).timestamp())
+        },
+        hashmap! {
+            "searchRules" => json!(["sales"]),
+            "exp" => json!((Utc::now() - Duration::hours(1)).timestamp())
+        },
+    ];
+
+    compute_forbidden_search!(tenant_tokens, ACCEPTED_KEYS);
+}
+
+#[actix_rt::test]
+#[cfg_attr(target_os = "windows", ignore)]
+async fn error_access_forbidden_routes() {
+    let mut server = Server::new_auth().await;
+    server.use_api_key("MASTER_KEY");
+
+    let content = json!({
+        "indexes": ["*"],
+        "actions": ["*"],
+        "expiresAt": (Utc::now() + Duration::hours(1)),
+    });
+
+    let (response, code) = server.add_api_key(content).await;
+    assert_eq!(code, 201);
+    assert!(response["key"].is_string());
+
+    let key = response["key"].as_str().unwrap();
+
+    let tenant_token = hashmap! {
+        "searchRules" => json!(["*"]),
+        "exp" => json!((Utc::now() + Duration::hours(1)).timestamp())
+    };
+    let web_token = generate_tenant_token(&key, tenant_token);
+    server.use_api_key(&web_token);
+
+    for ((method, route), actions) in AUTHORIZATIONS.iter() {
+        if !actions.contains("search") {
+            let (response, code) = server.dummy_request(method, route).await;
+            assert_eq!(response, INVALID_RESPONSE.clone());
+            assert_eq!(code, 403);
+        }
+    }
+}
+
+#[actix_rt::test]
+#[cfg_attr(target_os = "windows", ignore)]
+async fn error_access_expired_parent_key() {
+    use std::{thread, time};
+    let mut server = Server::new_auth().await;
+    server.use_api_key("MASTER_KEY");
+
+    let content = json!({
+        "indexes": ["*"],
+        "actions": ["*"],
+        "expiresAt": (Utc::now() + Duration::seconds(1)),
+    });
+
+    let (response, code) = server.add_api_key(content).await;
+    assert_eq!(code, 201);
+    assert!(response["key"].is_string());
+
+    let key = response["key"].as_str().unwrap();
+
+    let tenant_token = hashmap! {
+        "searchRules" => json!(["*"]),
+        "exp" => json!((Utc::now() + Duration::hours(1)).timestamp())
+    };
+    let web_token = generate_tenant_token(&key, tenant_token);
+    server.use_api_key(&web_token);
+
+    // test search request while parent_key is not expired
+    let (response, code) = server
+        .dummy_request("POST", "/indexes/products/search")
+        .await;
+    assert_ne!(response, INVALID_RESPONSE.clone());
+    assert_ne!(code, 403);
+
+    // wait until the key is expired.
+    thread::sleep(time::Duration::new(1, 0));
+
+    let (response, code) = server
+        .dummy_request("POST", "/indexes/products/search")
+        .await;
+    assert_eq!(response, INVALID_RESPONSE.clone());
+    assert_eq!(code, 403);
+}
+
+#[actix_rt::test]
+#[cfg_attr(target_os = "windows", ignore)]
+async fn error_access_modified_token() {
+    let mut server = Server::new_auth().await;
+    server.use_api_key("MASTER_KEY");
+
+    let content = json!({
+        "indexes": ["*"],
+        "actions": ["*"],
+        "expiresAt": (Utc::now() + Duration::hours(1)),
+    });
+
+    let (response, code) = server.add_api_key(content).await;
+    assert_eq!(code, 201);
+    assert!(response["key"].is_string());
+
+    let key = response["key"].as_str().unwrap();
+
+    let tenant_token = hashmap! {
+        "searchRules" => json!(["products"]),
+        "exp" => json!((Utc::now() + Duration::hours(1)).timestamp())
+    };
+    let web_token = generate_tenant_token(&key, tenant_token);
+    server.use_api_key(&web_token);
+
+    // test search request while web_token is valid
+    let (response, code) = server
+        .dummy_request("POST", "/indexes/products/search")
+        .await;
+    assert_ne!(response, INVALID_RESPONSE.clone());
+    assert_ne!(code, 403);
+
+    let tenant_token = hashmap! {
+        "searchRules" => json!(["*"]),
+        "exp" => json!((Utc::now() + Duration::hours(1)).timestamp())
+    };
+
+    let alt = generate_tenant_token(&key, tenant_token);
+    let altered_token = [
+        web_token.split('.').next().unwrap(),
+        alt.split('.').nth(1).unwrap(),
+        web_token.split('.').nth(2).unwrap(),
+    ]
+    .join(".");
+
+    server.use_api_key(&altered_token);
+    let (response, code) = server
+        .dummy_request("POST", "/indexes/products/search")
+        .await;
+    assert_eq!(response, INVALID_RESPONSE.clone());
+    assert_eq!(code, 403);
+}

--- a/meilisearch-lib/src/index_controller/mod.rs
+++ b/meilisearch-lib/src/index_controller/mod.rs
@@ -1,3 +1,4 @@
+use meilisearch_auth::SearchRules;
 use std::collections::BTreeMap;
 use std::fmt;
 use std::io::Cursor;
@@ -543,17 +544,14 @@ where
         Ok(stats)
     }
 
-    pub async fn get_all_stats(&self, index_filter: &Option<Vec<String>>) -> Result<Stats> {
+    pub async fn get_all_stats(&self, search_rules: &SearchRules) -> Result<Stats> {
         let mut last_task: Option<DateTime<_>> = None;
         let mut indexes = BTreeMap::new();
         let mut database_size = 0;
         let processing_task = self.task_store.get_processing_task().await?;
 
         for (index_uid, index) in self.index_resolver.list().await? {
-            if index_filter
-                .as_ref()
-                .map_or(false, |filter| !filter.contains(&index_uid))
-            {
+            if !search_rules.is_index_authorized(&index_uid) {
                 continue;
             }
 


### PR DESCRIPTION
Make meilisearch support JWT authentication signed with meilisearch API keys
using HS256, HS384 or HS512 algorithms.

Related spec: [specifications#89](https://github.com/meilisearch/specifications/pull/89) [rendered](https://github.com/meilisearch/specifications/blob/scoped-api-keys/text/0089-tenant-tokens.md)
Fix #1991 
