### PR TITLE
Simplify Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ COPY    meilisearch-http/Cargo.toml meilisearch-http/
 COPY    meilisearch-lib/Cargo.toml meilisearch-lib/
 
 ENV     RUSTFLAGS="-C target-feature=-crt-static"
+ENV     JEMALLOC_SYS_WITH_LG_PAGE 16
 
 # Create dummy main.rs files for each workspace member to be able to compile all the dependencies
 RUN     find . -type d -name "meilisearch-*" | xargs -I{} sh -c 'mkdir {}/src; echo "fn main() { }" > {}/src/main.rs;'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,43 +1,22 @@
 # Compile
-FROM    alpine:3.14 AS compiler
+FROM    rust:alpine3.14 AS compiler
 
-RUN     apk update --quiet \
-        && apk add -q --no-cache curl build-base
-
-RUN     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+RUN     apk add -q --update-cache --no-cache build-base openssl-dev
 
 WORKDIR /meilisearch
-
-COPY    Cargo.lock .
-COPY    Cargo.toml .
-
-COPY    meilisearch-auth/Cargo.toml meilisearch-auth/
-COPY    meilisearch-error/Cargo.toml meilisearch-error/
-COPY    meilisearch-http/Cargo.toml meilisearch-http/
-COPY    meilisearch-lib/Cargo.toml meilisearch-lib/
-
-ENV     RUSTFLAGS="-C target-feature=-crt-static"
-ENV     JEMALLOC_SYS_WITH_LG_PAGE 16
-
-# Create dummy main.rs files for each workspace member to be able to compile all the dependencies
-RUN     find . -type d -name "meilisearch-*" | xargs -I{} sh -c 'mkdir {}/src; echo "fn main() { }" > {}/src/main.rs;'
-# Use `cargo build` instead of `cargo vendor` because we need to not only download but compile dependencies too
-RUN     if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
-            export JEMALLOC_SYS_WITH_LG_PAGE=16; \
-        fi && \
-        $HOME/.cargo/bin/cargo build --release
-# Cleanup dummy main.rs files
-RUN     find . -path "*/src/main.rs" -delete
 
 ARG     COMMIT_SHA
 ARG     COMMIT_DATE
 ENV     COMMIT_SHA=${COMMIT_SHA} COMMIT_DATE=${COMMIT_DATE}
+ENV     RUSTFLAGS="-C target-feature=-crt-static"
 
 COPY    . .
-RUN     if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
+RUN     set -eux; \
+        apkArch="$(apk --print-arch)"; \
+        if [ "$apkArch" = "aarch64" ]; then \
             export JEMALLOC_SYS_WITH_LG_PAGE=16; \
         fi && \
-        $HOME/.cargo/bin/cargo build --release
+        cargo build --release
 
 # Run
 FROM    alpine:3.14


### PR DESCRIPTION
# Pull Request

## What does this PR do?

1. Fixes #2234
2. Replace `$TARGETPLATFORM` with `apk --print-arch` to make Dockerfile available for `docker build` as well, not just `docker buildx` (inspired by [rust-lang/docker-rust](https://github.com/rust-lang/docker-rust/blob/master/1.59.0/alpine3.14/Dockerfile#L13))

PTAL @curquiza 

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
