### PR TITLE
Change default bind address to localhost

### DIFF
--- a/meilisearch-http/src/analytics/segment_analytics.rs
+++ b/meilisearch-http/src/analytics/segment_analytics.rs
@@ -235,7 +235,7 @@ impl Segment {
             let dumps_dir = opt.dumps_dir != PathBuf::from("dumps/");
             let import_snapshot = opt.import_snapshot.is_some();
             let snapshots_dir = opt.snapshot_dir != PathBuf::from("snapshots/");
-            let http_addr = opt.http_addr != "127.0.0.1:7700";
+            let http_addr = opt.http_addr != default_http_addr();
 
             let mut infos = serde_json::to_value(opt).unwrap();
 

--- a/meilisearch-http/src/analytics/segment_analytics.rs
+++ b/meilisearch-http/src/analytics/segment_analytics.rs
@@ -26,6 +26,7 @@ use tokio::sync::mpsc::{self, Receiver, Sender};
 use uuid::Uuid;
 
 use crate::analytics::Analytics;
+use crate::option::default_http_addr;
 use crate::routes::indexes::documents::UpdateDocumentsQuery;
 use crate::Opt;
 

--- a/meilisearch-http/src/option.rs
+++ b/meilisearch-http/src/option.rs
@@ -465,7 +465,7 @@ fn default_db_path() -> PathBuf {
     PathBuf::from(DEFAULT_DB_PATH)
 }
 
-fn default_http_addr() -> String {
+pub fn default_http_addr() -> String {
     DEFAULT_HTTP_ADDR.to_string()
 }
 

--- a/meilisearch-http/src/option.rs
+++ b/meilisearch-http/src/option.rs
@@ -52,7 +52,7 @@ const MEILI_LOG_LEVEL: &str = "MEILI_LOG_LEVEL";
 const MEILI_ENABLE_METRICS_ROUTE: &str = "MEILI_ENABLE_METRICS_ROUTE";
 
 const DEFAULT_DB_PATH: &str = "./data.ms";
-const DEFAULT_HTTP_ADDR: &str = "127.0.0.1:7700";
+const DEFAULT_HTTP_ADDR: &str = "localhost:7700";
 const DEFAULT_ENV: &str = "development";
 const DEFAULT_MAX_INDEX_SIZE: &str = "100 GiB";
 const DEFAULT_MAX_TASK_DB_SIZE: &str = "100 GiB";


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #2782

## What does this PR do?
- Change the default bind address to `localhost` so that it can be accessed with IPv6

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
