### PR TITLE
Add error message for invalid task status

### DIFF
--- a/meilisearch-types/src/error.rs
+++ b/meilisearch-types/src/error.rs
@@ -147,6 +147,7 @@ pub enum Code {
     NoSpaceLeftOnDevice,
     DumpNotFound,
     TaskNotFound,
+    InvalidTaskStatus,
     PayloadTooLarge,
     RetrieveDocument,
     SearchDocuments,
@@ -232,6 +233,7 @@ impl Code {
                 ErrCode::authentication("missing_authorization_header", StatusCode::UNAUTHORIZED)
             }
             TaskNotFound => ErrCode::invalid("task_not_found", StatusCode::NOT_FOUND),
+            InvalidTaskStatus => ErrCode::invalid("invalid_task_status", StatusCode::BAD_REQUEST),
             DumpNotFound => ErrCode::invalid("dump_not_found", StatusCode::NOT_FOUND),
             NoSpaceLeftOnDevice => {
                 ErrCode::internal("no_space_left_on_device", StatusCode::INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #2940 

## What does this PR do?
- Makes Meilisearch show a correct error message for invalid task status as [this page](https://github.com/meilisearch/specifications/blob/main/text/0061-error-format-and-definitions.md#invalid_task_status) shows

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
