### PR TITLE
isolate the search in another task

### DIFF
--- a/meilisearch-http/src/routes/indexes/search.rs
+++ b/meilisearch-http/src/routes/indexes/search.rs
@@ -153,7 +153,7 @@ pub async fn search_with_url_query(
     let mut aggregate = SearchAggregator::from_query(&query, &req);
 
     let index = index_scheduler.index(&index_uid)?;
-    let search_result = perform_search(&index, query);
+    let search_result = tokio::task::spawn_blocking(move || perform_search(&index, query)).await?;
     if let Ok(ref search_result) = search_result {
         aggregate.succeed(search_result);
     }
@@ -185,7 +185,7 @@ pub async fn search_with_post(
     let mut aggregate = SearchAggregator::from_query(&query, &req);
 
     let index = index_scheduler.index(&index_uid)?;
-    let search_result = perform_search(&index, query);
+    let search_result = tokio::task::spawn_blocking(move || perform_search(&index, query)).await?;
     if let Ok(ref search_result) = search_result {
         aggregate.succeed(search_result);
     }


### PR DESCRIPTION
In case there is a failure on milli's side that should avoid blocking the tokio main thread
