### PR TITLE
Uncomment clippy from the ci check

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -2,7 +2,7 @@ status = [
     'Tests on ubuntu-18.04',
     'Tests on macos-latest',
     'Tests on windows-latest',
-    # 'Run Clippy',
+    'Run Clippy',
     'Run Rustfmt',
     'Run tests in debug',
 ]


### PR DESCRIPTION
The issue has been fixed in the latest release of rust. See https://github.com/rust-lang/rust-clippy/issues/8662
Fix #2305
