### PR TITLE
Release v0.26.1: bring "fix panic at start" commit (#2243) into stable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1713,7 +1713,7 @@ checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "meilisearch-auth"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "enum-iterator",
  "heed",
@@ -1728,7 +1728,7 @@ dependencies = [
 
 [[package]]
 name = "meilisearch-error"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "actix-web",
  "proptest",
@@ -1739,7 +1739,7 @@ dependencies = [
 
 [[package]]
 name = "meilisearch-http"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "actix-cors",
  "actix-rt",
@@ -1814,7 +1814,7 @@ dependencies = [
 
 [[package]]
 name = "meilisearch-lib"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "actix-rt",
  "actix-web",

--- a/meilisearch-auth/Cargo.toml
+++ b/meilisearch-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "meilisearch-auth"
-version = "0.26.0"
+version = "0.26.1"
 edition = "2021"
 
 [dependencies]

--- a/meilisearch-error/Cargo.toml
+++ b/meilisearch-error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "meilisearch-error"
-version = "0.26.0"
+version = "0.26.1"
 authors = ["marin <postma.marin@protonmail.com>"]
 edition = "2021"
 

--- a/meilisearch-http/Cargo.toml
+++ b/meilisearch-http/Cargo.toml
@@ -4,7 +4,7 @@ description = "Meilisearch HTTP server"
 edition = "2021"
 license = "MIT"
 name = "meilisearch-http"
-version = "0.26.0"
+version = "0.26.1"
 
 [[bin]]
 name = "meilisearch"

--- a/meilisearch-lib/Cargo.toml
+++ b/meilisearch-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "meilisearch-lib"
-version = "0.26.0"
+version = "0.26.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/meilisearch-lib/src/options.rs
+++ b/meilisearch-lib/src/options.rs
@@ -52,20 +52,20 @@ pub struct SchedulerConfig {
 
     // The maximum number of updates of the same type that can be batched together.
     // If unspecified, this is unlimited. A value of 0 is interpreted as 1.
-    #[clap(long, requires = "enable-autobatching", hide = true)]
+    #[clap(long, requires = "enable-auto-batching", hide = true)]
     pub max_batch_size: Option<usize>,
 
     // The maximum number of documents in a document batch. Since batches must contain at least one
     // update for the scheduler to make progress, the number of documents in a batch will be at
     // least the number of documents of its first update.
-    #[clap(long, requires = "enable-autobatching", hide = true)]
+    #[clap(long, requires = "enable-auto-batching", hide = true)]
     pub max_documents_per_batch: Option<usize>,
 
     /// Debounce duration in seconds
     ///
     /// When a new task is enqueued, the scheduler waits for `debounce_duration_sec` seconds for new updates before
     /// starting to process a batch of updates.
-    #[clap(long, requires = "enable-autobatching", hide = true)]
+    #[clap(long, requires = "enable-auto-batching", hide = true)]
     pub debounce_duration_sec: Option<u64>,
 }
 


### PR DESCRIPTION
2 commits
- cherry pick `32843f30d973349122ec5a37469ee09e6002b6f3` (merged in #2243)
- change the version in the Cargo toml files (from v0.26.0 to v0.26.1)