### PR TITLE
bug(auth): Make API keys accept Null descriptions

### DIFF
--- a/meilisearch-auth/src/key.rs
+++ b/meilisearch-auth/src/key.rs
@@ -20,13 +20,14 @@ pub struct Key {
 
 impl Key {
     pub fn create_from_value(value: Value) -> Result<Self> {
-        let description = value
-            .get("description")
-            .map(|des| {
+        let description = match value.get("description") {
+            Some(Value::Null) => None,
+            Some(des) => Some(
                 from_value(des.clone())
-                    .map_err(|_| AuthControllerError::InvalidApiKeyDescription(des.clone()))
-            })
-            .transpose()?;
+                    .map_err(|_| AuthControllerError::InvalidApiKeyDescription(des.clone()))?,
+            ),
+            None => None,
+        };
 
         let id = generate_id();
 

--- a/meilisearch-http/tests/auth/api_keys.rs
+++ b/meilisearch-http/tests/auth/api_keys.rs
@@ -1,6 +1,6 @@
 use crate::common::Server;
 use assert_json_diff::assert_json_include;
-use serde_json::json;
+use serde_json::{json, Value};
 use std::{thread, time};
 
 #[actix_rt::test]
@@ -127,6 +127,41 @@ async fn add_valid_api_key_no_description() {
     server.use_api_key("MASTER_KEY");
 
     let content = json!({
+        "indexes": ["products"],
+        "actions": [
+            "documents.add"
+        ],
+        "expiresAt": "2050-11-13T00:00:00"
+    });
+
+    let (response, code) = server.add_api_key(content).await;
+
+    assert!(response["key"].is_string());
+    assert!(response["expiresAt"].is_string());
+    assert!(response["createdAt"].is_string());
+    assert!(response["updatedAt"].is_string());
+
+    let expected_response = json!({
+        "actions": [
+            "documents.add"
+        ],
+        "indexes": [
+            "products"
+        ],
+        "expiresAt": "2050-11-13T00:00:00Z"
+    });
+
+    assert_json_include!(actual: response, expected: expected_response);
+    assert_eq!(code, 201);
+}
+
+#[actix_rt::test]
+async fn add_valid_api_key_null_description() {
+    let mut server = Server::new_auth().await;
+    server.use_api_key("MASTER_KEY");
+
+    let content = json!({
+        "description": Value::Null,
         "indexes": ["products"],
         "actions": [
             "documents.add"


### PR DESCRIPTION
Fix #2116
