### PR TITLE
Fix CI to send signal to Cloud team

### DIFF
--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -77,4 +77,4 @@ jobs:
           token: ${{ secrets.MEILI_BOT_GH_PAT }}
           repository: meilisearch/meilisearch-cloud
           event-type: cloud-docker-build
-          client-payload: '{ "meilisearch_version": "${{ steps.meta.outputs.tags }}", "stable": "${{ steps.check-tag-format.outputs.stable }}" }'
+          client-payload: '{ "meilisearch_version": "${{ github.ref_name }}", "stable": "${{ steps.check-tag-format.outputs.stable }}" }'


### PR DESCRIPTION
Hello @eskombro 👋 

I realized the CI we recently created together was not good when we release the official Meilisearch version. Indeed, in this case `steps.meta.outputs.tags` contains several tags, see: https://github.com/meilisearch/meilisearch/actions/runs/3197492898/jobs/5220776456

You might want to ask: why the CI, including the Cloud team signal, was available when releasing v0.29.1 and not v0.29.0? Good question, thanks for asking it Sam! It was a mistake on our side, it should not have been available for v0.29.1, and this is how I found out v0.29.1 was broken and contained commits it should not have. So I deleted everything and started the release process again for v0.29.1.
Anyway, since I had the chance to see the bug in this release mess, I want to take the opportunity to fix it. Now, we will only send the real tag. 
Here you have more documentation about what `github.ref_name` is: https://docs.github.com/en/actions/learn-github-actions/contexts

Bisous bisous!