### PR TITLE
Use nightly for cargo fmt in CI (for `release-v0.28.0` branch)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -83,7 +83,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: stable
           override: true
           components: rustfmt
       - name: Cache dependencies


### PR DESCRIPTION
Following https://github.com/meilisearch/meilisearch/pull/2519