### PR TITLE
Bail if config file contains 'config_file_path'

### DIFF
--- a/meilisearch-http/src/option.rs
+++ b/meilisearch-http/src/option.rs
@@ -257,6 +257,11 @@ impl Opt {
                 Ok(config) => {
                     // If the file is successfully read, we deserialize it with `toml`.
                     let opt_from_config = toml::from_slice::<Opt>(&config)?;
+                    // Return an error if config file contains 'config_file_path'
+                    // Using that key in the config file doesn't make sense bc it creates a logical loop (config file referencing itself)
+                    if opt_from_config.config_file_path.is_some() {
+                        anyhow::bail!("`config_file_path` is not supported in config file")
+                    }
                     // We inject the values from the toml in the corresponding env vars if needs be. Doing so, we respect the priority toml < env vars < cli args.
                     opt_from_config.export_to_env();
                     // Once injected we parse the cli args once again to take the new env vars into scope.


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #2801

## What does this PR do?
- Return an error if config file contains 'config_file_path'

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?
