### PR TITLE
Fix import resource leak

### DIFF
--- a/meilisearch-http/tests/dumps/mod.rs
+++ b/meilisearch-http/tests/dumps/mod.rs
@@ -8,7 +8,6 @@ use self::data::GetDump;
 
 // all the following test are ignored on windows. See #2364
 #[actix_rt::test]
-#[cfg_attr(target_os = "windows", ignore)]
 async fn import_dump_v1() {
     let temp = tempfile::tempdir().unwrap();
 
@@ -31,7 +30,6 @@ async fn import_dump_v1() {
 }
 
 #[actix_rt::test]
-#[cfg_attr(target_os = "windows", ignore)]
 async fn import_dump_v2_movie_raw() {
     let temp = tempfile::tempdir().unwrap();
 
@@ -95,7 +93,6 @@ async fn import_dump_v2_movie_raw() {
 }
 
 #[actix_rt::test]
-#[cfg_attr(target_os = "windows", ignore)]
 async fn import_dump_v2_movie_with_settings() {
     let temp = tempfile::tempdir().unwrap();
 
@@ -159,7 +156,6 @@ async fn import_dump_v2_movie_with_settings() {
 }
 
 #[actix_rt::test]
-#[cfg_attr(target_os = "windows", ignore)]
 async fn import_dump_v2_rubygems_with_settings() {
     let temp = tempfile::tempdir().unwrap();
 
@@ -223,7 +219,6 @@ async fn import_dump_v2_rubygems_with_settings() {
 }
 
 #[actix_rt::test]
-#[cfg_attr(target_os = "windows", ignore)]
 async fn import_dump_v3_movie_raw() {
     let temp = tempfile::tempdir().unwrap();
 
@@ -287,7 +282,6 @@ async fn import_dump_v3_movie_raw() {
 }
 
 #[actix_rt::test]
-#[cfg_attr(target_os = "windows", ignore)]
 async fn import_dump_v3_movie_with_settings() {
     let temp = tempfile::tempdir().unwrap();
 
@@ -351,7 +345,6 @@ async fn import_dump_v3_movie_with_settings() {
 }
 
 #[actix_rt::test]
-#[cfg_attr(target_os = "windows", ignore)]
 async fn import_dump_v3_rubygems_with_settings() {
     let temp = tempfile::tempdir().unwrap();
 
@@ -415,7 +408,6 @@ async fn import_dump_v3_rubygems_with_settings() {
 }
 
 #[actix_rt::test]
-#[cfg_attr(target_os = "windows", ignore)]
 async fn import_dump_v4_movie_raw() {
     let temp = tempfile::tempdir().unwrap();
 
@@ -479,7 +471,6 @@ async fn import_dump_v4_movie_raw() {
 }
 
 #[actix_rt::test]
-#[cfg_attr(target_os = "windows", ignore)]
 async fn import_dump_v4_movie_with_settings() {
     let temp = tempfile::tempdir().unwrap();
 
@@ -543,7 +534,6 @@ async fn import_dump_v4_movie_with_settings() {
 }
 
 #[actix_rt::test]
-#[cfg_attr(target_os = "windows", ignore)]
 async fn import_dump_v4_rubygems_with_settings() {
     let temp = tempfile::tempdir().unwrap();
 
@@ -607,7 +597,6 @@ async fn import_dump_v4_rubygems_with_settings() {
 }
 
 #[actix_rt::test]
-#[cfg_attr(target_os = "windows", ignore)]
 async fn import_dump_v5() {
     let temp = tempfile::tempdir().unwrap();
 

--- a/meilisearch-lib/src/dump/loaders/v5.rs
+++ b/meilisearch-lib/src/dump/loaders/v5.rs
@@ -37,9 +37,11 @@ pub fn load_dump(
         indexing_options,
     )?;
     UpdateFileStore::load_dump(src.as_ref(), &dst)?;
-    TaskStore::load_dump(&src, env)?;
+    TaskStore::load_dump(&src, env.clone())?;
     AuthController::load_dump(&src, &dst)?;
     analytics::copy_user_id(src.as_ref(), dst.as_ref());
+
+    env.as_ref().clone().prepare_for_closing();
 
     info!("Loading indexes.");
 


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #2878 

## What does this PR do?
After importing a database dump, the environment must be closed for two reasons:
1. If the dump is renamed while it is open, this allows the environment to be opened multiple times because the code that prevents this is based on the file path.
2. Windows does not normally allow a file to be renamed while it is open.

Unfortunately, there's a problem with the design of the `env` module in heed such that if you open a file and then drop the `Env` object, the environment will not be closed unless you try to open the same environment again with the same options and then call `prepare_for_closing`.

I noticed there are some places in meilisearch that do `if Arc::strong_count(&self.env) == 1 { self.env.as_ref().clone().prepare_for_closing(); }`, but not all places. This pattern is not thread safe and it's easy to mess up because the last code to execute must own the last reference to the `Arc`. With the current state of the code, that means `TaskStore::load_dump` needs to carefully manage the lifetime of it's `env` variable. If you just put the `if` statement in a `Drop` implementation for `TaskStore` and also at the bottom of `load_dump` it will not work. The last code in `load_dump` will run while there are two references, then the `drop` implementation will run and there will still be two references. The reference count will only reach 1 after Rust finishes dropping `TaskStore` as part of leaving `load_dump`, after executing the condition added to end of `load_dump`, and then the last reference will be dropped without executing the handler. There's also a problem because `Env` is `Clone` and this allows there to be more references to the environment than there are counted in the `Arc`. This pattern should probably be removed, but I worry just deleting it will cause additional problems.

I have a version of heed where dropping the last `Env` without calling `prepare_for_closing` on that `Env` or another pointing to the same path causes the environment to be closed, but the automated tests demonstrate a problem where multiple threads opening and closing the same environment without calling `prepare_for_closing` used to work and no longer does because the next thread to open the same path while `EnvInner::drop` is executing gets a `DatabaseClosing` error. Setting the tests to run single threaded would also fix it, but obviously any real code using threads the same way would have the same problem. I guess I could make it block until the close completes and open a new PR to heed if that's good.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
