### PR TITLE
Skip dashboard test if mini-dashboard feature is disabled

### DIFF
--- a/meilisearch-http/tests/dashboard/mod.rs
+++ b/meilisearch-http/tests/dashboard/mod.rs
@@ -1,5 +1,6 @@
 use crate::common::Server;
 
+#[cfg(feature = "mini-dashboard")]
 #[actix_rt::test]
 async fn dashboard_assets_load() {
     let server = Server::new().await;


### PR DESCRIPTION
Fixes #2813

Fixes the following error:

    cargo test --no-default-features
    ...
    error: couldn't read target/debug/build/meilisearch-http-ec029d8c902cf2cb/out/generated.rs: No such file or directory (os error 2)
     --> meilisearch-http/tests/dashboard/mod.rs:8:9
      |
    8 |         include!(concat!(env!("OUT_DIR"), "/generated.rs"));
      |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      |
      = note: this error originates in the macro `include` (in Nightly builds, run with -Z macro-backtrace for more info)

    error: could not compile `meilisearch-http` due to previous error