### PR TITLE
Implement tasks cancellation

### DIFF
--- a/meilisearch-auth/src/action.rs
+++ b/meilisearch-auth/src/action.rs
@@ -31,6 +31,8 @@ pub enum Action {
     TasksAll,
     #[serde(rename = "tasks.get")]
     TasksGet,
+    #[serde(rename = "tasks.cancel")]
+    TasksCancel,
     #[serde(rename = "settings.*")]
     SettingsAll,
     #[serde(rename = "settings.get")]
@@ -78,6 +80,7 @@ impl Action {
             INDEXES_DELETE => Some(Self::IndexesDelete),
             TASKS_ALL => Some(Self::TasksAll),
             TASKS_GET => Some(Self::TasksGet),
+            TASKS_CANCEL => Some(Self::TasksCancel),
             SETTINGS_ALL => Some(Self::SettingsAll),
             SETTINGS_GET => Some(Self::SettingsGet),
             SETTINGS_UPDATE => Some(Self::SettingsUpdate),
@@ -117,6 +120,7 @@ pub mod actions {
     pub const INDEXES_DELETE: u8 = IndexesDelete.repr();
     pub const TASKS_ALL: u8 = TasksAll.repr();
     pub const TASKS_GET: u8 = TasksGet.repr();
+    pub const TASKS_CANCEL: u8 = TasksCancel.repr();
     pub const SETTINGS_ALL: u8 = SettingsAll.repr();
     pub const SETTINGS_GET: u8 = SettingsGet.repr();
     pub const SETTINGS_UPDATE: u8 = SettingsUpdate.repr();

--- a/meilisearch-auth/src/store.rs
+++ b/meilisearch-auth/src/store.rs
@@ -122,6 +122,7 @@ impl HeedAuthStore {
                 }
                 Action::TasksAll => {
                     actions.insert(Action::TasksGet);
+                    actions.insert(Action::TasksCancel);
                 }
                 Action::StatsAll => {
                     actions.insert(Action::StatsGet);

--- a/meilisearch-http/src/task.rs
+++ b/meilisearch-http/src/task.rs
@@ -88,6 +88,7 @@ pub enum TaskStatus {
     Enqueued,
     Processing,
     Succeeded,
+    Canceled,
     Failed,
 }
 
@@ -119,6 +120,8 @@ impl FromStr for TaskStatus {
             Ok(TaskStatus::Processing)
         } else if status.eq_ignore_ascii_case("succeeded") {
             Ok(TaskStatus::Succeeded)
+        } else if status.eq_ignore_ascii_case("canceled") {
+            Ok(TaskStatus::Canceled)
         } else if status.eq_ignore_ascii_case("failed") {
             Ok(TaskStatus::Failed)
         } else {
@@ -361,6 +364,8 @@ impl From<Task> for TaskView {
                 }
                 (TaskStatus::Failed, Some(error.clone()), Some(*timestamp))
             }
+            // TODO what should I do in here? Should I replace something or what?
+            TaskEvent::Canceled { timestamp } => (TaskStatus::Canceled, None, Some(*timestamp)),
         };
 
         let enqueued_at = match events.first() {

--- a/meilisearch-lib/src/index_controller/mod.rs
+++ b/meilisearch-lib/src/index_controller/mod.rs
@@ -451,6 +451,11 @@ where
         Ok(task)
     }
 
+    pub async fn cancel_task(&self, id: TaskId, filter: Option<TaskFilter>) -> Result<Task> {
+        let task = self.scheduler.read().await.cancel_task(id, filter).await?;
+        Ok(task)
+    }
+
     pub async fn get_index_task(&self, index_uid: String, task_id: TaskId) -> Result<Task> {
         let creation_task_id = self
             .index_resolver

--- a/meilisearch-lib/src/tasks/batch.rs
+++ b/meilisearch-lib/src/tasks/batch.rs
@@ -27,10 +27,15 @@ impl BatchContent {
 
     pub fn push_event(&mut self, event: TaskEvent) {
         match self {
-            BatchContent::DocumentsAdditionBatch(ts) => {
-                ts.iter_mut().for_each(|t| t.events.push(event.clone()))
+            BatchContent::DocumentsAdditionBatch(ts) => ts
+                .iter_mut()
+                .filter(|t| !t.is_canceled())
+                .for_each(|t| t.events.push(event.clone())),
+            BatchContent::IndexUpdate(t) | BatchContent::Dump(t) => {
+                if !t.is_canceled() {
+                    t.events.push(event)
+                }
             }
-            BatchContent::IndexUpdate(t) | BatchContent::Dump(t) => t.events.push(event),
             BatchContent::Snapshot(_) | BatchContent::Empty => (),
         }
     }

--- a/meilisearch-lib/src/tasks/error.rs
+++ b/meilisearch-lib/src/tasks/error.rs
@@ -12,6 +12,8 @@ pub type Result<T> = std::result::Result<T, TaskError>;
 pub enum TaskError {
     #[error("Task `{0}` not found.")]
     UnexistingTask(TaskId),
+    #[error("Task `{0}` cannot be cancel as it is already finished or being processed.")]
+    InvalidTaskCancellation(TaskId),
     #[error("Internal error: {0}")]
     Internal(Box<dyn std::error::Error + Send + Sync + 'static>),
 }
@@ -28,6 +30,7 @@ impl ErrorCode for TaskError {
     fn error_code(&self) -> Code {
         match self {
             TaskError::UnexistingTask(_) => Code::TaskNotFound,
+            TaskError::InvalidTaskCancellation(_) => Code::InvalidTaskCancellation,
             TaskError::Internal(_) => Code::Internal,
         }
     }

--- a/meilisearch-lib/src/tasks/scheduler.rs
+++ b/meilisearch-lib/src/tasks/scheduler.rs
@@ -316,6 +316,10 @@ impl Scheduler {
         self.store.get_task(id, filter).await
     }
 
+    pub async fn cancel_task(&self, id: TaskId, filter: Option<TaskFilter>) -> Result<Task> {
+        self.store.cancel_task(id, filter).await
+    }
+
     pub async fn list_tasks(
         &self,
         offset: Option<TaskId>,

--- a/meilisearch-lib/src/tasks/task.rs
+++ b/meilisearch-lib/src/tasks/task.rs
@@ -110,9 +110,15 @@ impl Task {
         self.events.last().map_or(false, |event| {
             matches!(
                 event,
-                TaskEvent::Succeeded { .. } | TaskEvent::Failed { .. } | TaskEvent::Canceled { .. }
+                TaskEvent::Succeeded { .. } | TaskEvent::Failed { .. }
             )
         })
+    }
+
+    pub fn is_canceled(&self) -> bool {
+        self.events
+            .last()
+            .map_or(false, |event| matches!(event, TaskEvent::Canceled { .. }))
     }
 
     /// Return true when a task is being processed.

--- a/meilisearch-types/src/error.rs
+++ b/meilisearch-types/src/error.rs
@@ -147,6 +147,7 @@ pub enum Code {
     NoSpaceLeftOnDevice,
     DumpNotFound,
     TaskNotFound,
+    InvalidTaskCancellation,
     PayloadTooLarge,
     RetrieveDocument,
     SearchDocuments,
@@ -232,6 +233,10 @@ impl Code {
                 ErrCode::authentication("missing_authorization_header", StatusCode::UNAUTHORIZED)
             }
             TaskNotFound => ErrCode::invalid("task_not_found", StatusCode::NOT_FOUND),
+            InvalidTaskCancellation => ErrCode::invalid(
+                "invalid_task_cancellation",
+                StatusCode::UNPROCESSABLE_ENTITY,
+            ),
             DumpNotFound => ErrCode::invalid("dump_not_found", StatusCode::NOT_FOUND),
             NoSpaceLeftOnDevice => {
                 ErrCode::internal("no_space_left_on_device", StatusCode::INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
This PR implements a basic task cancellation system, it only works for already processed tasks (for now?):
 - [x] Introduce the `Tasks.cancel` action right for the API Keys.
 - [x] You can cancel one task at a time by calling the `DELETE /indexes/tasks/{taskId}`.
 - [x] Remove the tasks content when canceled.