### PR TITLE
feat(http): add analytics on typo tolerance setting

### DIFF
--- a/meilisearch-http/src/routes/indexes/settings.rs
+++ b/meilisearch-http/src/routes/indexes/settings.rs
@@ -171,7 +171,7 @@ make_setting_route!(
         use serde_json::json;
 
         analytics.publish(
-            "TypoToleranceUpdated Updated".to_string(),
+            "TypoTolerance Updated".to_string(),
             json!({
                 "typo_tolerance": {
                     "enabled": setting.as_ref().map(|s| !matches!(s.enabled, Setting::Set(false))).unwrap_or(true),

--- a/meilisearch-http/src/routes/indexes/settings.rs
+++ b/meilisearch-http/src/routes/indexes/settings.rs
@@ -145,8 +145,8 @@ make_setting_route!(
             "SortableAttributes Updated".to_string(),
             json!({
                 "sortable_attributes": {
-                    "total": setting.as_ref().map(|sort| sort.len()).unwrap_or(0),
-                    "has_geo": setting.as_ref().map(|sort| sort.contains("_geo")).unwrap_or(false),
+                    "total": setting.as_ref().map(|sort| sort.len()),
+                    "has_geo": setting.as_ref().map(|sort| sort.contains("_geo")),
                 },
             }),
             Some(req),
@@ -174,17 +174,15 @@ make_setting_route!(
             "TypoTolerance Updated".to_string(),
             json!({
                 "typo_tolerance": {
-                    "enabled": setting.as_ref().map(|s| !matches!(s.enabled, Setting::Set(false))).unwrap_or(true),
+                    "enabled": setting.as_ref().map(|s| !matches!(s.enabled, Setting::Set(false))),
                     "disable_on_attributes": setting
                         .as_ref()
                         .map(|s| s.disable_on_attributes.as_ref().set().map(|m| !m.is_empty()))
-                        .flatten()
-                        .unwrap_or(false),
+                        .flatten(),
                     "disable_on_words": setting
                         .as_ref()
                         .map(|s| s.disable_on_words.as_ref().set().map(|m| !m.is_empty()))
-                        .flatten()
-                        .unwrap_or(false),
+                        .flatten(),
                     "min_word_size_for_one_typo": setting
                         .as_ref()
                         .map(|s| s.min_word_size_for_typos
@@ -192,8 +190,7 @@ make_setting_route!(
                             .set()
                             .map(|s| s.one_typo.set()))
                         .flatten()
-                        .flatten()
-                        .unwrap_or(5),
+                        .flatten(),
                     "min_word_size_for_two_typos": setting
                         .as_ref()
                         .map(|s| s.min_word_size_for_typos
@@ -201,8 +198,7 @@ make_setting_route!(
                             .set()
                             .map(|s| s.two_typos.set()))
                         .flatten()
-                        .flatten()
-                        .unwrap_or(9),
+                        .flatten(),
                 },
             }),
             Some(req),
@@ -223,7 +219,7 @@ make_setting_route!(
             "SearchableAttributes Updated".to_string(),
             json!({
                 "searchable_attributes": {
-                    "total": setting.as_ref().map(|searchable| searchable.len()).unwrap_or(0),
+                    "total": setting.as_ref().map(|searchable| searchable.len()),
                 },
             }),
             Some(req),
@@ -315,15 +311,15 @@ pub async fn update_all(
                 "sort_position": settings.ranking_rules.as_ref().set().map(|sort| sort.iter().position(|s| s == "sort")),
             },
             "searchable_attributes": {
-                "total": settings.searchable_attributes.as_ref().set().map(|searchable| searchable.len()).unwrap_or(0),
+                "total": settings.searchable_attributes.as_ref().set().map(|searchable| searchable.len()),
             },
            "sortable_attributes": {
-                "total": settings.sortable_attributes.as_ref().set().map(|sort| sort.len()).unwrap_or(0),
-                "has_geo": settings.sortable_attributes.as_ref().set().map(|sort| sort.iter().any(|s| s == "_geo")).unwrap_or(false),
+                "total": settings.sortable_attributes.as_ref().set().map(|sort| sort.len()),
+                "has_geo": settings.sortable_attributes.as_ref().set().map(|sort| sort.iter().any(|s| s == "_geo")),
             },
            "filterable_attributes": {
-                "total": settings.filterable_attributes.as_ref().set().map(|filter| filter.len()).unwrap_or(0),
-                "has_geo": settings.filterable_attributes.as_ref().set().map(|filter| filter.iter().any(|s| s == "_geo")).unwrap_or(false),
+                "total": settings.filterable_attributes.as_ref().set().map(|filter| filter.len()),
+                "has_geo": settings.filterable_attributes.as_ref().set().map(|filter| filter.iter().any(|s| s == "_geo")),
             },
             "typo_tolerance": {
                 "enabled": settings.typo_tolerance
@@ -331,20 +327,17 @@ pub async fn update_all(
                     .set()
                     .map(|s| s.enabled.as_ref().set())
                     .flatten()
-                    .copied()
-                    .unwrap_or(true),
+                    .copied(),
                 "disable_on_attributes": settings.typo_tolerance
                     .as_ref()
                     .set()
                     .map(|s| s.disable_on_attributes.as_ref().set().map(|m| !m.is_empty()))
-                    .flatten()
-                    .unwrap_or(false),
+                    .flatten(),
                 "disable_on_words": settings.typo_tolerance
                     .as_ref()
                     .set()
                     .map(|s| s.disable_on_words.as_ref().set().map(|m| !m.is_empty()))
-                    .flatten()
-                    .unwrap_or(false),
+                    .flatten(),
                 "min_word_size_for_one_typo": settings.typo_tolerance
                     .as_ref()
                     .set()
@@ -353,8 +346,7 @@ pub async fn update_all(
                         .set()
                         .map(|s| s.one_typo.set()))
                     .flatten()
-                    .flatten()
-                    .unwrap_or(5),
+                    .flatten(),
                 "min_word_size_for_two_typos": settings.typo_tolerance
                     .as_ref()
                     .set()
@@ -363,8 +355,7 @@ pub async fn update_all(
                         .set()
                         .map(|s| s.two_typos.set()))
                     .flatten()
-                    .flatten()
-                    .unwrap_or(9),
+                    .flatten(),
             },
         }),
         Some(&req),

--- a/meilisearch-http/src/routes/indexes/settings.rs
+++ b/meilisearch-http/src/routes/indexes/settings.rs
@@ -177,27 +177,23 @@ make_setting_route!(
                     "enabled": setting.as_ref().map(|s| !matches!(s.enabled, Setting::Set(false))),
                     "disable_on_attributes": setting
                         .as_ref()
-                        .map(|s| s.disable_on_attributes.as_ref().set().map(|m| !m.is_empty()))
-                        .flatten(),
+                        .and_then(|s| s.disable_on_attributes.as_ref().set().map(|m| !m.is_empty())),
                     "disable_on_words": setting
                         .as_ref()
-                        .map(|s| s.disable_on_words.as_ref().set().map(|m| !m.is_empty()))
-                        .flatten(),
+                        .and_then(|s| s.disable_on_words.as_ref().set().map(|m| !m.is_empty())),
                     "min_word_size_for_one_typo": setting
                         .as_ref()
-                        .map(|s| s.min_word_size_for_typos
+                        .and_then(|s| s.min_word_size_for_typos
                             .as_ref()
                             .set()
                             .map(|s| s.one_typo.set()))
-                        .flatten()
                         .flatten(),
                     "min_word_size_for_two_typos": setting
                         .as_ref()
-                        .map(|s| s.min_word_size_for_typos
+                        .and_then(|s| s.min_word_size_for_typos
                             .as_ref()
                             .set()
                             .map(|s| s.two_typos.set()))
-                        .flatten()
                         .flatten(),
                 },
             }),
@@ -325,36 +321,31 @@ pub async fn update_all(
                 "enabled": settings.typo_tolerance
                     .as_ref()
                     .set()
-                    .map(|s| s.enabled.as_ref().set())
-                    .flatten()
+                    .and_then(|s| s.enabled.as_ref().set())
                     .copied(),
                 "disable_on_attributes": settings.typo_tolerance
                     .as_ref()
                     .set()
-                    .map(|s| s.disable_on_attributes.as_ref().set().map(|m| !m.is_empty()))
-                    .flatten(),
+                    .and_then(|s| s.disable_on_attributes.as_ref().set().map(|m| !m.is_empty())),
                 "disable_on_words": settings.typo_tolerance
                     .as_ref()
                     .set()
-                    .map(|s| s.disable_on_words.as_ref().set().map(|m| !m.is_empty()))
-                    .flatten(),
+                    .and_then(|s| s.disable_on_words.as_ref().set().map(|m| !m.is_empty())),
                 "min_word_size_for_one_typo": settings.typo_tolerance
                     .as_ref()
                     .set()
-                    .map(|s| s.min_word_size_for_typos
+                    .and_then(|s| s.min_word_size_for_typos
                         .as_ref()
                         .set()
                         .map(|s| s.one_typo.set()))
-                    .flatten()
                     .flatten(),
                 "min_word_size_for_two_typos": settings.typo_tolerance
                     .as_ref()
                     .set()
-                    .map(|s| s.min_word_size_for_typos
+                    .and_then(|s| s.min_word_size_for_typos
                         .as_ref()
                         .set()
                         .map(|s| s.two_typos.set()))
-                    .flatten()
                     .flatten(),
             },
         }),


### PR DESCRIPTION
Add analytics for the typo settings.

Also make settings analytics return null for settings that are not set, instead of a default value, as seen with @gmourier 