### PR TITLE
Fixup dumps-destination -> dump-directory section header in help link

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -45,7 +45,7 @@ log_level = "INFO"
 
 dump_dir = "dumps/"
 # Sets the directory where Meilisearch will create dump files.
-# https://docs.meilisearch.com/learn/configuration/instance_options.html#dumps-destination
+# https://docs.meilisearch.com/learn/configuration/instance_options.html#dump-directory
 
 # import_dump = "./path/to/my/file.dump"
 # Imports the dump file located at the specified path. Path must point to a .dump file.


### PR DESCRIPTION
# Pull Request

## Related issue
See https://github.com/meilisearch/product/discussions/560#discussioncomment-4323938

## What does this PR do?
- change link in help message to the future new section header #dump-directory