### PR TITLE
fix: add handle dumpCreation query on tasks request

### DIFF
--- a/meilisearch-http/src/routes/tasks.rs
+++ b/meilisearch-http/src/routes/tasks.rs
@@ -44,6 +44,7 @@ fn task_type_matches_content(type_: &TaskType, content: &TaskContent) -> bool {
         | (TaskType::DocumentAdditionOrUpdate, TaskContent::DocumentAddition { .. })
         | (TaskType::DocumentDeletion, TaskContent::DocumentDeletion{ .. })
         | (TaskType::SettingsUpdate, TaskContent::SettingsUpdate { .. })
+        | (TaskType::DumpCreation, TaskContent::Dump { .. })
     )
 }
 


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #2874 

## What does this PR do?
- add missing `DumpCreation` type in tasks route

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?