### PR TITLE
rename min word lenght for typo

### DIFF
--- a/meilisearch-lib/src/index/index.rs
+++ b/meilisearch-lib/src/index/index.rs
@@ -18,7 +18,7 @@ use crate::EnvSizer;
 
 use super::error::IndexError;
 use super::error::Result;
-use super::updates::{MinWordLengthTypoSetting, TypoSettings};
+use super::updates::{MinWordSizeTyposSetting, TypoSettings};
 use super::{Checked, Settings};
 
 pub type Document = Map<String, Value>;
@@ -170,7 +170,7 @@ impl Index {
             })
             .collect();
 
-        let min_typo_word_len = MinWordLengthTypoSetting {
+        let min_typo_word_len = MinWordSizeTyposSetting {
             one_typo: Setting::Set(self.min_word_len_one_typo(txn)?),
             two_typos: Setting::Set(self.min_word_len_two_typos(txn)?),
         };
@@ -190,7 +190,7 @@ impl Index {
 
         let typo_tolerance = TypoSettings {
             enabled: Setting::Set(self.authorize_typos(txn)?),
-            min_word_length_for_typo: Setting::Set(min_typo_word_len),
+            min_word_size_for_typos: Setting::Set(min_typo_word_len),
             disable_on_words: Setting::Set(disabled_words),
             disable_on_attributes: Setting::Set(disabled_attributes),
         };

--- a/meilisearch-lib/src/index/updates.rs
+++ b/meilisearch-lib/src/index/updates.rs
@@ -41,7 +41,7 @@ pub struct Unchecked;
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "camelCase")]
-pub struct MinWordLengthTypoSetting {
+pub struct MinWordSizeTyposSetting {
     #[cfg_attr(test, proptest(strategy = "test::setting_strategy()"))]
     #[serde(default, skip_serializing_if = "Setting::is_not_set")]
     pub one_typo: Setting<u8>,
@@ -60,7 +60,7 @@ pub struct TypoSettings {
     pub enabled: Setting<bool>,
     #[cfg_attr(test, proptest(strategy = "test::setting_strategy()"))]
     #[serde(default, skip_serializing_if = "Setting::is_not_set")]
-    pub min_word_length_for_typo: Setting<MinWordLengthTypoSetting>,
+    pub min_word_size_for_typos: Setting<MinWordSizeTyposSetting>,
     #[cfg_attr(test, proptest(strategy = "test::setting_strategy()"))]
     #[serde(default, skip_serializing_if = "Setting::is_not_set")]
     pub disable_on_words: Setting<BTreeSet<String>>,
@@ -381,7 +381,7 @@ pub fn apply_settings_to_builder(
                 Setting::NotSet => (),
             }
 
-            match value.min_word_length_for_typo {
+            match value.min_word_size_for_typos {
                 Setting::Set(ref setting) => {
                     match setting.one_typo {
                         Setting::Set(val) => builder.set_min_word_len_one_typo(val),


### PR DESCRIPTION
rename `minWordLengthForTypo` to `minWordSizeForTypos` as specified.

discussed here: https://github.com/meilisearch/specifications/pull/117#discussion_r850795714