### PR TITLE
Use ubuntu-18.04 container instead of GitHub hosted actions

### DIFF
--- a/.github/workflows/flaky.yml
+++ b/.github/workflows/flaky.yml
@@ -6,10 +6,20 @@ on:
 
 jobs:
   flaky:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:18.04
 
     steps:
     - uses: actions/checkout@v3
+    - name: Install needed dependencies
+      run: |
+        apt-get update && apt-get install -y curl
+        apt-get install build-essential -y
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
     - name: Install cargo-flaky
       run: cargo install cargo-flaky
     - name: Run cargo flaky 100 times

--- a/.github/workflows/flaky.yml
+++ b/.github/workflows/flaky.yml
@@ -8,8 +8,8 @@ jobs:
   flaky:
     runs-on: ubuntu-latest
     container:
+      # Use ubuntu-18.04 to compile with glibc 2.27, which are the production expectations
       image: ubuntu:18.04
-
     steps:
     - uses: actions/checkout@v3
     - name: Install needed dependencies

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -37,6 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: check-version
     container:
+      # Use ubuntu-18.04 to compile with glibc 2.27
       image: ubuntu:18.04
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -97,7 +97,6 @@ jobs:
     name: Publish binary for macOS silicon
     runs-on: ${{ matrix.os }}
     needs: check-version
-    continue-on-error: false
     strategy:
       fail-fast: false
       matrix:
@@ -134,7 +133,6 @@ jobs:
     name: Publish binary for aarch64
     runs-on: ${{ matrix.os }}
     needs: check-version
-    continue-on-error: false
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -32,30 +32,55 @@ jobs:
         if: github.event_name == 'release' && steps.check-tag-format.outputs.stable == 'true'
         run: bash .github/scripts/check-release.sh
 
-  publish:
+  publish-linux:
+    name: Publish binary for Linux
+    runs-on: ubuntu-latest
+    needs: check-version
+    container:
+      image: ubuntu:18.04
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install needed dependencies
+      run: |
+        apt-get update && apt-get install -y curl
+        apt-get install build-essential -y
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+    - name: Build
+      run: cargo build --release --locked
+    # No need to upload binaries for dry run (cron)
+    - name: Upload binaries to release
+      if: github.event_name == 'release'
+      uses: svenstaro/upload-release-action@2.3.0
+      with:
+        repo_token: ${{ secrets.MEILI_BOT_GH_PAT }}
+        file: target/release/meilisearch
+        asset_name: meilisearch-linux-amd64
+        tag: ${{ github.ref }}
+
+  publish-macos-windows:
     name: Publish binary for ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     needs: check-version
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, macos-latest, windows-latest]
+        os: [macos-latest, windows-latest]
         include:
-          - os: ubuntu-18.04
-            artifact_name: meilisearch
-            asset_name: meilisearch-linux-amd64
           - os: macos-latest
             artifact_name: meilisearch
             asset_name: meilisearch-macos-amd64
           - os: windows-latest
             artifact_name: meilisearch.exe
             asset_name: meilisearch-windows-amd64.exe
-
     steps:
-    - uses: hecrj/setup-rust-action@master
-      with:
-        rust-version: stable
     - uses: actions/checkout@v3
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
     - name: Build
       run: cargo build --release --locked
     # No need to upload binaries for dry run (cron)
@@ -80,7 +105,6 @@ jobs:
           - os: macos-latest
             target: aarch64-apple-darwin
             asset_name: meilisearch-macos-apple-silicon
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -121,11 +145,9 @@ jobs:
             linker: gcc-aarch64-linux-gnu
             use-cross: true
             asset_name: meilisearch-linux-aarch64
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-
       - name: Installing Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -133,16 +155,13 @@ jobs:
           profile: minimal
           target: ${{ matrix.target }}
           override: true
-
       - name: APT update
         run: |
           sudo apt update
-
       - name: Install target specific tools
         if: matrix.use-cross
         run: |
           sudo apt-get install -y ${{ matrix.linker }}
-
       - name: Configure target aarch64 GNU
         if: matrix.target == 'aarch64-unknown-linux-gnu'
         ## Environment variable is not passed using env:
@@ -154,17 +173,14 @@ jobs:
           echo '[target.aarch64-unknown-linux-gnu]' >> ~/.cargo/config
           echo 'linker = "aarch64-linux-gnu-gcc"' >> ~/.cargo/config
           echo 'JEMALLOC_SYS_WITH_LG_PAGE=16' >> $GITHUB_ENV
-
       - name: Cargo build
         uses: actions-rs/cargo@v1
         with:
           command: build
           use-cross: ${{ matrix.use-cross }}
           args: --release --target ${{ matrix.target }}
-
       - name: List target output files
         run: ls -lR ./target
-
       - name: Upload the binary to release
         # No need to upload binaries for dry run (cron)
         if: github.event_name == 'release'

--- a/.github/workflows/publish-deb-brew-pkg.yml
+++ b/.github/workflows/publish-deb-brew-pkg.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: check-version
     container:
+      # Use ubuntu-18.04 to compile with glibc 2.27
       image: ubuntu:18.04
     steps:
     - name: Install needed dependencies

--- a/.github/workflows/publish-deb-brew-pkg.yml
+++ b/.github/workflows/publish-deb-brew-pkg.yml
@@ -15,12 +15,19 @@ jobs:
 
   debian:
     name: Publish debian packagge
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     needs: check-version
+    container:
+      image: ubuntu:18.04
     steps:
-    - uses: hecrj/setup-rust-action@master
+    - name: Install needed dependencies
+      run: |
+        apt-get update && apt-get install -y curl
+        apt-get install build-essential -y
+    - uses: actions-rs/toolchain@v1
       with:
-        rust-version: stable
+        toolchain: stable
+        override: true
     - name: Install cargo-deb
       run: cargo install cargo-deb
     - uses: actions/checkout@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,6 +19,7 @@ jobs:
     name: Tests on ubuntu-18.04
     runs-on: ubuntu-latest
     container:
+      # Use ubuntu-18.04 to compile with glibc 2.27, which are the production expectations
       image: ubuntu:18.04
     steps:
     - uses: actions/checkout@v3
@@ -70,6 +71,7 @@ jobs:
     name: Run tests in debug
     runs-on: ubuntu-latest
     container:
+      # Use ubuntu-18.04 to compile with glibc 2.27, which are the production expectations
       image: ubuntu:18.04
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,13 +15,41 @@ env:
   RUSTFLAGS: "-D warnings"
 
 jobs:
-  tests:
+  test-linux:
+    name: Tests on ubuntu-18.04
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:18.04
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install rustup
+      run: |
+        apt-get update && apt-get install -y curl
+        apt-get install build-essential -y
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+    - name: Cache dependencies
+      uses: Swatinem/rust-cache@v2.2.0
+    - name: Run cargo check without any default features
+      uses: actions-rs/cargo@v1
+      with:
+        command: build
+        args: --locked --release --no-default-features
+    - name: Run cargo test
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --locked --release
+
+  test-others:
     name: Tests on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, macos-latest, windows-latest]
+        os: [macos-latest, windows-latest]
     steps:
     - uses: actions/checkout@v3
     - name: Cache dependencies
@@ -40,12 +68,17 @@ jobs:
   # We run tests in debug also, to make sure that the debug_assertions are hit
   test-debug:
     name: Run tests in debug
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:18.04
     steps:
       - uses: actions/checkout@v3
+      - name: Install rustup
+        run: |
+          apt-get update && apt-get install -y curl
+          apt-get install build-essential -y
       - uses: actions-rs/toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
           override: true
       - name: Cache dependencies
@@ -58,7 +91,7 @@ jobs:
 
   clippy:
     name: Run Clippy
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
@@ -77,7 +110,7 @@ jobs:
 
   fmt:
     name: Run Rustfmt
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,7 @@ jobs:
       image: ubuntu:18.04
     steps:
     - uses: actions/checkout@v3
-    - name: Install rustup
+    - name: Install needed dependencies
       run: |
         apt-get update && apt-get install -y curl
         apt-get install build-essential -y
@@ -73,7 +73,7 @@ jobs:
       image: ubuntu:18.04
     steps:
       - uses: actions/checkout@v3
-      - name: Install rustup
+      - name: Install needed dependencies
         run: |
           apt-get update && apt-get install -y curl
           apt-get install build-essential -y

--- a/.github/workflows/update-cargo-toml-version.yml
+++ b/.github/workflows/update-cargo-toml-version.yml
@@ -16,7 +16,7 @@ jobs:
 
   update-version-cargo-toml:
     name: Update version in Cargo.toml files
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
Related to (but does not fix totally) https://github.com/meilisearch/meilisearch/issues/3109 and https://github.com/meilisearch/product/discussions/547#discussioncomment-4109143

## For reviewers, what's the PR changes:
- Use ubuntu-latest where compiling with ubuntu-18.04 is not needed (`update-version-cargo-toml`, `fmt`, `clippy` jobs)
- Where ubuntu-18.04 is required
  - Use `ubuntu-latest` as runner
  - Use `ubuntu:18.04` as Docker container
  - Install the required dependencies (curl and cc)
  - Use `actions-rs/toolchain@v1` instead of `hecrj/setup-rust-action@master`. It's more stable and followed alternative. Plus it was easy to make it work with our container contrary to the old one. Change applied in all our CIs to be more consistent
- Remove some useless space to increase readability.