### PR TITLE
Rename `matchedDocuments` into `providedIds`

### DIFF
--- a/dump/src/reader/compat/v5_to_v6.rs
+++ b/dump/src/reader/compat/v5_to_v6.rs
@@ -143,7 +143,7 @@ impl CompatV5ToV6 {
                             received_document_ids,
                             deleted_documents,
                         } => v6::Details::DocumentDeletion {
-                            matched_documents: received_document_ids,
+                            provided_ids: received_document_ids,
                             deleted_documents,
                         },
                         v5::Details::ClearAll { deleted_documents } => {

--- a/index-scheduler/src/batch.rs
+++ b/index-scheduler/src/batch.rs
@@ -1075,7 +1075,7 @@ impl IndexScheduler {
                 for (task, documents) in tasks.iter_mut().zip(documents) {
                     task.status = Status::Succeeded;
                     task.details = Some(Details::DocumentDeletion {
-                        matched_documents: documents.len(),
+                        provided_ids: documents.len(),
                         deleted_documents: Some(deleted_documents.min(documents.len() as u64)),
                     });
                 }

--- a/index-scheduler/src/insta_snapshot.rs
+++ b/index-scheduler/src/insta_snapshot.rs
@@ -175,7 +175,7 @@ fn snapshot_details(d: &Details) -> String {
             format!("{{ primary_key: {primary_key:?} }}")
         }
         Details::DocumentDeletion {
-            matched_documents: received_document_ids,
+            provided_ids: received_document_ids,
             deleted_documents,
         } => format!("{{ received_document_ids: {received_document_ids}, deleted_documents: {deleted_documents:?} }}"),
         Details::ClearAll { deleted_documents } => {

--- a/index-scheduler/src/utils.rs
+++ b/index-scheduler/src/utils.rs
@@ -427,7 +427,7 @@ impl IndexScheduler {
                         _ => panic!(),
                     },
                     Details::DocumentDeletion {
-                        matched_documents: received_document_ids,
+                        provided_ids: received_document_ids,
                         deleted_documents,
                     } => {
                         if let Some(deleted_documents) = deleted_documents {

--- a/meilisearch-http/src/routes/tasks.rs
+++ b/meilisearch-http/src/routes/tasks.rs
@@ -86,7 +86,7 @@ pub struct DetailsView {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub primary_key: Option<Option<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub matched_documents: Option<usize>,
+    pub provided_ids: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deleted_documents: Option<Option<u64>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -123,10 +123,10 @@ impl From<Details> for DetailsView {
                 DetailsView { primary_key: Some(primary_key), ..DetailsView::default() }
             }
             Details::DocumentDeletion {
-                matched_documents: received_document_ids,
+                provided_ids: received_document_ids,
                 deleted_documents,
             } => DetailsView {
-                matched_documents: Some(received_document_ids),
+                provided_ids: Some(received_document_ids),
                 deleted_documents: Some(deleted_documents),
                 ..DetailsView::default()
             },

--- a/meilisearch-http/tests/tasks/mod.rs
+++ b/meilisearch-http/tests/tasks/mod.rs
@@ -411,7 +411,7 @@ async fn test_summarized_delete_batch() {
       "type": "documentDeletion",
       "canceledBy": null,
       "details": {
-        "matchedDocuments": 3,
+        "providedIds": 3,
         "deletedDocuments": 0
       },
       "error": {
@@ -441,7 +441,7 @@ async fn test_summarized_delete_batch() {
       "type": "documentDeletion",
       "canceledBy": null,
       "details": {
-        "matchedDocuments": 1,
+        "providedIds": 1,
         "deletedDocuments": 0
       },
       "error": null,
@@ -470,7 +470,7 @@ async fn test_summarized_delete_document() {
       "type": "documentDeletion",
       "canceledBy": null,
       "details": {
-        "matchedDocuments": 1,
+        "providedIds": 1,
         "deletedDocuments": 0
       },
       "error": {
@@ -500,7 +500,7 @@ async fn test_summarized_delete_document() {
       "type": "documentDeletion",
       "canceledBy": null,
       "details": {
-        "matchedDocuments": 1,
+        "providedIds": 1,
         "deletedDocuments": 0
       },
       "error": null,

--- a/meilisearch-types/src/tasks.rs
+++ b/meilisearch-types/src/tasks.rs
@@ -196,7 +196,7 @@ impl KindWithContent {
             }
             KindWithContent::DocumentDeletion { index_uid: _, documents_ids } => {
                 Some(Details::DocumentDeletion {
-                    matched_documents: documents_ids.len(),
+                    provided_ids: documents_ids.len(),
                     deleted_documents: None,
                 })
             }
@@ -239,7 +239,7 @@ impl KindWithContent {
             }
             KindWithContent::DocumentDeletion { index_uid: _, documents_ids } => {
                 Some(Details::DocumentDeletion {
-                    matched_documents: documents_ids.len(),
+                    provided_ids: documents_ids.len(),
                     deleted_documents: Some(0),
                 })
             }
@@ -466,7 +466,7 @@ pub enum Details {
     DocumentAdditionOrUpdate { received_documents: u64, indexed_documents: Option<u64> },
     SettingsUpdate { settings: Box<Settings<Unchecked>> },
     IndexInfo { primary_key: Option<String> },
-    DocumentDeletion { matched_documents: usize, deleted_documents: Option<u64> },
+    DocumentDeletion { provided_ids: usize, deleted_documents: Option<u64> },
     ClearAll { deleted_documents: Option<u64> },
     TaskCancelation { matched_tasks: u64, canceled_tasks: Option<u64>, original_filters: String },
     TaskDeletion { matched_tasks: u64, deleted_tasks: Option<u64>, original_filters: String },


### PR DESCRIPTION
This PR fixes https://github.com/meilisearch/meilisearch/issues/3078.