### PR TITLE
deny warnings in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,6 +12,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  RUSTFLAGS: "-D warnings"
 
 jobs:
   tests:


### PR DESCRIPTION
Add `RUSTFLAGS= -D warnings` to the CI so all warnings are treated as hard errors.