### PR TITLE
Explicitly restrict log level options to those that are documented

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -28,7 +28,7 @@ http_payload_size_limit = "100 MB"
 
 log_level = "INFO"
 # Defines how much detail should be present in Meilisearch's logs.
-# Meilisearch currently supports five log levels, listed in order of increasing verbosity: `ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`
+# Meilisearch currently supports six log levels, listed in order of increasing verbosity:  `OFF`, `ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`
 # https://docs.meilisearch.com/learn/configuration/instance_options.html#log-level
 
 max_index_size = "100 GiB"

--- a/meilisearch/src/analytics/segment_analytics.rs
+++ b/meilisearch/src/analytics/segment_analytics.rs
@@ -306,7 +306,7 @@ impl From<Opt> for Infos {
             max_index_size,
             max_task_db_size,
             http_payload_size_limit,
-            log_level,
+            log_level: log_level.to_string(),
             max_indexing_memory,
             max_indexing_threads,
             with_configuration_file: config_file_path.is_some(),

--- a/meilisearch/src/main.rs
+++ b/meilisearch/src/main.rs
@@ -7,6 +7,7 @@ use actix_web::web::Data;
 use actix_web::HttpServer;
 use index_scheduler::IndexScheduler;
 use meilisearch::analytics::Analytics;
+use meilisearch::option::LogLevel;
 use meilisearch::{analytics, create_app, setup_meilisearch, Opt};
 use meilisearch_auth::{generate_master_key, AuthController, MASTER_KEY_MIN_SIZE};
 
@@ -16,8 +17,8 @@ static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
 /// does all the setup before meilisearch is launched
 fn setup(opt: &Opt) -> anyhow::Result<()> {
     let mut log_builder = env_logger::Builder::new();
-    log_builder.parse_filters(&opt.log_level);
-    if opt.log_level == "info" {
+    log_builder.parse_filters(&opt.log_level.to_string());
+    if matches!(opt.log_level, LogLevel::Info) {
         // if we are in info we only allow the warn log_level for milli
         log_builder.filter_module("milli", log::LevelFilter::Warn);
     }


### PR DESCRIPTION
Fixes https://github.com/meilisearch/meilisearch/issues/3292



