### PR TITLE
Small changes on the Index scheduler

### DIFF
--- a/index-scheduler/src/batch.rs
+++ b/index-scheduler/src/batch.rs
@@ -397,8 +397,16 @@ impl IndexScheduler {
 
             let _index = self.get_index(rtxn, index_name)? & enqueued;
 
+            // If the autobatching is disabled we only take one task at a time.
+            let tasks_limit = if self.autobatching_enabled {
+                usize::MAX
+            } else {
+                1
+            };
+
             let enqueued = enqueued
                 .into_iter()
+                .take(tasks_limit)
                 .map(|task_id| {
                     self.get_task(rtxn, task_id)
                         .and_then(|task| task.ok_or(Error::CorruptedTaskQueue))

--- a/index-scheduler/src/lib.rs
+++ b/index-scheduler/src/lib.rs
@@ -348,7 +348,8 @@ impl IndexScheduler {
             }
         }
 
-        self.notify();
+        // notify the scheduler loop to execute a new tick
+        self.wake_up.signal();
 
         Ok(task.as_task_view())
     }
@@ -437,11 +438,6 @@ impl IndexScheduler {
             .unwrap();
 
         Ok(processed_tasks)
-    }
-
-    /// Notify the scheduler there is or may be work to do.
-    pub fn notify(&self) {
-        self.wake_up.signal()
     }
 }
 


### PR DESCRIPTION
This PR introduces a test that check that we are processing tasks that were sent very fast (and triggered only one signal) and we cleaned-up some code.