### PR TITLE
Add crude rate limiter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-governor"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fbf4afa1e2f7c28040febe2a7199ad0a5fed564dd645da06ab12642c7d22483"
+dependencies = [
+ "actix-http",
+ "actix-web",
+ "futures",
+ "governor",
+]
+
+[[package]]
 name = "actix-http"
 version = "3.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1018,6 +1030,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.12.3",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1450,6 +1475,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+
+[[package]]
 name = "futures-util"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1500,7 +1531,7 @@ checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1539,6 +1570,23 @@ name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
+name = "governor"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19775995ee20209163239355bc3ad2f33f83da35d9ef72dea26e5af753552c87"
+dependencies = [
+ "dashmap",
+ "futures",
+ "futures-timer",
+ "no-std-compat",
+ "nonzero_ext",
+ "parking_lot",
+ "quanta",
+ "rand",
+ "smallvec",
+]
 
 [[package]]
 name = "grenad"
@@ -2233,6 +2281,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "manifest-dir-macros"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2270,6 +2327,7 @@ name = "meilisearch"
 version = "0.30.1"
 dependencies = [
  "actix-cors",
+ "actix-governor",
  "actix-http",
  "actix-rt",
  "actix-web",
@@ -2512,7 +2570,7 @@ checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.42.0",
 ]
 
@@ -2537,6 +2595,12 @@ version = "0.1.0"
 source = "git+https://github.com/meilisearch/nelson.git?rev=675f13885548fb415ead8fbb447e9e6d9314000a#675f13885548fb415ead8fbb447e9e6d9314000a"
 
 [[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+
+[[package]]
 name = "nom"
 version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2556,6 +2620,12 @@ dependencies = [
  "memchr",
  "nom",
 ]
+
+[[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "ntapi"
@@ -2993,6 +3063,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
+name = "quanta"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20afe714292d5e879d8b12740aa223c6a88f118af41870e8b6196e39a02238a8"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "mach",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.10.2+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3059,6 +3145,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
  "rand_core",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "10.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6823ea29436221176fe662da99998ad3b4db2c7f31e7b6f5fe43adccd6320bb"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -4082,6 +4177,12 @@ dependencies = [
  "log",
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasi"

--- a/config.toml
+++ b/config.toml
@@ -73,6 +73,69 @@ ignore_dump_if_db_exists = false
 # https://docs.meilisearch.com/learn/configuration/instance_options.html#ignore-dump-if-db-exists
 
 
+#####################
+### RATE LIMITING ###
+#####################
+
+rate_limiting_disable_all = false
+# Prevents a Meilisearch instance from performing any rate limiting.
+# https://docs.meilisearch.com/learn/configuration/instance_options.html#rate-limiting-disable-all
+
+rate_limiting_disable_global = false
+# Prevents a Meilisearch instance from performing rate limiting global to all queries.
+# https://docs.meilisearch.com/learn/configuration/instance_options.html#rate-limiting-disable-global
+
+rate_limiting_global_pool = 100000
+# The maximum pool of search requests that can be performed before they are rejected.
+#
+# The pool starts full at the provided value, then each search request diminishes the pool by 1.
+# When the pool is empty the search request is rejected.
+# The pool is replenished by 1 depending on the cooldown period.
+# https://docs.meilisearch.com/learn/configuration/instance_options.html#rate-limiting-global-pool
+
+rate_limiting_global_cooldown_ns = 50000
+# The amount of time, in nanoseconds, before the pool of available search requests is replenished by 1 again.
+#
+# The maximum number of available search requests is given by `rate_limiting_global_pool`.
+# https://docs.meilisearch.com/learn/configuration/instance_options.html#rate-limiting-global-cooldown-ns
+
+rate_limiting_disable_ip = false
+# Prevents a Meilisearch instance from performing rate limiting per IP address.
+# https://docs.meilisearch.com/learn/configuration/instance_options.html#rate-limiting-disable-ip
+
+rate_limiting_ip_pool = 200
+# The maximum pool of search requests that can be performed from a specific IP before they are rejected.
+#
+# The pool starts full at the provided value, then each search request from the same IP address diminishes the pool by 1.
+# When the pool is empty the search request is rejected.
+# The pool is replenished by 1 depending on the cooldown period.
+# https://docs.meilisearch.com/learn/configuration/instance_options.html#rate-limiting-ip-pool
+
+rate_limiting_ip_cooldown_ns = 50000000
+# The amount of time, in nanoseconds, before the pool of available search requests for a specific IP address is replenished by 1 again.
+#
+# The maximum number of available search requests for a specific IP address is given by `rate_limiting_ip_pool`.
+# https://docs.meilisearch.com/learn/configuration/instance_options.html#rate-limiting-ip-cooldown-ns
+
+rate_limiting_disable_api_key = false
+# Prevents a Meilisearch instance from performing rate limiting per API key.
+# https://docs.meilisearch.com/learn/configuration/instance_options.html#rate-limiting-disable-api-key
+
+rate_limiting_api_key_pool = 10000
+# The maximum pool of search requests that can be performed using a specific API key before they are rejected.
+#
+# The pool starts full at the provided value, then each search request using the same API key diminishes the pool by 1.
+# When the pool is empty the search request is rejected.
+# The pool is replenished by 1 depending on the cooldown period.
+# https://docs.meilisearch.com/learn/configuration/instance_options.html#rate-limiting-api-key-pool
+
+rate_limiting_api_key_cooldown_ns = 500000
+# The amount of time, in nanoseconds, before the pool of available search requests using a specific API key is replenished by 1 again.
+#
+# The maximum number of available search requests using a specific API key is given by `rate_limiting_api_key_pool`.
+# https://docs.meilisearch.com/learn/configuration/instance_options.html#rate-limiting-api-key-cooldown-ns
+
+
 #################
 ### SNAPSHOTS ###
 #################

--- a/meilisearch/Cargo.toml
+++ b/meilisearch/Cargo.toml
@@ -8,6 +8,7 @@ version = "0.30.1"
 
 [dependencies]
 actix-cors = "0.6.3"
+actix-governor = "0.3.2"
 actix-http = { version = "3.2.2", default-features = false, features = ["compress-brotli", "compress-gzip", "rustls"] }
 actix-web = { version = "4.2.1", default-features = false, features = ["macros", "compress-brotli", "compress-gzip", "cookies", "rustls"] }
 actix-web-static-files = { git = "https://github.com/kilork/actix-web-static-files.git", rev = "2d3b6160", optional = true }
@@ -98,17 +99,7 @@ zip = { version = "0.6.2", optional = true }
 default = ["analytics", "meilisearch-types/default", "mini-dashboard"]
 metrics = ["prometheus"]
 analytics = ["segment"]
-mini-dashboard = [
-    "actix-web-static-files",
-    "static-files",
-    "anyhow",
-    "cargo_toml",
-    "hex",
-    "reqwest",
-    "sha-1",
-    "tempfile",
-    "zip",
-]
+mini-dashboard = ["actix-web-static-files", "static-files", "anyhow", "cargo_toml", "hex", "reqwest", "sha-1", "tempfile", "zip"]
 chinese = ["meilisearch-types/chinese"]
 hebrew = ["meilisearch-types/hebrew"]
 japanese = ["meilisearch-types/japanese"]

--- a/meilisearch/src/analytics/segment_analytics.rs
+++ b/meilisearch/src/analytics/segment_analytics.rs
@@ -25,7 +25,9 @@ use uuid::Uuid;
 
 use super::{config_user_id_path, DocumentDeletionKind, MEILISEARCH_CONFIG_PATH};
 use crate::analytics::Analytics;
-use crate::option::{default_http_addr, IndexerOpts, MaxMemory, MaxThreads, SchedulerConfig};
+use crate::option::{
+    default_http_addr, IndexerOpts, MaxMemory, MaxThreads, RateLimiterConfig, SchedulerConfig,
+};
 use crate::routes::indexes::documents::UpdateDocumentsQuery;
 use crate::routes::tasks::TasksFilterQueryRaw;
 use crate::routes::{create_all_stats, Stats};
@@ -241,6 +243,16 @@ struct Infos {
     ssl_require_auth: bool,
     ssl_resumption: bool,
     ssl_tickets: bool,
+    rate_limiting_disable_all: bool,
+    rate_limiting_disable_global: bool,
+    rate_limiting_global_pool: u32,
+    rate_limiting_global_cooldown_ns: u64,
+    rate_limiting_disable_ip: bool,
+    rate_limiting_ip_pool: u32,
+    rate_limiting_ip_cooldown_ns: u64,
+    rate_limiting_disable_api_key: bool,
+    rate_limiting_api_key_pool: u32,
+    rate_limiting_api_key_cooldown_ns: u64,
 }
 
 impl From<Opt> for Infos {
@@ -278,6 +290,7 @@ impl From<Opt> for Infos {
             scheduler_options,
             config_file_path,
             generate_master_key: _,
+            rate_limiter_options,
             #[cfg(all(not(debug_assertions), feature = "analytics"))]
                 no_analytics: _,
         } = options;
@@ -289,6 +302,18 @@ impl From<Opt> for Infos {
             max_indexing_memory,
             max_indexing_threads,
         } = indexer_options;
+        let RateLimiterConfig {
+            rate_limiting_disable_all,
+            rate_limiting_disable_global,
+            rate_limiting_global_pool,
+            rate_limiting_global_cooldown_ns,
+            rate_limiting_disable_ip,
+            rate_limiting_ip_pool,
+            rate_limiting_ip_cooldown_ns,
+            rate_limiting_disable_api_key,
+            rate_limiting_api_key_pool,
+            rate_limiting_api_key_cooldown_ns,
+        } = rate_limiter_options;
 
         // We're going to override every sensible information.
         // We consider information sensible if it contains a path, an address, or a key.
@@ -321,6 +346,16 @@ impl From<Opt> for Infos {
             ssl_require_auth,
             ssl_resumption,
             ssl_tickets,
+            rate_limiting_disable_all,
+            rate_limiting_disable_global,
+            rate_limiting_global_pool,
+            rate_limiting_global_cooldown_ns,
+            rate_limiting_disable_ip,
+            rate_limiting_ip_pool,
+            rate_limiting_ip_cooldown_ns,
+            rate_limiting_disable_api_key,
+            rate_limiting_api_key_pool,
+            rate_limiting_api_key_cooldown_ns,
         }
     }
 }

--- a/meilisearch/src/routes/indexes/mod.rs
+++ b/meilisearch/src/routes/indexes/mod.rs
@@ -15,12 +15,13 @@ use crate::analytics::Analytics;
 use crate::extractors::authentication::policies::*;
 use crate::extractors::authentication::{AuthenticationError, GuardedData};
 use crate::extractors::sequential_extractor::SeqHandler;
+use crate::RateLimiters;
 
 pub mod documents;
 pub mod search;
 pub mod settings;
 
-pub fn configure(cfg: &mut web::ServiceConfig) {
+pub fn configure(cfg: &mut web::ServiceConfig, rate_limiters: RateLimiters) {
     cfg.service(
         web::resource("")
             .route(web::get().to(list_indexes))
@@ -36,7 +37,7 @@ pub fn configure(cfg: &mut web::ServiceConfig) {
             )
             .service(web::resource("/stats").route(web::get().to(SeqHandler(get_index_stats))))
             .service(web::scope("/documents").configure(documents::configure))
-            .service(web::scope("/search").configure(search::configure))
+            .service(web::scope("/search").configure(|cfg| search::configure(cfg, rate_limiters)))
             .service(web::scope("/settings").configure(settings::configure)),
     );
 }

--- a/meilisearch/src/routes/indexes/search.rs
+++ b/meilisearch/src/routes/indexes/search.rs
@@ -17,10 +17,14 @@ use crate::search::{
     DEFAULT_HIGHLIGHT_POST_TAG, DEFAULT_HIGHLIGHT_PRE_TAG, DEFAULT_SEARCH_LIMIT,
     DEFAULT_SEARCH_OFFSET,
 };
+use crate::RateLimiters;
 
-pub fn configure(cfg: &mut web::ServiceConfig) {
+pub fn configure(cfg: &mut web::ServiceConfig, rate_limiters: RateLimiters) {
     cfg.service(
         web::resource("")
+            .wrap(rate_limiters.global.into_middleware())
+            .wrap(rate_limiters.ip.into_middleware())
+            .wrap(rate_limiters.api_key.into_middleware())
             .route(web::get().to(SeqHandler(search_with_url_query)))
             .route(web::post().to(SeqHandler(search_with_post))),
     );

--- a/meilisearch/src/routes/mod.rs
+++ b/meilisearch/src/routes/mod.rs
@@ -16,6 +16,7 @@ use self::indexes::IndexStats;
 use crate::analytics::Analytics;
 use crate::extractors::authentication::policies::*;
 use crate::extractors::authentication::GuardedData;
+use crate::RateLimiters;
 
 mod api_key;
 mod dump;
@@ -23,14 +24,14 @@ pub mod indexes;
 mod swap_indexes;
 pub mod tasks;
 
-pub fn configure(cfg: &mut web::ServiceConfig) {
+pub fn configure(cfg: &mut web::ServiceConfig, rate_limiters: RateLimiters) {
     cfg.service(web::scope("/tasks").configure(tasks::configure))
         .service(web::resource("/health").route(web::get().to(get_health)))
         .service(web::scope("/keys").configure(api_key::configure))
         .service(web::scope("/dumps").configure(dump::configure))
         .service(web::resource("/stats").route(web::get().to(get_stats)))
         .service(web::resource("/version").route(web::get().to(get_version)))
-        .service(web::scope("/indexes").configure(indexes::configure))
+        .service(web::scope("/indexes").configure(|cfg| indexes::configure(cfg, rate_limiters)))
         .service(web::scope("/swap-indexes").configure(swap_indexes::configure));
 }
 

--- a/meilisearch/tests/common/server.rs
+++ b/meilisearch/tests/common/server.rs
@@ -8,7 +8,7 @@ use actix_web::dev::ServiceResponse;
 use actix_web::http::StatusCode;
 use byte_unit::{Byte, ByteUnit};
 use clap::Parser;
-use meilisearch::option::{IndexerOpts, MaxMemory, Opt};
+use meilisearch::option::{IndexerOpts, MaxMemory, Opt, RateLimiterConfig};
 use meilisearch::{analytics, create_app, setup_meilisearch};
 use once_cell::sync::Lazy;
 use serde_json::{json, Value};
@@ -192,6 +192,10 @@ pub fn default_settings(dir: impl AsRef<Path>) -> Opt {
         max_task_db_size: Byte::from_unit(1.0, ByteUnit::GiB).unwrap(),
         http_payload_size_limit: Byte::from_unit(10.0, ByteUnit::MiB).unwrap(),
         snapshot_dir: ".".into(),
+        rate_limiter_options: RateLimiterConfig {
+            rate_limiting_disable_all: true,
+            ..Parser::parse_from(None as Option<&str>)
+        },
         indexer_options: IndexerOpts {
             // memory has to be unlimited because several meilisearch are running in test context.
             max_indexing_memory: MaxMemory::unlimited(),


### PR DESCRIPTION
# Pull Request

## Related issue
Related to #3126 (rate limiting)

## What does this PR do?
- Add 3 rate limiters to the search route: 
  - Global rate limiter that limits the total number of search requests regardless of their origin
  - IP rate limiter that limits the number of search requests per IP address of origin
  - API key rate limiter that limits the number of search requests per API key used in the request 
- Add a new set of `--rate-limiting-*` options to configure the rate limiters (enabled? pool size? cooldown duration?)

### Notes on the implementation

- **Actix Governor does not behave as expected**: for example with `cargo run --release -- --rate-limiting-api-key-pool 1 --rate-limiting-api-key-cooldown-ns 50000000000` I would expect that any request past the first one would be blocked for 50s, but this is not what happens: even at startup I'm allowed to send up to 8 requests, and then I have to wait for about 45s... Not sure where the fault lies here.
- For API keys, all requests without an API key are put in the same rate-limiting bucket. It would be better to disable the rate limiter when there is no API key but actix governor does not give this level of control. We could maybe imply `--rate-limiting-disable-api-key` when no Master Key was provided 🤔 .
- The cooldown is in ns, which is not very practical but might be necessary to allow maximum control. Alternatives involve somehow parsing a "human-readable" duration to allow for a `--rate-limiting-cooldown 4s`, which the std doesn't allow.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
