### PR TITLE
Feat(auth): Use hmac instead of sha256 to derivate API keys from master key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -927,6 +927,7 @@ checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1461,6 +1462,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "http"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1974,6 +1984,7 @@ version = "0.27.1"
 dependencies = [
  "base64",
  "enum-iterator",
+ "hmac",
  "meilisearch-error",
  "milli",
  "rand",
@@ -3271,6 +3282,12 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"

--- a/meilisearch-auth/Cargo.toml
+++ b/meilisearch-auth/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 base64 = "0.13.0"
 enum-iterator = "0.7.0"
+hmac = "0.12.1"
 meilisearch-error = { path = "../meilisearch-error" }
 milli = { git = "https://github.com/meilisearch/milli.git", tag = "v0.28.0" }
 rand = "0.8.4"

--- a/meilisearch-auth/src/store.rs
+++ b/meilisearch-auth/src/store.rs
@@ -11,7 +11,7 @@ use enum_iterator::IntoEnumIterator;
 use hmac::{Hmac, Mac};
 use milli::heed::types::{ByteSlice, DecodeIgnore, SerdeJson};
 use milli::heed::{Database, Env, EnvOpenOptions, RwTxn};
-use sha2::Sha256;
+use sha2::{Digest, Sha256};
 use time::OffsetDateTime;
 use uuid::Uuid;
 
@@ -243,7 +243,8 @@ impl<'a> milli::heed::BytesEncode<'a> for KeyIdActionCodec {
 }
 
 pub fn generate_key_as_base64(uid: &[u8], master_key: &[u8]) -> String {
-    let mut mac = Hmac::<Sha256>::new_from_slice(master_key).unwrap();
+    let master_key_sha = Sha256::digest(master_key);
+    let mut mac = Hmac::<Sha256>::new_from_slice(master_key_sha.as_slice()).unwrap();
     mac.update(uid);
 
     let result = mac.finalize();


### PR DESCRIPTION
Wrap sha256 in HMAC to derivate new API keys from the master key.
