### PR TITLE
Move if conditions to the steps and not to the whole job

### DIFF
--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -11,13 +11,13 @@ jobs:
     name: Check the version validity
     runs-on: ubuntu-latest
     # No need to check the version for dry run (cron)
-    if: github.event_name != 'schedule'
     steps:
       - uses: actions/checkout@v2
       # Check if the tag has the v<nmumber>.<number>.<number> format.
       # If yes, it means we are publishing an official release.
       # If no, we are releasing a RC, so no need to check the version.
       - name: Check tag format
+        if: github.event_name != 'schedule'
         id: check-tag-format
         run: |
           escaped_tag=$(printf "%q" ${{ github.ref_name }})
@@ -28,7 +28,7 @@ jobs:
             echo ::set-output name=stable::false
           fi
       - name: Check release validity
-        if: steps.check-tag-format.outputs.stable == 'true'
+        if: github.event_name != 'schedule' && steps.check-tag-format.outputs.stable == 'true'
         run: bash .github/scripts/check-release.sh
 
   publish:


### PR DESCRIPTION
Follows https://github.com/meilisearch/meilisearch/pull/2726
Fixes the CI. Moves the `if:` condition to the steps and not the whole `check-version` jobs, otherwise, the following jobs checking the compilation cannot run.
See: https://github.com/meilisearch/meilisearch/actions/runs/2968543407