### PR TITLE
Handle the error when user request an invalid id

### DIFF
--- a/meilisearch-http/src/routes/tasks.rs
+++ b/meilisearch-http/src/routes/tasks.rs
@@ -170,7 +170,7 @@ async fn get_tasks(
 
 async fn get_task(
     meilisearch: GuardedData<ActionPolicy<{ actions::TASKS_GET }>, MeiliSearch>,
-    task_id: Option<web::Path<TaskId>>,
+    task_id: web::Path<String>,
     req: HttpRequest,
     analytics: web::Data<dyn Analytics>,
 ) -> Result<HttpResponse, ResponseError> {
@@ -191,7 +191,9 @@ async fn get_task(
         Some(filters)
     };
 
-    let id = task_id.ok_or(TaskError::OutOfBounds)?;
+    let id = task_id
+        .parse::<TaskId>()
+        .map_err(|_| TaskError::OutOfBounds)?;
 
     let task: TaskView = meilisearch.get_task(id.into_inner(), filters).await?.into();
 

--- a/meilisearch-http/src/routes/tasks.rs
+++ b/meilisearch-http/src/routes/tasks.rs
@@ -1,4 +1,5 @@
 use actix_web::{web, HttpRequest, HttpResponse};
+use meilisearch_lib::tasks::error::TaskError;
 use meilisearch_lib::tasks::task::{TaskContent, TaskEvent, TaskId};
 use meilisearch_lib::tasks::TaskFilter;
 use meilisearch_lib::MeiliSearch;
@@ -169,7 +170,7 @@ async fn get_tasks(
 
 async fn get_task(
     meilisearch: GuardedData<ActionPolicy<{ actions::TASKS_GET }>, MeiliSearch>,
-    task_id: web::Path<TaskId>,
+    task_id: Option<web::Path<TaskId>>,
     req: HttpRequest,
     analytics: web::Data<dyn Analytics>,
 ) -> Result<HttpResponse, ResponseError> {
@@ -190,10 +191,9 @@ async fn get_task(
         Some(filters)
     };
 
-    let task: TaskView = meilisearch
-        .get_task(task_id.into_inner(), filters)
-        .await?
-        .into();
+    let id = task_id.ok_or(TaskError::OutOfBounds)?;
+
+    let task: TaskView = meilisearch.get_task(id.into_inner(), filters).await?.into();
 
     Ok(HttpResponse::Ok().json(task))
 }

--- a/meilisearch-http/tests/tasks/mod.rs
+++ b/meilisearch-http/tests/tasks/mod.rs
@@ -43,6 +43,24 @@ async fn get_task_status() {
 }
 
 #[actix_rt::test]
+async fn get_task_out_of_bounds() {
+    let server = Server::new().await;
+    let index = server.index("test");
+
+    let (response, code) = index.service.get("/tasks/99999999999999999").await;
+
+    let expected_response = json!({
+        "message": "Task id is out of bounds.",
+        "code": "task_not_found",
+        "type": "invalid_request",
+        "link": "https://docs.meilisearch.com/errors#task_not_found"
+    });
+
+    assert_eq!(code, 404);
+    assert_eq!(response, expected_response);
+}
+
+#[actix_rt::test]
 async fn list_tasks() {
     let server = Server::new().await;
     let index = server.index("test");

--- a/meilisearch-lib/src/tasks/error.rs
+++ b/meilisearch-lib/src/tasks/error.rs
@@ -14,6 +14,8 @@ pub enum TaskError {
     UnexistingTask(TaskId),
     #[error("Internal error: {0}")]
     Internal(Box<dyn std::error::Error + Send + Sync + 'static>),
+    #[error("Task id is out of bounds.")]
+    OutOfBounds,
 }
 
 internal_error!(
@@ -29,6 +31,7 @@ impl ErrorCode for TaskError {
         match self {
             TaskError::UnexistingTask(_) => Code::TaskNotFound,
             TaskError::Internal(_) => Code::Internal,
+            TaskError::OutOfBounds => Code::TaskNotFound,
         }
     }
 }


### PR DESCRIPTION
Context: https://github.com/meilisearch/meilisearch/issues/2555

Even keeping the u32 for performance reasons, the user still can reach a dead end by accessing a route with a big id, if they do that, it will respond with a 404 + internal error with an incorrect content-type.

This PR provides a way to handle this kind of error.

Code tips are appreciated 😬 