### PR TITLE
Add LTO and codegen-units=1 to release compile options

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,10 @@ members = [
     "permissive-json-pointer",
 ]
 
+[profile.release]
+codegen-units = 1
+lto = "thin"
+
 [profile.dev.package.flate2]
 opt-level = 3
 


### PR DESCRIPTION
This PR brings Meilisearch's release compile options in line with milli (see https://github.com/meilisearch/milli/pull/606 ). 

Adding LTO and codegen=units=1 will make compile times longer, but they also speed up the final binary significantly.