### PR TITLE
Feat(Search): Enhance formating search results

### DIFF
--- a/meilisearch-http/src/routes/indexes/search.rs
+++ b/meilisearch-http/src/routes/indexes/search.rs
@@ -2,7 +2,10 @@ use actix_web::{web, HttpRequest, HttpResponse};
 use log::debug;
 use meilisearch_auth::IndexSearchRules;
 use meilisearch_error::ResponseError;
-use meilisearch_lib::index::{default_crop_length, SearchQuery, DEFAULT_SEARCH_LIMIT};
+use meilisearch_lib::index::{
+    default_crop_length, default_crop_marker, default_highlight_post_tag,
+    default_highlight_pre_tag, SearchQuery, DEFAULT_SEARCH_LIMIT,
+};
 use meilisearch_lib::MeiliSearch;
 use serde::Deserialize;
 use serde_json::Value;
@@ -35,6 +38,12 @@ pub struct SearchQueryGet {
     #[serde(default = "Default::default")]
     matches: bool,
     facets_distribution: Option<String>,
+    #[serde(default = "default_highlight_pre_tag")]
+    highlight_pre_tag: String,
+    #[serde(default = "default_highlight_post_tag")]
+    highlight_post_tag: String,
+    #[serde(default = "default_crop_marker")]
+    crop_marker: String,
 }
 
 impl From<SearchQueryGet> for SearchQuery {
@@ -77,6 +86,9 @@ impl From<SearchQueryGet> for SearchQuery {
             sort,
             matches: other.matches,
             facets_distribution,
+            highlight_pre_tag: other.highlight_pre_tag,
+            highlight_post_tag: other.highlight_post_tag,
+            crop_marker: other.crop_marker,
         }
     }
 }

--- a/meilisearch-http/tests/search/errors.rs
+++ b/meilisearch-http/tests/search/errors.rs
@@ -37,6 +37,38 @@ async fn search_unexisting_parameter() {
 }
 
 #[actix_rt::test]
+async fn search_invalid_highlight_and_crop_tags() {
+    let server = Server::new().await;
+    let index = server.index("test");
+
+    let fields = &["cropMarker", "highlightPreTag", "highlightPostTag"];
+
+    for field in fields {
+        // object
+        index
+            .search(
+                json!({field.to_string(): {"marker": "<crop>"}}),
+                |response, code| {
+                    assert_eq!(code, 400, "field {} passing object: {}", &field, response);
+                    assert_eq!(response["code"], "bad_request");
+                },
+            )
+            .await;
+
+        // array
+        index
+            .search(
+                json!({field.to_string(): ["marker", "<crop>"]}),
+                |response, code| {
+                    assert_eq!(code, 400, "field {} passing array: {}", &field, response);
+                    assert_eq!(response["code"], "bad_request");
+                },
+            )
+            .await;
+    }
+}
+
+#[actix_rt::test]
 async fn filter_invalid_syntax_object() {
     let server = Server::new().await;
     let index = server.index("test");

--- a/meilisearch-lib/src/index/mod.rs
+++ b/meilisearch-lib/src/index/mod.rs
@@ -1,4 +1,7 @@
-pub use search::{default_crop_length, SearchQuery, SearchResult, DEFAULT_SEARCH_LIMIT};
+pub use search::{
+    default_crop_length, default_crop_marker, default_highlight_post_tag,
+    default_highlight_pre_tag, SearchQuery, SearchResult, DEFAULT_SEARCH_LIMIT,
+};
 pub use updates::{apply_settings_to_builder, Checked, Facets, Settings, Unchecked};
 
 mod dump;

--- a/meilisearch-lib/src/index_controller/mod.rs
+++ b/meilisearch-lib/src/index_controller/mod.rs
@@ -651,6 +651,9 @@ mod test {
 
     use crate::index::error::Result as IndexResult;
     use crate::index::Index;
+    use crate::index::{
+        default_crop_marker, default_highlight_post_tag, default_highlight_pre_tag,
+    };
     use crate::index_resolver::index_store::MockIndexStore;
     use crate::index_resolver::meta_store::MockIndexMetaStore;
     use crate::index_resolver::IndexResolver;
@@ -691,6 +694,9 @@ mod test {
             filter: None,
             sort: None,
             facets_distribution: None,
+            highlight_pre_tag: default_highlight_pre_tag(),
+            highlight_post_tag: default_highlight_post_tag(),
+            crop_marker: default_crop_marker(),
         };
 
         let result = SearchResult {


### PR DESCRIPTION
Add new settings and change crop_len behavior to count words instead of characters.

- [x] `highlightPreTag`
- [x] `highlightPostTag`
- [x] `cropMarker`
- [x] `cropLength` count word instead of chars
- [x] `cropLength` 0 is now considered as no `cropLength`
- [ ] ~smart crop finding the best matches interval~ (postponed)

Partially fixes  #2214. (no smart crop)
