### PR TITLE
Stop snapshotting the version of meilisearch in the dump

### DIFF
--- a/dump/src/writer.rs
+++ b/dump/src/writer.rs
@@ -292,10 +292,10 @@ pub(crate) mod test {
         // ==== checking the top level infos
         let metadata = fs::read_to_string(dump_path.join("metadata.json")).unwrap();
         let metadata: Metadata = serde_json::from_str(&metadata).unwrap();
-        insta::assert_json_snapshot!(metadata, { ".dumpDate" => "[date]" }, @r###"
+        insta::assert_json_snapshot!(metadata, { ".dumpDate" => "[date]", ".dbVersion" => "[version]" }, @r###"
         {
           "dumpVersion": "V6",
-          "dbVersion": "0.30.1",
+          "dbVersion": "[version]",
           "dumpDate": "[date]"
         }
         "###);


### PR DESCRIPTION
It might change, and we don't want to update this test every time we make a new release.
