### PR TITLE
Bump milli to v0.37.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1332,8 +1332,8 @@ dependencies = [
 
 [[package]]
 name = "filter-parser"
-version = "0.37.3"
-source = "git+https://github.com/meilisearch/milli.git?tag=v0.37.3#2101e3c6d592f6ce6cc25b6e4585f3a8a6246457"
+version = "0.37.4"
+source = "git+https://github.com/meilisearch/milli.git?tag=v0.37.4#e1d7d7231338803f940734b4d54a2de99f6b3c6b"
 dependencies = [
  "nom",
  "nom_locate",
@@ -1351,8 +1351,8 @@ dependencies = [
 
 [[package]]
 name = "flatten-serde-json"
-version = "0.37.3"
-source = "git+https://github.com/meilisearch/milli.git?tag=v0.37.3#2101e3c6d592f6ce6cc25b6e4585f3a8a6246457"
+version = "0.37.4"
+source = "git+https://github.com/meilisearch/milli.git?tag=v0.37.4#e1d7d7231338803f940734b4d54a2de99f6b3c6b"
 dependencies = [
  "serde_json",
 ]
@@ -1898,8 +1898,8 @@ dependencies = [
 
 [[package]]
 name = "json-depth-checker"
-version = "0.37.3"
-source = "git+https://github.com/meilisearch/milli.git?tag=v0.37.3#2101e3c6d592f6ce6cc25b6e4585f3a8a6246457"
+version = "0.37.4"
+source = "git+https://github.com/meilisearch/milli.git?tag=v0.37.4#e1d7d7231338803f940734b4d54a2de99f6b3c6b"
 dependencies = [
  "serde_json",
 ]
@@ -2417,8 +2417,8 @@ dependencies = [
 
 [[package]]
 name = "milli"
-version = "0.37.3"
-source = "git+https://github.com/meilisearch/milli.git?tag=v0.37.3#2101e3c6d592f6ce6cc25b6e4585f3a8a6246457"
+version = "0.37.4"
+source = "git+https://github.com/meilisearch/milli.git?tag=v0.37.4#e1d7d7231338803f940734b4d54a2de99f6b3c6b"
 dependencies = [
  "bimap",
  "bincode",

--- a/meilisearch-types/Cargo.toml
+++ b/meilisearch-types/Cargo.toml
@@ -12,7 +12,7 @@ either = { version = "1.6.1", features = ["serde"] }
 enum-iterator = "1.1.3"
 flate2 = "1.0.24"
 fst = "0.4.7"
-milli = { git = "https://github.com/meilisearch/milli.git", tag = "v0.37.3", default-features = false }
+milli = { git = "https://github.com/meilisearch/milli.git", tag = "v0.37.4", default-features = false }
 proptest = { version = "1.0.0", optional = true }
 proptest-derive = { version = "0.3.0", optional = true }
 roaring = { version = "0.10.0", features = ["serde"] }


### PR DESCRIPTION
This PR bumps the milli dependency to v0.37.4 for the next Meilisearch release.