### PR TITLE
Use Ubuntu 18.04 for all CI tasks that previously used Ubuntu 20.04

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,7 +6,7 @@ name: Execute code coverage
 
 jobs:
   nightly-coverage:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/flaky.yml
+++ b/.github/workflows/flaky.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   flaky:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -38,9 +38,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-18.04, macos-latest, windows-latest]
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-18.04
             artifact_name: meilisearch
             asset_name: meilisearch-linux-amd64
           - os: macos-latest
@@ -77,7 +77,7 @@ jobs:
       matrix:
         include:
           - build: aarch64
-            os: ubuntu-20.04
+            os: ubuntu-18.04
             target: aarch64-unknown-linux-gnu
             linker: gcc-aarch64-linux-gnu
             use-cross: true

--- a/.github/workflows/publish-deb-brew-pkg.yml
+++ b/.github/workflows/publish-deb-brew-pkg.yml
@@ -15,7 +15,7 @@ jobs:
 
   debian:
     name: Publish debian packagge
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     needs: check-version
     steps:
     - uses: hecrj/setup-rust-action@master
@@ -38,7 +38,7 @@ jobs:
 
   homebrew:
     name: Bump Homebrew formula
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     needs: check-version
     steps:
       - name: Create PR to Homebrew

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-18.04, macos-latest, windows-latest]
     steps:
     - uses: actions/checkout@v3
     - name: Cache dependencies
@@ -40,7 +40,7 @@ jobs:
   # We run tests in debug also, to make sure that the debug_assertions are hit
   test-debug:
     name: Run tests in debug
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
@@ -58,7 +58,7 @@ jobs:
 
   clippy:
     name: Run Clippy
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
@@ -77,7 +77,7 @@ jobs:
 
   fmt:
     name: Run Rustfmt
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/update-cargo-toml-version.yml
+++ b/.github/workflows/update-cargo-toml-version.yml
@@ -16,7 +16,7 @@ jobs:
 
   update-version-cargo-toml:
     name: Update version in Cargo.toml files
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1

--- a/bors.toml
+++ b/bors.toml
@@ -1,5 +1,5 @@
 status = [
-    'Tests on ubuntu-20.04',
+    'Tests on ubuntu-18.04',
     'Tests on macos-latest',
     'Tests on windows-latest',
     'Run Clippy',


### PR DESCRIPTION
This is to prevent linking with a version of glibc that is too recent.

With meilisearch v0.29.0 we inadvertently bumped the minimum supported glibc version to 2.29, which means it couldn't be run from Debian 10 (for example) anymore. By using Ubuntu 18.04, which uses glibc 2.27, we restore support for older Linux distros.

Fixes #2850 