### PR TITLE
Replace deprecated set-output in GitHub actions

### DIFF
--- a/.github/workflows/milestone-workflow.yml
+++ b/.github/workflows/milestone-workflow.yml
@@ -42,7 +42,6 @@ jobs:
           if [[ $MILESTONE_VERSION =~ ^v[0-9]+\.[0-9]+\.0$ ]]; then
             echo 'This is NOT a patch release'
             echo "is-patch=false" >> $GITHUB_OUTPUT
-
           elif [[ $MILESTONE_VERSION =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo 'This is a patch release'
             echo "is-patch=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/milestone-workflow.yml
+++ b/.github/workflows/milestone-workflow.yml
@@ -41,11 +41,11 @@ jobs:
           echo version: $MILESTONE_VERSION
           if [[ $MILESTONE_VERSION =~ ^v[0-9]+\.[0-9]+\.0$ ]]; then
             echo 'This is NOT a patch release'
-            echo "is-patch=false" >> ${GITHUB_OUTPUT}
+            echo "is-patch=false" >> $GITHUB_OUTPUT
 
           elif [[ $MILESTONE_VERSION =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo 'This is a patch release'
-            echo "is-patch=true" >> ${GITHUB_OUTPUT}
+            echo "is-patch=true" >> $GITHUB_OUTPUT
           else
             echo "Not a valid format of release, check the Milestone's title."
             echo 'Should be vX.Y.Z'

--- a/.github/workflows/milestone-workflow.yml
+++ b/.github/workflows/milestone-workflow.yml
@@ -41,10 +41,11 @@ jobs:
           echo version: $MILESTONE_VERSION
           if [[ $MILESTONE_VERSION =~ ^v[0-9]+\.[0-9]+\.0$ ]]; then
             echo 'This is NOT a patch release'
-            echo ::set-output name=is-patch::false
+            echo "is-patch=false" >> ${GITHUB_OUTPUT}
+
           elif [[ $MILESTONE_VERSION =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo 'This is a patch release'
-            echo ::set-output name=is-patch::true
+            echo "is-patch=true" >> ${GITHUB_OUTPUT}
           else
             echo "Not a valid format of release, check the Milestone's title."
             echo 'Should be vX.Y.Z'

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -25,7 +25,7 @@ jobs:
           if [[ $escaped_tag =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "stable=true" >> ${GITHUB_OUTPUT}
           else
-            echo "stable=false" >> ${GITHUB_OUTPUT}
+            echo "stable=false" >> $GITHUB_OUTPUT
           fi
       - name: Check release validity
         if: github.event_name != 'schedule' && steps.check-tag-format.outputs.stable == 'true'

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -23,9 +23,9 @@ jobs:
           escaped_tag=$(printf "%q" ${{ github.ref_name }})
 
           if [[ $escaped_tag =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo ::set-output name=stable::true
+            echo "stable=true" >> ${GITHUB_OUTPUT}
           else
-            echo ::set-output name=stable::false
+            echo "stable=false" >> ${GITHUB_OUTPUT}
           fi
       - name: Check release validity
         if: github.event_name != 'schedule' && steps.check-tag-format.outputs.stable == 'true'
@@ -66,7 +66,7 @@ jobs:
         file: target/release/${{ matrix.artifact_name }}
         asset_name: ${{ matrix.asset_name }}
         tag: ${{ github.ref }}
-        
+
   publish-macos-apple-silicon:
     name: Publish binary for macOS silicon
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -23,7 +23,7 @@ jobs:
           escaped_tag=$(printf "%q" ${{ github.ref_name }})
 
           if [[ $escaped_tag =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "stable=true" >> ${GITHUB_OUTPUT}
+            echo "stable=true" >> $GITHUB_OUTPUT
           else
             echo "stable=false" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -25,7 +25,7 @@ jobs:
           escaped_tag=$(printf "%q" ${{ github.ref_name }})
 
           if [[ $escaped_tag =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "stable=true" >> ${GITHUB_OUTPUT}
+            echo "stable=true" >> $GITHUB_OUTPUT
           else
             echo "stable=false" >> ${GITHUB_OUTPUT}
           fi

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -27,7 +27,7 @@ jobs:
           if [[ $escaped_tag =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "stable=true" >> $GITHUB_OUTPUT
           else
-            echo "stable=false" >> ${GITHUB_OUTPUT}
+            echo "stable=false" >> $GITHUB_OUTPUT
           fi
 
       # Check only the validity of the tag for official releases (not for pre-releases or other tags)

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -1,10 +1,10 @@
 ---
 on:
   schedule:
-    - cron: '0 4 * * *' # Every day at 4:00am
+    - cron: "0 4 * * *" # Every day at 4:00am
   push:
     tags:
-      - '*'
+      - "*"
 
 name: Publish tagged images to Docker Hub
 
@@ -25,9 +25,9 @@ jobs:
           escaped_tag=$(printf "%q" ${{ github.ref_name }})
 
           if [[ $escaped_tag =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo ::set-output name=stable::true
+            echo "stable=true" >> ${GITHUB_OUTPUT}
           else
-            echo ::set-output name=stable::false
+            echo "stable=false" >> ${GITHUB_OUTPUT}
           fi
 
       # Check only the validity of the tag for official releases (not for pre-releases or other tags)

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -1,10 +1,10 @@
 ---
 on:
   schedule:
-    - cron: "0 4 * * *" # Every day at 4:00am
+    - cron: '0 4 * * *' # Every day at 4:00am
   push:
     tags:
-      - "*"
+      - '*'
 
 name: Publish tagged images to Docker Hub
 


### PR DESCRIPTION
# Pull Request

This patch fixes #3011.

This patch fixes the deprecation warning regarding the usage of `set-output`.
This patch fixes the issues by switching the following format:

```
echo ::set-output name=[name]::[value]
```

into the following format:

```
echo "[name]=[value]" >> ${GITHUB_OUTPUT}
```


## Related issue
Fixes #3011

## What does this PR do?
- Fix CI/CD deprecation warnings.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
