### PR TITLE
Use ubuntu-latest when not impacting

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,7 +6,7 @@ name: Execute code coverage
 
 jobs:
   nightly-coverage:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/publish-deb-brew-pkg.yml
+++ b/.github/workflows/publish-deb-brew-pkg.yml
@@ -1,4 +1,4 @@
-name: Publish deb pkg to GitHub release & APT repository & Homebrew
+name: Publish to APT repository & Homebrew
 
 on:
   release:
@@ -38,7 +38,7 @@ jobs:
 
   homebrew:
     name: Bump Homebrew formula
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     needs: check-version
     steps:
       - name: Create PR to Homebrew


### PR DESCRIPTION
Minor changes
- Use `ubuntu-latest` for CI where there is no compilation
- rename one of the workflow (obsolete name)