### PR TITLE
temporary uses nextest in the CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,6 +31,11 @@ jobs:
       with:
         command: build
         args: --locked --release --no-default-features
+    - name: Install cargo-nextest
+      uses: actions-rs/cargo@v1
+      with:
+        command: install
+        args: cargo-nextest
     - name: Run cargo test
       uses: actions-rs/cargo@v1
       with:
@@ -50,6 +55,11 @@ jobs:
           override: true
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2.0.0
+      - name: Install cargo-nextest
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: cargo-nextest
       - name: Run tests in debug
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,8 +34,8 @@ jobs:
     - name: Run cargo test
       uses: actions-rs/cargo@v1
       with:
-        command: test
-        args: --locked --release
+        command: nextest
+        args: run --locked --release
 
   # We run tests in debug also, to make sure that the debug_assertions are hit
   test-debug:
@@ -53,8 +53,8 @@ jobs:
       - name: Run tests in debug
         uses: actions-rs/cargo@v1
         with:
-          command: test
-          args: --locked
+          command: nextest
+          args: run --locked
 
   clippy:
     name: Run Clippy


### PR DESCRIPTION
When we running cargo test we have a lot of tests that become flaky and trigger a deadlock. The issue seems to be linked to the fact that cargo test run all the tests in multiple threads instead of multiple environment. Thus, as a temporary fix I would like to move our test suite over nextest that run each test in a separate process.

Once this is merged we should open an issue to remove nextest from our CI.
The reason being that it doesn't run the doctests. We don't have a lot of doctests in meilisearch since we ship a binary and not a lib but I think it would be better to check the full test suite in the CI.