### PR TITLE
Improve download-latest.sh script: integrate apple-silicon binary

### DIFF
--- a/download-latest.sh
+++ b/download-latest.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # This script can optionally use a GitHub token to increase your request limit (for example, if using this script in a CI).
-# To make it work, fill the GITHUB_PAT environment variable with your GitHub token.
+# To use a GitHub token, pass it through the GITHUB_PAT environment variable.
 
 # GLOBALS
 

--- a/download-latest.sh
+++ b/download-latest.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# This script works with a GitHub token to increase your request limit (for example, if using this script in a CI).
+# This script can optionally use a GitHub token to increase your request limit (for example, if using this script in a CI).
 # To make it work, fill the GITHUB_PAT environment variable with your GitHub token.
 
 # GLOBALS

--- a/download-latest.sh
+++ b/download-latest.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# This script works with a GitHub token to increase your request limit (for example, if using this script in a CI).
+# To make it work, fill the GITHUB_PAT environment variable with your GitHub token.
+
 # GLOBALS
 
 # Colors
@@ -17,8 +20,8 @@ GITHUB_REL='https://github.com/meilisearch/meilisearch/releases/download/'
 
 # FUNCTIONS
 
-# Create GITHUB_PAT environment variable once you acquired the token to start using it.
-# Returns the tag of the latest stable release (in terms of semver and not of release date).
+# Gets the version of the latest stable version of Meilisearch by setting the $latest variable.
+# Returns 0 in case of success, 1 otherwise.
 get_latest() {
     # temp_file is needed because the grep would start before the download is over
     temp_file=$(mktemp -q /tmp/$PNAME.XXXXXXXXX)
@@ -71,9 +74,9 @@ get_archi() {
         archi='amd64'
         ;;
     'arm64')
-        # MacOS M1
+        # macOS M1/M2
         if [ $os = 'macos' ]; then
-            archi='amd64'
+            archi='apple-silicon'
         else
             archi='aarch64'
         fi

--- a/download-latest.sh
+++ b/download-latest.sh
@@ -10,9 +10,6 @@ DEFAULT='\033[0m'
 # Project name
 PNAME='meilisearch'
 
-# Version regexp i.e. v[number].[number].[number]
-GREP_SEMVER_REGEXP='v\([0-9]*\)[.]\([0-9]*\)[.]\([0-9]*\)$'
-
 # GitHub API address
 GITHUB_API='https://api.github.com/repos/meilisearch/meilisearch/releases'
 # GitHub Release address
@@ -20,126 +17,26 @@ GITHUB_REL='https://github.com/meilisearch/meilisearch/releases/download/'
 
 # FUNCTIONS
 
-# semverParseInto and semverLT from: https://github.com/cloudflare/semver_bash/blob/master/semver.sh
-# usage: semverParseInto version major minor patch special
-# version: the string version
-# major, minor, patch, special: will be assigned by the function
-semverParseInto() {
-    local RE='[^0-9]*\([0-9]*\)[.]\([0-9]*\)[.]\([0-9]*\)\([0-9A-Za-z-]*\)'
-    # MAJOR
-    eval $2=`echo $1 | sed -e "s#$RE#\1#"`
-    # MINOR
-    eval $3=`echo $1 | sed -e "s#$RE#\2#"`
-    # PATCH
-    eval $4=`echo $1 | sed -e "s#$RE#\3#"`
-    # SPECIAL
-    eval $5=`echo $1 | sed -e "s#$RE#\4#"`
-}
-
-# usage: semverLT version1 version2
-semverLT() {
-    local MAJOR_A=0
-    local MINOR_A=0
-    local PATCH_A=0
-    local SPECIAL_A=0
-
-    local MAJOR_B=0
-    local MINOR_B=0
-    local PATCH_B=0
-    local SPECIAL_B=0
-
-    semverParseInto $1 MAJOR_A MINOR_A PATCH_A SPECIAL_A
-    semverParseInto $2 MAJOR_B MINOR_B PATCH_B SPECIAL_B
-
-    if [ $MAJOR_A -lt $MAJOR_B ]; then
-        return 0
-    fi
-    if [ $MAJOR_A -le $MAJOR_B ] && [ $MINOR_A -lt $MINOR_B ]; then
-        return 0
-    fi
-    if [ $MAJOR_A -le $MAJOR_B ] && [ $MINOR_A -le $MINOR_B ] && [ $PATCH_A -lt $PATCH_B ]; then
-        return 0
-    fi
-    if [ "_$SPECIAL_A"  == '_' ] && [ "_$SPECIAL_B"  == '_' ] ; then
-        return 1
-    fi
-    if [ "_$SPECIAL_A"  == '_' ] && [ "_$SPECIAL_B"  != '_' ] ; then
-        return 1
-    fi
-    if [ "_$SPECIAL_A"  != '_' ] && [ "_$SPECIAL_B"  == '_' ] ; then
-        return 0
-    fi
-    if [ "_$SPECIAL_A" < "_$SPECIAL_B" ]; then
-        return 0
-    fi
-
-    return 1
-}
-
-# Get a token from: https://github.com/settings/tokens to increase rate limit (from 60 to 5000),
-# make sure the token scope is set to 'public_repo'.
 # Create GITHUB_PAT environment variable once you acquired the token to start using it.
 # Returns the tag of the latest stable release (in terms of semver and not of release date).
 get_latest() {
     # temp_file is needed because the grep would start before the download is over
     temp_file=$(mktemp -q /tmp/$PNAME.XXXXXXXXX)
+    latest_release="$GITHUB_API/latest"
+
     if [ $? -ne 0 ]; then
-        echo "$0: Can't create temp file, bye bye.."
+        echo "$0: Can't create temp file."
+        fetch_release_failure_usage
         exit 1
     fi
 
     if [ -z "$GITHUB_PAT" ]; then
-        curl -s $GITHUB_API > "$temp_file" || return 1
+        curl -s "$latest_release" > "$temp_file" || return 1
     else
-        curl -H "Authorization: token $GITHUB_PAT" -s $GITHUB_API > "$temp_file" || return 1
+        curl -H "Authorization: token $GITHUB_PAT" -s "$latest_release" > "$temp_file" || return 1
     fi
 
-    releases=$(cat "$temp_file" | \
-        grep -E '"tag_name":|"draft":|"prerelease":' \
-        | tr -d ',"' | cut -d ':' -f2 | tr -d ' ')
-        # Returns a list of [tag_name draft_boolean prerelease_boolean ...]
-        # Ex: v0.10.1 false false v0.9.1-rc.1 false true v0.9.0 false false...
-
-    i=0
-    latest=''
-    current_tag=''
-    for release_info in $releases; do
-        # Checking tag_name
-        if [ $i -eq 0 ]; then
-            # If it's not an alpha or beta release
-            if echo "$release_info" | grep -q "$GREP_SEMVER_REGEXP"; then
-                current_tag=$release_info
-            else
-                current_tag=''
-            fi
-            i=1
-        # Checking draft boolean
-        elif [ $i -eq 1 ]; then
-            if [ "$release_info" = 'true' ]; then
-                current_tag=''
-            fi
-            i=2
-        # Checking prerelease boolean
-        elif [ $i -eq 2 ]; then
-            if [ "$release_info" = 'true' ]; then
-                current_tag=''
-            fi
-            i=0
-            # If the current_tag is valid
-            if [ "$current_tag" != '' ]; then
-                # If there is no latest yes
-                if [ "$latest" = '' ]; then
-                    latest="$current_tag"
-                else
-                    # Comparing latest and the current tag
-                    semverLT $current_tag $latest
-                    if [ $? -eq 1 ]; then
-                        latest="$current_tag"
-                    fi
-                fi
-            fi
-        fi
-    done
+    latest="$(cat "$temp_file" | grep '"tag_name":' | cut -d ':' -f2 | tr -d '"' | tr -d ',' | tr -d ' ')"
 
     rm -f "$temp_file"
     return 0
@@ -210,12 +107,13 @@ fetch_release_failure_usage() {
     echo ''
     printf "$RED%s\n$DEFAULT" 'ERROR: Impossible to get the latest stable version of Meilisearch.'
     echo 'Please let us know about this issue: https://github.com/meilisearch/meilisearch/issues/new/choose'
+    echo ''
+    echo 'In the meantime, you can manually download the appropriate binary from the GitHub release assets here: https://github.com/meilisearch/meilisearch/releases/latest'
 }
 
 fill_release_variables() {
     # Fill $latest variable.
     if ! get_latest; then
-        # TO CHANGE.
         fetch_release_failure_usage
         exit 1
     fi


### PR DESCRIPTION
Fixes multiples issues: https://github.com/meilisearch/meilisearch/issues/3044, https://github.com/meilisearch/meilisearch/issues/3027, https://github.com/meilisearch/meilisearch/issues/2613, https://github.com/meilisearch/meilisearch/issues/3014


Improvement/Addition
- https://github.com/meilisearch/meilisearch/issues/3044
- https://github.com/meilisearch/meilisearch/issues/3027

Simplification
- With https://github.com/meilisearch/meilisearch/issues/3014, we removed the complex part to get the latest version of Meilisearch we can now get directly with the GitHub API

Bug fixes:
- Should remove the problem the users encountered in this issue (https://github.com/meilisearch/meilisearch/issues/2613) because the related part has been removed from the script