### PR TITLE
Add support for logging to syslog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,6 +1097,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-chain"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1485,6 +1494,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "hostname"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+dependencies = [
+ "libc",
+ "match_cfg",
+ "winapi",
 ]
 
 [[package]]
@@ -1998,6 +2018,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
+name = "match_cfg"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+
+[[package]]
 name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2081,6 +2107,7 @@ dependencies = [
  "slice-group-by",
  "static-files",
  "sysinfo",
+ "syslog",
  "tar",
  "tempfile",
  "thiserror",
@@ -3380,6 +3407,19 @@ dependencies = [
  "once_cell",
  "rayon",
  "winapi",
+]
+
+[[package]]
+name = "syslog"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978044cc68150ad5e40083c9f6a725e6fd02d7ba1bcf691ec2ff0d66c0b41acc"
+dependencies = [
+ "error-chain",
+ "hostname",
+ "libc",
+ "log",
+ "time 0.3.9",
 ]
 
 [[package]]

--- a/meilisearch-http/Cargo.toml
+++ b/meilisearch-http/Cargo.toml
@@ -70,6 +70,7 @@ siphasher = "0.3.10"
 slice-group-by = "0.3.0"
 static-files = { version = "0.2.3", optional = true }
 sysinfo = "0.23.5"
+syslog = "6.0.1"
 tar = "0.4.38"
 tempfile = "3.3.0"
 thiserror = "1.0.30"

--- a/meilisearch-http/src/option.rs
+++ b/meilisearch-http/src/option.rs
@@ -154,6 +154,10 @@ pub struct Opt {
     #[clap(long, env = "MEILI_LOG_LEVEL", default_value = "info")]
     pub log_level: String,
 
+    /// Send log messages to the local syslog instead of stderr.
+    #[clap(long, env = "MEILI_SYSLOG")]
+    pub syslog: bool,
+
     /// Enables Prometheus metrics and /metrics route.
     #[cfg(feature = "metrics")]
     #[clap(long, env = "MEILI_ENABLE_METRICS_ROUTE")]


### PR DESCRIPTION
Fixes #2811

If `MEILI_SYSLOG` is set or `--syslog` provided, the log messages will be sent to the local syslog instead of the stderr. The log level can be controlled using `MEILI_LOG_LEVEL` (or `--log-level`) as with logging to the stderr, but the value must be a valid syslog level, otherwise the program will panic.