### PR TITLE
fix the index creation

### DIFF
--- a/index-scheduler/src/batch.rs
+++ b/index-scheduler/src/batch.rs
@@ -749,10 +749,8 @@ impl IndexScheduler {
                 let index_uid = op.index_uid();
                 let index = if must_create_index {
                     // create the index if it doesn't already exist
-                    let mut wtxn = self.env.write_txn()?;
-                    let index = self.index_mapper.create_index(&mut wtxn, index_uid)?;
-                    wtxn.commit()?;
-                    index
+                    let wtxn = self.env.write_txn()?;
+                    self.index_mapper.create_index(wtxn, index_uid)?
                 } else {
                     let rtxn = self.env.read_txn()?;
                     self.index_mapper.index(&rtxn, index_uid)?
@@ -765,12 +763,11 @@ impl IndexScheduler {
                 Ok(tasks)
             }
             Batch::IndexCreation { index_uid, primary_key, task } => {
-                let mut wtxn = self.env.write_txn()?;
+                let wtxn = self.env.write_txn()?;
                 if self.index_mapper.exists(&wtxn, &index_uid)? {
                     return Err(Error::IndexAlreadyExists(index_uid));
                 }
-                self.index_mapper.create_index(&mut wtxn, &index_uid)?;
-                wtxn.commit()?;
+                self.index_mapper.create_index(wtxn, &index_uid)?;
 
                 self.process_batch(Batch::IndexUpdate { index_uid, primary_key, task })
             }

--- a/index-scheduler/src/index_mapper.rs
+++ b/index-scheduler/src/index_mapper.rs
@@ -83,7 +83,14 @@ impl IndexMapper {
 
                 let index_path = self.base_path.join(uuid.to_string());
                 fs::create_dir_all(&index_path)?;
-                self.create_or_open_index(&index_path)
+                let index = self.create_or_open_index(&index_path)?;
+
+                // TODO: this is far from perfect. If the caller don't commit or fail his commit
+                // then we end up with an available index that should not exist and is actually
+                // not available in the index_mapping database.
+                self.index_map.write().unwrap().insert(uuid, Available(index.clone()));
+
+                Ok(index)
             }
             error => error,
         }

--- a/index-scheduler/src/index_mapper.rs
+++ b/index-scheduler/src/index_mapper.rs
@@ -89,7 +89,7 @@ impl IndexMapper {
                 let index = self.create_or_open_index(&index_path)?;
 
                 wtxn.commit()?;
-                // TODO: it would be better to lazyly create the index. But we need an Index::open function for milli.
+                // TODO: it would be better to lazily create the index. But we need an Index::open function for milli.
                 if let Some(BeingDeleted) =
                     self.index_map.write().unwrap().insert(uuid, Available(index.clone()))
                 {

--- a/index-scheduler/src/lib.rs
+++ b/index-scheduler/src/lib.rs
@@ -774,9 +774,8 @@ impl IndexScheduler {
 
     /// Create a new index without any associated task.
     pub fn create_raw_index(&self, name: &str) -> Result<Index> {
-        let mut wtxn = self.env.write_txn()?;
-        let index = self.index_mapper.create_index(&mut wtxn, name)?;
-        wtxn.commit()?;
+        let wtxn = self.env.write_txn()?;
+        let index = self.index_mapper.create_index(wtxn, name)?;
 
         Ok(index)
     }


### PR DESCRIPTION
When an index is being created we insert it in the index_map straight away to avoid someone else from trying to re-open it. The definitive fix should be made on milli's side
