### PR TITLE
Add a dispatch to the publish binaries workflow

### DIFF
--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -1,4 +1,5 @@
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 2 * * *' # Every day at 2:00am
   release:


### PR DESCRIPTION
This PR adds a dispatch to the publish binaries workflow to help us debug #3094.