### PR TITLE
Fix publish release CI

### DIFF
--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -18,7 +18,7 @@ jobs:
       # If yes, it means we are publishing an official release.
       # If no, we are releasing a RC, so no need to check the version.
       - name: Check tag format
-        if: github.event_name != 'schedule'
+        if: github.event_name == 'release'
         id: check-tag-format
         run: |
           escaped_tag=$(printf "%q" ${{ github.ref_name }})
@@ -29,7 +29,7 @@ jobs:
             echo ::set-output name=stable::false
           fi
       - name: Check release validity
-        if: github.event_name != 'schedule' && steps.check-tag-format.outputs.stable == 'true'
+        if: github.event_name == 'release' && steps.check-tag-format.outputs.stable == 'true'
         run: bash .github/scripts/check-release.sh
 
   publish:
@@ -60,14 +60,14 @@ jobs:
       run: cargo build --release --locked
     # No need to upload binaries for dry run (cron)
     - name: Upload binaries to release
-      if: github.event_name != 'schedule'
+      if: github.event_name == 'release'
       uses: svenstaro/upload-release-action@v1-release
       with:
         repo_token: ${{ secrets.MEILI_BOT_GH_PAT }}
         file: target/release/${{ matrix.artifact_name }}
         asset_name: ${{ matrix.asset_name }}
         tag: ${{ github.ref }}
-        
+
   publish-macos-apple-silicon:
     name: Publish binary for macOS silicon
     runs-on: ${{ matrix.os }}
@@ -98,7 +98,7 @@ jobs:
           args: --release --target ${{ matrix.target }}
       - name: Upload the binary to release
         # No need to upload binaries for dry run (cron)
-        if: github.event_name != 'schedule'
+        if: github.event_name == 'release'
         uses: svenstaro/upload-release-action@v1-release
         with:
           repo_token: ${{ secrets.MEILI_BOT_GH_PAT }}
@@ -168,7 +168,7 @@ jobs:
 
       - name: Upload the binary to release
         # No need to upload binaries for dry run (cron)
-        if: github.event_name != 'schedule'
+        if: github.event_name == 'release'
         uses: svenstaro/upload-release-action@v1-release
         with:
           repo_token: ${{ secrets.MEILI_BOT_GH_PAT }}


### PR DESCRIPTION
Fix CI to avoid release creation when triggering manually the CI with `workflow_dispatch` -> only trigger the upload of binary when the event is `release` instead of different of `schedule`