### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,6 @@ dependencies = [
  "rand",
  "sha-1 0.10.0",
  "smallvec",
- "zstd",
 ]
 
 [[package]]
@@ -3998,33 +3997,4 @@ dependencies = [
  "flate2",
  "thiserror",
  "time 0.1.43",
-]
-
-[[package]]
-name = "zstd"
-version = "0.10.0+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b1365becbe415f3f0fcd024e2f7b45bacfb5bdd055f0dc113571394114e7bdd"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "4.1.4+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f7cd17c9af1a4d6c24beb1cc54b17e2ef7b593dc92f19e9d9acad8b182bbaee"
-dependencies = [
- "libc",
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "1.6.3+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc49afa5c8d634e75761feda8c592051e7eeb4683ba827211eb0d731d3402ea8"
-dependencies = [
- "cc",
- "libc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,18 +294,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arc-swap"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5d78ce20460b82d3fa150275ed9d55e21064fc7951177baacf86a145c4a4b1f"
-
-[[package]]
-name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
 name = "as-slice"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1085,7 +1073,7 @@ name = "filter-parser"
 version = "0.1.0"
 source = "git+https://github.com/meilisearch/milli.git?tag=v0.24.0#5863afa1a568950de2928ba2d78b95aee243dad1"
 dependencies = [
- "nom 7.1.1",
+ "nom",
  "nom_locate",
 ]
 
@@ -1595,15 +1583,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35e70ee094dc02fd9c13fdad4940090f22dbd6ac7c9e7094a46cf0232a50bc7c"
 
 [[package]]
-name = "iso8601-duration"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b51dd97fa24074214b9eb14da518957573f4dec3189112610ae1ccec9ac464"
-dependencies = [
- "nom 5.1.2",
-]
-
-[[package]]
 name = "itertools"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1690,19 +1669,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
 dependencies = [
  "fst",
-]
-
-[[package]]
-name = "lexical-core"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
-dependencies = [
- "arrayvec",
- "bitflags",
- "cfg-if 1.0.0",
- "ryu",
- "static_assertions",
 ]
 
 [[package]]
@@ -1956,7 +1922,6 @@ dependencies = [
  "actix-web",
  "actix-web-static-files",
  "anyhow",
- "arc-swap",
  "assert-json-diff",
  "async-stream",
  "async-trait",
@@ -1975,7 +1940,6 @@ dependencies = [
  "hex",
  "http",
  "indexmap",
- "iso8601-duration",
  "itertools",
  "jsonwebtoken",
  "log",
@@ -2060,7 +2024,6 @@ dependencies = [
  "once_cell",
  "parking_lot 0.11.2",
  "paste",
- "pin-project",
  "proptest",
  "proptest-derive",
  "rand",
@@ -2273,17 +2236,6 @@ source = "git+https://github.com/MarinPostma/nelson.git?rev=675f13885548fb415ead
 
 [[package]]
 name = "nom"
-version = "5.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
-dependencies = [
- "lexical-core",
- "memchr",
- "version_check",
-]
-
-[[package]]
-name = "nom"
 version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
@@ -2300,7 +2252,7 @@ checksum = "37794436ca3029a3089e0b95d42da1f0b565ad271e4d3bb4bad0c7bb70b10605"
 dependencies = [
  "bytecount",
  "memchr",
- "nom 7.1.1",
+ "nom",
 ]
 
 [[package]]
@@ -2583,26 +2535,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
 dependencies = [
  "siphasher",
-]
-
-[[package]]
-name = "pin-project"
-version = "1.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58ad3879ad3baf4e44784bc6a718a8698867bb991f8ce24d1bcbe2cfb4c3a75e"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
-dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.15",
- "syn 1.0.88",
 ]
 
 [[package]]
@@ -3324,12 +3256,6 @@ dependencies = [
  "mime_guess",
  "path-slash",
 ]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,7 +46,7 @@ dependencies = [
  "actix-tls",
  "actix-utils",
  "ahash 0.7.6",
- "base64 0.13.0",
+ "base64",
  "bitflags",
  "brotli",
  "bytes",
@@ -67,7 +67,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rand",
- "sha-1 0.10.0",
+ "sha-1",
  "smallvec",
 ]
 
@@ -386,12 +386,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
-
-[[package]]
-name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
@@ -434,15 +428,6 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array 0.14.5",
-]
 
 [[package]]
 name = "block-buffer"
@@ -578,9 +563,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_toml"
-version = "0.9.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3596addfb02dcdc06f5252ddda9f3785f9230f5827fb4284645240fa05ad92"
+checksum = "4e270ef0cd868745878982f7ce470aa898d0d4bb248af67f0cf66f54617913ef"
 dependencies = [
  "serde",
  "serde_derive",
@@ -634,19 +619,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e48477ece09d6a21c033cb604968524a37782532727055d6f6faafac1781e5c"
 dependencies = [
  "bincode",
-]
-
-[[package]]
-name = "chrono"
-version = "0.4.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
-dependencies = [
- "libc",
- "num-integer",
- "num-traits",
- "time 0.1.43",
- "winapi",
 ]
 
 [[package]]
@@ -883,19 +855,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2c9736e15e7df1638a7f6eee92a6511615c738246a052af5ba86f039b65aede"
 
 [[package]]
-name = "difference"
-version = "2.0.0"
+name = "difflib"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
-
-[[package]]
-name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array 0.14.5",
-]
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
@@ -903,7 +866,7 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
 dependencies = [
- "block-buffer 0.10.2",
+ "block-buffer",
  "crypto-common",
 ]
 
@@ -930,9 +893,9 @@ dependencies = [
 
 [[package]]
 name = "downcast"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb454f0228b18c7f4c3b0ebbee346ed9c52e7443b0999cd543ff3571205701d"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "either"
@@ -1096,9 +1059,9 @@ dependencies = [
 
 [[package]]
 name = "float-cmp"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1267f4ac4f343772758f7b1bdcbe767c218bbab93bb432acbf5162bbf85a6c4"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 dependencies = [
  "num-traits",
 ]
@@ -1526,7 +1489,7 @@ checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
 dependencies = [
  "http",
  "hyper",
- "rustls 0.20.4",
+ "rustls",
  "tokio",
  "tokio-rustls",
 ]
@@ -1637,11 +1600,11 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "7.2.0"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afabcc15e437a6484fc4f12d0fd63068fe457bf93f1c148d3d9649c60b103f32"
+checksum = "012bb02250fdd38faa5feee63235f7a459974440b9b57593822414c31f92839e"
 dependencies = [
- "base64 0.12.3",
+ "base64",
  "pem",
  "ring",
  "serde",
@@ -1951,7 +1914,7 @@ dependencies = [
  "num_cpus",
  "obkv",
  "once_cell",
- "parking_lot 0.11.2",
+ "parking_lot",
  "paste",
  "pin-project-lite",
  "platform-dirs",
@@ -1959,16 +1922,16 @@ dependencies = [
  "rayon",
  "regex",
  "reqwest",
- "rustls 0.20.4",
- "rustls-pemfile 0.2.1",
+ "rustls",
+ "rustls-pemfile",
  "segment",
  "serde",
  "serde_json",
  "serde_url_params",
- "sha-1 0.9.8",
+ "sha-1",
  "sha2",
  "siphasher",
- "slice-group-by 0.2.6",
+ "slice-group-by",
  "static-files",
  "sysinfo",
  "tar",
@@ -2021,7 +1984,7 @@ dependencies = [
  "num_cpus",
  "obkv",
  "once_cell",
- "parking_lot 0.11.2",
+ "parking_lot",
  "paste",
  "proptest",
  "proptest-derive",
@@ -2029,11 +1992,11 @@ dependencies = [
  "rayon",
  "regex",
  "reqwest",
- "rustls 0.19.1",
+ "rustls",
  "serde",
  "serde_json",
  "siphasher",
- "slice-group-by 0.2.6",
+ "slice-group-by",
  "sysinfo",
  "tar",
  "tempfile",
@@ -2058,7 +2021,7 @@ dependencies = [
  "lindera",
  "lindera-core",
  "once_cell",
- "slice-group-by 0.3.0",
+ "slice-group-by",
  "unicode-segmentation",
  "whatlang",
 ]
@@ -2120,7 +2083,7 @@ dependencies = [
  "rstar",
  "serde",
  "serde_json",
- "slice-group-by 0.3.0",
+ "slice-group-by",
  "smallstr",
  "smallvec",
  "tempfile",
@@ -2185,9 +2148,9 @@ dependencies = [
 
 [[package]]
 name = "mockall"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ab571328afa78ae322493cacca3efac6a0f2e0a67305b4df31fd439ef129ac0"
+checksum = "3d4d70639a72f972725db16350db56da68266ca368b2a1fe26724a903ad3d6b8"
 dependencies = [
  "cfg-if 1.0.0",
  "downcast",
@@ -2200,9 +2163,9 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7e25b214433f669161f414959594216d8e6ba83b6679d3db96899c0b4639033"
+checksum = "79ef208208a0dea3f72221e26e904cdc6db2e481d9ade89081ddd494f1dbaa6b"
 dependencies = [
  "cfg-if 1.0.0",
  "proc-macro2 1.0.36",
@@ -2271,9 +2234,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.2.6"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -2340,12 +2303,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
 name = "openssl"
 version = "0.10.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2408,37 +2365,12 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.5",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.1",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
-dependencies = [
- "cfg-if 1.0.0",
- "instant",
- "libc",
- "redox_syscall",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -2483,13 +2415,11 @@ checksum = "4ec91767ecc0a0bbe558ce8c9da33c068066c57ecc8bb8477ef8c1ad3ef77c27"
 
 [[package]]
 name = "pem"
-version = "0.8.3"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd56cbd21fea48d0c440b41cd69c589faacade08c992d9a54e471b79d0fd13eb"
+checksum = "e9a3b09a20e374558580a4914d3b7d89bd61b954a5a5e1dcbea98753addb1947"
 dependencies = [
- "base64 0.13.0",
- "once_cell",
- "regex",
+ "base64",
 ]
 
 [[package]]
@@ -2571,12 +2501,13 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "predicates"
-version = "1.0.8"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49cfaf7fdaa3bfacc6fa3e7054e65148878354a5cfddcf661df4c851f8021df"
+checksum = "a5aab5be6e4732b473071984b3164dbbfb7a3674d30ea5ff44410b6bcd960c3c"
 dependencies = [
- "difference",
+ "difflib",
  "float-cmp",
+ "itertools",
  "normalize-line-endings",
  "predicates-core",
  "regex",
@@ -2682,6 +2613,15 @@ name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
+name = "quickcheck"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
+dependencies = [
+ "rand",
+]
 
 [[package]]
 name = "quote"
@@ -2822,7 +2762,7 @@ version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46a1f7aa4f35e5e8b4160449f51afc758f0ce6454315a9fa7d0d113e958c41eb"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2841,8 +2781,8 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.20.4",
- "rustls-pemfile 0.3.0",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -2919,36 +2859,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
-dependencies = [
- "base64 0.13.0",
- "log",
- "ring",
- "sct 0.6.1",
- "webpki 0.21.4",
-]
-
-[[package]]
-name = "rustls"
 version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fbfeb8d0ddb84706bc597a5574ab8912817c52a397f819e5b614e2265206921"
 dependencies = [
  "log",
  "ring",
- "sct 0.7.0",
- "webpki 0.22.0",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
-dependencies = [
- "base64 0.13.0",
+ "sct",
+ "webpki",
 ]
 
 [[package]]
@@ -2957,7 +2875,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ee86d63972a7c661d1536fefe8c3c8407321c3df668891286de28abcd087360"
 dependencies = [
- "base64 0.13.0",
+ "base64",
 ]
 
 [[package]]
@@ -3008,16 +2926,6 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "sct"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "sct"
@@ -3128,39 +3036,24 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if 1.0.0",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
-]
-
-[[package]]
-name = "sha-1"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.10.3",
+ "digest",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.9.9"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
 dependencies = [
- "block-buffer 0.9.0",
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
+ "digest",
 ]
 
 [[package]]
@@ -3174,13 +3067,14 @@ dependencies = [
 
 [[package]]
 name = "simple_asn1"
-version = "0.4.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692ca13de57ce0613a363c8c2f1de925adebc81b04c923ac60c5488bb44abe4b"
+checksum = "4a762b1c38b9b990c694b9c2f8abe3372ce6a9ceaae6bca39cfc46e054f45745"
 dependencies = [
- "chrono",
  "num-bigint",
  "num-traits",
+ "thiserror",
+ "time 0.3.7",
 ]
 
 [[package]]
@@ -3194,12 +3088,6 @@ name = "slab"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
-
-[[package]]
-name = "slice-group-by"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f7474f0b646d228360ab62ed974744617bc869d959eac8403bfa3665931a7fb"
 
 [[package]]
 name = "slice-group-by"
@@ -3307,9 +3195,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.20.5"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e223c65cd36b485a34c2ce6e38efa40777d31c4166d9076030c74cdcf971679f"
+checksum = "07fa4c84a5305909b0eedfcc8d1f2fafdbede645bb700a45ecaafe681a0ac5d6"
 dependencies = [
  "cfg-if 1.0.0",
  "core-foundation-sys",
@@ -3426,6 +3314,7 @@ dependencies = [
  "itoa 1.0.1",
  "libc",
  "num_threads",
+ "quickcheck",
  "serde",
  "time-macros",
 ]
@@ -3463,7 +3352,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "once_cell",
- "parking_lot 0.12.0",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -3498,9 +3387,9 @@ version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a27d5f2b839802bd8267fa19b0530f5a08b9c08cd417976be2a65d130fe1c11b"
 dependencies = [
- "rustls 0.20.4",
+ "rustls",
  "tokio",
- "webpki 0.22.0",
+ "webpki",
 ]
 
 [[package]]
@@ -3680,18 +3569,18 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vergen"
-version = "5.1.17"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cf88d94e969e7956d924ba70741316796177fa0c79a2c9f4ab04998d96e966e"
+checksum = "4db743914c971db162f35bf46601c5a63ec4452e61461937b4c1ab817a60c12e"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
- "chrono",
  "enum-iterator",
  "getset",
  "git2",
  "rustversion",
  "thiserror",
+ "time 0.3.7",
 ]
 
 [[package]]
@@ -3820,16 +3709,6 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.21.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "webpki"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
@@ -3844,7 +3723,7 @@ version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "552ceb903e957524388c4d3475725ff2c8b7960922063af6ce53c9a43da07449"
 dependencies = [
- "webpki 0.22.0",
+ "webpki",
 ]
 
 [[package]]

--- a/meilisearch-auth/Cargo.toml
+++ b/meilisearch-auth/Cargo.toml
@@ -5,11 +5,11 @@ edition = "2021"
 
 [dependencies]
 enum-iterator = "0.7.0"
-sha2 = "0.9.6"
 meilisearch-error = { path = "../meilisearch-error" }
-serde_json = { version = "1.0.67", features = ["preserve_order"] }
-time = { version = "0.3.7", features = ["serde-well-known", "formatting", "parsing", "macros"] }
-rand = "0.8.4"
-serde = { version = "1.0.130", features = ["derive"] }
-thiserror = "1.0.28"
 milli = { git = "https://github.com/meilisearch/milli.git", tag = "v0.24.0" }
+rand = "0.8.4"
+serde = { version = "1.0.136", features = ["derive"] }
+serde_json = { version = "1.0.79", features = ["preserve_order"] }
+sha2 = "0.10.2"
+thiserror = "1.0.30"
+time = { version = "0.3.7", features = ["serde-well-known", "formatting", "parsing", "macros"] }

--- a/meilisearch-error/Cargo.toml
+++ b/meilisearch-error/Cargo.toml
@@ -5,11 +5,11 @@ authors = ["marin <postma.marin@protonmail.com>"]
 edition = "2021"
 
 [dependencies]
-actix-web = { version = "4", default-features = false }
+actix-web = { version = "4.0.1", default-features = false }
 proptest = { version = "1.0.0", optional = true }
 proptest-derive = { version = "0.3.0", optional = true }
-serde = { version = "1.0.130", features = ["derive"] }
-serde_json = "1.0.69"
+serde = { version = "1.0.136", features = ["derive"] }
+serde_json = "1.0.79"
 
 [features]
 test-traits = ["proptest", "proptest-derive"]

--- a/meilisearch-http/Cargo.toml
+++ b/meilisearch-http/Cargo.toml
@@ -86,6 +86,8 @@ serde_url_params = "0.2.1"
 urlencoding = "2.1.0"
 
 [features]
+default = ["analytics", "mini-dashboard"]
+analytics = ["segment"]
 mini-dashboard = [
     "actix-web-static-files",
     "static-files",
@@ -97,8 +99,6 @@ mini-dashboard = [
     "tempfile",
     "zip",
 ]
-analytics = ["segment"]
-default = ["analytics", "mini-dashboard"]
 
 [target.'cfg(target_os = "linux")'.dependencies]
 tikv-jemallocator = "0.4.1"

--- a/meilisearch-http/Cargo.toml
+++ b/meilisearch-http/Cargo.toml
@@ -23,7 +23,7 @@ zip = { version = "0.5.13", optional = true }
 
 [dependencies]
 actix-cors = "0.6"
-actix-web = { version = "4", features = ["rustls"] }
+actix-web = { version = "4", default-features = false, features = ["macros", "compress-brotli", "compress-gzip", "cookies", "rustls"] }
 actix-web-static-files = { git = "https://github.com/kilork/actix-web-static-files.git", rev = "2d3b6160", optional = true }
 anyhow = { version = "1.0.43", features = ["backtrace"] }
 async-stream = "0.3.2"

--- a/meilisearch-http/Cargo.toml
+++ b/meilisearch-http/Cargo.toml
@@ -26,7 +26,6 @@ actix-cors = "0.6"
 actix-web = { version = "4", features = ["rustls"] }
 actix-web-static-files = { git = "https://github.com/kilork/actix-web-static-files.git", rev = "2d3b6160", optional = true }
 anyhow = { version = "1.0.43", features = ["backtrace"] }
-arc-swap = "1.3.2"
 async-stream = "0.3.2"
 async-trait = "0.1.51"
 bstr = "0.2.17"
@@ -41,7 +40,6 @@ futures = "0.3.17"
 futures-util = "0.3.17"
 http = "0.2.4"
 indexmap = { version = "1.7.0", features = ["serde-1"] }
-iso8601-duration = "0.1.0"
 itertools = "0.10.1"
 jsonwebtoken = "7"
 log = "0.4.14"

--- a/meilisearch-http/Cargo.toml
+++ b/meilisearch-http/Cargo.toml
@@ -11,77 +11,77 @@ name = "meilisearch"
 path = "src/main.rs"
 
 [build-dependencies]
-static-files = { version = "0.2.1", optional = true }
-anyhow = { version = "1.0.43", optional = true }
-cargo_toml = { version = "0.9", optional = true }
+anyhow = { version = "1.0.56", optional = true }
+cargo_toml = { version = "0.11.4", optional = true }
 hex = { version = "0.4.3", optional = true }
-reqwest = { version = "0.11.4", features = ["blocking", "rustls-tls"], default-features = false, optional = true }
-sha-1 = { version = "0.9.8", optional = true }
-tempfile = { version = "3.2.0", optional = true }
-vergen = { version = "5.1.15", default-features = false, features = ["git"] }
+reqwest = { version = "0.11.9", features = ["blocking", "rustls-tls"], default-features = false, optional = true }
+sha-1 = { version = "0.10.0", optional = true }
+static-files = { version = "0.2.3", optional = true }
+tempfile = { version = "3.3.0", optional = true }
+vergen = { version = "7.0.0", default-features = false, features = ["git"] }
 zip = { version = "0.5.13", optional = true }
 
 [dependencies]
-actix-cors = "0.6"
-actix-web = { version = "4", default-features = false, features = ["macros", "compress-brotli", "compress-gzip", "cookies", "rustls"] }
+actix-cors = "0.6.1"
+actix-web = { version = "4.0.1", default-features = false, features = ["macros", "compress-brotli", "compress-gzip", "cookies", "rustls"] }
 actix-web-static-files = { git = "https://github.com/kilork/actix-web-static-files.git", rev = "2d3b6160", optional = true }
-anyhow = { version = "1.0.43", features = ["backtrace"] }
-async-stream = "0.3.2"
-async-trait = "0.1.51"
+anyhow = { version = "1.0.56", features = ["backtrace"] }
+async-stream = "0.3.3"
+async-trait = "0.1.52"
 bstr = "0.2.17"
-byte-unit = { version = "4.0.12", default-features = false, features = ["std", "serde"] }
+byte-unit = { version = "4.0.14", default-features = false, features = ["std", "serde"] }
 bytes = "1.1.0"
-crossbeam-channel = "0.5.1"
+clap = { version = "3.1.6", features = ["derive", "env"] }
+crossbeam-channel = "0.5.2"
 either = "1.6.1"
 env_logger = "0.9.0"
-flate2 = "1.0.21"
+flate2 = "1.0.22"
 fst = "0.4.7"
-futures = "0.3.17"
-futures-util = "0.3.17"
-http = "0.2.4"
-indexmap = { version = "1.7.0", features = ["serde-1"] }
-itertools = "0.10.1"
-jsonwebtoken = "7"
+futures = "0.3.21"
+futures-util = "0.3.21"
+http = "0.2.6"
+indexmap = { version = "1.8.0", features = ["serde-1"] }
+itertools = "0.10.3"
+jsonwebtoken = "8.0.1"
 log = "0.4.14"
 meilisearch-auth = { path = "../meilisearch-auth" }
 meilisearch-error = { path = "../meilisearch-error" }
 meilisearch-lib = { path = "../meilisearch-lib" }
+milli = { git = "https://github.com/meilisearch/milli.git", tag = "v0.24.0" }
 mime = "0.3.16"
-num_cpus = "1.13.0"
+num_cpus = "1.13.1"
 obkv = "0.2.0"
-once_cell = "1.8.0"
-parking_lot = "0.11.2"
+once_cell = "1.10.0"
+parking_lot = "0.12.0"
+pin-project-lite = "0.2.8"
 platform-dirs = "0.3.0"
-rand = "0.8.4"
+rand = "0.8.5"
 rayon = "1.5.1"
-regex = "1.5.4"
-rustls = "0.20.2"
-rustls-pemfile = "0.2"
+regex = "1.5.5"
+rustls = "0.20.4"
+rustls-pemfile = "0.3.0"
 segment = { version = "0.2.0", optional = true }
-serde = { version = "1.0.130", features = ["derive"] }
-serde_json = { version = "1.0.67", features = ["preserve_order"] }
-sha2 = "0.9.6"
-siphasher = "0.3.7"
-slice-group-by = "0.2.6"
-static-files = { version = "0.2.1", optional = true }
-clap = { version = "3.0", features = ["derive", "env"] }
-sysinfo = "0.20.2"
-tar = "0.4.37"
-tempfile = "3.2.0"
-thiserror = "1.0.28"
+serde = { version = "1.0.136", features = ["derive"] }
+serde_json = { version = "1.0.79", features = ["preserve_order"] }
+sha2 = "0.10.2"
+siphasher = "0.3.10"
+slice-group-by = "0.3.0"
+static-files = { version = "0.2.3", optional = true }
+sysinfo = "0.23.5"
+tar = "0.4.38"
+tempfile = "3.3.0"
+thiserror = "1.0.30"
 time = { version = "0.3.7", features = ["serde-well-known", "formatting", "parsing", "macros"] }
-tokio = { version = "1.11.0", features = ["full"] }
-tokio-stream = "0.1.7"
+tokio = { version = "1.17.0", features = ["full"] }
+tokio-stream = "0.1.8"
 uuid = { version = "0.8.2", features = ["serde"] }
 walkdir = "2.3.2"
-milli = { git = "https://github.com/meilisearch/milli.git", tag = "v0.24.0" }
-pin-project-lite = "0.2.8"
 
 [dev-dependencies]
-actix-rt = "2.2.0"
+actix-rt = "2.7.0"
 assert-json-diff = "2.0.1"
 maplit = "1.0.2"
-paste = "1.0.5"
+paste = "1.0.6"
 serde_url_params = "0.2.1"
 urlencoding = "2.1.0"
 
@@ -101,7 +101,7 @@ mini-dashboard = [
 ]
 
 [target.'cfg(target_os = "linux")'.dependencies]
-tikv-jemallocator = "0.4.1"
+tikv-jemallocator = "0.4.3"
 
 [package.metadata.mini-dashboard]
 assets-url = "https://github.com/meilisearch/mini-dashboard/releases/download/v0.1.9/build.zip"

--- a/meilisearch-http/src/extractors/authentication/mod.rs
+++ b/meilisearch-http/src/extractors/authentication/mod.rs
@@ -144,6 +144,7 @@ pub mod policies {
     pub static TENANT_TOKEN_VALIDATION: Lazy<Validation> = Lazy::new(|| {
         let mut validation = Validation::default();
         validation.validate_exp = false;
+        validation.required_spec_claims.remove("exp");
         validation.algorithms = vec![Algorithm::HS256, Algorithm::HS384, Algorithm::HS512];
         validation
     });
@@ -205,9 +206,7 @@ pub mod policies {
                 return None;
             }
 
-            let mut validation = Validation::default();
-            validation.validate_exp = false;
-            validation.validate_nbf = false;
+            let mut validation = TENANT_TOKEN_VALIDATION.clone();
             validation.insecure_disable_signature_validation();
             let dummy_key = DecodingKey::from_secret(b"secret");
             let token_data = decode::<Claims>(token, &dummy_key, &validation).ok()?;

--- a/meilisearch-lib/Cargo.toml
+++ b/meilisearch-lib/Cargo.toml
@@ -6,60 +6,60 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-actix-web = { version = "4", default-features = false }
-anyhow = { version = "1.0.43", features = ["backtrace"] }
-async-stream = "0.3.2"
-async-trait = "0.1.51"
-byte-unit = { version = "4.0.12", default-features = false, features = ["std"] }
+actix-web = { version = "4.0.1", default-features = false }
+anyhow = { version = "1.0.56", features = ["backtrace"] }
+async-stream = "0.3.3"
+async-trait = "0.1.52"
+atomic_refcell = "0.1.8"
+byte-unit = { version = "4.0.14", default-features = false, features = ["std"] }
 bytes = "1.1.0"
+clap = { version = "3.1.6", features = ["derive", "env"] }
+crossbeam-channel = "0.5.2"
 csv = "1.1.6"
-crossbeam-channel = "0.5.1"
+derivative = "2.2.0"
 either = "1.6.1"
-flate2 = "1.0.21"
+flate2 = "1.0.22"
+fs_extra = "1.2.0"
 fst = "0.4.7"
-futures = "0.3.17"
-futures-util = "0.3.17"
-http = "0.2.4"
-indexmap = { version = "1.7.0", features = ["serde-1"] }
-itertools = "0.10.1"
+futures = "0.3.21"
+futures-util = "0.3.21"
+http = "0.2.6"
+indexmap = { version = "1.8.0", features = ["serde-1"] }
+itertools = "0.10.3"
 lazy_static = "1.4.0"
 log = "0.4.14"
-meilisearch-error = { path = "../meilisearch-error" }
 meilisearch-auth = { path = "../meilisearch-auth" }
+meilisearch-error = { path = "../meilisearch-error" }
 milli = { git = "https://github.com/meilisearch/milli.git", tag = "v0.24.0" }
 mime = "0.3.16"
-num_cpus = "1.13.0"
-once_cell = "1.8.0"
-parking_lot = "0.11.2"
-rand = "0.8.4"
+num_cpus = "1.13.1"
+obkv = "0.2.0"
+once_cell = "1.10.0"
+parking_lot = "0.12.0"
+rand = "0.8.5"
 rayon = "1.5.1"
-regex = "1.5.4"
-rustls = "0.19.1"
-serde = { version = "1.0.130", features = ["derive"] }
-serde_json = { version = "1.0.67", features = ["preserve_order"] }
-siphasher = "0.3.7"
-slice-group-by = "0.2.6"
-clap = { version = "3.0", features = ["derive", "env"] }
-tar = "0.4.37"
-tempfile = "3.2.0"
-thiserror = "1.0.28"
+regex = "1.5.5"
+reqwest = { version = "0.11.9", features = ["json", "rustls-tls"], default-features = false, optional = true }
+rustls = "0.20.4"
+serde = { version = "1.0.136", features = ["derive"] }
+serde_json = { version = "1.0.79", features = ["preserve_order"] }
+siphasher = "0.3.10"
+slice-group-by = "0.3.0"
+sysinfo = "0.23.5"
+tar = "0.4.38"
+tempfile = "3.3.0"
+thiserror = "1.0.30"
 time = { version = "0.3.7", features = ["serde-well-known", "formatting", "parsing", "macros"] }
-tokio = { version = "1.11.0", features = ["full"] }
+tokio = { version = "1.17.0", features = ["full"] }
 uuid = { version = "0.8.2", features = ["serde"] }
 walkdir = "2.3.2"
-obkv = "0.2.0"
-whoami = { version = "1.1.3", optional = true }
-reqwest = { version = "0.11.4", features = ["json", "rustls-tls"], default-features = false, optional = true }
-sysinfo = "0.20.2"
-derivative = "2.2.0"
-fs_extra = "1.2.0"
-atomic_refcell = "0.1.8"
+whoami = { version = "1.2.1", optional = true }
 
 [dev-dependencies]
-actix-rt = "2.2.0"
-mockall = "0.10.2"
-paste = "1.0.5"
-nelson = { git = "https://github.com/MarinPostma/nelson.git", rev = "675f13885548fb415ead8fbb447e9e6d9314000a"}
+actix-rt = "2.7.0"
 meilisearch-error = { path = "../meilisearch-error", features = ["test-traits"] }
+mockall = "0.11.0"
+nelson = { git = "https://github.com/MarinPostma/nelson.git", rev = "675f13885548fb415ead8fbb447e9e6d9314000a"}
+paste = "1.0.6"
 proptest = "1.0.0"
 proptest-derive = "0.3.0"

--- a/meilisearch-lib/Cargo.toml
+++ b/meilisearch-lib/Cargo.toml
@@ -48,7 +48,6 @@ tokio = { version = "1.11.0", features = ["full"] }
 uuid = { version = "0.8.2", features = ["serde"] }
 walkdir = "2.3.2"
 obkv = "0.2.0"
-pin-project = "1.0.8"
 whoami = { version = "1.1.3", optional = true }
 reqwest = { version = "0.11.4", features = ["json", "rustls-tls"], default-features = false, optional = true }
 sysinfo = "0.20.2"


### PR DESCRIPTION
This PR upgrade and updates the dependencies of meilisearch, but first I removed three unused dependencies. I used [cargo udeps](https://github.com/est31/cargo-udeps) to detect those and [cargo upgrade](https://github.com/killercup/cargo-edit/blob/master/README.md#available-subcommands) to upgrade ⬆️

~This PR **must** be merged when https://github.com/meilisearch/milli/pull/465 is merged and then must be updated accordingly i.e. using the latest version of milli.~