### PR TITLE
Always display `deletedDocuments` in the `IndexDeletion` details

### DIFF
--- a/index-scheduler/src/snapshots/lib.rs/document_addition_and_index_deletion/1.snap
+++ b/index-scheduler/src/snapshots/lib.rs/document_addition_and_index_deletion/1.snap
@@ -8,7 +8,7 @@ source: index-scheduler/src/lib.rs
 ### All Tasks:
 0 {uid: 0, status: enqueued, details: { primary_key: None }, kind: IndexCreation { index_uid: "doggos", primary_key: None }}
 1 {uid: 1, status: enqueued, details: { received_documents: 1, indexed_documents: None }, kind: DocumentAdditionOrUpdate { index_uid: "doggos", primary_key: Some("id"), method: ReplaceDocuments, content_file: 00000000-0000-0000-0000-000000000000, documents_count: 1, allow_index_creation: true }}
-2 {uid: 2, status: enqueued, kind: IndexDeletion { index_uid: "doggos" }}
+2 {uid: 2, status: enqueued, details: { deleted_documents: None }, kind: IndexDeletion { index_uid: "doggos" }}
 ----------------------------------------------------------------------
 ### Status:
 enqueued [0,1,2,]

--- a/index-scheduler/src/snapshots/lib.rs/document_addition_and_index_deletion_on_unexisting_index/1.snap
+++ b/index-scheduler/src/snapshots/lib.rs/document_addition_and_index_deletion_on_unexisting_index/1.snap
@@ -7,7 +7,7 @@ source: index-scheduler/src/lib.rs
 ----------------------------------------------------------------------
 ### All Tasks:
 0 {uid: 0, status: enqueued, details: { received_documents: 1, indexed_documents: None }, kind: DocumentAdditionOrUpdate { index_uid: "doggos", primary_key: Some("id"), method: ReplaceDocuments, content_file: 00000000-0000-0000-0000-000000000000, documents_count: 1, allow_index_creation: true }}
-1 {uid: 1, status: enqueued, kind: IndexDeletion { index_uid: "doggos" }}
+1 {uid: 1, status: enqueued, details: { deleted_documents: None }, kind: IndexDeletion { index_uid: "doggos" }}
 ----------------------------------------------------------------------
 ### Status:
 enqueued [0,1,]

--- a/index-scheduler/src/snapshots/lib.rs/insert_task_while_another_task_is_processing/1.snap
+++ b/index-scheduler/src/snapshots/lib.rs/insert_task_while_another_task_is_processing/1.snap
@@ -8,7 +8,7 @@ source: index-scheduler/src/lib.rs
 ### All Tasks:
 0 {uid: 0, status: enqueued, details: { primary_key: Some("id") }, kind: IndexCreation { index_uid: "index_a", primary_key: Some("id") }}
 1 {uid: 1, status: enqueued, details: { primary_key: Some("id") }, kind: IndexCreation { index_uid: "index_b", primary_key: Some("id") }}
-2 {uid: 2, status: enqueued, kind: IndexDeletion { index_uid: "index_a" }}
+2 {uid: 2, status: enqueued, details: { deleted_documents: None }, kind: IndexDeletion { index_uid: "index_a" }}
 ----------------------------------------------------------------------
 ### Status:
 enqueued [0,1,2,]

--- a/meilisearch-http/tests/tasks/mod.rs
+++ b/meilisearch-http/tests/tasks/mod.rs
@@ -654,6 +654,9 @@ async fn test_summarized_index_deletion() {
       "status": "failed",
       "type": "indexDeletion",
       "canceledBy": null,
+      "details": {
+        "deletedDocuments": 0
+      },
       "error": {
         "message": "Index `test` not found.",
         "code": "index_not_found",

--- a/meilisearch-types/src/tasks.rs
+++ b/meilisearch-types/src/tasks.rs
@@ -200,13 +200,12 @@ impl KindWithContent {
                     deleted_documents: None,
                 })
             }
-            KindWithContent::DocumentClear { .. } => {
+            KindWithContent::DocumentClear { .. } | KindWithContent::IndexDeletion { .. } => {
                 Some(Details::ClearAll { deleted_documents: None })
             }
             KindWithContent::SettingsUpdate { new_settings, .. } => {
                 Some(Details::SettingsUpdate { settings: new_settings.clone() })
             }
-            KindWithContent::IndexDeletion { .. } => None,
             KindWithContent::IndexCreation { primary_key, .. }
             | KindWithContent::IndexUpdate { primary_key, .. } => {
                 Some(Details::IndexInfo { primary_key: primary_key.clone() })


### PR DESCRIPTION
This PR fixes #3108 by always displaying a `deletedDocuments` details info.