### PR TITLE
Improve docker CI: push vX.Y tag (without patch) to DockerHub (for v0.28.0)

### DIFF
--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -27,6 +27,20 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Check tag format
+        id: check-tag-format
+        run: |
+          # Escape submitted tag name
+          escaped_tag=$(printf "%q" ${{ github.ref_name }})
+
+          # Check if tag has format v<nmumber>.<number>.<number> and set output.match
+          # to create a vX.Y (without patch version) Docker tag
+          if [[ $escaped_tag =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo ::set-output name=match::true
+          else
+            echo ::set-output name=match::false
+          fi
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v3
@@ -37,6 +51,7 @@ jobs:
           flavor: latest=false
           tags: |
             type=ref,event=tag
+            type=semver,pattern=v{{major}}.{{minor}},enable=${{ steps.check-tag-format.outputs.match }}
             type=raw,value=latest,enable=${{ github.event_name == 'release' }}
 
       - name: Build and push


### PR DESCRIPTION
Bringing a commit from main ([5ae5b06](https://github.com/meilisearch/meilisearch/pull/2521/commits/5ae5b060188b491f64be98b43281058581f9d847)) into release-v0.28.0 to have this change already applied for v0.28.0

Following the one merged on main: https://github.com/meilisearch/meilisearch/pull/2521