### PR TITLE
Feat(Analytics): Add analytics for search format options

### DIFF
--- a/meilisearch-lib/src/index/mod.rs
+++ b/meilisearch-lib/src/index/mod.rs
@@ -1,6 +1,7 @@
 pub use search::{
     default_crop_length, default_crop_marker, default_highlight_post_tag,
-    default_highlight_pre_tag, SearchQuery, SearchResult, DEFAULT_SEARCH_LIMIT,
+    default_highlight_pre_tag, SearchQuery, SearchResult, DEFAULT_CROP_LENGTH, DEFAULT_CROP_MARKER,
+    DEFAULT_HIGHLIGHT_POST_TAG, DEFAULT_HIGHLIGHT_PRE_TAG, DEFAULT_SEARCH_LIMIT,
 };
 pub use updates::{apply_settings_to_builder, Checked, Facets, Settings, Unchecked};
 

--- a/meilisearch-lib/src/index/search.rs
+++ b/meilisearch-lib/src/index/search.rs
@@ -35,17 +35,17 @@ pub const fn default_crop_length() -> usize {
     DEFAULT_CROP_LENGTH
 }
 
-const DEFAULT_CROP_MARKER: &str = "…";
+pub const DEFAULT_CROP_MARKER: &str = "…";
 pub fn default_crop_marker() -> String {
     DEFAULT_CROP_MARKER.to_string()
 }
 
-const DEFAULT_HIGHLIGHT_PRE_TAG: &str = "<em>";
+pub const DEFAULT_HIGHLIGHT_PRE_TAG: &str = "<em>";
 pub fn default_highlight_pre_tag() -> String {
     DEFAULT_HIGHLIGHT_PRE_TAG.to_string()
 }
 
-const DEFAULT_HIGHLIGHT_POST_TAG: &str = "</em>";
+pub const DEFAULT_HIGHLIGHT_POST_TAG: &str = "</em>";
 pub fn default_highlight_post_tag() -> String {
     DEFAULT_HIGHLIGHT_POST_TAG.to_string()
 }


### PR DESCRIPTION
Specification: [#120](https://github.com/meilisearch/specifications/pull/120) ([f5c6a8e](https://github.com/meilisearch/specifications/commit/f5c6a8e183e22cc3b80d9a0251c411250f31674f))

fix #2308