### PR TITLE
Hard limit the number of results returned by a search

### DIFF
--- a/meilisearch-lib/src/index/search.rs
+++ b/meilisearch-lib/src/index/search.rs
@@ -34,6 +34,10 @@ pub const fn default_crop_length() -> usize {
     DEFAULT_CROP_LENGTH
 }
 
+/// The maximimum number of results that the engine
+/// will be able to return in one search call.
+pub const HARD_RESULT_LIMIT: usize = 1000;
+
 #[derive(Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SearchQuery {
@@ -123,6 +127,8 @@ impl Index {
             candidates,
             ..
         } = search.execute()?;
+
+        let documents_ids: Vec<_> = documents_ids.into_iter().take(HARD_RESULT_LIMIT).collect();
 
         let fields_ids_map = self.fields_ids_map(&rtxn).unwrap();
 


### PR DESCRIPTION
This PR fixes #2133 by hard-limiting the number of results that a search request can return at any time. I would like the guidance of @MarinPostma to test that, should I use a mocking test here? Or should I do anything else?

I talked about touching the _nb_hits_ value with @qdequele and we concluded that it was not correct to do so.

Could you please confirm that it is the right place to change that?