### PR TITLE
Extract the dates out of the dumpv5.

### DIFF
--- a/dump/src/reader/v5/mod.rs
+++ b/dump/src/reader/v5/mod.rs
@@ -208,7 +208,7 @@ impl V5IndexReader {
         for line in tasks.lines() {
             let task: Task = serde_json::from_str(&line?)?;
 
-            if task.index_uid().unwrap_or_default().to_string() == name {
+            if *task.index_uid().unwrap_or_default().to_string() == name {
                 if updated_at.is_none() {
                     updated_at = task.updated_at()
                 }

--- a/dump/src/reader/v5/mod.rs
+++ b/dump/src/reader/v5/mod.rs
@@ -56,7 +56,6 @@ pub type Checked = settings::Checked;
 pub type Unchecked = settings::Unchecked;
 
 pub type Task = tasks::Task;
-pub type TaskEvent = tasks::TaskEvent;
 pub type Key = keys::Key;
 
 // ===== Other types to clarify the code of the compat module

--- a/dump/src/reader/v5/mod.rs
+++ b/dump/src/reader/v5/mod.rs
@@ -142,7 +142,7 @@ impl V5Reader {
             V5IndexReader::new(
                 index.uid.clone(),
                 &self.dump.path().join("indexes").join(index.index_meta.uuid.to_string()),
-                BufReader::new(self.tasks.get_ref().try_clone().unwrap()),
+                BufReader::new(File::open(&self.dump.path().join("updates").join("data.jsonl")).unwrap()),
             )
         }))
     }

--- a/dump/src/reader/v5/mod.rs
+++ b/dump/src/reader/v5/mod.rs
@@ -210,15 +210,11 @@ impl V5IndexReader {
 
             if *task.index_uid().unwrap_or_default().to_string() == name {
                 if updated_at.is_none() {
-                    updated_at = task.updated_at()
-                }
-
-                if created_at.is_none() {
-                    created_at = task.created_at()
+                    updated_at = task.processed_at()
                 }
 
                 if task.id as usize == index_metadata.creation_task_id {
-                    created_at = task.processed_at();
+                    created_at = task.created_at();
 
                     break;
                 }

--- a/dump/src/reader/v5/mod.rs
+++ b/dump/src/reader/v5/mod.rs
@@ -143,7 +143,7 @@ impl V5Reader {
                 &self.dump.path().join("indexes").join(index.index_meta.uuid.to_string()),
                 &index.index_meta,
                 BufReader::new(
-                    File::open(&self.dump.path().join("updates").join("data.jsonl")).unwrap(),
+                    File::open(self.dump.path().join("updates").join("data.jsonl")).unwrap(),
                 ),
             )
         }))

--- a/dump/src/reader/v5/tasks.rs
+++ b/dump/src/reader/v5/tasks.rs
@@ -179,13 +179,6 @@ impl Task {
             _ => None,
         }
     }
-
-    pub fn updated_at(&self) -> Option<OffsetDateTime> {
-        match self.events.last() {
-            Some(TaskEvent::Created(ts)) => Some(*ts),
-            _ => None,
-        }
-    }
 }
 
 impl IndexUid {

--- a/dump/src/reader/v5/tasks.rs
+++ b/dump/src/reader/v5/tasks.rs
@@ -179,6 +179,14 @@ impl Task {
             _ => None,
         }
     }
+
+
+    pub fn updated_at(&self) -> Option<OffsetDateTime> {
+        match self.events.last() {
+            Some(TaskEvent::Created(ts)) => Some(*ts),
+            _ => None,
+        }
+    }
 }
 
 impl IndexUid {

--- a/dump/src/reader/v5/tasks.rs
+++ b/dump/src/reader/v5/tasks.rs
@@ -180,7 +180,6 @@ impl Task {
         }
     }
 
-
     pub fn updated_at(&self) -> Option<OffsetDateTime> {
         match self.events.last() {
             Some(TaskEvent::Created(ts)) => Some(*ts),

--- a/dump/src/reader/v5/tasks.rs
+++ b/dump/src/reader/v5/tasks.rs
@@ -140,6 +140,13 @@ impl Task {
             TaskContent::Dump { .. } => None,
         }
     }
+
+    pub fn processed_at(&self) -> Option<OffsetDateTime> {
+        match self.events.last() {
+            Some(TaskEvent::Succeeded { result: _, timestamp }) => Some(*timestamp),
+            _ => None,
+        }
+    }
 }
 
 impl IndexUid {

--- a/dump/src/reader/v5/tasks.rs
+++ b/dump/src/reader/v5/tasks.rs
@@ -147,6 +147,38 @@ impl Task {
             _ => None,
         }
     }
+
+    pub fn created_at(&self) -> Option<OffsetDateTime> {
+        match &self.content {
+            TaskContent::IndexCreation { index_uid: _, primary_key: _ } => {
+                match self.events.first() {
+                    Some(TaskEvent::Created(ts)) => Some(*ts),
+                    _ => None,
+                }
+            }
+            TaskContent::DocumentAddition {
+                index_uid: _,
+                content_uuid: _,
+                merge_strategy: _,
+                primary_key: _,
+                documents_count: _,
+                allow_index_creation: _,
+            } => match self.events.first() {
+                Some(TaskEvent::Created(ts)) => Some(*ts),
+                _ => None,
+            },
+            TaskContent::SettingsUpdate {
+                index_uid: _,
+                settings: _,
+                is_deletion: _,
+                allow_index_creation: _,
+            } => match self.events.first() {
+                Some(TaskEvent::Created(ts)) => Some(*ts),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
 }
 
 impl IndexUid {


### PR DESCRIPTION
Hi there, 

please review this PR that tries to fix #2986. I'm still learning Rust and I found that #2986 is an excellent way for me to read and learn what others do with Rust. So please excuse my semantics ...

Stay safe and healthy.

---

# Pull Request

This patch possibly fixes #2986.

This patch introduces a way to fill the IndexMetadata.created_at and IndexMetadata.updated_at keys from the tasks events. This is done by reading the creation date of the first event (created_at) and the creation date of the last event (updated_at).


## Related issue
Fixes #2986

## What does this PR do?
- Extract the dates out of the dumpv5.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
