### PR TITLE
Extract the dates out of the dumpv4.

### DIFF
--- a/dump/src/reader/v4/mod.rs
+++ b/dump/src/reader/v4/mod.rs
@@ -23,6 +23,7 @@ pub type Checked = settings::Checked;
 pub type Unchecked = settings::Unchecked;
 
 pub type Task = tasks::Task;
+pub type TaskEvent = tasks::TaskEvent;
 pub type Key = keys::Key;
 
 // everything related to the settings
@@ -100,6 +101,7 @@ impl V4Reader {
             V4IndexReader::new(
                 index.uid.clone(),
                 &self.dump.path().join("indexes").join(index.index_meta.uuid.to_string()),
+                BufReader::new(self.tasks.get_ref().try_clone().unwrap()),
             )
         }))
     }
@@ -147,16 +149,31 @@ pub struct V4IndexReader {
 }
 
 impl V4IndexReader {
-    pub fn new(name: String, path: &Path) -> Result<Self> {
+    pub fn new(name: String, path: &Path, tasks: BufReader<File>) -> Result<Self> {
         let meta = File::open(path.join("meta.json"))?;
         let meta: DumpMeta = serde_json::from_reader(meta)?;
+
+        let mut index_tasks: Vec<Task> = vec![];
+
+        for line in tasks.lines() {
+            let task: Task = serde_json::from_str(&line?)?;
+
+            if task.index_uid.to_string() == name {
+                index_tasks.push(task)
+            }
+        }
 
         let metadata = IndexMetadata {
             uid: name,
             primary_key: meta.primary_key,
-            // FIXME: Iterate over the whole task queue to find the creation and last update date.
-            created_at: OffsetDateTime::now_utc(),
-            updated_at: OffsetDateTime::now_utc(),
+            created_at: match index_tasks.first().unwrap().events.first() {
+                Some(TaskEvent::Created(ts)) => *ts,
+                _ => OffsetDateTime::now_utc(),
+            },
+            updated_at: match index_tasks.last().unwrap().events.last() {
+                Some(TaskEvent::Created(ts)) => *ts,
+                _ => OffsetDateTime::now_utc(),
+            },
         };
 
         let ret = V4IndexReader {


### PR DESCRIPTION
Hi there, 

please review this PR that tries to fix #2987. I'm still learning Rust and I found that #2987 is an excellent way for me to read and learn what others do with Rust. So please excuse my semantics ...

Stay safe and healthy.

---

# Pull Request

This patch possibly fixes #2987.

This patch introduces a way to fill the IndexMetadata.created_at and IndexMetadata.updated_at keys from the tasks events. This is done by reading the creation date of the first event (created_at) and the creation date of the last event (updated_at).


## Related issue
Fixes #2987

## What does this PR do?
- Extract the dates out of the dumpv4.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
