### PR TITLE
Use ubuntu-latest for Docker CI

### DIFF
--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -14,7 +14,7 @@ name: Publish tagged images to Docker Hub
 
 jobs:
   docker:
-    runs-on: docker
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Ensuring it's worth to still use a personal GitHub runner

Just push `test-docker-ci` tag on this branch, to check using `ubuntu-latest`, so the native GitHub runner, is way more slower than our personal GitHub runner
https://github.com/meilisearch/meilisearch/actions/runs/3621631699