### PR TITLE
Reconsider the Windows tests

### DIFF
--- a/meilisearch-http/tests/auth/tenant_token.rs
+++ b/meilisearch-http/tests/auth/tenant_token.rs
@@ -203,7 +203,6 @@ macro_rules! compute_forbidden_search {
 }
 
 #[actix_rt::test]
-#[cfg_attr(target_os = "windows", ignore)]
 async fn search_authorized_simple_token() {
     let tenant_tokens = vec![
         hashmap! {
@@ -252,7 +251,6 @@ async fn search_authorized_simple_token() {
 }
 
 #[actix_rt::test]
-#[cfg_attr(target_os = "windows", ignore)]
 async fn search_authorized_filter_token() {
     let tenant_tokens = vec![
         hashmap! {
@@ -306,7 +304,6 @@ async fn search_authorized_filter_token() {
 }
 
 #[actix_rt::test]
-#[cfg_attr(target_os = "windows", ignore)]
 async fn filter_search_authorized_filter_token() {
     let tenant_tokens = vec![
         hashmap! {
@@ -360,7 +357,6 @@ async fn filter_search_authorized_filter_token() {
 }
 
 #[actix_rt::test]
-#[cfg_attr(target_os = "windows", ignore)]
 async fn error_search_token_forbidden_parent_key() {
     let tenant_tokens = vec![
         hashmap! {
@@ -393,7 +389,6 @@ async fn error_search_token_forbidden_parent_key() {
 }
 
 #[actix_rt::test]
-#[cfg_attr(target_os = "windows", ignore)]
 async fn error_search_forbidden_token() {
     let tenant_tokens = vec![
         // bad index
@@ -448,7 +443,6 @@ async fn error_search_forbidden_token() {
 }
 
 #[actix_rt::test]
-#[cfg_attr(target_os = "windows", ignore)]
 async fn error_access_forbidden_routes() {
     let mut server = Server::new_auth().await;
     server.use_api_key("MASTER_KEY");
@@ -483,7 +477,6 @@ async fn error_access_forbidden_routes() {
 }
 
 #[actix_rt::test]
-#[cfg_attr(target_os = "windows", ignore)]
 async fn error_access_expired_parent_key() {
     use std::{thread, time};
     let mut server = Server::new_auth().await;
@@ -523,7 +516,6 @@ async fn error_access_expired_parent_key() {
 }
 
 #[actix_rt::test]
-#[cfg_attr(target_os = "windows", ignore)]
 async fn error_access_modified_token() {
     let mut server = Server::new_auth().await;
     server.use_api_key("MASTER_KEY");

--- a/meilisearch-http/tests/dumps/mod.rs
+++ b/meilisearch-http/tests/dumps/mod.rs
@@ -8,6 +8,7 @@ use crate::common::{default_settings, GetAllDocumentsOptions, Server};
 
 // all the following test are ignored on windows. See #2364
 #[actix_rt::test]
+#[cfg_attr(target_os = "windows", ignore)]
 async fn import_dump_v1() {
     let temp = tempfile::tempdir().unwrap();
 

--- a/meilisearch-http/tests/dumps/mod.rs
+++ b/meilisearch-http/tests/dumps/mod.rs
@@ -8,7 +8,6 @@ use crate::common::{default_settings, GetAllDocumentsOptions, Server};
 
 // all the following test are ignored on windows. See #2364
 #[actix_rt::test]
-#[cfg_attr(target_os = "windows", ignore)]
 async fn import_dump_v1() {
     let temp = tempfile::tempdir().unwrap();
 
@@ -25,7 +24,6 @@ async fn import_dump_v1() {
 }
 
 #[actix_rt::test]
-#[cfg_attr(target_os = "windows", ignore)]
 async fn import_dump_v2_movie_raw() {
     let temp = tempfile::tempdir().unwrap();
 
@@ -87,7 +85,6 @@ async fn import_dump_v2_movie_raw() {
 }
 
 #[actix_rt::test]
-#[cfg_attr(target_os = "windows", ignore)]
 async fn import_dump_v2_movie_with_settings() {
     let temp = tempfile::tempdir().unwrap();
 
@@ -151,7 +148,6 @@ async fn import_dump_v2_movie_with_settings() {
 }
 
 #[actix_rt::test]
-#[cfg_attr(target_os = "windows", ignore)]
 async fn import_dump_v2_rubygems_with_settings() {
     let temp = tempfile::tempdir().unwrap();
 
@@ -215,7 +211,6 @@ async fn import_dump_v2_rubygems_with_settings() {
 }
 
 #[actix_rt::test]
-#[cfg_attr(target_os = "windows", ignore)]
 async fn import_dump_v3_movie_raw() {
     let temp = tempfile::tempdir().unwrap();
 
@@ -277,7 +272,6 @@ async fn import_dump_v3_movie_raw() {
 }
 
 #[actix_rt::test]
-#[cfg_attr(target_os = "windows", ignore)]
 async fn import_dump_v3_movie_with_settings() {
     let temp = tempfile::tempdir().unwrap();
 
@@ -341,7 +335,6 @@ async fn import_dump_v3_movie_with_settings() {
 }
 
 #[actix_rt::test]
-#[cfg_attr(target_os = "windows", ignore)]
 async fn import_dump_v3_rubygems_with_settings() {
     let temp = tempfile::tempdir().unwrap();
 
@@ -405,7 +398,6 @@ async fn import_dump_v3_rubygems_with_settings() {
 }
 
 #[actix_rt::test]
-#[cfg_attr(target_os = "windows", ignore)]
 async fn import_dump_v4_movie_raw() {
     let temp = tempfile::tempdir().unwrap();
 
@@ -467,7 +459,6 @@ async fn import_dump_v4_movie_raw() {
 }
 
 #[actix_rt::test]
-#[cfg_attr(target_os = "windows", ignore)]
 async fn import_dump_v4_movie_with_settings() {
     let temp = tempfile::tempdir().unwrap();
 
@@ -531,7 +522,6 @@ async fn import_dump_v4_movie_with_settings() {
 }
 
 #[actix_rt::test]
-#[cfg_attr(target_os = "windows", ignore)]
 async fn import_dump_v4_rubygems_with_settings() {
     let temp = tempfile::tempdir().unwrap();
 
@@ -595,7 +585,6 @@ async fn import_dump_v4_rubygems_with_settings() {
 }
 
 #[actix_rt::test]
-#[cfg_attr(target_os = "windows", ignore)]
 async fn import_dump_v5() {
     let temp = tempfile::tempdir().unwrap();
 

--- a/meilisearch-http/tests/index/delete_index.rs
+++ b/meilisearch-http/tests/index/delete_index.rs
@@ -44,7 +44,6 @@ async fn error_delete_unexisting_index() {
 }
 
 #[actix_rt::test]
-#[cfg_attr(target_os = "windows", ignore)]
 async fn loop_delete_add_documents() {
     let server = Server::new().await;
     let index = server.index("test");


### PR DESCRIPTION
This PR removes the `ignore` cfg on top of a lot of our tests. Now that we reworked the index scheduler we can make them pass again!

Fixes #2038, fixes #1966.