### PR TITLE
move index uid in task content

### DIFF
--- a/meilisearch-http/src/routes/tasks.rs
+++ b/meilisearch-http/src/routes/tasks.rs
@@ -38,9 +38,9 @@ fn task_type_matches_content(type_: &TaskType, content: &TaskContent) -> bool {
     matches!((type_, content),
           (TaskType::IndexCreation, TaskContent::IndexCreation { .. })
         | (TaskType::IndexUpdate, TaskContent::IndexUpdate { .. })
-        | (TaskType::IndexDeletion, TaskContent::IndexDeletion)
+        | (TaskType::IndexDeletion, TaskContent::IndexDeletion { .. })
         | (TaskType::DocumentAdditionOrUpdate, TaskContent::DocumentAddition { .. })
-        | (TaskType::DocumentDeletion, TaskContent::DocumentDeletion(_))
+        | (TaskType::DocumentDeletion, TaskContent::DocumentDeletion{ .. })
         | (TaskType::SettingsUpdate, TaskContent::SettingsUpdate { .. })
     )
 }

--- a/meilisearch-lib/src/dump/compat/v3.rs
+++ b/meilisearch-lib/src/dump/compat/v3.rs
@@ -4,10 +4,10 @@ use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 use uuid::Uuid;
 
-use super::v4::{Task, TaskEvent};
+use super::v4::{Task, TaskContent, TaskEvent};
 use crate::index::{Settings, Unchecked};
 use crate::index_resolver::IndexUid;
-use crate::tasks::task::{DocumentDeletion, TaskContent, TaskId, TaskResult};
+use crate::tasks::task::{DocumentDeletion, TaskId, TaskResult};
 
 use super::v2;
 
@@ -59,9 +59,9 @@ pub enum Update {
     ClearDocuments,
 }
 
-impl From<Update> for TaskContent {
-    fn from(other: Update) -> Self {
-        match other {
+impl From<Update> for super::v4::TaskContent {
+    fn from(update: Update) -> Self {
+        match update {
             Update::DeleteDocuments(ids) => {
                 TaskContent::DocumentDeletion(DocumentDeletion::Ids(ids))
             }
@@ -186,10 +186,10 @@ impl Failed {
 impl From<(UpdateStatus, String, TaskId)> for Task {
     fn from((update, uid, task_id): (UpdateStatus, String, TaskId)) -> Self {
         // Dummy task
-        let mut task = Task {
+        let mut task = super::v4::Task {
             id: task_id,
-            index_uid: IndexUid::new(uid).unwrap(),
-            content: TaskContent::IndexDeletion,
+            index_uid: IndexUid::new_unchecked(uid),
+            content: super::v4::TaskContent::IndexDeletion,
             events: Vec::new(),
         };
 

--- a/meilisearch-lib/src/dump/compat/v4.rs
+++ b/meilisearch-lib/src/dump/compat/v4.rs
@@ -1,9 +1,14 @@
 use meilisearch_error::ResponseError;
+use milli::update::IndexDocumentsMethod;
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
+use uuid::Uuid;
 
+use crate::index::{Settings, Unchecked};
 use crate::tasks::batch::BatchId;
-use crate::tasks::task::{TaskContent, TaskEvent as NewTaskEvent, TaskId, TaskResult};
+use crate::tasks::task::{
+    DocumentDeletion, TaskContent as NewTaskContent, TaskEvent as NewTaskEvent, TaskId, TaskResult,
+};
 use crate::IndexUid;
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -18,8 +23,7 @@ impl From<Task> for crate::tasks::task::Task {
     fn from(other: Task) -> Self {
         Self {
             id: other.id,
-            index_uid: Some(other.index_uid),
-            content: other.content,
+            content: NewTaskContent::from((other.index_uid, other.content)),
             events: other.events.into_iter().map(Into::into).collect(),
         }
     }
@@ -62,6 +66,80 @@ impl From<TaskEvent> for NewTaskEvent {
                 NewTaskEvent::Succeeded { result, timestamp }
             }
             TaskEvent::Failed { error, timestamp } => NewTaskEvent::Failed { error, timestamp },
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[allow(clippy::large_enum_variant)]
+pub enum TaskContent {
+    DocumentAddition {
+        content_uuid: Uuid,
+        merge_strategy: IndexDocumentsMethod,
+        primary_key: Option<String>,
+        documents_count: usize,
+        allow_index_creation: bool,
+    },
+    DocumentDeletion(DocumentDeletion),
+    SettingsUpdate {
+        settings: Settings<Unchecked>,
+        /// Indicates whether the task was a deletion
+        is_deletion: bool,
+        allow_index_creation: bool,
+    },
+    IndexDeletion,
+    IndexCreation {
+        primary_key: Option<String>,
+    },
+    IndexUpdate {
+        primary_key: Option<String>,
+    },
+    Dump {
+        uid: String,
+    },
+}
+
+impl From<(IndexUid, TaskContent)> for NewTaskContent {
+    fn from((index_uid, content): (IndexUid, TaskContent)) -> Self {
+        match content {
+            TaskContent::DocumentAddition {
+                content_uuid,
+                merge_strategy,
+                primary_key,
+                documents_count,
+                allow_index_creation,
+            } => NewTaskContent::DocumentAddition {
+                index_uid,
+                content_uuid,
+                merge_strategy,
+                primary_key,
+                documents_count,
+                allow_index_creation,
+            },
+            TaskContent::DocumentDeletion(deletion) => NewTaskContent::DocumentDeletion {
+                index_uid,
+                deletion,
+            },
+            TaskContent::SettingsUpdate {
+                settings,
+                is_deletion,
+                allow_index_creation,
+            } => NewTaskContent::SettingsUpdate {
+                index_uid,
+                settings,
+                is_deletion,
+                allow_index_creation,
+            },
+            TaskContent::IndexDeletion => NewTaskContent::IndexDeletion { index_uid },
+            TaskContent::IndexCreation { primary_key } => NewTaskContent::IndexCreation {
+                index_uid,
+                primary_key,
+            },
+            TaskContent::IndexUpdate { primary_key } => NewTaskContent::IndexUpdate {
+                index_uid,
+                primary_key,
+            },
+            TaskContent::Dump { uid } => NewTaskContent::Dump { uid },
         }
     }
 }

--- a/meilisearch-lib/src/tasks/handlers/index_resolver_handler.rs
+++ b/meilisearch-lib/src/tasks/handlers/index_resolver_handler.rs
@@ -55,6 +55,7 @@ mod test {
         task::{Task, TaskContent},
     };
     use crate::update_file_store::{Result as FileStoreResult, UpdateFileStore};
+    use crate::IndexUid;
 
     use super::*;
     use milli::update::IndexDocumentsMethod;
@@ -103,13 +104,13 @@ mod test {
 
         let task = Task {
             id: 1,
-            index_uid: None,
             content: TaskContent::DocumentAddition {
                 content_uuid,
                 merge_strategy: IndexDocumentsMethod::ReplaceDocuments,
                 primary_key: None,
                 documents_count: 100,
                 allow_index_creation: true,
+                index_uid: IndexUid::new_unchecked("test"),
             },
             events: Vec::new(),
         };
@@ -130,7 +131,6 @@ mod test {
 
         let task = Task {
             id: 1,
-            index_uid: None,
             content: TaskContent::Dump {
                 uid: String::from("hello"),
             },

--- a/meilisearch-lib/src/tasks/handlers/mod.rs
+++ b/meilisearch-lib/src/tasks/handlers/mod.rs
@@ -17,9 +17,9 @@ mod test {
             TaskContent::DocumentAddition { .. } => {
                 BatchContent::DocumentsAdditionBatch(vec![task])
             }
-            TaskContent::DocumentDeletion(_)
+            TaskContent::DocumentDeletion { .. }
             | TaskContent::SettingsUpdate { .. }
-            | TaskContent::IndexDeletion
+            | TaskContent::IndexDeletion { .. }
             | TaskContent::IndexCreation { .. }
             | TaskContent::IndexUpdate { .. } => BatchContent::IndexUpdate(task),
             TaskContent::Dump { .. } => BatchContent::Dump(task),


### PR DESCRIPTION
this pr moves the index_uid from the `Task` to the `TaskContent`. This is because the task can now have content that do not target a particular index.
