### PR TITLE
Improve handling invalid taskIds and return descriptive response

### DIFF
--- a/meilisearch-http/src/routes/tasks.rs
+++ b/meilisearch-http/src/routes/tasks.rs
@@ -199,10 +199,7 @@ async fn get_task(
         .parse::<TaskId>()
         .map_err(|_| TaskError::InvalidTask(task_id.into_inner()))?;
 
-    let task: TaskView = meilisearch
-        .get_task(id, filters)
-        .await?
-        .into();
+    let task: TaskView = meilisearch.get_task(id, filters).await?.into();
 
     Ok(HttpResponse::Ok().json(task))
 }

--- a/meilisearch-http/src/routes/tasks.rs
+++ b/meilisearch-http/src/routes/tasks.rs
@@ -1,4 +1,5 @@
 use actix_web::{web, HttpRequest, HttpResponse};
+use meilisearch_lib::tasks::error::TaskError;
 use meilisearch_lib::tasks::task::{TaskContent, TaskEvent, TaskId};
 use meilisearch_lib::tasks::TaskFilter;
 use meilisearch_lib::MeiliSearch;
@@ -173,7 +174,7 @@ async fn get_tasks(
 
 async fn get_task(
     meilisearch: GuardedData<ActionPolicy<{ actions::TASKS_GET }>, MeiliSearch>,
-    task_id: web::Path<TaskId>,
+    task_id: web::Path<String>,
     req: HttpRequest,
     analytics: web::Data<dyn Analytics>,
 ) -> Result<HttpResponse, ResponseError> {
@@ -194,8 +195,12 @@ async fn get_task(
         Some(filters)
     };
 
+    let id = task_id
+        .parse::<TaskId>()
+        .map_err(|_| TaskError::InvalidTask(task_id.into_inner()))?;
+
     let task: TaskView = meilisearch
-        .get_task(task_id.into_inner(), filters)
+        .get_task(id, filters)
         .await?
         .into();
 

--- a/meilisearch-http/tests/tasks/mod.rs
+++ b/meilisearch-http/tests/tasks/mod.rs
@@ -43,6 +43,23 @@ async fn get_task_status() {
 }
 
 #[actix_rt::test]
+async fn get_invalid_task() {
+    let server = Server::new().await;
+    let index = server.index("test");
+    let (response, code) = index.service.get("/tasks/hello").await;
+
+    let expected_response = json!({
+        "message": "Invalid task id `hello`.",
+        "code": "task_not_found",
+        "type": "invalid_request",
+        "link": "https://docs.meilisearch.com/errors#task_not_found"
+    });
+
+    assert_eq!(response, expected_response);
+    assert_eq!(code, 404);
+}
+
+#[actix_rt::test]
 async fn list_tasks() {
     let server = Server::new().await;
     let index = server.index("test");

--- a/meilisearch-http/tests/tasks/mod.rs
+++ b/meilisearch-http/tests/tasks/mod.rs
@@ -50,13 +50,13 @@ async fn get_invalid_task() {
 
     let expected_response = json!({
         "message": "Invalid task id `hello`.",
-        "code": "task_not_found",
+        "code": "invalid_task_id",
         "type": "invalid_request",
-        "link": "https://docs.meilisearch.com/errors#task_not_found"
+        "link": "https://docs.meilisearch.com/errors#invalid_task_id"
     });
 
     assert_eq!(response, expected_response);
-    assert_eq!(code, 404);
+    assert_eq!(code, 400);
 }
 
 #[actix_rt::test]

--- a/meilisearch-lib/src/tasks/error.rs
+++ b/meilisearch-lib/src/tasks/error.rs
@@ -12,6 +12,8 @@ pub type Result<T> = std::result::Result<T, TaskError>;
 pub enum TaskError {
     #[error("Task `{0}` not found.")]
     UnexistingTask(TaskId),
+    #[error("Invalid task id `{0}`.")]
+    InvalidTask(String),
     #[error("Internal error: {0}")]
     Internal(Box<dyn std::error::Error + Send + Sync + 'static>),
 }
@@ -28,6 +30,7 @@ impl ErrorCode for TaskError {
     fn error_code(&self) -> Code {
         match self {
             TaskError::UnexistingTask(_) => Code::TaskNotFound,
+            TaskError::InvalidTask(_) => Code::TaskNotFound,
             TaskError::Internal(_) => Code::Internal,
         }
     }

--- a/meilisearch-lib/src/tasks/error.rs
+++ b/meilisearch-lib/src/tasks/error.rs
@@ -30,7 +30,7 @@ impl ErrorCode for TaskError {
     fn error_code(&self) -> Code {
         match self {
             TaskError::UnexistingTask(_) => Code::TaskNotFound,
-            TaskError::InvalidTask(_) => Code::TaskNotFound,
+            TaskError::InvalidTask(_) => Code::InvalidTaskId,
             TaskError::Internal(_) => Code::Internal,
         }
     }

--- a/meilisearch-types/src/error.rs
+++ b/meilisearch-types/src/error.rs
@@ -147,6 +147,7 @@ pub enum Code {
     NoSpaceLeftOnDevice,
     DumpNotFound,
     TaskNotFound,
+    InvalidTaskId,
     PayloadTooLarge,
     RetrieveDocument,
     SearchDocuments,
@@ -232,6 +233,7 @@ impl Code {
                 ErrCode::authentication("missing_authorization_header", StatusCode::UNAUTHORIZED)
             }
             TaskNotFound => ErrCode::invalid("task_not_found", StatusCode::NOT_FOUND),
+            InvalidTaskId => ErrCode::invalid("invalid_task_id", StatusCode::BAD_REQUEST),
             DumpNotFound => ErrCode::invalid("dump_not_found", StatusCode::NOT_FOUND),
             NoSpaceLeftOnDevice => {
                 ErrCode::internal("no_space_left_on_device", StatusCode::INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
## Summary
This PR fixes issue #2593 . 
Followed the suggestion made by  @MarinPostma in #2562 to pass `TaskId` as a `String` into the route handler and try parsing it there.

## Example

```bash
❯ curl -s -X GET 'http://localhost:7700/tasks/hello' | jq
{
  "message": "Invalid task id `hello`.",
  "code": "task_not_found",
  "type": "invalid_request",
  "link": "https://docs.meilisearch.com/errors#task_not_found"
}
❯
❯ curl -s -X GET 'http://localhost:7700/tasks/999999999999999999999' | jq
{
  "message": "Invalid task id `999999999999999999999`.",
  "code": "task_not_found",
  "type": "invalid_request",
  "link": "https://docs.meilisearch.com/errors#task_not_found"
}
```

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

