### PR TITLE
Implement the IndexScheduler basic operations

### DIFF
--- a/index-scheduler/src/autobatcher.rs
+++ b/index-scheduler/src/autobatcher.rs
@@ -207,7 +207,7 @@ impl BatchKind {
 
             (BatchKind::Settings { settings_ids }, Kind::DocumentClear) => {
                 ControlFlow::Continue(BatchKind::ClearAndSettings {
-                    settings_ids: settings_ids.clone(),
+                    settings_ids: settings_ids,
                     other: vec![id],
                 })
             }

--- a/index-scheduler/src/batch.rs
+++ b/index-scheduler/src/batch.rs
@@ -350,7 +350,7 @@ impl IndexScheduler {
             // matter.
             let index_name = task.indexes().unwrap()[0];
 
-            let _index = self.get_index(rtxn, &index_name)? & enqueued;
+            let _index = self.get_index(rtxn, index_name)? & enqueued;
 
             let enqueued = enqueued
                 .into_iter()
@@ -382,7 +382,7 @@ impl IndexScheduler {
                     | IndexOperation::DocumentClear { ref index_uid, .. } => {
                         // only get the index, don't create it
                         let rtxn = self.env.read_txn()?;
-                        self.index_mapper.index(&rtxn, &index_uid)?
+                        self.index_mapper.index(&rtxn, index_uid)?
                     }
                     IndexOperation::DocumentImport { ref index_uid, .. }
                     | IndexOperation::Settings { ref index_uid, .. }
@@ -390,7 +390,7 @@ impl IndexScheduler {
                     | IndexOperation::SettingsAndDocumentImport { ref index_uid, .. } => {
                         // create the index if it doesn't already exist
                         let mut wtxn = self.env.write_txn()?;
-                        let index = self.index_mapper.index(&mut wtxn, index_uid)?;
+                        let index = self.index_mapper.create_index(&mut wtxn, index_uid)?;
                         wtxn.commit()?;
                         index
                     }

--- a/index-scheduler/src/batch.rs
+++ b/index-scheduler/src/batch.rs
@@ -6,7 +6,7 @@ use crate::{
 use index::{Settings, Unchecked};
 use milli::{
     heed::{RoTxn, RwTxn},
-    update::{DocumentAdditionResult, IndexDocumentsMethod},
+    update::{DocumentAdditionResult, DocumentDeletionResult, IndexDocumentsMethod},
     DocumentId,
 };
 use uuid::Uuid;
@@ -490,7 +490,32 @@ impl IndexScheduler {
                 index_uid,
                 documents,
                 tasks,
-            } => todo!(),
+            } => {
+                let rtxn = self.env.read_txn()?;
+                let index = self.index_mapper.index(&rtxn, &index_uid)?;
+
+                let ret = index.delete_documents(&documents);
+                for task in tasks {
+                    match ret {
+                        Ok(DocumentDeletionResult {
+                            deleted_documents,
+                            remaining_documents: _,
+                        }) => {
+                            // TODO we are assigning the same amount of documents to
+                            //      all the tasks that are in the same batch. That's wrong!
+                            task.details = Some(Details::DocumentDeletion {
+                                received_document_ids: documents.len(),
+                                deleted_documents: Some(deleted_documents),
+                            });
+                        }
+                        Err(error) => {
+                            task.error = Some(error.into());
+                        }
+                    }
+                }
+
+                Ok(tasks)
+            }
             Batch::Settings {
                 index_uid,
                 settings,

--- a/index-scheduler/src/batch.rs
+++ b/index-scheduler/src/batch.rs
@@ -388,6 +388,8 @@ impl IndexScheduler {
                     | IndexOperation::Settings { ref index_uid, .. }
                     | IndexOperation::DocumentClearAndSetting { ref index_uid, .. }
                     | IndexOperation::SettingsAndDocumentImport { ref index_uid, .. } => {
+                        // TODO check if the user was allowed to create an index.
+
                         // create the index if it doesn't already exist
                         let mut wtxn = self.env.write_txn()?;
                         let index = self.index_mapper.create_index(&mut wtxn, index_uid)?;

--- a/index-scheduler/src/batch.rs
+++ b/index-scheduler/src/batch.rs
@@ -4,11 +4,8 @@ use crate::{
     Error, IndexScheduler, Result, TaskId,
 };
 use index::{Settings, Unchecked};
-use milli::{
-    heed::{RoTxn, RwTxn},
-    update::{DocumentAdditionResult, DocumentDeletionResult, IndexDocumentsMethod},
-    DocumentId,
-};
+use milli::heed::RoTxn;
+use milli::update::{DocumentAdditionResult, DocumentDeletionResult, IndexDocumentsMethod};
 use uuid::Uuid;
 
 pub(crate) enum Batch {
@@ -432,6 +429,7 @@ impl IndexScheduler {
             Batch::Snapshot(_) => todo!(),
             Batch::Dump(_) => todo!(),
             Batch::DocumentClear { tasks, .. } => todo!(),
+            // TODO we should merge both document import with a method field
             Batch::DocumentAddition {
                 index_uid,
                 primary_key,
@@ -480,22 +478,55 @@ impl IndexScheduler {
             } => {
                 todo!();
             }
+            // TODO we should merge both document import with a method field
             Batch::DocumentUpdate {
                 index_uid,
                 primary_key,
                 content_files,
-                tasks,
-            } => todo!(),
+                mut tasks,
+            } => {
+                // we NEED a write transaction for the index creation.
+                // To avoid blocking the whole process we're going to commit asap.
+                let mut wtxn = self.env.write_txn()?;
+                let index = self.index_mapper.create_index(&mut wtxn, &index_uid)?;
+                wtxn.commit()?;
+
+                let ret = index.update_documents(
+                    IndexDocumentsMethod::UpdateDocuments,
+                    primary_key,
+                    self.file_store.clone(),
+                    content_files,
+                )?;
+
+                for (task, ret) in tasks.iter_mut().zip(ret) {
+                    match ret {
+                        Ok(DocumentAdditionResult {
+                            indexed_documents,
+                            number_of_documents,
+                        }) => {
+                            task.details = Some(Details::DocumentAddition {
+                                received_documents: number_of_documents,
+                                indexed_documents,
+                            });
+                        }
+                        Err(error) => {
+                            task.error = Some(error.into());
+                        }
+                    }
+                }
+
+                Ok(tasks)
+            }
             Batch::DocumentDeletion {
                 index_uid,
                 documents,
-                tasks,
+                mut tasks,
             } => {
                 let rtxn = self.env.read_txn()?;
                 let index = self.index_mapper.index(&rtxn, &index_uid)?;
 
                 let ret = index.delete_documents(&documents);
-                for task in tasks {
+                for task in &mut tasks {
                     match ret {
                         Ok(DocumentDeletionResult {
                             deleted_documents,
@@ -508,7 +539,7 @@ impl IndexScheduler {
                                 deleted_documents: Some(deleted_documents),
                             });
                         }
-                        Err(error) => {
+                        Err(ref error) => {
                             task.error = Some(error.into());
                         }
                     }

--- a/index-scheduler/src/index_mapper.rs
+++ b/index-scheduler/src/index_mapper.rs
@@ -133,4 +133,8 @@ impl IndexMapper {
 
         Ok(())
     }
+
+    pub fn indexer_config(&self) -> &IndexerConfig {
+        &self.indexer_config
+    }
 }

--- a/index-scheduler/src/index_mapper.rs
+++ b/index-scheduler/src/index_mapper.rs
@@ -72,8 +72,8 @@ impl IndexMapper {
     pub fn index(&self, rtxn: &RoTxn, name: &str) -> Result<Index> {
         let uuid = self
             .index_mapping
-            .get(&rtxn, name)?
-            .ok_or(Error::IndexNotFound(name.to_string()))?;
+            .get(rtxn, name)?
+            .ok_or_else(|| Error::IndexNotFound(name.to_string()))?;
 
         // we clone here to drop the lock before entering the match
         let index = self.index_map.read().unwrap().get(&uuid).cloned();
@@ -109,7 +109,7 @@ impl IndexMapper {
 
     pub fn indexes(&self, rtxn: &RoTxn) -> Result<Vec<Index>> {
         self.index_mapping
-            .iter(&rtxn)?
+            .iter(rtxn)?
             .map(|ret| {
                 ret.map_err(Error::from)
                     .and_then(|(name, _)| self.index(rtxn, name))
@@ -122,11 +122,11 @@ impl IndexMapper {
         let lhs_uuid = self
             .index_mapping
             .get(wtxn, lhs)?
-            .ok_or(Error::IndexNotFound(lhs.to_string()))?;
+            .ok_or_else(|| Error::IndexNotFound(lhs.to_string()))?;
         let rhs_uuid = self
             .index_mapping
             .get(wtxn, rhs)?
-            .ok_or(Error::IndexNotFound(rhs.to_string()))?;
+            .ok_or_else(|| Error::IndexNotFound(rhs.to_string()))?;
 
         self.index_mapping.put(wtxn, lhs, &rhs_uuid)?;
         self.index_mapping.put(wtxn, rhs, &lhs_uuid)?;

--- a/index-scheduler/src/index_scheduler.rs
+++ b/index-scheduler/src/index_scheduler.rs
@@ -189,10 +189,10 @@ impl IndexScheduler {
             processing_tasks: self.processing_tasks.clone(),
             file_store: self.file_store.clone(),
             env: self.env.clone(),
-            all_tasks: self.all_tasks.clone(),
-            status: self.status.clone(),
-            kind: self.kind.clone(),
-            index_tasks: self.index_tasks.clone(),
+            all_tasks: self.all_tasks,
+            status: self.status,
+            kind: self.kind,
+            index_tasks: self.index_tasks,
             index_mapper: self.index_mapper.clone(),
             wake_up: self.wake_up.clone(),
 
@@ -279,7 +279,7 @@ impl IndexScheduler {
                 .map(|task| match processing.contains(task.uid) {
                     true => TaskView {
                         status: Status::Processing,
-                        started_at: Some(started_at.clone()),
+                        started_at: Some(started_at),
                         ..task
                     },
                     false => task,
@@ -309,7 +309,9 @@ impl IndexScheduler {
 
         if let Some(indexes) = task.indexes() {
             for index in indexes {
-                self.update_index(&mut wtxn, index, |bitmap| drop(bitmap.insert(task.uid)))?;
+                self.update_index(&mut wtxn, index, |bitmap| {
+                    bitmap.insert(task.uid);
+                })?;
             }
         }
 

--- a/index-scheduler/src/task.rs
+++ b/index-scheduler/src/task.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 
 use crate::{Error, TaskId};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TaskView {
     pub uid: TaskId,

--- a/index-scheduler/src/task.rs
+++ b/index-scheduler/src/task.rs
@@ -327,6 +327,7 @@ pub enum Details {
     #[serde(rename_all = "camelCase")]
     DocumentDeletion {
         received_document_ids: usize,
+        // TODO why is this optional?
         deleted_documents: Option<u64>,
     },
     #[serde(rename_all = "camelCase")]

--- a/index-scheduler/src/utils.rs
+++ b/index-scheduler/src/utils.rs
@@ -73,12 +73,12 @@ impl IndexScheduler {
             })?;
         }
 
-        self.all_tasks.put(wtxn, &BEU32::new(task.uid), &task)?;
+        self.all_tasks.put(wtxn, &BEU32::new(task.uid), task)?;
         Ok(())
     }
 
     pub(crate) fn get_index(&self, rtxn: &RoTxn, index: &str) -> Result<RoaringBitmap> {
-        Ok(self.index_tasks.get(&rtxn, index)?.unwrap_or_default())
+        Ok(self.index_tasks.get(rtxn, index)?.unwrap_or_default())
     }
 
     pub(crate) fn put_index(
@@ -96,7 +96,7 @@ impl IndexScheduler {
         index: &str,
         f: impl Fn(&mut RoaringBitmap),
     ) -> Result<()> {
-        let mut tasks = self.get_index(&wtxn, index)?;
+        let mut tasks = self.get_index(wtxn, index)?;
         f(&mut tasks);
         self.put_index(wtxn, index, &tasks)?;
 
@@ -104,7 +104,7 @@ impl IndexScheduler {
     }
 
     pub(crate) fn get_status(&self, rtxn: &RoTxn, status: Status) -> Result<RoaringBitmap> {
-        Ok(self.status.get(&rtxn, &status)?.unwrap_or_default())
+        Ok(self.status.get(rtxn, &status)?.unwrap_or_default())
     }
 
     pub(crate) fn put_status(
@@ -122,7 +122,7 @@ impl IndexScheduler {
         status: Status,
         f: impl Fn(&mut RoaringBitmap),
     ) -> Result<()> {
-        let mut tasks = self.get_status(&wtxn, status)?;
+        let mut tasks = self.get_status(wtxn, status)?;
         f(&mut tasks);
         self.put_status(wtxn, status, &tasks)?;
 
@@ -130,7 +130,7 @@ impl IndexScheduler {
     }
 
     pub(crate) fn get_kind(&self, rtxn: &RoTxn, kind: Kind) -> Result<RoaringBitmap> {
-        Ok(self.kind.get(&rtxn, &kind)?.unwrap_or_default())
+        Ok(self.kind.get(rtxn, &kind)?.unwrap_or_default())
     }
 
     pub(crate) fn put_kind(
@@ -148,7 +148,7 @@ impl IndexScheduler {
         kind: Kind,
         f: impl Fn(&mut RoaringBitmap),
     ) -> Result<()> {
-        let mut tasks = self.get_kind(&wtxn, kind)?;
+        let mut tasks = self.get_kind(wtxn, kind)?;
         f(&mut tasks);
         self.put_kind(wtxn, kind, &tasks)?;
 

--- a/index/src/error.rs
+++ b/index/src/error.rs
@@ -40,6 +40,17 @@ impl ErrorCode for IndexError {
     }
 }
 
+impl ErrorCode for &IndexError {
+    fn error_code(&self) -> Code {
+        match self {
+            IndexError::Internal(_) => Code::Internal,
+            IndexError::DocumentNotFound(_) => Code::DocumentNotFound,
+            IndexError::Facet(e) => e.error_code(),
+            IndexError::Milli(e) => MilliError(e).error_code(),
+        }
+    }
+}
+
 impl From<milli::UserError> for IndexError {
     fn from(error: milli::UserError) -> IndexError {
         IndexError::Milli(error.into())

--- a/index/src/index.rs
+++ b/index/src/index.rs
@@ -256,10 +256,10 @@ impl Index {
         &self,
         rtxn: &'a RoTxn,
     ) -> Result<impl Iterator<Item = Result<Document>> + 'a> {
-        let fields_ids_map = self.fields_ids_map(&rtxn)?;
+        let fields_ids_map = self.fields_ids_map(rtxn)?;
         let all_fields: Vec<_> = fields_ids_map.iter().map(|(id, _)| id).collect();
 
-        Ok(self.inner.all_documents(&rtxn)?.map(move |ret| {
+        Ok(self.inner.all_documents(rtxn)?.map(move |ret| {
             ret.map_err(IndexError::from)
                 .and_then(|(_key, document)| -> Result<_> {
                     Ok(obkv_to_json(&all_fields, &fields_ids_map, document)?)

--- a/index/src/index.rs
+++ b/index/src/index.rs
@@ -9,7 +9,6 @@ use fst::IntoStreamer;
 use milli::heed::{CompactionOption, EnvOpenOptions, RoTxn};
 use milli::update::{IndexerConfig, Setting};
 use milli::{obkv_to_json, FieldDistribution, DEFAULT_VALUES_PER_FACET};
-use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use time::OffsetDateTime;
 

--- a/meilisearch-http/src/routes/indexes/documents.rs
+++ b/meilisearch-http/src/routes/indexes/documents.rs
@@ -285,24 +285,13 @@ async fn document_addition(
         }
     };
 
-    let task = match method {
-        IndexDocumentsMethod::ReplaceDocuments => KindWithContent::DocumentAddition {
-            content_file: uuid,
-            documents_count,
-            primary_key,
-            allow_index_creation,
-            index_uid,
-        },
-
-        IndexDocumentsMethod::UpdateDocuments => KindWithContent::DocumentUpdate {
-            content_file: uuid,
-            documents_count,
-            primary_key,
-            allow_index_creation,
-            index_uid,
-        },
-        // TODO: TAMO: can I get rids of the `non_exhaustive` on the IndexDocumentsMethod enum
-        _ => todo!(),
+    let task = KindWithContent::DocumentImport {
+        method,
+        content_file: uuid,
+        documents_count,
+        primary_key,
+        allow_index_creation,
+        index_uid,
     };
 
     let scheduler = index_scheduler.clone();

--- a/meilisearch-http/src/routes/indexes/documents.rs
+++ b/meilisearch-http/src/routes/indexes/documents.rs
@@ -239,13 +239,12 @@ async fn document_addition(
             return Err(MeilisearchHttpError::InvalidContentType(
                 format!("{}/{}", type_, subtype),
                 ACCEPTED_CONTENT_TYPE.clone(),
-            )
-            .into())
+            ))
         }
         None => {
-            return Err(
-                MeilisearchHttpError::MissingContentType(ACCEPTED_CONTENT_TYPE.clone()).into(),
-            )
+            return Err(MeilisearchHttpError::MissingContentType(
+                ACCEPTED_CONTENT_TYPE.clone(),
+            ))
         }
     };
 
@@ -277,7 +276,7 @@ async fn document_addition(
         Ok(Ok(documents_count)) => documents_count,
         Ok(Err(e)) => {
             index_scheduler.delete_update_file(uuid)?;
-            return Err(e.into());
+            return Err(e);
         }
         Err(e) => {
             index_scheduler.delete_update_file(uuid)?;


### PR DESCRIPTION
This PR implements the basic batched operations:
  - `DocumentClear`
  - `DocumentImport` (it now has a `method` field which is either `Replace` or `Update`)
  - `SettingsAndDocumentImport`
  - `DocumentDeletion`
  - `Settings`
  - `DocumentClearAndSetting`

It introduces an `IndexOperation` sub-enum that allows having a clean recursive system which reduces the number of lines of code to write when processing multiple index-related operations.

This PR also exported the write transaction to allow us to execute multiple operations on a single index atomically e.g. batched settings and document additions.