### PR TITLE
Allow task abortion

### DIFF
--- a/meilisearch-auth/src/action.rs
+++ b/meilisearch-auth/src/action.rs
@@ -24,6 +24,8 @@ pub enum Action {
     IndexesDelete = actions::INDEXES_DELETE,
     #[serde(rename = "tasks.get")]
     TasksGet = actions::TASKS_GET,
+    #[serde(rename = "tasks.abort")]
+    TasksAbort = actions::TASKS_ABORT,
     #[serde(rename = "settings.get")]
     SettingsGet = actions::SETTINGS_GET,
     #[serde(rename = "settings.update")]
@@ -72,28 +74,7 @@ impl Action {
     }
 
     pub fn repr(&self) -> u8 {
-        use actions::*;
-        match self {
-            Self::All => ALL,
-            Self::Search => SEARCH,
-            Self::DocumentsAdd => DOCUMENTS_ADD,
-            Self::DocumentsGet => DOCUMENTS_GET,
-            Self::DocumentsDelete => DOCUMENTS_DELETE,
-            Self::IndexesAdd => INDEXES_CREATE,
-            Self::IndexesGet => INDEXES_GET,
-            Self::IndexesUpdate => INDEXES_UPDATE,
-            Self::IndexesDelete => INDEXES_DELETE,
-            Self::TasksGet => TASKS_GET,
-            Self::SettingsGet => SETTINGS_GET,
-            Self::SettingsUpdate => SETTINGS_UPDATE,
-            Self::StatsGet => STATS_GET,
-            Self::DumpsCreate => DUMPS_CREATE,
-            Self::Version => VERSION,
-            Self::KeysAdd => KEYS_CREATE,
-            Self::KeysGet => KEYS_GET,
-            Self::KeysUpdate => KEYS_UPDATE,
-            Self::KeysDelete => KEYS_DELETE,
-        }
+        *self as u8
     }
 }
 
@@ -117,4 +98,5 @@ pub mod actions {
     pub const KEYS_GET: u8 = 17;
     pub const KEYS_UPDATE: u8 = 18;
     pub const KEYS_DELETE: u8 = 19;
+    pub const TASKS_ABORT: u8 = 20;
 }

--- a/meilisearch-auth/src/action.rs
+++ b/meilisearch-auth/src/action.rs
@@ -60,6 +60,7 @@ impl Action {
             INDEXES_UPDATE => Some(Self::IndexesUpdate),
             INDEXES_DELETE => Some(Self::IndexesDelete),
             TASKS_GET => Some(Self::TasksGet),
+            TASKS_ABORT => Some(Self::TasksAbort),
             SETTINGS_GET => Some(Self::SettingsGet),
             SETTINGS_UPDATE => Some(Self::SettingsUpdate),
             STATS_GET => Some(Self::StatsGet),

--- a/meilisearch-http/src/routes/tasks.rs
+++ b/meilisearch-http/src/routes/tasks.rs
@@ -21,7 +21,7 @@ const DEFAULT_LIMIT: fn() -> usize = || 20;
 pub fn configure(cfg: &mut web::ServiceConfig) {
     cfg.service(web::resource("").route(web::get().to(SeqHandler(get_tasks))))
         .service(web::resource("/{task_id}").route(web::get().to(SeqHandler(get_task))))
-        .service(web::resource("/{task_id}/abort").route(web::get().to(SeqHandler(abort_task))));
+        .service(web::resource("/abort").route(web::post().to(SeqHandler(abort_task))));
 }
 
 #[derive(Deserialize, Debug)]
@@ -201,11 +201,11 @@ async fn get_task(
 
 async fn abort_task(
     meilisearch: GuardedData<ActionPolicy<{ actions::TASKS_ABORT }>, MeiliSearch>,
-    task_id: web::Path<TaskId>,
+    task_ids: web::Json<Vec<TaskId>>,
     _analytics: web::Data<dyn Analytics>,
 ) -> Result<HttpResponse, ResponseError> {
     let task = meilisearch
-        .register_abort_task(vec![task_id.into_inner()])
+        .register_abort_task(task_ids.into_inner())
         .await?;
 
     let view: SummarizedTaskView = task.into();

--- a/meilisearch-http/src/routes/tasks.rs
+++ b/meilisearch-http/src/routes/tasks.rs
@@ -20,8 +20,8 @@ const DEFAULT_LIMIT: fn() -> usize = || 20;
 
 pub fn configure(cfg: &mut web::ServiceConfig) {
     cfg.service(web::resource("").route(web::get().to(SeqHandler(get_tasks))))
-        .service(web::resource("/{task_id}").route(web::get().to(SeqHandler(get_task))))
-        .service(web::resource("/abort").route(web::post().to(SeqHandler(abort_task))));
+        .service(web::resource("/abort").route(web::post().to(SeqHandler(abort_task))))
+        .service(web::resource("/{task_id}").route(web::get().to(SeqHandler(get_task))));
 }
 
 #[derive(Deserialize, Debug)]

--- a/meilisearch-http/src/task.rs
+++ b/meilisearch-http/src/task.rs
@@ -346,6 +346,7 @@ impl From<Task> for TaskView {
                 }
                 (TaskStatus::Succeeded, None, Some(*timestamp))
             }
+            TaskEvent::Aborted { timestamp } => (TaskStatus::Aborted, None, Some(*timestamp)),
             TaskEvent::Failed { timestamp, error } => {
                 match details {
                     Some(TaskDetails::DocumentDeletion {
@@ -370,7 +371,6 @@ impl From<Task> for TaskView {
                 }
                 (TaskStatus::Failed, Some(error.clone()), Some(*timestamp))
             }
-            TaskEvent::Aborted { timestamp } => (TaskStatus::Aborted, None, Some(*timestamp)),
         };
 
         let enqueued_at = match events.first() {

--- a/meilisearch-http/src/task.rs
+++ b/meilisearch-http/src/task.rs
@@ -24,6 +24,7 @@ pub enum TaskType {
     DocumentDeletion,
     SettingsUpdate,
     DumpCreation,
+    TaskAbortion,
 }
 
 impl From<TaskContent> for TaskType {
@@ -36,7 +37,7 @@ impl From<TaskContent> for TaskType {
             TaskContent::DocumentDeletion { .. } => TaskType::DocumentDeletion,
             TaskContent::SettingsUpdate { .. } => TaskType::SettingsUpdate,
             TaskContent::Dump { .. } => TaskType::DumpCreation,
-            TaskContent::TaskAbortion { .. } => todo!(),
+            TaskContent::TaskAbortion { .. } => TaskType::TaskAbortion,
         }
     }
 }
@@ -93,6 +94,7 @@ pub enum TaskStatus {
     Processing,
     Succeeded,
     Failed,
+    Aborted,
 }
 
 #[derive(Debug)]
@@ -296,7 +298,7 @@ impl From<Task> for TaskView {
                 TaskType::DumpCreation,
                 Some(TaskDetails::Dump { dump_uid: uid }),
             ),
-            TaskContent::TaskAbortion { .. } => todo!(),
+            TaskContent::TaskAbortion { .. } => (TaskType::TaskAbortion, None),
         };
 
         // An event always has at least one event: "Created"
@@ -368,7 +370,7 @@ impl From<Task> for TaskView {
                 }
                 (TaskStatus::Failed, Some(error.clone()), Some(*timestamp))
             }
-            TaskEvent::Aborted { .. } => todo!(),
+            TaskEvent::Aborted { timestamp } => (TaskStatus::Aborted, None, Some(*timestamp)),
         };
 
         let enqueued_at = match events.first() {

--- a/meilisearch-http/src/task.rs
+++ b/meilisearch-http/src/task.rs
@@ -38,6 +38,7 @@ impl From<TaskContent> for TaskType {
             TaskContent::SettingsUpdate { .. } => TaskType::SettingsUpdate,
             TaskContent::Dump { .. } => TaskType::DumpCreation,
             TaskContent::TasksAbortion { .. } => TaskType::TaskAbortion,
+            TaskContent::TasksClear => todo!(),
         }
     }
 }
@@ -299,6 +300,7 @@ impl From<Task> for TaskView {
                 Some(TaskDetails::Dump { dump_uid: uid }),
             ),
             TaskContent::TasksAbortion { .. } => (TaskType::TaskAbortion, None),
+            TaskContent::TasksClear => todo!(),
         };
 
         // An event always has at least one event: "Created"

--- a/meilisearch-http/src/task.rs
+++ b/meilisearch-http/src/task.rs
@@ -37,8 +37,7 @@ impl From<TaskContent> for TaskType {
             TaskContent::DocumentDeletion { .. } => TaskType::DocumentDeletion,
             TaskContent::SettingsUpdate { .. } => TaskType::SettingsUpdate,
             TaskContent::Dump { .. } => TaskType::DumpCreation,
-            TaskContent::TasksAbortion { .. } => TaskType::TaskAbortion,
-            TaskContent::TasksClear => todo!(),
+            TaskContent::TasksAbortion { .. } | TaskContent::TasksClear => TaskType::TaskAbortion,
         }
     }
 }
@@ -299,8 +298,9 @@ impl From<Task> for TaskView {
                 TaskType::DumpCreation,
                 Some(TaskDetails::Dump { dump_uid: uid }),
             ),
-            TaskContent::TasksAbortion { .. } => (TaskType::TaskAbortion, None),
-            TaskContent::TasksClear => todo!(),
+            TaskContent::TasksAbortion { .. } | TaskContent::TasksClear => {
+                (TaskType::TaskAbortion, None)
+            }
         };
 
         // An event always has at least one event: "Created"

--- a/meilisearch-http/src/task.rs
+++ b/meilisearch-http/src/task.rs
@@ -36,6 +36,7 @@ impl From<TaskContent> for TaskType {
             TaskContent::DocumentDeletion { .. } => TaskType::DocumentDeletion,
             TaskContent::SettingsUpdate { .. } => TaskType::SettingsUpdate,
             TaskContent::Dump { .. } => TaskType::DumpCreation,
+            TaskContent::TaskAbortion { .. } => todo!(),
         }
     }
 }
@@ -295,6 +296,7 @@ impl From<Task> for TaskView {
                 TaskType::DumpCreation,
                 Some(TaskDetails::Dump { dump_uid: uid }),
             ),
+            TaskContent::TaskAbortion { .. } => todo!(),
         };
 
         // An event always has at least one event: "Created"

--- a/meilisearch-http/src/task.rs
+++ b/meilisearch-http/src/task.rs
@@ -366,6 +366,7 @@ impl From<Task> for TaskView {
                 }
                 (TaskStatus::Failed, Some(error.clone()), Some(*timestamp))
             }
+            TaskEvent::Aborted { .. } => todo!(),
         };
 
         let enqueued_at = match events.first() {

--- a/meilisearch-http/src/task.rs
+++ b/meilisearch-http/src/task.rs
@@ -37,7 +37,7 @@ impl From<TaskContent> for TaskType {
             TaskContent::DocumentDeletion { .. } => TaskType::DocumentDeletion,
             TaskContent::SettingsUpdate { .. } => TaskType::SettingsUpdate,
             TaskContent::Dump { .. } => TaskType::DumpCreation,
-            TaskContent::TaskAbortion { .. } => TaskType::TaskAbortion,
+            TaskContent::TasksAbortion { .. } => TaskType::TaskAbortion,
         }
     }
 }
@@ -298,7 +298,7 @@ impl From<Task> for TaskView {
                 TaskType::DumpCreation,
                 Some(TaskDetails::Dump { dump_uid: uid }),
             ),
-            TaskContent::TaskAbortion { .. } => (TaskType::TaskAbortion, None),
+            TaskContent::TasksAbortion { .. } => (TaskType::TaskAbortion, None),
         };
 
         // An event always has at least one event: "Created"

--- a/meilisearch-http/tests/auth/authorization.rs
+++ b/meilisearch-http/tests/auth/authorization.rs
@@ -16,6 +16,7 @@ pub static AUTHORIZATIONS: Lazy<HashMap<(&'static str, &'static str), HashSet<&'
             ("GET",     "/indexes/products/documents/0") =>                    hashset!{"documents.get", "*"},
             ("DELETE",  "/indexes/products/documents/0") =>                    hashset!{"documents.delete", "*"},
             ("GET",     "/tasks") =>                                           hashset!{"tasks.get", "*"},
+            ("POST",    "/tasks/abort") =>                                     hashset!{"tasks.abort", "*"},
             ("GET",     "/tasks?indexUid=products") =>                         hashset!{"tasks.get", "*"},
             ("GET",     "/tasks/0") =>                                         hashset!{"tasks.get", "*"},
             ("PATCH",   "/indexes/products/") =>                               hashset!{"indexes.update", "*"},

--- a/meilisearch-http/tests/common/index.rs
+++ b/meilisearch-http/tests/common/index.rs
@@ -95,7 +95,10 @@ impl Index<'_> {
             let (response, status_code) = self.service.get(&url).await;
             assert_eq!(200, status_code, "response: {}", response);
 
-            if response["status"] == "succeeded" || response["status"] == "failed" {
+            if response["status"] == "succeeded"
+                || response["status"] == "failed"
+                || response["status"] == "aborted"
+            {
                 return response;
             }
 

--- a/meilisearch-http/tests/common/server.rs
+++ b/meilisearch-http/tests/common/server.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
 use clap::Parser;
+use meilisearch_lib::tasks::task::TaskId;
 use std::path::Path;
 
 use actix_web::http::StatusCode;
@@ -143,6 +144,10 @@ impl Server {
 
     pub async fn get_dump_status(&self, uid: &str) -> (Value, StatusCode) {
         self.service.get(format!("/dumps/{}/status", uid)).await
+    }
+
+    pub async fn abort_task(&self, ids: Vec<TaskId>) -> (Value, StatusCode) {
+        self.service.post("/tasks/abort", ids.into()).await
     }
 }
 

--- a/meilisearch-http/tests/documents/add_documents.rs
+++ b/meilisearch-http/tests/documents/add_documents.rs
@@ -1020,7 +1020,7 @@ async fn add_documents_invalid_geo_field() {
     index.wait_task(2).await;
     let (response, code) = index.get_task(2).await;
     assert_eq!(code, 200);
-    assert_eq!(response["status"], "succeeded");
+    assert_eq!(response["status"], "succeeded", "{response}");
 }
 
 #[actix_rt::test]

--- a/meilisearch-http/tests/search/mod.rs
+++ b/meilisearch-http/tests/search/mod.rs
@@ -708,9 +708,7 @@ async fn faceting_max_values_per_facet() {
             }),
             |response, code| {
                 assert_eq!(code, 200, "{}", response);
-                let numbers = dbg!(&response)["facetDistribution"]["number"]
-                    .as_object()
-                    .unwrap();
+                let numbers = &response["facetDistribution"]["number"].as_object().unwrap();
                 assert_eq!(numbers.len(), 10_000);
             },
         )

--- a/meilisearch-http/tests/tasks/mod.rs
+++ b/meilisearch-http/tests/tasks/mod.rs
@@ -247,7 +247,7 @@ async fn abort_processed_task() {
     let (_, code) = server.abort_task(vec![0]).await;
     assert_eq!(code, 200);
     let ret = index.wait_task(1).await;
-    assert_eq!(ret["status"], "failed");
+    assert_eq!(ret["status"], "succeeded");
 }
 
 #[actix_rt::test]

--- a/meilisearch-lib/src/index_controller/mod.rs
+++ b/meilisearch-lib/src/index_controller/mod.rs
@@ -233,10 +233,12 @@ impl IndexControllerBuilder {
             meta_env.clone(),
             index_resolver.clone(),
         ));
+
         let task_store = TaskStore::new(meta_env)?;
 
         // register all the batch handlers for use with the scheduler.
         let handlers: Vec<Arc<dyn BatchHandler + Sync + Send + 'static>> = vec![
+            Arc::new(task_store.clone()),
             index_resolver.clone(),
             dump_handler,
             Arc::new(SnapshotHandler),

--- a/meilisearch-lib/src/index_controller/mod.rs
+++ b/meilisearch-lib/src/index_controller/mod.rs
@@ -430,6 +430,10 @@ where
             },
         };
 
+        self.register_task_content(content).await
+    }
+
+    async fn register_task_content(&self, content: TaskContent) -> Result<Task> {
         let task = self.task_store.register(content).await?;
         self.scheduler.read().await.notify();
 
@@ -439,13 +443,19 @@ where
     pub async fn register_dump_task(&self) -> Result<Task> {
         let uid = dump::generate_uid();
         let content = TaskContent::Dump { uid };
-        let task = self.task_store.register(content).await?;
-        self.scheduler.read().await.notify();
-        Ok(task)
+
+        self.register_task_content(content).await
+    }
+
+    pub async fn register_abort_task(&self, tasks: Vec<TaskId>) -> Result<Task> {
+        let content = TaskContent::TaskAbortion { tasks };
+
+        self.register_task_content(content).await
     }
 
     pub async fn get_task(&self, id: TaskId, filter: Option<TaskFilter>) -> Result<Task> {
         let task = self.scheduler.read().await.get_task(id, filter).await?;
+
         Ok(task)
     }
 

--- a/meilisearch-lib/src/index_controller/mod.rs
+++ b/meilisearch-lib/src/index_controller/mod.rs
@@ -449,8 +449,14 @@ where
         self.register_task_content(content).await
     }
 
-    pub async fn register_abort_task(&self, tasks: Vec<TaskId>) -> Result<Task> {
+    pub async fn register_abort_tasks(&self, tasks: Vec<TaskId>) -> Result<Task> {
         let content = TaskContent::TasksAbortion { tasks };
+
+        self.register_task_content(content).await
+    }
+
+    pub async fn register_clear_tasks(&self) -> Result<Task> {
+        let content = TaskContent::TasksClear;
 
         self.register_task_content(content).await
     }

--- a/meilisearch-lib/src/index_controller/mod.rs
+++ b/meilisearch-lib/src/index_controller/mod.rs
@@ -450,7 +450,7 @@ where
     }
 
     pub async fn register_abort_task(&self, tasks: Vec<TaskId>) -> Result<Task> {
-        let content = TaskContent::TaskAbortion { tasks };
+        let content = TaskContent::TasksAbortion { tasks };
 
         self.register_task_content(content).await
     }

--- a/meilisearch-lib/src/index_resolver/mod.rs
+++ b/meilisearch-lib/src/index_resolver/mod.rs
@@ -103,6 +103,10 @@ mod real {
                 .map(get_content_uuid)
                 .collect::<Vec<_>>();
 
+            if content_uuids.is_empty() {
+                return;
+            }
+
             match tasks.first() {
                 Some(Task {
                     id,

--- a/meilisearch-lib/src/index_resolver/mod.rs
+++ b/meilisearch-lib/src/index_resolver/mod.rs
@@ -99,7 +99,7 @@ mod real {
 
             let content_uuids = tasks
                 .iter()
-                .filter(|t| t.is_aborted())
+                .filter(|t| !t.is_aborted())
                 .map(get_content_uuid)
                 .collect::<Vec<_>>();
 
@@ -172,7 +172,7 @@ mod real {
                     };
 
                     // do not push event to aborted tasks
-                    for task in tasks.iter_mut().filter(|t| t.is_aborted()) {
+                    for task in tasks.iter_mut().filter(|t| !t.is_aborted()) {
                         task.events.push(event.clone());
                     }
                 }

--- a/meilisearch-lib/src/index_resolver/mod.rs
+++ b/meilisearch-lib/src/index_resolver/mod.rs
@@ -97,7 +97,11 @@ mod real {
                 }
             }
 
-            let content_uuids = tasks.iter().map(get_content_uuid).collect::<Vec<_>>();
+            let content_uuids = tasks
+                .iter()
+                .filter(|t| t.is_aborted())
+                .map(get_content_uuid)
+                .collect::<Vec<_>>();
 
             match tasks.first() {
                 Some(Task {
@@ -167,7 +171,8 @@ mod real {
                         },
                     };
 
-                    for task in tasks.iter_mut() {
+                    // do not push event to aborted tasks
+                    for task in tasks.iter_mut().filter(|t| t.is_aborted()) {
                         task.events.push(event.clone());
                     }
                 }

--- a/meilisearch-lib/src/tasks/batch.rs
+++ b/meilisearch-lib/src/tasks/batch.rs
@@ -11,6 +11,7 @@ pub enum BatchContent {
     DocumentsAdditionBatch(Vec<Task>),
     IndexUpdate(Task),
     Dump(Task),
+    TaskAbortion(Task),
     Snapshot(SnapshotJob),
     // Symbolizes a empty batch. This can occur when we were woken, but there wasn't any work to do.
     Empty,
@@ -20,7 +21,9 @@ impl BatchContent {
     pub fn first(&self) -> Option<&Task> {
         match self {
             BatchContent::DocumentsAdditionBatch(ts) => ts.first(),
-            BatchContent::Dump(t) | BatchContent::IndexUpdate(t) => Some(t),
+            BatchContent::Dump(t)
+            | BatchContent::IndexUpdate(t)
+            | BatchContent::TaskAbortion(t) => Some(t),
             BatchContent::Snapshot(_) | BatchContent::Empty => None,
         }
     }
@@ -30,7 +33,9 @@ impl BatchContent {
             BatchContent::DocumentsAdditionBatch(ts) => {
                 ts.iter_mut().for_each(|t| t.events.push(event.clone()))
             }
-            BatchContent::IndexUpdate(t) | BatchContent::Dump(t) => t.events.push(event),
+            BatchContent::IndexUpdate(t)
+            | BatchContent::Dump(t)
+            | BatchContent::TaskAbortion(t) => t.events.push(event),
             BatchContent::Snapshot(_) | BatchContent::Empty => (),
         }
     }
@@ -56,7 +61,10 @@ impl Batch {
     pub fn len(&self) -> usize {
         match self.content {
             BatchContent::DocumentsAdditionBatch(ref ts) => ts.len(),
-            BatchContent::IndexUpdate(_) | BatchContent::Dump(_) | BatchContent::Snapshot(_) => 1,
+            BatchContent::IndexUpdate(_)
+            | BatchContent::Dump(_)
+            | BatchContent::Snapshot(_)
+            | BatchContent::TaskAbortion(_) => 1,
             BatchContent::Empty => 0,
         }
     }

--- a/meilisearch-lib/src/tasks/batch.rs
+++ b/meilisearch-lib/src/tasks/batch.rs
@@ -30,12 +30,17 @@ impl BatchContent {
 
     pub fn push_event(&mut self, event: TaskEvent) {
         match self {
-            BatchContent::DocumentsAdditionBatch(ts) => {
-                ts.iter_mut().for_each(|t| t.events.push(event.clone()))
-            }
+            BatchContent::DocumentsAdditionBatch(ts) => ts
+                .iter_mut()
+                .filter(|t| !t.is_aborted())
+                .for_each(|t| t.events.push(event.clone())),
             BatchContent::IndexUpdate(t)
             | BatchContent::Dump(t)
-            | BatchContent::TaskAbortion(t) => t.events.push(event),
+            | BatchContent::TaskAbortion(t) => {
+                if !t.is_aborted() {
+                    t.events.push(event)
+                }
+            }
             BatchContent::Snapshot(_) | BatchContent::Empty => (),
         }
     }

--- a/meilisearch-lib/src/tasks/error.rs
+++ b/meilisearch-lib/src/tasks/error.rs
@@ -12,6 +12,8 @@ pub type Result<T> = std::result::Result<T, TaskError>;
 pub enum TaskError {
     #[error("Task `{0}` not found.")]
     UnexistingTask(TaskId),
+    #[error("Cannot abort already processed task")]
+    AbortProcessedTask,
     #[error("Internal error: {0}")]
     Internal(Box<dyn std::error::Error + Send + Sync + 'static>),
 }
@@ -29,6 +31,7 @@ impl ErrorCode for TaskError {
         match self {
             TaskError::UnexistingTask(_) => Code::TaskNotFound,
             TaskError::Internal(_) => Code::Internal,
+            TaskError::AbortProcessedTask => todo!(),
         }
     }
 }

--- a/meilisearch-lib/src/tasks/error.rs
+++ b/meilisearch-lib/src/tasks/error.rs
@@ -12,8 +12,6 @@ pub type Result<T> = std::result::Result<T, TaskError>;
 pub enum TaskError {
     #[error("Task `{0}` not found.")]
     UnexistingTask(TaskId),
-    #[error("Cannot abort already processed task")]
-    AbortProcessedTask,
     #[error("Internal error: {0}")]
     Internal(Box<dyn std::error::Error + Send + Sync + 'static>),
 }
@@ -31,7 +29,6 @@ impl ErrorCode for TaskError {
         match self {
             TaskError::UnexistingTask(_) => Code::TaskNotFound,
             TaskError::Internal(_) => Code::Internal,
-            TaskError::AbortProcessedTask => Code::InvalidTaskAbort,
         }
     }
 }

--- a/meilisearch-lib/src/tasks/error.rs
+++ b/meilisearch-lib/src/tasks/error.rs
@@ -31,7 +31,7 @@ impl ErrorCode for TaskError {
         match self {
             TaskError::UnexistingTask(_) => Code::TaskNotFound,
             TaskError::Internal(_) => Code::Internal,
-            TaskError::AbortProcessedTask => Code::BadRequest,
+            TaskError::AbortProcessedTask => Code::InvalidTaskAbort,
         }
     }
 }

--- a/meilisearch-lib/src/tasks/error.rs
+++ b/meilisearch-lib/src/tasks/error.rs
@@ -31,7 +31,7 @@ impl ErrorCode for TaskError {
         match self {
             TaskError::UnexistingTask(_) => Code::TaskNotFound,
             TaskError::Internal(_) => Code::Internal,
-            TaskError::AbortProcessedTask => todo!(),
+            TaskError::AbortProcessedTask => Code::BadRequest,
         }
     }
 }

--- a/meilisearch-lib/src/tasks/handlers/dump_handler.rs
+++ b/meilisearch-lib/src/tasks/handlers/dump_handler.rs
@@ -156,7 +156,7 @@ mod test {
             content: TaskContent::Dump {
                 uid: "test".to_string(),
             },
-            events: vec![TaskEvent::abort()],
+            events: vec![TaskEvent::aborted()],
         };
 
         assert!(task.is_aborted());

--- a/meilisearch-lib/src/tasks/handlers/index_resolver_handler.rs
+++ b/meilisearch-lib/src/tasks/handlers/index_resolver_handler.rs
@@ -81,7 +81,8 @@ mod test {
                     | BatchContent::IndexUpdate(_) => assert!(index_resolver.accept(&batch)),
                 BatchContent::Dump(_)
                     | BatchContent::Snapshot(_)
-                    | BatchContent::Empty => assert!(!index_resolver.accept(&batch)),
+                    | BatchContent::Empty
+                    | BatchContent::TaskAbortion(_) => assert!(!index_resolver.accept(&batch)),
             }
         }
     }

--- a/meilisearch-lib/src/tasks/handlers/index_resolver_handler.rs
+++ b/meilisearch-lib/src/tasks/handlers/index_resolver_handler.rs
@@ -22,7 +22,9 @@ where
                 self.process_document_addition_batch(tasks).await;
             }
             BatchContent::IndexUpdate(ref mut task) => {
-                self.process_task(task).await;
+                if !task.is_aborted() {
+                    self.process_task(task).await;
+                }
             }
             _ => unreachable!(),
         }
@@ -32,6 +34,7 @@ where
 
     async fn finish(&self, batch: &Batch) {
         if let BatchContent::DocumentsAdditionBatch(ref tasks) = batch.content {
+            // we do not ignore the aborted tasks here, since we want to remove their content.
             for task in tasks {
                 if let Some(content_uuid) = task.get_content_uuid() {
                     if let Err(e) = self.delete_content_file(content_uuid).await {
@@ -50,6 +53,7 @@ mod test {
     use crate::index_resolver::{
         error::Result as IndexResult, index_store::MockIndexStore, meta_store::MockIndexMetaStore,
     };
+    use crate::tasks::task::TaskEvent;
     use crate::tasks::{
         handlers::test::task_to_batch,
         task::{Task, TaskContent},
@@ -196,5 +200,58 @@ mod test {
                 }
             }
         }
+    }
+
+    #[actix_rt::test]
+    async fn test_abort_task() {
+        let task = Task {
+            id: 1,
+            content: TaskContent::IndexUpdate {
+                index_uid: IndexUid::new_unchecked("hello"),
+                primary_key: None,
+            },
+            events: vec![TaskEvent::abort()],
+        };
+
+        let batch = task_to_batch(task.clone());
+
+        let mocker = Mocker::default();
+        let index_resolver: IndexResolver<HeedMetaStore, MapIndexStore> =
+            IndexResolver::mock(mocker);
+
+        let batch = index_resolver.process_batch(batch).await;
+        assert!(index_resolver.accept(&batch));
+        assert_eq!(batch.content.first().unwrap(), &task);
+
+        index_resolver.finish(&batch).await;
+    }
+
+    #[actix_rt::test]
+    async fn test_cleanup_after_abort() {
+        let content_uuid = Uuid::new_v4();
+        let task = Task {
+            id: 1,
+            content: TaskContent::DocumentAddition {
+                index_uid: IndexUid::new_unchecked("hello"),
+                content_uuid,
+                merge_strategy: IndexDocumentsMethod::ReplaceDocuments,
+                primary_key: None,
+                documents_count: 10,
+                allow_index_creation: true,
+            },
+            events: vec![TaskEvent::abort()],
+        };
+
+        let batch = task_to_batch(task.clone());
+
+        let mocker = Mocker::default();
+        mocker
+            .when::<Uuid, IndexResult<()>>("delete_content_file")
+            .then(|_| Ok(()));
+
+        let index_resolver: IndexResolver<HeedMetaStore, MapIndexStore> =
+            IndexResolver::mock(mocker);
+
+        index_resolver.finish(&batch).await;
     }
 }

--- a/meilisearch-lib/src/tasks/handlers/index_resolver_handler.rs
+++ b/meilisearch-lib/src/tasks/handlers/index_resolver_handler.rs
@@ -210,7 +210,7 @@ mod test {
                 index_uid: IndexUid::new_unchecked("hello"),
                 primary_key: None,
             },
-            events: vec![TaskEvent::abort()],
+            events: vec![TaskEvent::aborted()],
         };
 
         let batch = task_to_batch(task.clone());
@@ -239,7 +239,7 @@ mod test {
                 documents_count: 10,
                 allow_index_creation: true,
             },
-            events: vec![TaskEvent::abort()],
+            events: vec![TaskEvent::aborted()],
         };
 
         let batch = task_to_batch(task.clone());

--- a/meilisearch-lib/src/tasks/handlers/mod.rs
+++ b/meilisearch-lib/src/tasks/handlers/mod.rs
@@ -23,6 +23,7 @@ mod test {
             | TaskContent::IndexCreation { .. }
             | TaskContent::IndexUpdate { .. } => BatchContent::IndexUpdate(task),
             TaskContent::Dump { .. } => BatchContent::Dump(task),
+            TaskContent::TaskAbortion { .. } => todo!(),
         };
 
         Batch {

--- a/meilisearch-lib/src/tasks/handlers/mod.rs
+++ b/meilisearch-lib/src/tasks/handlers/mod.rs
@@ -24,7 +24,7 @@ mod test {
             | TaskContent::IndexCreation { .. }
             | TaskContent::IndexUpdate { .. } => BatchContent::IndexUpdate(task),
             TaskContent::Dump { .. } => BatchContent::Dump(task),
-            TaskContent::TaskAbortion { .. } => todo!(),
+            TaskContent::TaskAbortion { .. } => BatchContent::TaskAbortion(task),
         };
 
         Batch {

--- a/meilisearch-lib/src/tasks/handlers/mod.rs
+++ b/meilisearch-lib/src/tasks/handlers/mod.rs
@@ -2,6 +2,7 @@ pub mod dump_handler;
 pub mod empty_handler;
 mod index_resolver_handler;
 pub mod snapshot_handler;
+mod task_store_handler;
 
 #[cfg(test)]
 mod test {

--- a/meilisearch-lib/src/tasks/handlers/mod.rs
+++ b/meilisearch-lib/src/tasks/handlers/mod.rs
@@ -24,7 +24,7 @@ mod test {
             | TaskContent::IndexCreation { .. }
             | TaskContent::IndexUpdate { .. } => BatchContent::IndexUpdate(task),
             TaskContent::Dump { .. } => BatchContent::Dump(task),
-            TaskContent::TaskAbortion { .. } => BatchContent::TaskAbortion(task),
+            TaskContent::TasksAbortion { .. } => BatchContent::TaskAbortion(task),
         };
 
         Batch {

--- a/meilisearch-lib/src/tasks/handlers/mod.rs
+++ b/meilisearch-lib/src/tasks/handlers/mod.rs
@@ -24,7 +24,9 @@ mod test {
             | TaskContent::IndexCreation { .. }
             | TaskContent::IndexUpdate { .. } => BatchContent::IndexUpdate(task),
             TaskContent::Dump { .. } => BatchContent::Dump(task),
-            TaskContent::TasksAbortion { .. } => BatchContent::TaskAbortion(task),
+            TaskContent::TasksAbortion { .. } | TaskContent::TasksClear => {
+                BatchContent::TaskAbortion(task)
+            }
         };
 
         Batch {

--- a/meilisearch-lib/src/tasks/handlers/task_store_handler.rs
+++ b/meilisearch-lib/src/tasks/handlers/task_store_handler.rs
@@ -1,0 +1,40 @@
+use crate::tasks::batch::{Batch, BatchContent};
+use crate::tasks::task::{Task, TaskContent, TaskEvent, TaskResult};
+use crate::tasks::{BatchHandler, TaskStore};
+
+#[async_trait::async_trait]
+impl BatchHandler for TaskStore {
+    fn accept(&self, batch: &Batch) -> bool {
+        matches!(batch.content, BatchContent::TaskAbortion(_))
+    }
+
+    async fn process_batch(&self, mut batch: Batch) -> Batch {
+        match batch.content {
+            BatchContent::TaskAbortion(Task {
+                content: TaskContent::TaskAbortion { ref tasks },
+                ref mut events,
+                ..
+            }) => {
+                let mut updated_tasks = Vec::with_capacity(tasks.len());
+                for id in tasks {
+                    let mut task = self.get_task(*id, None).await.unwrap();
+                    if !task.is_finished() {
+                        task.events.push(TaskEvent::abort());
+                        updated_tasks.push(task);
+                    } else {
+                        panic!("can't abort already processed task");
+                    }
+                }
+
+                self.update_tasks(updated_tasks).await.unwrap();
+
+                events.push(TaskEvent::succeeded(TaskResult::Other));
+            }
+            _ => unreachable!(),
+        }
+
+        batch
+    }
+
+    async fn finish(&self, _: &Batch) {}
+}

--- a/meilisearch-lib/src/tasks/handlers/task_store_handler.rs
+++ b/meilisearch-lib/src/tasks/handlers/task_store_handler.rs
@@ -38,11 +38,10 @@ impl BatchHandler for TaskStore {
                 ..
             }) => {
                 if !events.iter().any(TaskEvent::is_aborted) {
-                    match self.abort_updates(tasks).await {
+                    match dbg!(self.abort_updates(tasks).await) {
                         Ok(_) => events.push(TaskEvent::succeeded(TaskResult::Other)),
                         Err(e) => events.push(TaskEvent::failed(e)),
                     }
-                    events.push(TaskEvent::succeeded(TaskResult::Other));
                 }
             }
             _ => unreachable!(),

--- a/meilisearch-lib/src/tasks/handlers/task_store_handler.rs
+++ b/meilisearch-lib/src/tasks/handlers/task_store_handler.rs
@@ -37,11 +37,13 @@ impl BatchHandler for TaskStore {
                 ref mut events,
                 ..
             }) => {
-                match self.abort_updates(tasks).await {
-                    Ok(_) => events.push(TaskEvent::succeeded(TaskResult::Other)),
-                    Err(e) => events.push(TaskEvent::failed(e)),
+                if !events.iter().any(TaskEvent::is_aborted) {
+                    match self.abort_updates(tasks).await {
+                        Ok(_) => events.push(TaskEvent::succeeded(TaskResult::Other)),
+                        Err(e) => events.push(TaskEvent::failed(e)),
+                    }
+                    events.push(TaskEvent::succeeded(TaskResult::Other));
                 }
-                events.push(TaskEvent::succeeded(TaskResult::Other));
             }
             _ => unreachable!(),
         }

--- a/meilisearch-lib/src/tasks/handlers/task_store_handler.rs
+++ b/meilisearch-lib/src/tasks/handlers/task_store_handler.rs
@@ -3,7 +3,7 @@ use crate::tasks::task::{Task, TaskContent, TaskEvent, TaskId, TaskResult};
 use crate::tasks::{error::TaskError, BatchHandler, Result, TaskStore};
 
 impl TaskStore {
-    async fn abort_updates(&self, ids: &[TaskId]) -> Result<()> {
+    async fn abort_tasks(&self, ids: &[TaskId]) -> Result<()> {
         let mut tasks = Vec::with_capacity(ids.len());
 
         for id in ids {
@@ -51,7 +51,7 @@ impl BatchHandler for TaskStore {
                 ..
             }) => {
                 if !events.iter().any(TaskEvent::is_aborted) {
-                    match self.abort_updates(tasks).await {
+                    match self.abort_tasks(tasks).await {
                         Ok(_) => events.push(TaskEvent::succeeded(TaskResult::Other)),
                         Err(e) => events.push(TaskEvent::failed(e)),
                     }

--- a/meilisearch-lib/src/tasks/handlers/task_store_handler.rs
+++ b/meilisearch-lib/src/tasks/handlers/task_store_handler.rs
@@ -33,7 +33,7 @@ impl BatchHandler for TaskStore {
     async fn process_batch(&self, mut batch: Batch) -> Batch {
         match batch.content {
             BatchContent::TaskAbortion(Task {
-                content: TaskContent::TaskAbortion { ref tasks },
+                content: TaskContent::TasksAbortion { ref tasks },
                 ref mut events,
                 ..
             }) => {

--- a/meilisearch-lib/src/tasks/handlers/task_store_handler.rs
+++ b/meilisearch-lib/src/tasks/handlers/task_store_handler.rs
@@ -11,7 +11,7 @@ impl TaskStore {
             // Since updates are processed sequentially, no updates can be in an undecided state
             // here, therefore it's ok to only check for completion.
             if !task.is_finished() {
-                task.events.push(TaskEvent::abort());
+                task.events.push(TaskEvent::aborted());
                 tasks.push(task);
             } else {
                 return Err(TaskError::AbortProcessedTask);
@@ -38,7 +38,7 @@ impl BatchHandler for TaskStore {
                 ..
             }) => {
                 if !events.iter().any(TaskEvent::is_aborted) {
-                    match dbg!(self.abort_updates(tasks).await) {
+                    match self.abort_updates(tasks).await {
                         Ok(_) => events.push(TaskEvent::succeeded(TaskResult::Other)),
                         Err(e) => events.push(TaskEvent::failed(e)),
                     }

--- a/meilisearch-lib/src/tasks/scheduler.rs
+++ b/meilisearch-lib/src/tasks/scheduler.rs
@@ -161,6 +161,7 @@ impl From<&Task> for TaskListIdentifier {
             }
             TaskContent::Dump { .. } => TaskListIdentifier::Dump,
             TaskContent::TasksAbortion { .. } => TaskListIdentifier::TaskAbortion,
+            TaskContent::TasksClear => todo!(),
         }
     }
 }

--- a/meilisearch-lib/src/tasks/scheduler.rs
+++ b/meilisearch-lib/src/tasks/scheduler.rs
@@ -143,6 +143,7 @@ impl From<&Task> for TaskListIdentifier {
                 TaskListIdentifier::Index(index_uid.as_str().to_string())
             }
             TaskContent::Dump { .. } => TaskListIdentifier::Dump,
+            TaskContent::TaskAbortion { .. } => todo!(),
         }
     }
 }

--- a/meilisearch-lib/src/tasks/scheduler.rs
+++ b/meilisearch-lib/src/tasks/scheduler.rs
@@ -309,9 +309,7 @@ impl Scheduler {
 
     fn register_task(&mut self, task: Task) {
         assert!(!task.is_finished());
-        if !task.is_aborted() {
-            self.tasks.insert(task);
-        }
+        self.tasks.insert(task);
     }
 
     /// Clears the processing list, this method should be called when the processing of a batch is finished.

--- a/meilisearch-lib/src/tasks/scheduler.rs
+++ b/meilisearch-lib/src/tasks/scheduler.rs
@@ -380,7 +380,6 @@ impl Scheduler {
             .await?
             .into_iter()
             .for_each(|t| {
-                self.next_fetched_task_id = t.id + 1;
                 self.register_task(t);
             });
 

--- a/meilisearch-lib/src/tasks/scheduler.rs
+++ b/meilisearch-lib/src/tasks/scheduler.rs
@@ -160,7 +160,7 @@ impl From<&Task> for TaskListIdentifier {
                 TaskListIdentifier::Index(index_uid.as_str().to_string())
             }
             TaskContent::Dump { .. } => TaskListIdentifier::Dump,
-            TaskContent::TaskAbortion { .. } => TaskListIdentifier::TaskAbortion,
+            TaskContent::TasksAbortion { .. } => TaskListIdentifier::TaskAbortion,
         }
     }
 }
@@ -199,7 +199,7 @@ impl TaskQueue {
             | TaskContent::IndexDeletion { .. }
             | TaskContent::IndexCreation { .. }
             | TaskContent::IndexUpdate { .. } => TaskType::IndexUpdate,
-            TaskContent::TaskAbortion { .. } => TaskType::TaskAbortion,
+            TaskContent::TasksAbortion { .. } => TaskType::TaskAbortion,
             _ => unreachable!("unhandled task type"),
         };
 
@@ -636,7 +636,7 @@ mod test {
         queue.insert(gen_task(6, gen_doc_addition_task_content("test2")));
         queue.insert(gen_task(7, gen_doc_addition_task_content("test1")));
         queue.insert(gen_task(8, TaskContent::Dump { uid: "adump".to_owned() }));
-        queue.insert(gen_task(9, TaskContent::TaskAbortion { tasks: vec![10] }));
+        queue.insert(gen_task(9, TaskContent::TasksAbortion { tasks: vec![10] }));
 
         let config = SchedulerConfig::default();
 

--- a/meilisearch-lib/src/tasks/scheduler.rs
+++ b/meilisearch-lib/src/tasks/scheduler.rs
@@ -636,8 +636,13 @@ mod test {
         queue.insert(gen_task(6, gen_doc_addition_task_content("test2")));
         queue.insert(gen_task(7, gen_doc_addition_task_content("test1")));
         queue.insert(gen_task(8, TaskContent::Dump { uid: "adump".to_owned() }));
+        queue.insert(gen_task(9, TaskContent::TaskAbortion { tasks: vec![10] }));
 
         let config = SchedulerConfig::default();
+
+        // Make sure that the task abortion is processed before everybody else.
+        let batch = make_batch(&mut queue, &config);
+        assert_eq!(batch, Processing::TaskAbortion(9));
 
         // Make sure that the dump is processed before everybody else.
         let batch = make_batch(&mut queue, &config);

--- a/meilisearch-lib/src/tasks/scheduler.rs
+++ b/meilisearch-lib/src/tasks/scheduler.rs
@@ -380,6 +380,7 @@ impl Scheduler {
             .await?
             .into_iter()
             .for_each(|t| {
+                self.next_fetched_task_id = t.id + 1;
                 self.register_task(t);
             });
 

--- a/meilisearch-lib/src/tasks/scheduler.rs
+++ b/meilisearch-lib/src/tasks/scheduler.rs
@@ -160,8 +160,9 @@ impl From<&Task> for TaskListIdentifier {
                 TaskListIdentifier::Index(index_uid.as_str().to_string())
             }
             TaskContent::Dump { .. } => TaskListIdentifier::Dump,
-            TaskContent::TasksAbortion { .. } => TaskListIdentifier::TaskAbortion,
-            TaskContent::TasksClear => todo!(),
+            TaskContent::TasksAbortion { .. } | TaskContent::TasksClear => {
+                TaskListIdentifier::TaskAbortion
+            }
         }
     }
 }
@@ -200,7 +201,7 @@ impl TaskQueue {
             | TaskContent::IndexDeletion { .. }
             | TaskContent::IndexCreation { .. }
             | TaskContent::IndexUpdate { .. } => TaskType::IndexUpdate,
-            TaskContent::TasksAbortion { .. } => TaskType::TaskAbortion,
+            TaskContent::TasksAbortion { .. } | TaskContent::TasksClear => TaskType::TaskAbortion,
             _ => unreachable!("unhandled task type"),
         };
 

--- a/meilisearch-lib/src/tasks/task.rs
+++ b/meilisearch-lib/src/tasks/task.rs
@@ -79,6 +79,12 @@ impl TaskEvent {
             timestamp: OffsetDateTime::now_utc(),
         }
     }
+
+    pub fn abort() -> Self {
+        Self::Aborted {
+            timestamp: OffsetDateTime::now_utc(),
+        }
+    }
 }
 
 /// A task represents an operation that Meilisearch must do.

--- a/meilisearch-lib/src/tasks/task.rs
+++ b/meilisearch-lib/src/tasks/task.rs
@@ -114,7 +114,7 @@ impl Task {
         self.events.last().map_or(false, |event| {
             matches!(
                 event,
-                TaskEvent::Succeeded { .. } | TaskEvent::Failed { .. }
+                TaskEvent::Succeeded { .. } | TaskEvent::Failed { .. } | TaskEvent::Aborted { .. }
             )
         })
     }

--- a/meilisearch-lib/src/tasks/task.rs
+++ b/meilisearch-lib/src/tasks/task.rs
@@ -155,6 +155,7 @@ impl Task {
             | TaskContent::IndexUpdate { index_uid, .. } => Some(index_uid.as_str()),
             TaskContent::Dump { .. } => None,
             TaskContent::TasksAbortion { .. } => None,
+            TaskContent::TasksClear => todo!(),
         }
     }
 
@@ -212,6 +213,7 @@ pub enum TaskContent {
     TasksAbortion {
         tasks: Vec<TaskId>,
     },
+    TasksClear,
 }
 
 #[cfg(test)]

--- a/meilisearch-lib/src/tasks/task.rs
+++ b/meilisearch-lib/src/tasks/task.rs
@@ -129,6 +129,7 @@ impl Task {
             | TaskContent::IndexCreation { index_uid, .. }
             | TaskContent::IndexUpdate { index_uid, .. } => Some(index_uid.as_str()),
             TaskContent::Dump { .. } => None,
+            TaskContent::TaskAbortion { .. } => None,
         }
     }
 }
@@ -178,6 +179,9 @@ pub enum TaskContent {
     },
     Dump {
         uid: String,
+    },
+    TaskAbortion {
+        tasks: Vec<TaskId>,
     },
 }
 

--- a/meilisearch-lib/src/tasks/task.rs
+++ b/meilisearch-lib/src/tasks/task.rs
@@ -153,9 +153,9 @@ impl Task {
             | TaskContent::IndexDeletion { index_uid }
             | TaskContent::IndexCreation { index_uid, .. }
             | TaskContent::IndexUpdate { index_uid, .. } => Some(index_uid.as_str()),
-            TaskContent::Dump { .. } => None,
-            TaskContent::TasksAbortion { .. } => None,
-            TaskContent::TasksClear => todo!(),
+            TaskContent::Dump { .. }
+            | TaskContent::TasksAbortion { .. }
+            | TaskContent::TasksClear => None,
         }
     }
 

--- a/meilisearch-lib/src/tasks/task.rs
+++ b/meilisearch-lib/src/tasks/task.rs
@@ -154,7 +154,7 @@ impl Task {
             | TaskContent::IndexCreation { index_uid, .. }
             | TaskContent::IndexUpdate { index_uid, .. } => Some(index_uid.as_str()),
             TaskContent::Dump { .. } => None,
-            TaskContent::TaskAbortion { .. } => None,
+            TaskContent::TasksAbortion { .. } => None,
         }
     }
 
@@ -209,7 +209,7 @@ pub enum TaskContent {
     Dump {
         uid: String,
     },
-    TaskAbortion {
+    TasksAbortion {
         tasks: Vec<TaskId>,
     },
 }

--- a/meilisearch-lib/src/tasks/task.rs
+++ b/meilisearch-lib/src/tasks/task.rs
@@ -58,6 +58,11 @@ pub enum TaskEvent {
         #[serde(with = "time::serde::rfc3339")]
         timestamp: OffsetDateTime,
     },
+    Aborted {
+        #[cfg_attr(test, proptest(strategy = "test::datetime_strategy()"))]
+        #[serde(with = "time::serde::rfc3339")]
+        timestamp: OffsetDateTime,
+    },
 }
 
 impl TaskEvent {

--- a/meilisearch-lib/src/tasks/task.rs
+++ b/meilisearch-lib/src/tasks/task.rs
@@ -16,6 +16,7 @@ pub enum TaskResult {
     DocumentAddition { indexed_documents: u64 },
     DocumentDeletion { deleted_documents: u64 },
     ClearAll { deleted_documents: u64 },
+    TaskAbortion { aborted_tasks: u64 },
     Other,
 }
 
@@ -132,6 +133,15 @@ impl Task {
                 TaskEvent::Succeeded { .. } | TaskEvent::Failed { .. } | TaskEvent::Aborted { .. }
             )
         })
+    }
+
+    /// Returns whether the task is pending.
+    ///
+    /// A task is pending if it is nor finished nor processing.
+    pub fn is_pending(&self) -> bool {
+        self.events
+            .last()
+            .map_or(false, |event| matches!(event, TaskEvent::Created { .. }))
     }
 
     /// Return the content_uuid of the `Task` if there is one.

--- a/meilisearch-lib/src/tasks/task.rs
+++ b/meilisearch-lib/src/tasks/task.rs
@@ -85,6 +85,10 @@ impl TaskEvent {
             timestamp: OffsetDateTime::now_utc(),
         }
     }
+
+    pub fn is_aborted(&self) -> bool {
+        matches!(self, Self::Aborted { .. })
+    }
 }
 
 /// A task represents an operation that Meilisearch must do.
@@ -137,6 +141,10 @@ impl Task {
             TaskContent::Dump { .. } => None,
             TaskContent::TaskAbortion { .. } => None,
         }
+    }
+
+    pub fn is_aborted(&self) -> bool {
+        self.events.iter().any(TaskEvent::is_aborted)
     }
 }
 

--- a/meilisearch-lib/src/tasks/task_store/mod.rs
+++ b/meilisearch-lib/src/tasks/task_store/mod.rs
@@ -157,6 +157,11 @@ impl TaskStore {
                     debug_assert!(matches!(task.content, TaskContent::Dump { .. }));
                     BatchContent::Dump(task)
                 }
+                Processing::TaskAbortion(id) => {
+                    let task = store.get(&txn, id)?.ok_or(TaskError::UnexistingTask(id))?;
+                    debug_assert!(matches!(task.content, TaskContent::TaskAbortion { .. }));
+                    BatchContent::TaskAbortion(task)
+                }
                 Processing::Nothing => BatchContent::Empty,
             };
 

--- a/meilisearch-lib/src/tasks/task_store/mod.rs
+++ b/meilisearch-lib/src/tasks/task_store/mod.rs
@@ -158,7 +158,7 @@ impl TaskStore {
                 }
                 Processing::TaskAbortion(id) => {
                     let task = store.get(&txn, id)?.ok_or(TaskError::UnexistingTask(id))?;
-                    debug_assert!(matches!(task.content, TaskContent::TaskAbortion { .. }));
+                    debug_assert!(matches!(task.content, TaskContent::TasksAbortion { .. }));
                     BatchContent::TaskAbortion(task)
                 }
                 Processing::Nothing => BatchContent::Empty,

--- a/meilisearch-lib/src/tasks/task_store/mod.rs
+++ b/meilisearch-lib/src/tasks/task_store/mod.rs
@@ -7,7 +7,6 @@ use std::sync::Arc;
 
 use log::debug;
 use milli::heed::{Env, RwTxn};
-use time::OffsetDateTime;
 
 use super::batch::BatchContent;
 use super::error::TaskError;
@@ -80,7 +79,7 @@ impl TaskStore {
         let task = tokio::task::spawn_blocking(move || -> Result<Task> {
             let mut txn = store.wtxn()?;
             let next_task_id = store.next_task_id(&mut txn)?;
-            let created_at = TaskEvent::Created(OffsetDateTime::now_utc());
+            let created_at = TaskEvent::created();
             let task = Task {
                 id: next_task_id,
                 content,

--- a/meilisearch-lib/src/tasks/task_store/mod.rs
+++ b/meilisearch-lib/src/tasks/task_store/mod.rs
@@ -143,34 +143,19 @@ impl TaskStore {
                             .get(&txn, *id)?
                             .ok_or(TaskError::UnexistingTask(*id))?;
 
-                        if !task.is_aborted() {
-                            tasks.push(task);
-                        }
+                        tasks.push(task);
                     }
 
-                    if !tasks.is_empty() {
-                        BatchContent::DocumentsAdditionBatch(tasks)
-                    } else {
-                        BatchContent::Empty
-                    }
+                    BatchContent::DocumentsAdditionBatch(tasks)
                 }
                 Processing::IndexUpdate(id) => {
                     let task = store.get(&txn, id)?.ok_or(TaskError::UnexistingTask(id))?;
-
-                    if !task.is_aborted() {
-                        BatchContent::IndexUpdate(task)
-                    } else {
-                        BatchContent::Empty
-                    }
+                    BatchContent::IndexUpdate(task)
                 }
                 Processing::Dump(id) => {
                     let task = store.get(&txn, id)?.ok_or(TaskError::UnexistingTask(id))?;
                     debug_assert!(matches!(task.content, TaskContent::Dump { .. }));
-                    if !task.is_aborted() {
-                        BatchContent::Dump(task)
-                    } else {
-                        BatchContent::Empty
-                    }
+                    BatchContent::Dump(task)
                 }
                 Processing::Nothing => BatchContent::Empty,
             };

--- a/meilisearch-lib/src/tasks/update_loop.rs
+++ b/meilisearch-lib/src/tasks/update_loop.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use time::OffsetDateTime;
 use tokio::sync::{watch, RwLock};
 use tokio::time::interval_at;
 
@@ -63,9 +62,7 @@ impl UpdateLoop {
             .expect("No performer found for batch")
             .clone();
 
-        batch
-            .content
-            .push_event(TaskEvent::Processing(OffsetDateTime::now_utc()));
+        batch.content.push_event(TaskEvent::processing());
 
         batch.content = {
             self.scheduler

--- a/meilisearch-types/src/error.rs
+++ b/meilisearch-types/src/error.rs
@@ -170,6 +170,8 @@ pub enum Code {
     InvalidApiKeyUid,
     ImmutableField,
     ApiKeyAlreadyExists,
+
+    InvalidTaskAbort,
 }
 
 impl Code {
@@ -283,6 +285,7 @@ impl Code {
             InvalidMinWordLengthForTypo => {
                 ErrCode::invalid("invalid_min_word_length_for_typo", StatusCode::BAD_REQUEST)
             }
+            InvalidTaskAbort => ErrCode::invalid("invalid_task_abort", StatusCode::BAD_REQUEST),
         }
     }
 

--- a/meilisearch-types/src/error.rs
+++ b/meilisearch-types/src/error.rs
@@ -170,8 +170,6 @@ pub enum Code {
     InvalidApiKeyUid,
     ImmutableField,
     ApiKeyAlreadyExists,
-
-    InvalidTaskAbort,
 }
 
 impl Code {
@@ -285,7 +283,6 @@ impl Code {
             InvalidMinWordLengthForTypo => {
                 ErrCode::invalid("invalid_min_word_length_for_typo", StatusCode::BAD_REQUEST)
             }
-            InvalidTaskAbort => ErrCode::invalid("invalid_task_abort", StatusCode::BAD_REQUEST),
         }
     }
 

--- a/permissive-json-pointer/src/lib.rs
+++ b/permissive-json-pointer/src/lib.rs
@@ -729,7 +729,7 @@ mod tests {
         map_leaf_values(
             value.as_object_mut().unwrap(),
             ["jean.race.name"],
-            |key, value| match (value, dbg!(key)) {
+            |key, value| match (value, key) {
                 (Value::String(name), "jean.race.name") => *name = S("patou"),
                 _ => unreachable!(),
             },


### PR DESCRIPTION
This pr introduces the ability to cancel pending tasks.

Two new routes are added to conveniently cancel pending tasks: tasks that aren't processed nor finished. A call to any of those routes will create a new task aborting the requested tasks. This task has the highest priority, meaning that it will be processed as soon as the current processing task is finished.

Aborting an already processing/processed task is a no-op, and the abort task will be marked as successful, even though the requested task has not been aborted.

The newly created routes are:
- `POST /tasks/abort`: takes a JSON array of the task ids to be aborted
- `POST /tasks/clear`: clears the task queue by marking all pending updates as aborted.

on success, an abortion task will return the number of tasks that have been aborted in the `abortedTasks` field of the `details` field of the task view.

When a task is marked as aborted, it is not removed from the scheduler right away. That is because cleaning might be necessary to do so (e.g removing update files for the document updates). Rather than that, the update is left in the scheduler and is ignored by the batch handler. It is the `BatchHandler` job to clean after all the tasks it is handed.