### PR TITLE
Enable the client to specify a custom csv delimiter for parsing documents

### DIFF
--- a/meilisearch-http/src/routes/indexes/documents.rs
+++ b/meilisearch-http/src/routes/indexes/documents.rs
@@ -246,7 +246,9 @@ async fn document_addition(
     {
         Some(("application", "json")) => DocumentAdditionFormat::Json,
         Some(("application", "x-ndjson")) => DocumentAdditionFormat::Ndjson,
-        Some(("text", "csv")) => DocumentAdditionFormat::Csv(csv_delimiter.map_or(',' as u8, |delim| delim as u8)),
+        Some(("text", "csv")) => {
+            DocumentAdditionFormat::Csv(csv_delimiter.map_or(',' as u8, |delim| delim as u8))
+        }
         Some((type_, subtype)) => {
             return Err(MeilisearchHttpError::InvalidContentType(
                 format!("{}/{}", type_, subtype),

--- a/meilisearch-lib/src/document_formats.rs
+++ b/meilisearch-lib/src/document_formats.rs
@@ -97,7 +97,9 @@ pub fn read_csv(input: impl Read, writer: impl Write + Seek, delimiter: u8) -> R
     let csv = csv::ReaderBuilder::new()
         .delimiter(delimiter)
         .from_reader(input);
-    builder.append_csv(csv).map_err(|e| (PayloadType::Csv(delimiter), e))?;
+    builder
+        .append_csv(csv)
+        .map_err(|e| (PayloadType::Csv(delimiter), e))?;
 
     let count = builder.documents_count();
     let _ = builder

--- a/meilisearch-lib/src/index_controller/mod.rs
+++ b/meilisearch-lib/src/index_controller/mod.rs
@@ -402,7 +402,9 @@ where
                     let reader = Cursor::new(buffer);
                     let count = match format {
                         DocumentAdditionFormat::Json => read_json(reader, &mut *update_file)?,
-                        DocumentAdditionFormat::Csv(delimiter) => read_csv(reader, &mut *update_file, delimiter)?,
+                        DocumentAdditionFormat::Csv(delimiter) => {
+                            read_csv(reader, &mut *update_file, delimiter)?
+                        }
                         DocumentAdditionFormat::Ndjson => read_ndjson(reader, &mut *update_file)?,
                     };
 

--- a/meilisearch-lib/src/index_controller/mod.rs
+++ b/meilisearch-lib/src/index_controller/mod.rs
@@ -96,7 +96,7 @@ impl<U, I> Clone for IndexController<U, I> {
 #[derive(Debug)]
 pub enum DocumentAdditionFormat {
     Json,
-    Csv,
+    Csv(u8),
     Ndjson,
 }
 
@@ -105,7 +105,7 @@ impl fmt::Display for DocumentAdditionFormat {
         match self {
             DocumentAdditionFormat::Json => write!(f, "json"),
             DocumentAdditionFormat::Ndjson => write!(f, "ndjson"),
-            DocumentAdditionFormat::Csv => write!(f, "csv"),
+            DocumentAdditionFormat::Csv(_) => write!(f, "csv"),
         }
     }
 }
@@ -402,7 +402,7 @@ where
                     let reader = Cursor::new(buffer);
                     let count = match format {
                         DocumentAdditionFormat::Json => read_json(reader, &mut *update_file)?,
-                        DocumentAdditionFormat::Csv => read_csv(reader, &mut *update_file)?,
+                        DocumentAdditionFormat::Csv(delimiter) => read_csv(reader, &mut *update_file, delimiter)?,
                         DocumentAdditionFormat::Ndjson => read_ndjson(reader, &mut *update_file)?,
                     };
 


### PR DESCRIPTION
# Pull Request

## What does this PR do?
Fixes #2806

This PR adds the ability to specify custom csv delimiters, which I think is a very common use case, especially with large amounts of pre-existing data.

### Description
In `meilisearch-lib`, I added a `u8` parameter to the `DocumentAdditionFormat::Csv` document type.

In `meilisearch-http`, I added the field `pub csv_delimiter: Option<char>,` to `UpdateDocumentsQuery` (the actual query parameter is in camelCase thanks to serde: `csvDelimiter`)

The default delimiter is the comma (44), just like before. For example, the query for data delimited with semicolons:

```
POST localhost:7700/indexes/example/documents?csvDelimiter=%3B
```

`cargo test` succeeded on my system, and I was able to add documents using different delimiters using postman.

## PR checklist
Please check if your PR fulfills the following requirements:
- [X] Does this PR fix an existing issue?
- [X] Have you read the contributing guidelines?
- [X] Have you made sure that the title is accurate and descriptive of the changes?
