### PR TITLE
Setup COMMIT_SHA and COMMIT_DATE build args in the Docker image

### DIFF
--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -39,6 +39,14 @@ jobs:
         if: github.event_name != 'schedule' && steps.check-tag-format.outputs.stable == 'true'
         run: bash .github/scripts/check-release.sh
 
+      - name: Set build-args for Docker buildx
+        id: build-metadata
+        run: |
+          # Extract commit date
+          commit_date=$(git show -s --format=%cD ${{ github.sha }})
+
+          echo "date=$commit_date" >> $GITHUB_OUTPUT
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
 
@@ -72,6 +80,9 @@ jobs:
           push: ${{ github.event_name != 'schedule' }}
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
+          build-args: |
+            COMMIT_SHA=${{ github.sha }}
+            COMMIT_DATE=${{ steps.build-metadata.outputs.date }}
 
       # /!\ Don't touch this without checking with Cloud team
       - name: Send CI information to Cloud team


### PR DESCRIPTION
GitHub auto-closed my PR when I synced changes with my remote 🤷‍♂️  https://github.com/meilisearch/meilisearch/pull/2550

In any case, the summary of changes is quite similar:

- Fix `git` usage from my last attempt (when you use `actions/checkout`) you get the `git` command to use.
- Add the `build-args` definition from https://github.com/docker/build-push-action#inputs, which is supposed to work precisely as docker build `--build-arg`. 

Fixes https://github.com/meilisearch/meilisearch/issues/2028

The result will be like this:

<img width="556" alt="image" src="https://user-images.githubusercontent.com/4116980/206019608-2713559a-1f58-4ff3-9fec-7720783993ac.png">

