### PR TITLE
Fix: avoid embedding the user input into the error response.

### DIFF
--- a/meilisearch-http/tests/documents/add_documents.rs
+++ b/meilisearch-http/tests/documents/add_documents.rs
@@ -312,16 +312,7 @@ async fn error_add_malformed_json_documents() {
     // truncate
 
     // length = 100
-    let long = String::from_utf8(
-        "0123456789"
-            .as_bytes()
-            .iter()
-            .cycle()
-            .cloned()
-            .take(100)
-            .collect_vec(),
-    )
-    .unwrap();
+    let long = "0123456789".repeat(10);
 
     let document = format!("\"{}\"", long);
     let req = test::TestRequest::put()

--- a/meilisearch-http/tests/documents/add_documents.rs
+++ b/meilisearch-http/tests/documents/add_documents.rs
@@ -321,9 +321,7 @@ async fn error_add_malformed_json_documents() {
         .to_request();
     let res = test::call_service(&app, req).await;
     let body = test::read_body(res).await;
-    dbg!(&body);
     let response: Value = serde_json::from_slice(&body).unwrap_or_default();
-    dbg!(&response);
     assert_eq!(status_code, 400);
     assert_eq!(
         response["message"],

--- a/meilisearch-http/tests/documents/add_documents.rs
+++ b/meilisearch-http/tests/documents/add_documents.rs
@@ -1,6 +1,5 @@
 use crate::common::{GetAllDocumentsOptions, Server};
 use actix_web::test;
-use itertools::Itertools;
 use meilisearch_http::{analytics, create_app};
 use serde_json::{json, Value};
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
@@ -329,7 +328,7 @@ async fn error_add_malformed_json_documents() {
     assert_eq!(
         response["message"],
         json!(
-            r#"The `json` payload provided is malformed. `Couldn't serialize document value: invalid type: string "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789", expected a documents, or a sequence of documents. at line 1 column 102`."#
+            r#"The `json` payload provided is malformed. `Couldn't serialize document value: invalid type: string "0123456789012345678901234567...890123456789", expected a documents, or a sequence of documents. at line 1 column 102`."#
         )
     );
     assert_eq!(response["code"], json!("malformed_payload"));
@@ -355,7 +354,7 @@ async fn error_add_malformed_json_documents() {
     assert_eq!(
         response["message"],
         json!(
-            r#"The `json` payload provided is malformed. `Couldn't serialize document value: invalid type: string "01234567890123456789012345678901234567890123456789 ... 1234567890123456789012345678901234567890123456789m", expected a documents, or a sequence of documents. at line 1 column 103`."#
+            r#"The `json` payload provided is malformed. `Couldn't serialize document value: invalid type: string "0123456789012345678901234567...90123456789m", expected a documents, or a sequence of documents. at line 1 column 103`."#
         )
     );
     assert_eq!(response["code"], json!("malformed_payload"));

--- a/meilisearch-http/tests/documents/add_documents.rs
+++ b/meilisearch-http/tests/documents/add_documents.rs
@@ -345,9 +345,7 @@ async fn error_add_malformed_json_documents() {
         .to_request();
     let res = test::call_service(&app, req).await;
     let body = test::read_body(res).await;
-    dbg!(&body);
     let response: Value = serde_json::from_slice(&body).unwrap_or_default();
-    dbg!(&response);
     assert_eq!(status_code, 400);
     assert_eq!(
         response["message"],

--- a/meilisearch-http/tests/documents/add_documents.rs
+++ b/meilisearch-http/tests/documents/add_documents.rs
@@ -348,8 +348,7 @@ async fn error_add_malformed_json_documents() {
         json!("https://docs.meilisearch.com/errors#malformed_payload")
     );
 
-
-
+    // add one more char to the long string to test if the truncating works.
     let document = format!("\"{}m\"", long);
     let req = test::TestRequest::put()
         .uri("/indexes/dog/documents")

--- a/meilisearch-http/tests/documents/add_documents.rs
+++ b/meilisearch-http/tests/documents/add_documents.rs
@@ -212,7 +212,7 @@ async fn error_add_malformed_csv_documents() {
     assert_eq!(
         response["message"],
         json!(
-            r#"The `csv` payload provided is malformed. `CSV error: record 1 (line: 2, byte: 12): found record with 3 fields, but the previous record has 2 fields`."#
+            r#"The `csv` payload provided is malformed: `CSV error: record 1 (line: 2, byte: 12): found record with 3 fields, but the previous record has 2 fields`."#
         )
     );
     assert_eq!(response["code"], json!("malformed_payload"));
@@ -236,7 +236,7 @@ async fn error_add_malformed_csv_documents() {
     assert_eq!(
         response["message"],
         json!(
-            r#"The `csv` payload provided is malformed. `CSV error: record 1 (line: 2, byte: 12): found record with 3 fields, but the previous record has 2 fields`."#
+            r#"The `csv` payload provided is malformed: `CSV error: record 1 (line: 2, byte: 12): found record with 3 fields, but the previous record has 2 fields`."#
         )
     );
     assert_eq!(response["code"], json!("malformed_payload"));
@@ -274,7 +274,7 @@ async fn error_add_malformed_json_documents() {
     assert_eq!(
         response["message"],
         json!(
-            r#"The `json` payload provided is malformed. `Couldn't serialize document value. at line 1 column 14`"#
+            r#"The `json` payload provided is malformed. `Couldn't serialize document value at line 1 column 14`"#
         )
     );
     assert_eq!(response["code"], json!("malformed_payload"));
@@ -298,7 +298,7 @@ async fn error_add_malformed_json_documents() {
     assert_eq!(
         response["message"],
         json!(
-            r#"The `json` payload provided is malformed. `Couldn't serialize document value. at line 1 column 14`"#
+            r#"The `json` payload provided is malformed. `Couldn't serialize document value at line 1 column 14`"#
         )
     );
     assert_eq!(response["code"], json!("malformed_payload"));
@@ -336,7 +336,7 @@ async fn error_add_malformed_ndjson_documents() {
     assert_eq!(
         response["message"],
         json!(
-            r#"The `ndjson` payload provided is malformed. `Couldn't serialize document value. at line 1 column 2`"#
+            r#"The `ndjson` payload provided is malformed. `Couldn't serialize document value at line 1 column 2`"#
         )
     );
     assert_eq!(response["code"], json!("malformed_payload"));
@@ -360,7 +360,7 @@ async fn error_add_malformed_ndjson_documents() {
     assert_eq!(
         response["message"],
         json!(
-            r#"The `ndjson` payload provided is malformed. `Couldn't serialize document value. at line 1 column 2`"#
+            r#"The `ndjson` payload provided is malformed. `Couldn't serialize document value at line 1 column 2`"#
         )
     );
     assert_eq!(response["code"], json!("malformed_payload"));

--- a/meilisearch-http/tests/documents/add_documents.rs
+++ b/meilisearch-http/tests/documents/add_documents.rs
@@ -274,7 +274,7 @@ async fn error_add_malformed_json_documents() {
     assert_eq!(
         response["message"],
         json!(
-            r#"The `json` payload provided is malformed. `Couldn't serialize document value: key must be a string at line 1 column 14`."#
+            r#"The `json` payload provided is malformed. `Couldn't serialize document value. at line 1 column 14`"#
         )
     );
     assert_eq!(response["code"], json!("malformed_payload"));
@@ -298,7 +298,7 @@ async fn error_add_malformed_json_documents() {
     assert_eq!(
         response["message"],
         json!(
-            r#"The `json` payload provided is malformed. `Couldn't serialize document value: key must be a string at line 1 column 14`."#
+            r#"The `json` payload provided is malformed. `Couldn't serialize document value. at line 1 column 14`"#
         )
     );
     assert_eq!(response["code"], json!("malformed_payload"));
@@ -336,7 +336,7 @@ async fn error_add_malformed_ndjson_documents() {
     assert_eq!(
         response["message"],
         json!(
-            r#"The `ndjson` payload provided is malformed. `Couldn't serialize document value: key must be a string at line 1 column 2`."#
+            r#"The `ndjson` payload provided is malformed. `Couldn't serialize document value. at line 1 column 2`"#
         )
     );
     assert_eq!(response["code"], json!("malformed_payload"));
@@ -360,7 +360,7 @@ async fn error_add_malformed_ndjson_documents() {
     assert_eq!(
         response["message"],
         json!(
-            r#"The `ndjson` payload provided is malformed. `Couldn't serialize document value: key must be a string at line 1 column 2`."#
+            r#"The `ndjson` payload provided is malformed. `Couldn't serialize document value. at line 1 column 2`"#
         )
     );
     assert_eq!(response["code"], json!("malformed_payload"));

--- a/meilisearch-lib/src/document_formats.rs
+++ b/meilisearch-lib/src/document_formats.rs
@@ -39,22 +39,15 @@ impl Display for DocumentFormatError {
                     // https://github.com/meilisearch/meilisearch/issues/2107
                     // The user input maybe insanely long. We need to truncate it.
                     let mut serde_msg = se.to_string();
-                    let prefix = r#"invalid type: string ""#;
-                    if serde_msg.starts_with(prefix) {
-                        let start_idx = prefix.len();
-                        if let Some(end_idx) = serde_msg.rfind("\"") {
-                            if end_idx - start_idx > 100 {
-                                serde_msg.replace_range(start_idx + 50..end_idx - 50, " ... ");
-                            }
-                        } else {
-                            serde_msg = String::from("");
-                        }
+                    let ellipsis = "...";
+                    if serde_msg.len() > 100 + ellipsis.len() {
+                        serde_msg.replace_range(50..serde_msg.len() - 50, ellipsis);
                     }
 
                     write!(
-                    f,
-                    "The `{}` payload provided is malformed. `Couldn't serialize document value: {}`.",
-                    b,serde_msg
+                        f,
+                        "The `{}` payload provided is malformed. `Couldn't serialize document value: {}`.",
+                        b, serde_msg
                 )
                 }
                 _ => write!(f, "The `{}` payload provided is malformed: `{}`.", b, me),

--- a/meilisearch-lib/src/document_formats.rs
+++ b/meilisearch-lib/src/document_formats.rs
@@ -55,8 +55,8 @@ impl Display for DocumentFormatError {
 
                     write!(
                     f,
-                    "The `{}` payload provided is malformed. `Couldn't serialize document value: {}. at line {} column {} `",
-                    b, se.line(), se.column(),serde_msg
+                    "The `{}` payload provided is malformed. `Couldn't serialize document value: {}`.",
+                    b,serde_msg
                 )
                 }
                 _ => write!(f, "The `{}` payload provided is malformed: `{}`.", b, me),

--- a/meilisearch-lib/src/document_formats.rs
+++ b/meilisearch-lib/src/document_formats.rs
@@ -41,7 +41,7 @@ impl Display for DocumentFormatError {
                     let mut serde_msg = se.to_string();
                     let ellipsis = "...";
                     if serde_msg.len() > 100 + ellipsis.len() {
-                        serde_msg.replace_range(50..serde_msg.len() - 50, ellipsis);
+                        serde_msg.replace_range(50..serde_msg.len() - 85, ellipsis);
                     }
 
                     write!(

--- a/meilisearch-lib/src/document_formats.rs
+++ b/meilisearch-lib/src/document_formats.rs
@@ -29,6 +29,7 @@ pub enum DocumentFormatError {
     Internal(Box<dyn std::error::Error + Send + Sync + 'static>),
     MalformedPayload(Box<milli::documents::Error>, PayloadType),
 }
+
 impl Display for DocumentFormatError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/meilisearch-lib/src/document_formats.rs
+++ b/meilisearch-lib/src/document_formats.rs
@@ -62,6 +62,7 @@ impl Display for DocumentFormatError {
         }
     }
 }
+
 impl std::error::Error for DocumentFormatError {}
 
 impl From<(PayloadType, milli::documents::Error)> for DocumentFormatError {

--- a/meilisearch-lib/src/document_formats.rs
+++ b/meilisearch-lib/src/document_formats.rs
@@ -32,14 +32,14 @@ pub enum DocumentFormatError {
 impl Display for DocumentFormatError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Internal(e) => write!(f, "An internal error has occurred. `{}`.", e),
+            Self::Internal(e) => write!(f, "An internal error has occurred: `{}`.", e),
             Self::MalformedPayload(me, b) => match me.borrow() {
                 milli::documents::Error::JsonError(se) => write!(
                     f,
-                    "The `{}` payload provided is malformed. `Couldn't serialize document value. at line {} column {}`",
-                    b,se.line(),se.column()
+                    "The `{}` payload provided is malformed. `Couldn't serialize document value at line {} column {}`",
+                    b, se.line(), se.column()
                 ),
-                _ => write!(f, "The `{}` payload provided is malformed. `{}`.", b, me),
+                _ => write!(f, "The `{}` payload provided is malformed: `{}`.", b, me),
             },
         }
     }

--- a/meilisearch-lib/src/document_formats.rs
+++ b/meilisearch-lib/src/document_formats.rs
@@ -35,13 +35,10 @@ impl Display for DocumentFormatError {
             Self::Internal(e) => write!(f, "An internal error has occurred: `{}`.", e),
             Self::MalformedPayload(me, b) => match me.borrow() {
                 milli::documents::Error::JsonError(se) => {
-                    // "invalid type: {}, expected {}"
-                    let mut serde_msg = se.to_string();
-
                     // https://github.com/meilisearch/meilisearch/issues/2107
                     // The user input maybe insanely long. We need to truncate it.
+                    let mut serde_msg = se.to_string();
                     let prefix = r#"invalid type: string ""#;
-
                     if serde_msg.starts_with(prefix) {
                         let start_idx = prefix.len();
                         if let Some(end_idx) = serde_msg.rfind("\"") {

--- a/meilisearch-lib/src/document_formats.rs
+++ b/meilisearch-lib/src/document_formats.rs
@@ -34,12 +34,12 @@ impl Display for DocumentFormatError {
         match self {
             Self::Internal(e) => write!(f, "An internal error has occurred. `{}`.", e),
             Self::MalformedPayload(me, b) => match me.borrow() {
-                milli::documents::Error::JsonError(_) => write!(
+                milli::documents::Error::JsonError(se) => write!(
                     f,
-                    "The `{}` payload provided is malformed. line: {}",
-                    b, "TODO"
+                    "The `{}` payload provided is malformed. `Couldn't serialize document value. at line {} column {}`",
+                    b,se.line(),se.column()
                 ),
-                _ => write!(f, "The `{}` payload provided is malformed. line: {}", b, me),
+                _ => write!(f, "The `{}` payload provided is malformed. `{}`.", b, me),
             },
         }
     }

--- a/meilisearch-lib/src/document_formats.rs
+++ b/meilisearch-lib/src/document_formats.rs
@@ -1,4 +1,5 @@
-use std::fmt;
+use std::borrow::Borrow;
+use std::fmt::{self, Debug, Display};
 use std::io::{self, BufRead, BufReader, BufWriter, Cursor, Read, Seek, Write};
 
 use meilisearch_error::{internal_error, Code, ErrorCode};
@@ -23,16 +24,27 @@ impl fmt::Display for PayloadType {
     }
 }
 
-#[derive(thiserror::Error, Debug)]
+#[derive(Debug)]
 pub enum DocumentFormatError {
-    #[error("An internal error has occurred. `{0}`.")]
     Internal(Box<dyn std::error::Error + Send + Sync + 'static>),
-    #[error("The `{1}` payload provided is malformed. `{0}`.")]
-    MalformedPayload(
-        Box<dyn std::error::Error + Send + Sync + 'static>,
-        PayloadType,
-    ),
+    MalformedPayload(Box<milli::documents::Error>, PayloadType),
 }
+impl Display for DocumentFormatError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Internal(e) => write!(f, "An internal error has occurred. `{}`.", e),
+            Self::MalformedPayload(me, b) => match me.borrow() {
+                milli::documents::Error::JsonError(_) => write!(
+                    f,
+                    "The `{}` payload provided is malformed. line: {}",
+                    b, "TODO"
+                ),
+                _ => write!(f, "The `{}` payload provided is malformed. line: {}", b, me),
+            },
+        }
+    }
+}
+impl std::error::Error for DocumentFormatError {}
 
 impl From<(PayloadType, milli::documents::Error)> for DocumentFormatError {
     fn from((ty, error): (PayloadType, milli::documents::Error)) -> Self {


### PR DESCRIPTION
# Pull Request

## What does this PR do?
Fix #2107. 

The problem is meilisearch embeds the user input to the error message. 

The reason for this problem is `milli` throws a `serde_json: Error` whose `Display` implementation will do this embedding.  

I tried to solve this problem in this PR by manually implementing the `Display` trait for `DocumentFormatError` instead of deriving automatically.

<!-- Please link the issue you're trying to fix with this PR, if none then please create an issue first. -->

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
