### PR TITLE
Update internal CLI documentation

### DIFF
--- a/meilisearch-http/src/option.rs
+++ b/meilisearch-http/src/option.rs
@@ -273,7 +273,7 @@ pub struct Opt {
 
     /// Defines how much detail should be present in Meilisearch's logs.
 
-    /// Meilisearch currently supports four log levels, listed in order of increasing verbosity:
+    /// Meilisearch currently supports five log levels, listed in order of increasing verbosity:
     ///
     /// `'ERROR'`: only log unexpected events indicating Meilisearch is not functioning as expected
     /// `'WARN'`: log all unexpected events, regardless of their severity

--- a/meilisearch-http/src/option.rs
+++ b/meilisearch-http/src/option.rs
@@ -184,7 +184,7 @@ pub struct Opt {
     /// * A database already exists
     /// * No valid snapshot can be found in the specified path
     ///
-    /// This behavior can be modified with the `--ignore-snapshot-if-db-exists` and 
+    /// This behavior can be modified with the `--ignore-snapshot-if-db-exists` and
     /// `--ignore-missing-snapshot` options, respectively.
     ///
     /// *This option is not available as an environment variable.*

--- a/meilisearch-http/src/option.rs
+++ b/meilisearch-http/src/option.rs
@@ -81,20 +81,7 @@ pub struct Opt {
     #[clap(long, env = MEILI_MASTER_KEY)]
     pub master_key: Option<String>,
 
-    /// Configures the instance's environment. Value must be either production or development.
-    /// `production`
-    /// * Setting a master key is mandatory
-    /// * The search preview interface is disabled
-    ///
-    /// `development`:
-    /// Setting a master key is optional
-    /// Search preview is enabled
-    ///
-    /// # TIP
-    ///
-    /// When the server environment is set to development, providing a master key is not mandatory.
-    /// This is useful when debugging and prototyping, but dangerous otherwise since API routes
-    /// are unprotected.
+    /// Configures the instance's environment. Value must be either `production` or `development`.
     #[clap(long, env = MEILI_ENV, default_value_t = default_env(), possible_values = &POSSIBLE_ENV)]
     #[serde(default = "default_env")]
     pub env: String,
@@ -109,43 +96,29 @@ pub struct Opt {
     #[clap(long, env = MEILI_NO_ANALYTICS)]
     pub no_analytics: bool,
 
-    /// Sets the maximum size of the index. Value must be given in bytes or explicitly stating a base unit.
-    ///
-    /// For example, the default value can be written as `107374182400`, `'107.7Gb'`, or `'107374 Mb'`.
-    ///
-    /// The index stores processed data and is different from the task database, which handles pending tasks.
+    /// Sets the maximum size of the index. Value must be given in bytes or explicitly stating a base unit (for instance: 107374182400, '107.7Gb', or '107374 Mb').
     #[clap(long, env = MEILI_MAX_INDEX_SIZE, default_value_t = default_max_index_size())]
     #[serde(default = "default_max_index_size")]
     pub max_index_size: Byte,
 
     /// Sets the maximum size of the task database. Value must be given in bytes or explicitly stating a
-    /// base unit. For example, the default value can be written as `107374182400`, `'107.7Gb'`, or
-    /// `'107374 Mb'`.
-    ///
-    /// The task database handles pending tasks. This is different from the index database, which only
-    /// stores processed data.
+    /// base unit (for instance: 107374182400, '107.7Gb', or '107374 Mb').
     #[clap(long, env = MEILI_MAX_TASK_DB_SIZE, default_value_t = default_max_task_db_size())]
     #[serde(default = "default_max_task_db_size")]
     pub max_task_db_size: Byte,
 
     /// Sets the maximum size of accepted payloads. Value must be given in bytes or explicitly stating a
-    /// base unit. For example, the default value can be written as `107374182400`, `'107.7Gb'`, or
-    /// `'107374 Mb'`.
+    /// base unit (for instance: 107374182400, '107.7Gb', or '107374 Mb').
     #[clap(long, env = MEILI_HTTP_PAYLOAD_SIZE_LIMIT, default_value_t = default_http_payload_size_limit())]
     #[serde(default = "default_http_payload_size_limit")]
     pub http_payload_size_limit: Byte,
 
     /// Sets the server's SSL certificates.
-    ///
-    /// Value must be a path to PEM-formatted certificates. The first certificate should certify the
-    /// KEYFILE supplied by --ssl-key-path. The last certificate should be a root CA.
     #[serde(skip_serializing)]
     #[clap(long, env = MEILI_SSL_CERT_PATH, parse(from_os_str))]
     pub ssl_cert_path: Option<PathBuf>,
 
     /// Sets the server's SSL key files.
-    ///
-    /// Value must be a path to an RSA private key or PKCS8-encoded private key, both in PEM format.
     #[serde(skip_serializing)]
     #[clap(long, env = MEILI_SSL_KEY_PATH, parse(from_os_str))]
     pub ssl_key_path: Option<PathBuf>,
@@ -162,8 +135,6 @@ pub struct Opt {
     pub ssl_ocsp_path: Option<PathBuf>,
 
     /// Makes SSL authentication mandatory.
-    ///
-    /// Sends a fatal alert if the client does not complete client authentication.
     #[serde(skip_serializing, default)]
     #[clap(long, env = MEILI_SSL_REQUIRE_AUTH)]
     pub ssl_require_auth: bool,
@@ -179,15 +150,6 @@ pub struct Opt {
     pub ssl_tickets: bool,
 
     /// Launches Meilisearch after importing a previously-generated snapshot at the given filepath.
-    ///
-    /// This command will throw an error if:
-    /// * A database already exists
-    /// * No valid snapshot can be found in the specified path
-    ///
-    /// This behavior can be modified with the `--ignore-snapshot-if-db-exists` and
-    /// `--ignore-missing-snapshot` options, respectively.
-    ///
-    /// *This option is not available as an environment variable.*
     #[clap(long, env = MEILI_IMPORT_SNAPSHOT)]
     pub import_snapshot: Option<PathBuf>,
 
@@ -195,8 +157,6 @@ pub struct Opt {
     /// does not point to a valid snapshot file.
     ///
     /// This command will throw an error if `--import-snapshot` is not defined.
-    ///
-    /// *This option is not available as an environment variable.*
     #[clap(
         long,
         env = MEILI_IGNORE_MISSING_SNAPSHOT,
@@ -210,8 +170,6 @@ pub struct Opt {
     /// and Meilisearch will launch using the existing database.
     ///
     /// This command will throw an error if `--import-snapshot` is not defined.
-    ///
-    /// *This option is not available as an environment variable.*
     #[clap(
         long,
         env = MEILI_IGNORE_SNAPSHOT_IF_DB_EXISTS,
@@ -237,11 +195,6 @@ pub struct Opt {
 
     /// Imports the dump file located at the specified path. Path must point to a `.dump` file.
     /// If a database already exists, Meilisearch will throw an error and abort launch.
-    ///
-    /// Meilisearch will only launch once the dump data has been fully indexed.
-    /// The time this takes depends on the size of the dump file.
-    ///
-    /// *This option is not available as an environment variable.*
     #[clap(long, env = MEILI_IMPORT_DUMP, conflicts_with = "import-snapshot")]
     pub import_dump: Option<PathBuf>,
 
@@ -260,8 +213,6 @@ pub struct Opt {
     /// launch using the existing database.
     ///
     /// This option will trigger an error if `--import-dump` is not defined.
-    ///
-    /// *This option is not available as an environment variable.*
     #[clap(long, env = MEILI_IGNORE_DUMP_IF_DB_EXISTS, requires = "import-dump")]
     #[serde(default)]
     pub ignore_dump_if_db_exists: bool,
@@ -272,16 +223,8 @@ pub struct Opt {
     pub dumps_dir: PathBuf,
 
     /// Defines how much detail should be present in Meilisearch's logs.
-
-    /// Meilisearch currently supports five log levels, listed in order of increasing verbosity:
     ///
-    /// `'ERROR'`: only log unexpected events indicating Meilisearch is not functioning as expected
-    /// `'WARN'`: log all unexpected events, regardless of their severity
-    /// `'INFO'`: log all events. This is the default value of --log-level
-    /// `'DEBUG'`: log all events and include detailed information on Meilisearch's internal processes.
-    ///     Useful when diagnosing issues and debugging
-    /// `'TRACE'`: log all events and include even more detailed information on Meilisearch's internal processes.
-    ///     We do not advise using this level as it is extremely verbose. Use `'DEBUG'` before considering `'TRACE'`.
+    /// Meilisearch currently supports five log levels, listed in order of increasing verbosity: ERROR, WARN, INFO, DEBUG, TRACE.
     #[clap(long, env = MEILI_LOG_LEVEL, default_value_t = default_log_level())]
     #[serde(default = "default_log_level")]
     pub log_level: String,

--- a/meilisearch-http/src/option.rs
+++ b/meilisearch-http/src/option.rs
@@ -203,8 +203,6 @@ pub struct Opt {
     /// a valid dump file. Instead, Meilisearch will start normally without importing any dump.
     ///
     /// This option will trigger an error if `--import-dump` is not defined.
-    ///
-    /// *This option is not available as an environment variable.*
     #[clap(long, env = MEILI_IGNORE_MISSING_DUMP, requires = "import-dump")]
     #[serde(default)]
     pub ignore_missing_dump: bool,

--- a/meilisearch-http/src/option.rs
+++ b/meilisearch-http/src/option.rs
@@ -235,16 +235,33 @@ pub struct Opt {
     #[serde(default = "default_snapshot_interval_sec")]
     pub snapshot_interval_sec: u64,
 
-    /// Import a dump from the specified path, must be a `.dump` file.
+    /// Imports the dump file located at the specified path. Path must point to a `.dump` file.
+    /// If a database already exists, Meilisearch will throw an error and abort launch.
+    ///
+    /// Meilisearch will only launch once the dump data has been fully indexed.
+    /// The time this takes depends on the size of the dump file.
+    ///
+    /// *This option is not available as an environment variable.*
     #[clap(long, env = MEILI_IMPORT_DUMP, conflicts_with = "import-snapshot")]
     pub import_dump: Option<PathBuf>,
 
-    /// If the dump doesn't exist, load or create the database specified by `db-path` instead.
+    /// Prevents Meilisearch from throwing an error when `--import-dump` does not point to
+    /// a valid dump file. Instead, Meilisearch will start normally without importing any dump.
+    ///
+    /// This option will trigger an error if `--import-dump` is not defined.
+    ///
+    /// *This option is not available as an environment variable.*
     #[clap(long, env = MEILI_IGNORE_MISSING_DUMP, requires = "import-dump")]
     #[serde(default)]
     pub ignore_missing_dump: bool,
 
-    /// Ignore the dump if a database already exists, and load that database instead.
+    /// Prevents a Meilisearch instance with an existing database from throwing an error
+    /// when using `--import-dump`. Instead, the dump will be ignored and Meilisearch will
+    /// launch using the existing database.
+    ///
+    /// This option will trigger an error if `--import-dump` is not defined.
+    ///
+    /// *This option is not available as an environment variable.*
     #[clap(long, env = MEILI_IGNORE_DUMP_IF_DB_EXISTS, requires = "import-dump")]
     #[serde(default)]
     pub ignore_dump_if_db_exists: bool,
@@ -254,7 +271,17 @@ pub struct Opt {
     #[serde(default = "default_dumps_dir")]
     pub dumps_dir: PathBuf,
 
-    /// Set the log level. # Possible values: [ERROR, WARN, INFO, DEBUG, TRACE]
+    /// Defines how much detail should be present in Meilisearch's logs.
+
+    /// Meilisearch currently supports four log levels, listed in order of increasing verbosity:
+    ///
+    /// `'ERROR'`: only log unexpected events indicating Meilisearch is not functioning as expected
+    /// `'WARN'`: log all unexpected events, regardless of their severity
+    /// `'INFO'`: log all events. This is the default value of --log-level
+    /// `'DEBUG'`: log all events and include detailed information on Meilisearch's internal processes.
+    ///     Useful when diagnosing issues and debugging
+    /// `'TRACE'`: log all events and include even more detailed information on Meilisearch's internal processes.
+    ///     We do not advise using this level as it is extremely verbose. Use `'DEBUG'` before considering `'TRACE'`.
     #[clap(long, env = MEILI_LOG_LEVEL, default_value_t = default_log_level())]
     #[serde(default = "default_log_level")]
     pub log_level: String,

--- a/meilisearch-http/src/option.rs
+++ b/meilisearch-http/src/option.rs
@@ -71,12 +71,12 @@ pub struct Opt {
     #[serde(default = "default_db_path")]
     pub db_path: PathBuf,
 
-    /// The address on which the http server will listen.
+    /// Sets the HTTP address and port Meilisearch will use.
     #[clap(long, env = MEILI_HTTP_ADDR, default_value_t = default_http_addr())]
     #[serde(default = "default_http_addr")]
     pub http_addr: String,
 
-    /// Sets the instance's master key, automatically protecting all routes except GET /health
+    /// Sets the instance's master key, automatically protecting all routes except `GET /health`.
     #[serde(skip_serializing)]
     #[clap(long, env = MEILI_MASTER_KEY)]
     pub master_key: Option<String>,
@@ -128,8 +128,9 @@ pub struct Opt {
     #[clap(long, env = MEILI_SSL_AUTH_PATH, parse(from_os_str))]
     pub ssl_auth_path: Option<PathBuf>,
 
-    /// Read DER-encoded OCSP response from OCSPFILE and staple to certificate.
-    /// Optional
+    /// Sets the server's OCSP file. *Optional*
+    ///
+    /// Reads DER-encoded OCSP response from OCSPFILE and staple to certificate.
     #[serde(skip_serializing)]
     #[clap(long, env = MEILI_SSL_OCSP_PATH, parse(from_os_str))]
     pub ssl_ocsp_path: Option<PathBuf>,
@@ -217,7 +218,7 @@ pub struct Opt {
     #[serde(default)]
     pub ignore_dump_if_db_exists: bool,
 
-    /// Folder where dumps are created when the dump route is called.
+    /// Sets the directory where Meilisearch will create dump files.
     #[clap(long, env = MEILI_DUMPS_DIR, default_value_os_t = default_dumps_dir())]
     #[serde(default = "default_dumps_dir")]
     pub dumps_dir: PathBuf,
@@ -243,7 +244,7 @@ pub struct Opt {
     #[clap(flatten)]
     pub scheduler_options: SchedulerConfig,
 
-    /// The path to a configuration file that should be used to setup the engine.
+    /// Set the path to a configuration file that should be used to setup the engine.
     /// Format must be TOML.
     #[serde(skip_serializing)]
     #[clap(long)]

--- a/meilisearch-lib/src/options.rs
+++ b/meilisearch-lib/src/options.rs
@@ -17,7 +17,7 @@ const DEFAULT_LOG_EVERY_N: usize = 100000;
 #[derive(Debug, Clone, Parser, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", deny_unknown_fields)]
 pub struct IndexerOpts {
-    /// The amount of documents to skip before printing
+    /// Sets the amount of documents to skip before printing
     /// a log regarding the indexing advancement.
     #[serde(skip_serializing, default = "default_log_every_n")]
     #[clap(long, default_value_t = default_log_every_n(), hide = true)] // 100k
@@ -28,20 +28,15 @@ pub struct IndexerOpts {
     #[clap(long, hide = true)]
     pub max_nb_chunks: Option<usize>,
 
-    /// The maximum amount of memory the indexer will use.
-    ///
-    /// In case the engine is unable to retrieve the available memory the engine will
-    /// try to use the memory it needs but without real limit, this can lead to
-    /// Out-Of-Memory issues and it is recommended to specify the amount of memory to use.
+    /// Sets the maximum amount of RAM Meilisearch can use when indexing. By default, Meilisearch
+    /// uses no more than two thirds of available memory.
     #[clap(long, env = MEILI_MAX_INDEXING_MEMORY, default_value_t)]
     #[serde(default)]
     pub max_indexing_memory: MaxMemory,
 
-    /// The maximum number of threads the indexer will use.
-    /// If the number set is higher than the real number of cores available in the machine,
-    /// it will use the maximum number of available cores.
-    ///
-    /// It defaults to half of the available threads.
+    /// Sets the maximum number of threads Meilisearch can use during indexation. By default, the
+    /// indexer avoids using more than half of a machine's total processing units. This ensures
+    /// Meilisearch is always ready to perform searches, even while you are updating an index.
     #[clap(long, env = MEILI_MAX_INDEXING_THREADS, default_value_t)]
     #[serde(default)]
     pub max_indexing_threads: MaxThreads,
@@ -50,8 +45,7 @@ pub struct IndexerOpts {
 #[derive(Debug, Clone, Parser, Default, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", deny_unknown_fields)]
 pub struct SchedulerConfig {
-    /// The engine will disable task auto-batching,
-    /// and will sequencialy compute each task one by one.
+    /// Deactivates auto-batching when provided.
     #[clap(long, env = DISABLE_AUTO_BATCHING)]
     #[serde(default)]
     pub disable_auto_batching: bool,


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #2810

## What does this PR do?
- Make internal CLI documentation match the online one

## Remarks
- Scope is limited to `meilisearch/meilisearch-http/src/option.rs`, not the flattened structs: should I also take care of them?
- Could not find online docs for `enable_metrics_route`
- Max column width wrapping was done by hand, so may not be perfect
- I removed the links from the internal doc: should I put them back?

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?
