### PR TITLE
Merge `--schedule-snapshot` and `--snapshot-interval-sec` options

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -73,16 +73,14 @@ ignore_dump_if_db_exists = false
 #################
 
 schedule_snapshot = false
-# Activates scheduled snapshots when provided.
+# Enables scheduled snapshots when true, disable when false (the default).
+# If the value is given as an integer, then enables the scheduled snapshot with the passed value as the interval
+# between each snapshot, in seconds.
 # https://docs.meilisearch.com/learn/configuration/instance_options.html#schedule-snapshot-creation
 
 snapshot_dir = "snapshots/"
 # Sets the directory where Meilisearch will store snapshots.
 # https://docs.meilisearch.com/learn/configuration/instance_options.html#snapshot-destination
-
-snapshot_interval_sec = 86400
-# Defines the interval between each snapshot. Value must be given in seconds.
-# https://docs.meilisearch.com/learn/configuration/instance_options.html#snapshot-interval
 
 # import_snapshot = "./path/to/my/snapshot"
 # Launches Meilisearch after importing a previously-generated snapshot at the given filepath.

--- a/meilisearch/src/lib.rs
+++ b/meilisearch/src/lib.rs
@@ -41,6 +41,7 @@ use meilisearch_types::tasks::KindWithContent;
 use meilisearch_types::versioning::{check_version_file, create_version_file};
 use meilisearch_types::{compression, milli, VERSION_FILE_NAME};
 pub use option::Opt;
+use option::ScheduleSnapshot;
 
 use crate::error::MeilisearchHttpError;
 
@@ -169,8 +170,8 @@ pub fn setup_meilisearch(opt: &Opt) -> anyhow::Result<(Arc<IndexScheduler>, Auth
 
     // We create a loop in a thread that registers snapshotCreation tasks
     let index_scheduler = Arc::new(index_scheduler);
-    if opt.schedule_snapshot {
-        let snapshot_delay = Duration::from_secs(opt.snapshot_interval_sec);
+    if let ScheduleSnapshot::Enabled(snapshot_delay) = opt.schedule_snapshot {
+        let snapshot_delay = Duration::from_secs(snapshot_delay);
         let index_scheduler = index_scheduler.clone();
         thread::Builder::new()
             .name(String::from("register-snapshot-tasks"))

--- a/meilisearch/tests/snapshot/mod.rs
+++ b/meilisearch/tests/snapshot/mod.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use meilisearch::option::ScheduleSnapshot;
 use meilisearch::Opt;
 use tokio::time::sleep;
 
@@ -36,8 +37,7 @@ async fn perform_snapshot() {
 
     let options = Opt {
         snapshot_dir: snapshot_dir.path().to_owned(),
-        snapshot_interval_sec: 1,
-        schedule_snapshot: true,
+        schedule_snapshot: ScheduleSnapshot::Enabled(1),
         ..default_settings(temp.path())
     };
 


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #3131

## What does this PR do?
- Removes `--snapshot-interval-sec`
- `--schedule-snapshot` now accepts an optional integer value specifying the interval in seconds
- The config file no longer has a snapshot_interval_sec key.  Instead, the schedule_snapshot key now additionally accepts an integer value specifying the interval in seconds
- The env variable MEILI_SNAPSHOT_INTERVAL no longer exists
- The env variable MEILI_SCHEDULE_SNAPSHOT is always specified to the interval of the snapshot in seconds when defined. If snapshots are disabled the variable is undefined.

---

Relevant part of the `--help`

<img width="885" alt="Capture d’écran 2022-12-27 à 18 22 32" src="https://user-images.githubusercontent.com/41078892/209700626-1a1292c1-14e3-45b6-8265-e0adbd76ecf1.png">

---

### Tests

| `schedule_snapshot` in config.toml | `--schedule-snapshot` flag on CLI | `MEILI_SCHEDULE_SNAPSHOT` | `opt.schedule_snapshot` |
|--|--|--|--|
| missing | missing | missing | `Disabled`
| `false` | missing | missing | `Disabled`
| `true` | missing | missing | `Enabled(86400)`
| `1234` | missing | missing | `Enabled(1234)`
| missing | `--schedule-snapshot` | missing | `Enabled(86400)`
| `false` | `--schedule-snapshot` | missing | `Enabled(86400)` 
| missing | `--schedule-snapshot 2345` | missing | `Enabled(2345)`
| `false` | `--schedule-snapshot 2345` | missing | `Enabled(2345)`
| `true` | `--schedule-snapshot 2345` | missing | `Enabled(2345)`
| `1234` | `--schedule-snapshot 2345` | missing | `Enabled(2345)`
| `false` | `--schedule-snapshot 2345` | 3456 | `Enabled(2345)`
| `false` | `--schedule-snapshot` | 3456 | **`Enabled(86400)`**
| `1234` | missing | 3456 | `Enabled(3456)`
| `false` | missing | 3456 | `Enabled(3456)`


## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
