### PR TITLE
Bring back v0.30.1 changes to `main`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "dump"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "anyhow",
  "big_s",
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "file-store"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "faux",
  "tempfile",
@@ -1767,7 +1767,7 @@ dependencies = [
 
 [[package]]
 name = "index-scheduler"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "anyhow",
  "big_s",
@@ -2257,7 +2257,7 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "meili-snap"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "insta",
  "md5",
@@ -2266,7 +2266,7 @@ dependencies = [
 
 [[package]]
 name = "meilisearch-auth"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "enum-iterator",
  "hmac",
@@ -2283,7 +2283,7 @@ dependencies = [
 
 [[package]]
 name = "meilisearch-http"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "actix-cors",
  "actix-http",
@@ -2366,7 +2366,7 @@ dependencies = [
 
 [[package]]
 name = "meilisearch-types"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -2747,7 +2747,7 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "permissive-json-pointer"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "big_s",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1625,7 +1625,7 @@ dependencies = [
  "libc",
  "lmdb-rkv-sys",
  "once_cell",
- "page_size",
+ "page_size 0.4.2",
  "synchronoise",
  "url",
  "zerocopy",
@@ -1783,6 +1783,7 @@ dependencies = [
  "meili-snap",
  "meilisearch-types",
  "nelson",
+ "page_size 0.5.0",
  "roaring",
  "serde",
  "serde_json",
@@ -2658,6 +2659,16 @@ name = "page_size"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eebde548fbbf1ea81a99b128872779c437752fb99f217c45245e1a61dcd9edcd"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "page_size"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b7663cbd190cfd818d08efa8497f6cd383076688c49a391ef7c0d03cd12b561"
 dependencies = [
  "libc",
  "winapi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1332,8 +1332,8 @@ dependencies = [
 
 [[package]]
 name = "filter-parser"
-version = "0.37.0"
-source = "git+https://github.com/meilisearch/milli.git?tag=v0.37.0#57c9f03e514436a2cca799b2a28cd89247682be0"
+version = "0.37.1"
+source = "git+https://github.com/meilisearch/milli.git?tag=v0.37.1#e1b2113cd9a467410841a254286e5e25961af43e"
 dependencies = [
  "nom",
  "nom_locate",
@@ -1351,8 +1351,8 @@ dependencies = [
 
 [[package]]
 name = "flatten-serde-json"
-version = "0.37.0"
-source = "git+https://github.com/meilisearch/milli.git?tag=v0.37.0#57c9f03e514436a2cca799b2a28cd89247682be0"
+version = "0.37.1"
+source = "git+https://github.com/meilisearch/milli.git?tag=v0.37.1#e1b2113cd9a467410841a254286e5e25961af43e"
 dependencies = [
  "serde_json",
 ]
@@ -1897,8 +1897,8 @@ dependencies = [
 
 [[package]]
 name = "json-depth-checker"
-version = "0.37.0"
-source = "git+https://github.com/meilisearch/milli.git?tag=v0.37.0#57c9f03e514436a2cca799b2a28cd89247682be0"
+version = "0.37.1"
+source = "git+https://github.com/meilisearch/milli.git?tag=v0.37.1#e1b2113cd9a467410841a254286e5e25961af43e"
 dependencies = [
  "serde_json",
 ]
@@ -2416,8 +2416,8 @@ dependencies = [
 
 [[package]]
 name = "milli"
-version = "0.37.0"
-source = "git+https://github.com/meilisearch/milli.git?tag=v0.37.0#57c9f03e514436a2cca799b2a28cd89247682be0"
+version = "0.37.1"
+source = "git+https://github.com/meilisearch/milli.git?tag=v0.37.1#e1b2113cd9a467410841a254286e5e25961af43e"
 dependencies = [
  "bimap",
  "bincode",

--- a/dump/Cargo.toml
+++ b/dump/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dump"
-version = "0.30.0"
+version = "0.30.1"
 edition = "2021"
 
 [dependencies]

--- a/dump/src/writer.rs
+++ b/dump/src/writer.rs
@@ -295,7 +295,7 @@ pub(crate) mod test {
         insta::assert_json_snapshot!(metadata, { ".dumpDate" => "[date]" }, @r###"
         {
           "dumpVersion": "V6",
-          "dbVersion": "0.30.0",
+          "dbVersion": "0.30.1",
           "dumpDate": "[date]"
         }
         "###);

--- a/file-store/Cargo.toml
+++ b/file-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file-store"
-version = "0.30.0"
+version = "0.30.1"
 edition = "2021"
 
 [dependencies]

--- a/index-scheduler/Cargo.toml
+++ b/index-scheduler/Cargo.toml
@@ -13,6 +13,7 @@ enum-iterator = "1.1.3"
 file-store = { path = "../file-store" }
 log = "0.4.14"
 meilisearch-types = { path = "../meilisearch-types" }
+page_size = "0.5.0"
 roaring = { version = "0.10.0", features = ["serde"] }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = { version = "1.0.85", features = ["preserve_order"] }

--- a/index-scheduler/Cargo.toml
+++ b/index-scheduler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "index-scheduler"
-version = "0.30.0"
+version = "0.30.1"
 edition = "2021"
 
 [dependencies]

--- a/index-scheduler/src/index_mapper.rs
+++ b/index-scheduler/src/index_mapper.rs
@@ -13,7 +13,7 @@ use uuid::Uuid;
 
 use self::IndexStatus::{Available, BeingDeleted};
 use crate::uuid_codec::UuidCodec;
-use crate::{Error, Result};
+use crate::{clamp_to_page_size, Error, Result};
 
 const INDEX_MAPPING: &str = "index-mapping";
 
@@ -68,7 +68,7 @@ impl IndexMapper {
     /// The path *must* exists or an error will be thrown.
     fn create_or_open_index(&self, path: &Path) -> Result<Index> {
         let mut options = EnvOpenOptions::new();
-        options.map_size(self.index_size);
+        options.map_size(clamp_to_page_size(self.index_size));
         options.max_readers(1024);
         Ok(Index::new(options, path)?)
     }

--- a/index-scheduler/src/lib.rs
+++ b/index-scheduler/src/lib.rs
@@ -1112,8 +1112,8 @@ mod tests {
                 indexes_path: tempdir.path().join("indexes"),
                 snapshots_path: tempdir.path().join("snapshots"),
                 dumps_path: tempdir.path().join("dumps"),
-                task_db_size: 1024 * 1024, // 1 MiB
-                index_size: 1024 * 1024,   // 1 MiB
+                task_db_size: 1000 * 1000, // 1 MB, we don't use MiB on purpose.
+                index_size: 1000 * 1000,   // 1 MB, we don't use MiB on purpose.
                 indexer_config: IndexerConfig::default(),
                 autobatching_enabled,
             };

--- a/index-scheduler/src/lib.rs
+++ b/index-scheduler/src/lib.rs
@@ -55,7 +55,7 @@ use utils::{filter_out_references_to_newer_tasks, keep_tasks_within_datetimes, m
 use uuid::Uuid;
 
 use crate::index_mapper::IndexMapper;
-use crate::utils::check_index_swap_validity;
+use crate::utils::{check_index_swap_validity, clamp_to_page_size};
 
 pub(crate) type BEI128 =
     meilisearch_types::heed::zerocopy::I128<meilisearch_types::heed::byteorder::BE>;
@@ -362,7 +362,7 @@ impl IndexScheduler {
 
         let env = heed::EnvOpenOptions::new()
             .max_dbs(10)
-            .map_size(options.task_db_size)
+            .map_size(clamp_to_page_size(options.task_db_size))
             .open(options.tasks_path)?;
         let file_store = FileStore::new(&options.update_file_path)?;
 

--- a/index-scheduler/src/utils.rs
+++ b/index-scheduler/src/utils.rs
@@ -324,6 +324,11 @@ pub(crate) fn check_index_swap_validity(task: &Task) -> Result<()> {
     Ok(())
 }
 
+/// Clamp the provided value to be a multiple of system page size.
+pub fn clamp_to_page_size(size: usize) -> usize {
+    size / page_size::get() * page_size::get()
+}
+
 #[cfg(test)]
 impl IndexScheduler {
     /// Asserts that the index scheduler's content is internally consistent.

--- a/meili-snap/Cargo.toml
+++ b/meili-snap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "meili-snap"
-version = "0.30.0"
+version = "0.30.1"
 edition = "2021"
 
 [dependencies]

--- a/meilisearch-auth/Cargo.toml
+++ b/meilisearch-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "meilisearch-auth"
-version = "0.30.0"
+version = "0.30.1"
 edition = "2021"
 
 [dependencies]

--- a/meilisearch-http/Cargo.toml
+++ b/meilisearch-http/Cargo.toml
@@ -4,7 +4,7 @@ description = "Meilisearch HTTP server"
 edition = "2021"
 license = "MIT"
 name = "meilisearch-http"
-version = "0.30.0"
+version = "0.30.1"
 
 [[bin]]
 name = "meilisearch"

--- a/meilisearch-types/Cargo.toml
+++ b/meilisearch-types/Cargo.toml
@@ -12,7 +12,7 @@ either = { version = "1.6.1", features = ["serde"] }
 enum-iterator = "1.1.3"
 flate2 = "1.0.24"
 fst = "0.4.7"
-milli = { git = "https://github.com/meilisearch/milli.git", tag = "v0.37.0", default-features = false }
+milli = { git = "https://github.com/meilisearch/milli.git", tag = "v0.37.1", default-features = false }
 proptest = { version = "1.0.0", optional = true }
 proptest-derive = { version = "0.3.0", optional = true }
 roaring = { version = "0.10.0", features = ["serde"] }

--- a/meilisearch-types/Cargo.toml
+++ b/meilisearch-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "meilisearch-types"
-version = "0.30.0"
+version = "0.30.1"
 authors = ["marin <postma.marin@protonmail.com>"]
 edition = "2021"
 

--- a/permissive-json-pointer/Cargo.toml
+++ b/permissive-json-pointer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "permissive-json-pointer"
-version = "0.30.0"
+version = "0.30.1"
 edition = "2021"
 description = "A permissive json pointer"
 readme = "README.md"


### PR DESCRIPTION
I was not able to just import `release-v0.30.1` to `main`, see:
<img width="1371" alt="Capture d’écran 2022-12-06 à 20 03 50" src="https://user-images.githubusercontent.com/20380692/206000844-b39b3063-7da2-475f-b3e4-1791c39a7c2f.png">

So I cherry-picked the commits.

⚠️ ⚠️ ⚠️ I had a git conflict here

<img width="730" alt="Capture d’écran 2022-12-06 à 20 09 04" src="https://user-images.githubusercontent.com/20380692/206001007-f56bc28f-c0b1-46a0-bb60-cce4e73b9584.png">


⚠️ ⚠️ ⚠️ Check out carefully how I fixed it
