### PR TITLE
fix(http): fix panic when sending document update without content type header

### DIFF
--- a/meilisearch-http/src/analytics/segment_analytics.rs
+++ b/meilisearch-http/src/analytics/segment_analytics.rs
@@ -535,7 +535,7 @@ impl DocumentsAggregator {
             .headers()
             .get(CONTENT_TYPE)
             .map(|s| s.to_str().unwrap_or("unkown"))
-            .unwrap()
+            .unwrap_or("unkown")
             .to_string();
         ret.content_types.insert(content_type);
         ret.index_creation = index_creation;


### PR DESCRIPTION
I found a panic when pushing documents without a content-type. This fixes is by returning unknown instead of crashing.
