### PR TITLE
Add CI to push a latest git tag for every stable Meilisearch release

### DIFF
--- a/.github/workflows/latest-git-tag.yml
+++ b/.github/workflows/latest-git-tag.yml
@@ -1,0 +1,19 @@
+# Create or update a latest git tag when releasing a stable vesrsin of Meilisearch
+name: Update latest git tag
+on:
+  workflow_dispatch:
+  release:
+    types: [released]
+
+jobs:
+  update-latest-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: rickstaa/action-create-tag@v1
+        with:
+          tag: "latest"
+          message: "Latest stable release of Meilisearch"
+          # Move the tag if `latest` already exists
+          force_push_tag: true
+          github_token: ${{ secrets.MEILI_BOT_GH_PAT }}

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -3,8 +3,12 @@ on:
   schedule:
     - cron: '0 4 * * *' # Every day at 4:00am
   push:
-    tags:
-      - '*'
+    # Will run for every tag pushed except `latest`
+    # When the `latest` git tag is created with this [CI](../latest-git-tag.yml)
+    # we don't need to create a Docker `latest` image again.
+    # The `latest` Docker image push is already done in this CI when releasing a stable version of Meilisearch.
+    tags-ignore:
+      - latest
 
 name: Publish tagged images to Docker Hub
 


### PR DESCRIPTION
Fixes partially #3147.

- Add a CI to add/update a `latest` git tag ONLY when releasing a stable version of Meilisearch (not for pre-release or for custom tag for prototypes)
- Update the Docker CI to avoid being triggered when `latest` git tag is pushed: the CI is still triggered when a git tag is pushed, except for the `latest` tag.
Reminder: the `latest` Docker image is already created and pushed when releasing a stable version of Meilisearch. This step is already present in our current Docker CI.