### PR TITLE
Send the analytics to `telemetry.meilisearch.com` instead of segment

### DIFF
--- a/meilisearch-http/Cargo.toml
+++ b/meilisearch-http/Cargo.toml
@@ -57,6 +57,7 @@ platform-dirs = "0.3.0"
 rand = "0.8.5"
 rayon = "1.5.1"
 regex = "1.5.5"
+reqwest = { version = "0.11.4", features = ["rustls-tls", "json"], default-features = false }
 rustls = "0.20.4"
 rustls-pemfile = "0.3.0"
 segment = { version = "0.2.0", optional = true }


### PR DESCRIPTION
Fix #2425