### PR TITLE
Prepend question mark to the `originalFilters` of the task deletion and cancelation

### DIFF
--- a/meilisearch-http/src/routes/tasks.rs
+++ b/meilisearch-http/src/routes/tasks.rs
@@ -537,7 +537,7 @@ async fn delete_tasks(
         &index_scheduler.filters().search_rules.authorized_indexes(),
     )?;
     let task_deletion =
-        KindWithContent::TaskDeletion { query: req.query_string().to_string(), tasks };
+        KindWithContent::TaskDeletion { query: format!("?{}", req.query_string()), tasks };
 
     let task = task::spawn_blocking(move || index_scheduler.register(task_deletion)).await??;
     let task: SummarizedTaskView = task.into();

--- a/meilisearch-http/src/routes/tasks.rs
+++ b/meilisearch-http/src/routes/tasks.rs
@@ -485,7 +485,7 @@ async fn cancel_tasks(
         &index_scheduler.filters().search_rules.authorized_indexes(),
     )?;
     let task_cancelation =
-        KindWithContent::TaskCancelation { query: req.query_string().to_string(), tasks };
+        KindWithContent::TaskCancelation { query: format!("?{}", req.query_string()), tasks };
 
     let task = task::spawn_blocking(move || index_scheduler.register(task_cancelation)).await??;
     let task: SummarizedTaskView = task.into();

--- a/meilisearch-http/tests/tasks/mod.rs
+++ b/meilisearch-http/tests/tasks/mod.rs
@@ -837,7 +837,7 @@ async fn test_summarized_task_deletion() {
       "details": {
         "matchedTasks": 1,
         "deletedTasks": 1,
-        "originalFilters": "uids=0"
+        "originalFilters": "?uids=0"
       },
       "error": null,
       "duration": "[duration]",

--- a/meilisearch-http/tests/tasks/mod.rs
+++ b/meilisearch-http/tests/tasks/mod.rs
@@ -804,7 +804,7 @@ async fn test_summarized_task_cancelation() {
       "details": {
         "matchedTasks": 1,
         "canceledTasks": 0,
-        "originalFilters": "uids=0"
+        "originalFilters": "?uids=0"
       },
       "error": null,
       "duration": "[duration]",


### PR DESCRIPTION
This pull request fixes #3064 by prepending [the HTTP query question mark](https://en.wikipedia.org/wiki/Question_mark#Computing) to the `originalFilters` of the task deletion and cancelation.