### PR TITLE
Chores: Add a dedicated section for Language Support in the issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,7 @@
 contact_links:
+  - name: Language support request & feedback
+    url: https://github.com/meilisearch/product/discussions/categories/feedback-feature-proposal?discussions_q=label%3Aproduct%3Acore%3Atokenizer+category%3A%22Feedback+%26+Feature+Proposal%22
+    about:  The requests and feedback regarding Language support are not managed in this repository. Please upvote the related discussion in our dedicated product repository or open a new one if it doesn't exist.
   - name: Feature request & feedback
     url: https://github.com/meilisearch/product/discussions/categories/feedback-feature-proposal
     about: The feature requests and feedback regarding the already existing features are not managed in this repository. Please open a discussion in our dedicated product repository


### PR DESCRIPTION


This new section in put upper than the feature proposal because language support is kind of a sub-category of it,
and so, in the reading order, we choose to create a feature proposal only if it is not related to Language.
