### PR TITLE
Remove the connection keep-alive timeout

### DIFF
--- a/meilisearch-http/src/main.rs
+++ b/meilisearch-http/src/main.rs
@@ -2,6 +2,7 @@ use std::env;
 use std::sync::Arc;
 
 use actix_web::HttpServer;
+use actix_web::http::KeepAlive;
 use clap::Parser;
 use meilisearch_auth::AuthController;
 use meilisearch_http::analytics;
@@ -83,7 +84,8 @@ async fn run_http(
         )
     })
     // Disable signals allows the server to terminate immediately when a user enter CTRL-C
-    .disable_signals();
+    .disable_signals()
+    .keep_alive(KeepAlive::Os);
 
     if let Some(config) = opt.get_ssl_config()? {
         http_server

--- a/meilisearch-http/src/main.rs
+++ b/meilisearch-http/src/main.rs
@@ -1,8 +1,8 @@
 use std::env;
 use std::sync::Arc;
 
-use actix_web::HttpServer;
 use actix_web::http::KeepAlive;
+use actix_web::HttpServer;
 use clap::Parser;
 use meilisearch_auth::AuthController;
 use meilisearch_http::analytics;


### PR DESCRIPTION
# Pull Request

## What does this PR do?
Fixes <https://github.com/meilisearch/meilisearch-go/issues/221>.
Meilisearch has a default connection keep-alive timeout for 5s, which means it will close the connections with idle time >= 5s.
This PR set actix-web keep-alive config to `KeepAlive::Os`, let the client and system to decide when to close the connection.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?
