### PR TITLE
meilisearch-lib was missing a feature in its cargo.toml

### DIFF
--- a/meilisearch-lib/Cargo.toml
+++ b/meilisearch-lib/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = { version = "1.0.56", features = ["backtrace"] }
 async-stream = "0.3.3"
 async-trait = "0.1.52"
 atomic_refcell = "0.1.8"
-byte-unit = { version = "4.0.14", default-features = false, features = ["std"] }
+byte-unit = { version = "4.0.14", default-features = false, features = ["std", "serde"] }
 bytes = "1.1.0"
 clap = { version = "3.1.6", features = ["derive", "env"] }
 crossbeam-channel = "0.5.2"


### PR DESCRIPTION
Meilisearch-lib was missing a feature to compile on its own