### PR TITLE
Accept an environment variable to enable the metrics route

### DIFF
--- a/meilisearch-http/src/option.rs
+++ b/meilisearch-http/src/option.rs
@@ -147,7 +147,7 @@ pub struct Opt {
     pub log_level: String,
 
     /// Enables Prometheus metrics and /metrics route.
-    #[clap(long)]
+    #[clap(long, env = "MEILI_ENABLE_METRICS_ROUTE")]
     pub enable_metrics_route: bool,
 
     #[serde(flatten)]


### PR DESCRIPTION
With the PR Meilisearch is able to accept the `MEILI_ENABLE_METRICS_ROUTE` environment variable to enable the newly introduces metrics route.