### PR TITLE
Fix max dbs error

### DIFF
--- a/meilisearch-auth/src/lib.rs
+++ b/meilisearch-auth/src/lib.rs
@@ -17,6 +17,7 @@ use sha2::{Digest, Sha256};
 pub use action::{actions, Action};
 use error::{AuthControllerError, Result};
 pub use key::Key;
+pub use store::open_auth_store_env;
 use store::HeedAuthStore;
 
 #[derive(Clone)]

--- a/meilisearch-auth/src/store.rs
+++ b/meilisearch-auth/src/store.rs
@@ -39,14 +39,18 @@ impl Drop for HeedAuthStore {
     }
 }
 
+pub fn open_auth_store_env(path: &Path) -> heed::Result<heed::Env> {
+    let mut options = EnvOpenOptions::new();
+    options.map_size(AUTH_STORE_SIZE); // 1GB
+    options.max_dbs(2);
+    options.open(path)
+}
+
 impl HeedAuthStore {
     pub fn new(path: impl AsRef<Path>) -> Result<Self> {
         let path = path.as_ref().join(AUTH_DB_PATH);
         create_dir_all(&path)?;
-        let mut options = EnvOpenOptions::new();
-        options.map_size(AUTH_STORE_SIZE); // 1GB
-        options.max_dbs(2);
-        let env = Arc::new(options.open(path)?);
+        let env = Arc::new(open_auth_store_env(path.as_ref())?);
         let keys = env.create_database(Some(KEY_DB_NAME))?;
         let action_keyid_index_expiration =
             env.create_database(Some(KEY_ID_ACTION_INDEX_EXPIRATION_DB_NAME))?;

--- a/meilisearch-http/src/routes/mod.rs
+++ b/meilisearch-http/src/routes/mod.rs
@@ -128,7 +128,6 @@ async fn get_stats(
     meilisearch: GuardedData<ActionPolicy<{ actions::STATS_GET }>, MeiliSearch>,
 ) -> Result<HttpResponse, ResponseError> {
     let search_rules = &meilisearch.filters().search_rules;
-
     let response = meilisearch.get_all_stats(search_rules).await?;
 
     debug!("returns: {:?}", response);

--- a/meilisearch-lib/src/index_controller/mod.rs
+++ b/meilisearch-lib/src/index_controller/mod.rs
@@ -48,6 +48,13 @@ pub type Payload = Box<
     dyn Stream<Item = std::result::Result<Bytes, PayloadError>> + Send + Sync + 'static + Unpin,
 >;
 
+pub fn open_meta_env(path: &Path, size: usize) -> heed::Result<heed::Env> {
+    let mut options = heed::EnvOpenOptions::new();
+    options.map_size(size);
+    options.max_dbs(20);
+    options.open(path)
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct IndexMetadata {
@@ -201,11 +208,7 @@ impl IndexControllerBuilder {
 
         std::fs::create_dir_all(db_path.as_ref())?;
 
-        let mut options = heed::EnvOpenOptions::new();
-        options.map_size(task_store_size);
-        options.max_dbs(20);
-
-        let meta_env = Arc::new(options.open(&db_path)?);
+        let meta_env = Arc::new(open_meta_env(db_path.as_ref(), task_store_size)?);
 
         let update_file_store = UpdateFileStore::new(&db_path)?;
         // Create or overwrite the version file for this DB


### PR DESCRIPTION
Factor the way we open environments to make sure they are always opened with the same options.


The issue was that indexes were first opened in snapshots with incorrect options, and heed cache returned an environment with incorrect open options on subsequent index open.

fix #2190
