### PR TITLE
Name spawned threads

### DIFF
--- a/meilisearch-http/src/option.rs
+++ b/meilisearch-http/src/option.rs
@@ -501,8 +501,10 @@ impl TryFrom<&IndexerOpts> for IndexerConfig {
     type Error = anyhow::Error;
 
     fn try_from(other: &IndexerOpts) -> Result<Self, Self::Error> {
-        let thread_pool =
-            rayon::ThreadPoolBuilder::new().num_threads(*other.max_indexing_threads).build()?;
+        let thread_pool = rayon::ThreadPoolBuilder::new()
+            .thread_name(|index| format!("indexing-thread:{index}"))
+            .num_threads(*other.max_indexing_threads)
+            .build()?;
 
         Ok(Self {
             log_every_n: Some(other.log_every_n),


### PR DESCRIPTION
# Pull Request

## Related issue
None, this is to improve debuggability

## What does this PR do?
- This PR replaces the raw `thread::spawn(...)` calls by `thread::Builder::new().name(...).spawn(...).unwrap()` calls so that we can give meaningful names to threads. 
- This PR also setup the `rayon` thread pool to give a name to its threads.
- This improves debuggability, as the thread names are reported by debuggers:

<img width="411" alt="Capture d’écran 2022-11-16 à 10 26 27" src="https://user-images.githubusercontent.com/41078892/202141870-a88663aa-d2f8-494f-b4da-709fdbd072ba.png">

(screen showing vscode's debugger and its main/scheduler/indexing threads)

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
