### PR TITLE
Bump the `milli` and `grenad` dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1332,8 +1332,8 @@ dependencies = [
 
 [[package]]
 name = "filter-parser"
-version = "0.35.1"
-source = "git+https://github.com/meilisearch/milli.git?tag=v0.35.1#c3b75bbe5dad27aab76fe5a0d0c70aaadf81c48c"
+version = "0.37.0"
+source = "git+https://github.com/meilisearch/milli.git?tag=v0.37.0#57c9f03e514436a2cca799b2a28cd89247682be0"
 dependencies = [
  "nom",
  "nom_locate",
@@ -1351,8 +1351,8 @@ dependencies = [
 
 [[package]]
 name = "flatten-serde-json"
-version = "0.35.1"
-source = "git+https://github.com/meilisearch/milli.git?tag=v0.35.1#c3b75bbe5dad27aab76fe5a0d0c70aaadf81c48c"
+version = "0.37.0"
+source = "git+https://github.com/meilisearch/milli.git?tag=v0.37.0#57c9f03e514436a2cca799b2a28cd89247682be0"
 dependencies = [
  "serde_json",
 ]
@@ -1616,8 +1616,8 @@ checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "heed"
-version = "0.12.2"
-source = "git+https://github.com/meilisearch/heed?tag=v0.12.3#076971765f4ce09591ed7e19e45ea817580a53e3"
+version = "0.12.4"
+source = "git+https://github.com/meilisearch/heed?tag=v0.12.4#7a4542bc72dd60ef0f508c89900ea292218223fb"
 dependencies = [
  "byteorder",
  "heed-traits",
@@ -1634,12 +1634,12 @@ dependencies = [
 [[package]]
 name = "heed-traits"
 version = "0.7.0"
-source = "git+https://github.com/meilisearch/heed?tag=v0.12.3#076971765f4ce09591ed7e19e45ea817580a53e3"
+source = "git+https://github.com/meilisearch/heed?tag=v0.12.4#7a4542bc72dd60ef0f508c89900ea292218223fb"
 
 [[package]]
 name = "heed-types"
 version = "0.7.2"
-source = "git+https://github.com/meilisearch/heed?tag=v0.12.3#076971765f4ce09591ed7e19e45ea817580a53e3"
+source = "git+https://github.com/meilisearch/heed?tag=v0.12.4#7a4542bc72dd60ef0f508c89900ea292218223fb"
 dependencies = [
  "bincode",
  "heed-traits",
@@ -1897,8 +1897,8 @@ dependencies = [
 
 [[package]]
 name = "json-depth-checker"
-version = "0.35.1"
-source = "git+https://github.com/meilisearch/milli.git?tag=v0.35.1#c3b75bbe5dad27aab76fe5a0d0c70aaadf81c48c"
+version = "0.37.0"
+source = "git+https://github.com/meilisearch/milli.git?tag=v0.37.0#57c9f03e514436a2cca799b2a28cd89247682be0"
 dependencies = [
  "serde_json",
 ]
@@ -2154,8 +2154,8 @@ checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
 name = "lmdb-rkv-sys"
-version = "0.15.0"
-source = "git+https://github.com/meilisearch/lmdb-rs#8f0fe377a98d177cabbd056e777778f559df2bb6"
+version = "0.15.1"
+source = "git+https://github.com/meilisearch/lmdb-rs#5592bf5a812905cf0c633404ef8f8f4057112c65"
 dependencies = [
  "cc",
  "libc",
@@ -2416,8 +2416,8 @@ dependencies = [
 
 [[package]]
 name = "milli"
-version = "0.35.1"
-source = "git+https://github.com/meilisearch/milli.git?tag=v0.35.1#c3b75bbe5dad27aab76fe5a0d0c70aaadf81c48c"
+version = "0.37.0"
+source = "git+https://github.com/meilisearch/milli.git?tag=v0.37.0#57c9f03e514436a2cca799b2a28cd89247682be0"
 dependencies = [
  "bimap",
  "bincode",

--- a/meilisearch-types/Cargo.toml
+++ b/meilisearch-types/Cargo.toml
@@ -12,7 +12,7 @@ either = { version = "1.6.1", features = ["serde"] }
 enum-iterator = "1.1.3"
 flate2 = "1.0.24"
 fst = "0.4.7"
-milli = { git = "https://github.com/meilisearch/milli.git", tag = "v0.35.1", default-features = false }
+milli = { git = "https://github.com/meilisearch/milli.git", tag = "v0.37.0", default-features = false }
 proptest = { version = "1.0.0", optional = true }
 proptest-derive = { version = "0.3.0", optional = true }
 roaring = { version = "0.10.0", features = ["serde"] }


### PR DESCRIPTION
This PR is bumping the milli direct and the grenad indirect dependencies.