### PR TITLE
Index scheduler fix and simplify autobatcher

### DIFF
--- a/index-scheduler/src/batch.rs
+++ b/index-scheduler/src/batch.rs
@@ -413,16 +413,16 @@ impl IndexScheduler {
             // matter.
             let index_name = task.indexes().unwrap()[0];
 
-            let _index = self.get_index(rtxn, index_name)? & enqueued;
+            let index_tasks = self.index_tasks(rtxn, index_name)? & enqueued;
 
-            // If the autobatching is disabled we only take one task at a time.
+            // If autobatching is disabled we only take one task at a time.
             let tasks_limit = if self.autobatching_enabled {
                 usize::MAX
             } else {
                 1
             };
 
-            let enqueued = enqueued
+            let enqueued = index_tasks
                 .into_iter()
                 .take(tasks_limit)
                 .map(|task_id| {

--- a/index-scheduler/src/lib.rs
+++ b/index-scheduler/src/lib.rs
@@ -276,7 +276,7 @@ impl IndexScheduler {
         if let Some(index) = query.index_uid {
             let mut index_tasks = RoaringBitmap::new();
             for index in index {
-                index_tasks |= self.get_index(&rtxn, &index)?;
+                index_tasks |= self.index_tasks(&rtxn, &index)?;
             }
             tasks &= index_tasks;
         }

--- a/index-scheduler/src/snapshot.rs
+++ b/index-scheduler/src/snapshot.rs
@@ -3,13 +3,10 @@ use meilisearch_types::heed::{
     Database, RoTxn,
 };
 use meilisearch_types::milli::{RoaringBitmapCodec, BEU32};
+use meilisearch_types::tasks::{Details, Task};
 use roaring::RoaringBitmap;
 
-use crate::{
-    index_mapper::IndexMapper,
-    task::{Details, Task},
-    IndexScheduler, Kind, Status,
-};
+use crate::{index_mapper::IndexMapper, IndexScheduler, Kind, Status};
 
 pub fn snapshot_index_scheduler(scheduler: &IndexScheduler) -> String {
     let IndexScheduler {

--- a/index-scheduler/src/utils.rs
+++ b/index-scheduler/src/utils.rs
@@ -73,7 +73,8 @@ impl IndexScheduler {
         Ok(())
     }
 
-    pub(crate) fn get_index(&self, rtxn: &RoTxn, index: &str) -> Result<RoaringBitmap> {
+    /// Returns the whole set of tasks that belongs to this index.
+    pub(crate) fn index_tasks(&self, rtxn: &RoTxn, index: &str) -> Result<RoaringBitmap> {
         Ok(self.index_tasks.get(rtxn, index)?.unwrap_or_default())
     }
 
@@ -92,7 +93,7 @@ impl IndexScheduler {
         index: &str,
         f: impl Fn(&mut RoaringBitmap),
     ) -> Result<()> {
-        let mut tasks = self.get_index(wtxn, index)?;
+        let mut tasks = self.index_tasks(wtxn, index)?;
         f(&mut tasks);
         self.put_index(wtxn, index, &tasks)?;
 


### PR DESCRIPTION
This PR fixes the auto-batching system to ensure it doesn't batch tasks from different indexes. It also simplifies the rules for auto-batching tasks with different index creation rights.