### PR TITLE
Update checkout v2 to v3 in CI manifests and use a unique GitHub PAT

### DIFF
--- a/.github/workflows/create-issue-dependencies.yml
+++ b/.github/workflows/create-issue-dependencies.yml
@@ -3,7 +3,7 @@ on:
   schedule:
     - cron: '0 0 1 */3 *'
   workflow_dispatch:
-  
+
 jobs:
   create-issue:
     runs-on: ubuntu-latest
@@ -12,12 +12,12 @@ jobs:
     - name: Create an issue
       uses: actions-ecosystem/action-create-issue@v1
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ secrets.MEILI_BOT_GH_PAT }}
         title: Upgrade dependencies
         body: |
           We need to update the dependencies of the Meilisearch repository, and, if possible, the dependencies of all the core-team repositories that Meilisearch depends on (milli, charabia, heed...).
 
-          ⚠️ This issue should only be done at the beginning of the sprint!     
+          ⚠️ This issue should only be done at the beginning of the sprint!
         labels: |
           dependencies
           maintenance

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     # No need to check the version for dry run (cron)
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       # Check if the tag has the v<nmumber>.<number>.<number> format.
       # If yes, it means we are publishing an official release.
       # If no, we are releasing a RC, so no need to check the version.

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -62,7 +62,7 @@ jobs:
       if: github.event_name != 'schedule'
       uses: svenstaro/upload-release-action@v1-release
       with:
-        repo_token: ${{ secrets.PUBLISH_TOKEN }}
+        repo_token: ${{ secrets.MEILI_BOT_GH_PAT }}
         file: target/release/${{ matrix.artifact_name }}
         asset_name: ${{ matrix.asset_name }}
         tag: ${{ github.ref }}
@@ -132,7 +132,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: svenstaro/upload-release-action@v1-release
         with:
-          repo_token: ${{ secrets.PUBLISH_TOKEN }}
+          repo_token: ${{ secrets.MEILI_BOT_GH_PAT }}
           file: target/${{ matrix.target }}/release/meilisearch
           asset_name: ${{ matrix.asset_name }}
           tag: ${{ github.ref }}

--- a/.github/workflows/publish-deb-brew-pkg.yml
+++ b/.github/workflows/publish-deb-brew-pkg.yml
@@ -9,7 +9,7 @@ jobs:
     name: Check the version validity
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Check release validity
         run: bash .github/scripts/check-release.sh
 

--- a/.github/workflows/publish-deb-brew-pkg.yml
+++ b/.github/workflows/publish-deb-brew-pkg.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Upload debian pkg to release
       uses: svenstaro/upload-release-action@v1-release
       with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        repo_token: ${{ secrets.MEILI_BOT_GH_PAT }}
         file: target/debian/meilisearch.deb
         asset_name: meilisearch.deb
         tag: ${{ github.ref }}

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -12,7 +12,7 @@ jobs:
   docker:
     runs-on: docker
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Check if the tag has the v<nmumber>.<number>.<number> format. If yes, it means we are publishing an official release.
       # In this situation, we need to set `output.stable` to create/update the following tags (additionally to the `vX.Y.Z` Docker tag):


### PR DESCRIPTION
Upgrade the missing checkout v2 into v3
Probably a bad merge conflicts that make them removed when merging `stable` into `main` after v0.28.0 release.

Also, use `MEILI_BOT_GH_PAT` instead of `PUBLISH_TOKEN` and the default github token, which allow us to remove useless GitHub secrets (once this PR is merged and v0.29.0 is release because `PUBLISH_TOKEN` is still used on `release-v0.29.0`)