### PR TITLE
Fix dump bug

### DIFF
--- a/meilisearch-lib/src/index_controller/mod.rs
+++ b/meilisearch-lib/src/index_controller/mod.rs
@@ -196,10 +196,7 @@ impl IndexControllerBuilder {
                 task_store_size,
                 &indexer_options,
             )?;
-        }
-
-        let db_exists = db_path.as_ref().exists();
-        if db_exists {
+        } else if db_path.as_ref().exists() {
             // Directory could be pre-created without any database in.
             let db_is_empty = db_path.as_ref().read_dir()?.next().is_none();
             if !db_is_empty {


### PR DESCRIPTION
Only check db version file if we aren't loading a dump or a snapshot, because we can assume that if we are loading a dump or a snapshot, then we can safely work with the database. The db version file will be (over)written just after that.

This was introduced by #2356.
fix #2389
