### PR TITLE
Update docker volume path

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ meilisearch
 #### Docker
 
 ```bash
-docker run -p 7700:7700 -v "$(pwd)/data.ms:/data.ms" getmeili/meilisearch
+docker run -p 7700:7700 -v "$(pwd)/data.ms:/meili_data/data.ms" getmeili/meilisearch
 ```
 
 #### Announcing a cloud-hosted Meilisearch

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ meilisearch
 #### Docker
 
 ```bash
-docker run -p 7700:7700 -v "$(pwd)/data.ms:/meili_data/data.ms" getmeili/meilisearch
+docker run -p 7700:7700 -v "$(pwd)/meili_data:/meili_data" getmeili/meilisearch
 ```
 
 #### Announcing a cloud-hosted Meilisearch


### PR DESCRIPTION
Currently, the args `$(pwd)/data.ms:/data.ms` cannot share data from the container, makes docker volume same as the [Dockerfile](https://github.com/0x0x1/meilisearch/blob/67b6f4340aaea005471a0ad41c700bde1d88afe9/Dockerfile#L40) to fixing it.

