### PR TITLE
Don't panic when the error length is slightly over 100

### DIFF
--- a/meilisearch-lib/src/document_formats.rs
+++ b/meilisearch-lib/src/document_formats.rs
@@ -47,7 +47,8 @@ impl Display for DocumentFormatError {
                     let trim_input_prefix_len = 50;
                     let trim_input_suffix_len = 85;
 
-                    if serde_msg.len() > trim_input_prefix_len + trim_input_suffix_len + ellipsis.len()
+                    if serde_msg.len()
+                        > trim_input_prefix_len + trim_input_suffix_len + ellipsis.len()
                     {
                         serde_msg.replace_range(
                             trim_input_prefix_len..serde_msg.len() - trim_input_suffix_len,
@@ -143,14 +144,9 @@ pub fn read_json(input: impl Read, writer: impl Write + Seek) -> Result<usize> {
 
     let content: ArrayOrSingleObject = serde_json::from_reader(reader)
         .map_err(Error::Json)
-        .map_err(|e| {
-            println!("Błąd o taki: {:#?}", e);
-            (PayloadType::Json, e)
-        })?;
+        .map_err(|e| (PayloadType::Json, e))?;
 
-    println!("content o taki: {:#?}", content);
     for object in content.inner.map_right(|o| vec![o]).into_inner() {
-        println!("{:#?}", object);
         builder
             .append_json_object(&object)
             .map_err(Into::into)
@@ -158,8 +154,6 @@ pub fn read_json(input: impl Read, writer: impl Write + Seek) -> Result<usize> {
     }
 
     let count = builder.documents_count();
-    println!("{count}");
-
     let _ = builder
         .into_inner()
         .map_err(Into::into)

--- a/meilisearch-lib/src/document_formats.rs
+++ b/meilisearch-lib/src/document_formats.rs
@@ -44,8 +44,15 @@ impl Display for DocumentFormatError {
                     // The user input maybe insanely long. We need to truncate it.
                     let mut serde_msg = se.to_string();
                     let ellipsis = "...";
-                    if serde_msg.len() > (50 + 85) + ellipsis.len() {
-                        serde_msg.replace_range(50..serde_msg.len() - 85, ellipsis);
+                    let trim_input_prefix_len = 50;
+                    let trim_input_suffix_len = 85;
+
+                    if serde_msg.len() > trim_input_prefix_len + trim_input_suffix_len + ellipsis.len()
+                    {
+                        serde_msg.replace_range(
+                            trim_input_prefix_len..serde_msg.len() - trim_input_suffix_len,
+                            ellipsis,
+                        );
                     }
 
                     write!(
@@ -136,9 +143,14 @@ pub fn read_json(input: impl Read, writer: impl Write + Seek) -> Result<usize> {
 
     let content: ArrayOrSingleObject = serde_json::from_reader(reader)
         .map_err(Error::Json)
-        .map_err(|e| (PayloadType::Json, e))?;
+        .map_err(|e| {
+            println!("Błąd o taki: {:#?}", e);
+            (PayloadType::Json, e)
+        })?;
 
+    println!("content o taki: {:#?}", content);
     for object in content.inner.map_right(|o| vec![o]).into_inner() {
+        println!("{:#?}", object);
         builder
             .append_json_object(&object)
             .map_err(Into::into)
@@ -146,6 +158,8 @@ pub fn read_json(input: impl Read, writer: impl Write + Seek) -> Result<usize> {
     }
 
     let count = builder.documents_count();
+    println!("{count}");
+
     let _ = builder
         .into_inner()
         .map_err(Into::into)

--- a/meilisearch-lib/src/document_formats.rs
+++ b/meilisearch-lib/src/document_formats.rs
@@ -44,7 +44,7 @@ impl Display for DocumentFormatError {
                     // The user input maybe insanely long. We need to truncate it.
                     let mut serde_msg = se.to_string();
                     let ellipsis = "...";
-                    if serde_msg.len() > 100 + ellipsis.len() {
+                    if serde_msg.len() > (50 + 85) + ellipsis.len() {
                         serde_msg.replace_range(50..serde_msg.len() - 85, ellipsis);
                     }
 


### PR DESCRIPTION
# Pull Request

## What does this PR do?
Fixes PR #2207 as [the last commit](https://github.com/meilisearch/meilisearch/pull/2207/commits/7ece7a9d9ee3015a84f3b19f6b7360b7099b5388) has changed number of the characters at the end to leave in place from `50` to `85` **but the lower limit of a string length wasn't changed**.
Therefore, any data (e.g. example string from issue #2680) was causing `meilisearch` to **panic**.

So I simply raised the minimum value from `100` to `135` (`50 + 85`) to ensure that `replace_range()` won't panic due to an inverted range.
At the same time I am in favor of the `85` value which was changed in the @CNLHC's last commit.


## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing ~issue~ pull request?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
