### PR TITLE
fix(analytics): flatten the scheduler options

### DIFF
--- a/meilisearch-http/src/option.rs
+++ b/meilisearch-http/src/option.rs
@@ -42,6 +42,7 @@ pub struct Opt {
 
     /// Do not send analytics to Meili.
     #[cfg(all(not(debug_assertions), feature = "analytics"))]
+    #[serde(skip)] // we can't send true
     #[clap(long, env = "MEILI_NO_ANALYTICS")]
     pub no_analytics: bool,
 
@@ -148,6 +149,7 @@ pub struct Opt {
     #[clap(skip)]
     pub indexer_options: IndexerOpts,
 
+    #[serde(flatten)]
     #[clap(flatten)]
     pub scheduler_options: SchedulerConfig,
 }


### PR DESCRIPTION
Implement missing part of [this spec](https://github.com/meilisearch/specifications/blob/develop/text/0034-telemetry-policies.md) by flattening the scheduler options.