### PR TITLE
Slight changes for prometheus metrics

### DIFF
--- a/grafana-dashboards/dashboard.json
+++ b/grafana-dashboards/dashboard.json
@@ -112,7 +112,7 @@
             },
             "editorMode": "builder",
             "exemplar": true,
-            "expr": "meilisearch_database_size{job=\"meilisearch\", instance=\"$instance\"}",
+            "expr": "meilisearch_db_size_bytes{job=\"meilisearch\", instance=\"$instance\"}",
             "interval": "",
             "legendFormat": "",
             "range": true,
@@ -178,7 +178,7 @@
             },
             "editorMode": "builder",
             "exemplar": true,
-            "expr": "meilisearch_total_index{job=\"meilisearch\", instance=\"$instance\"}",
+            "expr": "meilisearch_index_count{job=\"meilisearch\", instance=\"$instance\"}",
             "interval": "",
             "legendFormat": "",
             "range": true,
@@ -239,7 +239,7 @@
               "uid": "1MRsknzVz"
             },
             "editorMode": "builder",
-            "expr": "meilisearch_docs_count{job=\"meilisearch\", index=\"$Index\", instance=\"$instance\"}",
+            "expr": "meilisearch_index_docs_count{job=\"meilisearch\", index=\"$Index\", instance=\"$instance\"}",
             "hide": false,
             "range": true,
             "refId": "A"
@@ -1000,7 +1000,7 @@
       ]
     },
     "timezone": "",
-    "title": "MeiliSearch",
+    "title": "Meilisearch",
     "uid": "7wcZ94dnz",
     "version": 47,
     "weekStart": ""

--- a/meilisearch-http/src/metrics.rs
+++ b/meilisearch-http/src/metrics.rs
@@ -16,18 +16,18 @@ lazy_static! {
         &["method", "path"]
     )
     .expect("Can't create a metric");
-    pub static ref MEILISEARCH_DB_SIZE: IntGauge = register_int_gauge!(opts!(
-        "meilisearch_database_size",
-        "MeiliSearch Stats DbSize"
+    pub static ref MEILISEARCH_DB_SIZE_BYTES: IntGauge = register_int_gauge!(opts!(
+        "meilisearch_db_size_bytes",
+        "Meilisearch Db Size In Bytes"
     ))
     .expect("Can't create a metric");
     pub static ref MEILISEARCH_INDEX_COUNT: IntGauge = register_int_gauge!(opts!(
-        "meilisearch_total_index",
-        "MeiliSearch Stats Index Count"
+        "meilisearch_index_count",
+        "Meilisearch Index Count"
     ))
     .expect("Can't create a metric");
-    pub static ref MEILISEARCH_DOCS_COUNT: IntGaugeVec = register_int_gauge_vec!(
-        opts!("meilisearch_docs_count", "MeiliSearch Stats Docs Count"),
+    pub static ref MEILISEARCH_INDEX_DOCS_COUNT: IntGaugeVec = register_int_gauge_vec!(
+        opts!("meilisearch_index_docs_count", "Meilisearch Index Docs Count"),
         &["index"]
     )
     .expect("Can't create a metric");

--- a/meilisearch-http/src/metrics.rs
+++ b/meilisearch-http/src/metrics.rs
@@ -21,13 +21,14 @@ lazy_static! {
         "Meilisearch Db Size In Bytes"
     ))
     .expect("Can't create a metric");
-    pub static ref MEILISEARCH_INDEX_COUNT: IntGauge = register_int_gauge!(opts!(
-        "meilisearch_index_count",
-        "Meilisearch Index Count"
-    ))
-    .expect("Can't create a metric");
+    pub static ref MEILISEARCH_INDEX_COUNT: IntGauge =
+        register_int_gauge!(opts!("meilisearch_index_count", "Meilisearch Index Count"))
+            .expect("Can't create a metric");
     pub static ref MEILISEARCH_INDEX_DOCS_COUNT: IntGaugeVec = register_int_gauge_vec!(
-        opts!("meilisearch_index_docs_count", "Meilisearch Index Docs Count"),
+        opts!(
+            "meilisearch_index_docs_count",
+            "Meilisearch Index Docs Count"
+        ),
         &["index"]
     )
     .expect("Can't create a metric");

--- a/meilisearch-http/src/routes/mod.rs
+++ b/meilisearch-http/src/routes/mod.rs
@@ -287,11 +287,11 @@ pub async fn get_metrics(
     let search_rules = &meilisearch.filters().search_rules;
     let response = meilisearch.get_all_stats(search_rules).await?;
 
-    crate::metrics::MEILISEARCH_DB_SIZE.set(response.database_size as i64);
+    crate::metrics::MEILISEARCH_DB_SIZE_BYTES.set(response.database_size as i64);
     crate::metrics::MEILISEARCH_INDEX_COUNT.set(response.indexes.len() as i64);
 
     for (index, value) in response.indexes.iter() {
-        crate::metrics::MEILISEARCH_DOCS_COUNT
+        crate::metrics::MEILISEARCH_INDEX_DOCS_COUNT
             .with_label_values(&[index])
             .set(value.number_of_documents as i64);
     }


### PR DESCRIPTION
# Pull Request

## What does this PR do?

- Replace "MeiliSearch" with "Meilisearch"
- Brings some consistency between rust identifier and exposed metrics names
- Add suffix describing unit, in plural form. e.g `MEILISEARCH_DB_SIZE_BYTES` (https://prometheus.io/docs/practices/naming/#metric-names)
- Update dashboard.json starter file