### PR TITLE
Update milli v0.33.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1139,8 +1139,8 @@ dependencies = [
 
 [[package]]
 name = "filter-parser"
-version = "0.33.0"
-source = "git+https://github.com/meilisearch/milli.git?tag=v0.33.0#a79ff8a1a98a807f40f970131c8de2ab11560de5"
+version = "0.33.2"
+source = "git+https://github.com/meilisearch/milli.git?tag=v0.33.2#f7c352a32db002fdd6aa7f5ce544043c0acca202"
 dependencies = [
  "nom",
  "nom_locate",
@@ -1164,8 +1164,8 @@ dependencies = [
 
 [[package]]
 name = "flatten-serde-json"
-version = "0.33.0"
-source = "git+https://github.com/meilisearch/milli.git?tag=v0.33.0#a79ff8a1a98a807f40f970131c8de2ab11560de5"
+version = "0.33.2"
+source = "git+https://github.com/meilisearch/milli.git?tag=v0.33.2#f7c352a32db002fdd6aa7f5ce544043c0acca202"
 dependencies = [
  "serde_json",
 ]
@@ -1683,8 +1683,8 @@ dependencies = [
 
 [[package]]
 name = "json-depth-checker"
-version = "0.33.0"
-source = "git+https://github.com/meilisearch/milli.git?tag=v0.33.0#a79ff8a1a98a807f40f970131c8de2ab11560de5"
+version = "0.33.2"
+source = "git+https://github.com/meilisearch/milli.git?tag=v0.33.2#f7c352a32db002fdd6aa7f5ce544043c0acca202"
 dependencies = [
  "serde_json",
 ]
@@ -2221,8 +2221,8 @@ dependencies = [
 
 [[package]]
 name = "milli"
-version = "0.33.0"
-source = "git+https://github.com/meilisearch/milli.git?tag=v0.33.0#a79ff8a1a98a807f40f970131c8de2ab11560de5"
+version = "0.33.2"
+source = "git+https://github.com/meilisearch/milli.git?tag=v0.33.2#f7c352a32db002fdd6aa7f5ce544043c0acca202"
 dependencies = [
  "bimap",
  "bincode",

--- a/meilisearch-auth/Cargo.toml
+++ b/meilisearch-auth/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 enum-iterator = "0.7.0"
 hmac = "0.12.1"
 meilisearch-types = { path = "../meilisearch-types" }
-milli = { git = "https://github.com/meilisearch/milli.git", tag = "v0.33.0" }
+milli = { git = "https://github.com/meilisearch/milli.git", tag = "v0.33.2" }
 rand = "0.8.4"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = { version = "1.0.85", features = ["preserve_order"] }

--- a/meilisearch-lib/Cargo.toml
+++ b/meilisearch-lib/Cargo.toml
@@ -28,7 +28,7 @@ lazy_static = "1.4.0"
 log = "0.4.14"
 meilisearch-auth = { path = "../meilisearch-auth" }
 meilisearch-types = { path = "../meilisearch-types" }
-milli = { git = "https://github.com/meilisearch/milli.git", tag = "v0.33.0" }
+milli = { git = "https://github.com/meilisearch/milli.git", tag = "v0.33.2" }
 mime = "0.3.16"
 num_cpus = "1.13.1"
 obkv = "0.2.0"


### PR DESCRIPTION
closes #2722


⚠️ : merging into [release-v0.29.0](https://github.com/meilisearch/meilisearch/tree/release-v0.29.0)