### PR TITLE
Updates invalid ranking rules test

### DIFF
--- a/meilisearch-http/tests/settings/get_settings.rs
+++ b/meilisearch-http/tests/settings/get_settings.rs
@@ -283,7 +283,7 @@ async fn error_set_invalid_ranking_rules() {
     assert_eq!(response["status"], "failed");
 
     let expected_error = json!({
-        "message": r#"`manyTheFish` ranking rule is invalid. Valid ranking rules are Words, Typo, Sort, Proximity, Attribute, Exactness and custom ranking rules."#,
+        "message": r#"`manyTheFish` ranking rule is invalid. Valid ranking rules are words, typo, sort, proximity, attribute, exactness and custom ranking rules."#,
         "code": "invalid_ranking_rule",
         "type": "invalid_request",
         "link": "https://docs.meilisearch.com/errors#invalid_ranking_rule"


### PR DESCRIPTION
I submitted [this](https://github.com/meilisearch/milli/pull/536) PR in [meilisearch/milli](https://github.com/meilisearch/milli) to address #2407. In case the PR is merged, the [error_set_invalid_ranking_rules()](https://github.com/meilisearch/meilisearch/blob/ae4e419db4da282c8301b807975c346e1953dbf4/meilisearch-http/tests/settings/get_settings.rs#L271) test will fail because the error message changed. Hence I am submitting this PR to change the test :)
