### PR TITLE
Fix total memory computation

### DIFF
--- a/meilisearch-http/src/option.rs
+++ b/meilisearch-http/src/option.rs
@@ -575,7 +575,7 @@ fn total_memory_bytes() -> Option<u64> {
         let memory_kind = RefreshKind::new().with_memory();
         let mut system = System::new_with_specifics(memory_kind);
         system.refresh_memory();
-        Some(system.total_memory() * 1024) // KiB into bytes
+        Some(system.total_memory())
     } else {
         None
     }


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #3018 

## What does this PR do?
- Don't multiply the total memory value returned by sysinfo by 1024 anymore:
  According to the [changelog of sysinfo 0.26.0](https://github.com/GuillaumeGomez/sysinfo/blob/master/CHANGELOG.md#0260), units are now in bytes and not KBs.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
