### PR TITLE
Fix dump import without instance uid

### DIFF
--- a/dump/src/reader/v6/mod.rs
+++ b/dump/src/reader/v6/mod.rs
@@ -1,7 +1,6 @@
 use std::fs::{self, File};
 use std::io::{BufRead, BufReader, ErrorKind};
 use std::path::Path;
-use std::str::FromStr;
 
 pub use meilisearch_types::milli;
 use tempfile::TempDir;

--- a/dump/src/reader/v6/mod.rs
+++ b/dump/src/reader/v6/mod.rs
@@ -1,5 +1,5 @@
 use std::fs::{self, File};
-use std::io::{BufRead, BufReader};
+use std::io::{BufRead, BufReader, ErrorKind};
 use std::path::Path;
 use std::str::FromStr;
 
@@ -44,7 +44,7 @@ pub type Code = meilisearch_types::error::Code;
 
 pub struct V6Reader {
     dump: TempDir,
-    instance_uid: Uuid,
+    instance_uid: Option<Uuid>,
     metadata: Metadata,
     tasks: BufReader<File>,
     keys: BufReader<File>,
@@ -53,8 +53,11 @@ pub struct V6Reader {
 impl V6Reader {
     pub fn open(dump: TempDir) -> Result<Self> {
         let meta_file = fs::read(dump.path().join("metadata.json"))?;
-        let instance_uid = fs::read_to_string(dump.path().join("instance_uid.uuid"))?;
-        let instance_uid = Uuid::from_str(&instance_uid)?;
+        let instance_uid = match fs::read_to_string(dump.path().join("instance_uid.uuid")) {
+            Ok(uuid) => Some(Uuid::parse_str(&uuid)?),
+            Err(e) if e.kind() == ErrorKind::NotFound => None,
+            Err(e) => return Err(e.into()),
+        };
 
         Ok(V6Reader {
             metadata: serde_json::from_reader(&*meta_file)?,
@@ -74,7 +77,7 @@ impl V6Reader {
     }
 
     pub fn instance_uid(&self) -> Result<Option<Uuid>> {
-        Ok(Some(self.instance_uid))
+        Ok(self.instance_uid)
     }
 
     pub fn indexes(&self) -> Result<Box<dyn Iterator<Item = Result<V6IndexReader>> + '_>> {


### PR DESCRIPTION
When creating a dump without any instance-uid (that can happen if you’ve always run meilisearch with the `--no-analytics` flag), you could get an error when trying to load the dump.
