### PR TITLE
Fix CI checking version compatibility

### DIFF
--- a/.github/scripts/check-release.sh
+++ b/.github/scripts/check-release.sh
@@ -1,15 +1,15 @@
-#!/bin/sh
+#!/bin/bash
 
 # check_tag $current_tag $file_tag $file_name
 function check_tag {
-  if [ "$1" != "$2" ]; then
-      echo "Error: the current tag does not match the version in $3: found $1 - expected $2"
+  if [[ "$1" != "$2" ]]; then
+      echo "Error: the current tag does not match the version in $3: found $2 - expected $1"
       ret=1
   fi
 }
 
 ret=0
-current_tag=$(echo $GITHUB_REF | tr -d 'refs/tags/v')
+current_tag=${GITHUB_REF#'refs/tags/v'}
 
 toml_files='*/Cargo.toml'
 for toml_file in $toml_files;
@@ -22,7 +22,7 @@ lock_file='Cargo.lock'
 lock_tag=$(grep -A 1 'name = "meilisearch-auth"' $lock_file | grep version | cut -d '=' -f 2 | tr -d '"' | tr -d ' ')
 check_tag $current_tag $lock_tag $lock_file
 
-if [ "$ret" -eq 0 ] ; then
+if [[ "$ret" -eq 0 ]] ; then
   echo 'OK'
 fi
 exit $ret

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Check release validity
-        run: sh .github/scripts/check-release.sh
+        run: bash .github/scripts/check-release.sh
 
   publish:
     name: Publish binary for ${{ matrix.os }}

--- a/.github/workflows/publish-deb-brew-pkg.yml
+++ b/.github/workflows/publish-deb-brew-pkg.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Check release validity
-        run: sh .github/scripts/check-release.sh
+        run: bash .github/scripts/check-release.sh
 
   debian:
     name: Publish debian packagge

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -32,8 +32,8 @@ jobs:
 
       # Check only the validity of the tag for official releases (not for pre-releases or other tags)
       - name: Check release validity
-        if: github.event_name != 'schedule' && steps.check-tag-format.outputs.stable
-        run: sh .github/scripts/check-release.sh
+        if: github.event_name != 'schedule' && steps.check-tag-format.outputs.stable == 'true'
+        run: bash .github/scripts/check-release.sh
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -58,8 +58,8 @@ jobs:
           flavor: latest=false
           tags: |
             type=ref,event=tag
-            type=semver,pattern=v{{major}}.{{minor}},enable=${{ steps.check-tag-format.outputs.stable }}
-            type=raw,value=latest,enable=${{ steps.check-tag-format.outputs.stable }}
+            type=semver,pattern=v{{major}}.{{minor}},enable=${{ steps.check-tag-format.outputs.stable == 'true' }}
+            type=raw,value=latest,enable=${{ steps.check-tag-format.outputs.stable == 'true' }}
 
       - name: Build and push
         id: docker_build


### PR DESCRIPTION
- Fix CI checks in `if` regarding the `stable` variable created
- Fix command to remove prefix `refs/tags/v` from `GITHUB_REF` in `check-release.sh` script
- Change from `sh` to `bash` for `check-release.sh` script, indeed this line `current_tag=${GITHUB_REF#'refs/tags/v'}` does not work with `sh`. It should be ok since most of the distributions have `bash` and the GHA handle it as well
- Fix error message