### PR TITLE
Implement more index mapper operations

### DIFF
--- a/index-scheduler/src/batch.rs
+++ b/index-scheduler/src/batch.rs
@@ -440,7 +440,13 @@ impl IndexScheduler {
 
                 Ok(vec![task])
             }
-            Batch::IndexDeletion { index_uid, tasks } => todo!(),
+            Batch::IndexDeletion { index_uid, tasks } => {
+                let wtxn = self.env.write_txn()?;
+                // The write transaction is directly owned and commited here.
+                let index = self.index_mapper.delete_index(wtxn, &index_uid)?;
+
+                todo!("update the tasks and mark them as succeeded");
+            }
         }
     }
 

--- a/index-scheduler/src/batch.rs
+++ b/index-scheduler/src/batch.rs
@@ -136,14 +136,16 @@ impl IndexScheduler {
                 let mut documents_counts = Vec::new();
                 let mut content_files = Vec::new();
                 for task in &tasks {
-                    if let KindWithContent::DocumentImport {
-                        content_file,
-                        documents_count,
-                        ..
-                    } = task.kind
-                    {
-                        documents_counts.push(documents_count);
-                        content_files.push(content_file);
+                    match task.kind {
+                        KindWithContent::DocumentImport {
+                            content_file,
+                            documents_count,
+                            ..
+                        } => {
+                            documents_counts.push(documents_count);
+                            content_files.push(content_file);
+                        }
+                        _ => unreachable!(),
                     }
                 }
 

--- a/index-scheduler/src/index_mapper.rs
+++ b/index-scheduler/src/index_mapper.rs
@@ -1,7 +1,7 @@
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::{Arc, RwLock, RwLockWriteGuard};
+use std::sync::{Arc, RwLock};
 use std::{fs, thread};
 
 use log::error;

--- a/index-scheduler/src/lib.rs
+++ b/index-scheduler/src/lib.rs
@@ -400,7 +400,6 @@ impl IndexScheduler {
                 for mut task in tasks {
                     task.started_at = Some(started_at);
                     task.finished_at = Some(finished_at);
-                    task.status = Status::Succeeded;
                     // the info field should've been set by the process_batch function
 
                     self.update_task(&mut wtxn, &task)?;
@@ -616,7 +615,7 @@ mod tests {
 
         let (uuid, mut file) = index_scheduler.create_update_file().unwrap();
         let documents_count =
-            document_formats::read_json(content.as_bytes(), file.as_file_mut()).unwrap();
+            document_formats::read_json(content.as_bytes(), file.as_file_mut()).unwrap() as u64;
         index_scheduler
             .register(KindWithContent::DocumentImport {
                 index_uid: S("doggos"),

--- a/index-scheduler/src/task.rs
+++ b/index-scheduler/src/task.rs
@@ -279,7 +279,7 @@ impl KindWithContent {
             KindWithContent::Settings { new_settings, .. } => Some(Details::Settings {
                 settings: new_settings.clone(),
             }),
-            KindWithContent::IndexDeletion { .. } => Some(Details::IndexInfo { primary_key: None }),
+            KindWithContent::IndexDeletion { .. } => None,
             KindWithContent::IndexCreation { primary_key, .. }
             | KindWithContent::IndexUpdate { primary_key, .. } => Some(Details::IndexInfo {
                 primary_key: primary_key.clone(),

--- a/meilisearch-http/src/routes/indexes/documents.rs
+++ b/meilisearch-http/src/routes/indexes/documents.rs
@@ -274,7 +274,7 @@ async fn document_addition(
         .await;
 
     let documents_count = match documents_count {
-        Ok(Ok(documents_count)) => documents_count,
+        Ok(Ok(documents_count)) => documents_count as u64,
         Ok(Err(e)) => {
             index_scheduler.delete_update_file(uuid)?;
             return Err(e);


### PR DESCRIPTION
This PR implement more of the index operations:
 - `IndexCreation`
 - `IndexDeletion` (please review this in details)
 - `IndexUpdate`
 - Updates the statuses of the tasks for when they succeed or fail.