### PR TITLE
chore(bors): comments clippy out

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -2,7 +2,7 @@ status = [
     'Tests on ubuntu-18.04',
     'Tests on macos-latest',
     'Tests on windows-latest',
-    'Run Clippy',
+    # 'Run Clippy',
     'Run Rustfmt',
     'Run tests in debug',
 ]


### PR DESCRIPTION
There is currently an issue with clippy that stops us from merging PRs.
https://github.com/rust-lang/rust-clippy/issues/8662#issuecomment-1093899755

We can't use clippy in the CI while that's not merged
