### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,8 +80,8 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "465a6172cf69b960917811022d8f29bc0b7fa1398bc4f78b3c466673db1213b6"
 dependencies = [
- "quote",
- "syn",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -99,9 +99,9 @@ dependencies = [
 
 [[package]]
 name = "actix-rt"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ea16c295198e958ef31930a6ef37d0fb64e9ca3b6116e6b93a8bdae96ee1000"
+checksum = "15265b6b8e2347670eb363c47fc8c75208b4a4994b27192f345fcbe707804f3e"
 dependencies = [
  "actix-macros",
  "futures-core",
@@ -214,9 +214,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa9362663c8643d67b2d5eafba49e4cb2c8a053a29ed00a0bea121f17c76b13"
 dependencies = [
  "actix-router",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -300,9 +300,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anyhow"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 dependencies = [
  "backtrace",
 ]
@@ -333,20 +333,20 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.61"
+version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705339e0e4a9690e2908d2b3d049d85682cf19fbd5782494498fbf7003a6a282"
+checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -452,6 +452,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
 name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -507,9 +516,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45ea9b00a7b3f2988e9a65ad3917e62123c38dba709b666506207be96d1790b"
+checksum = "b7f0778972c64420fdedc63f09919c8a88bda7b25135357fd25a5d9f3257e832"
 dependencies = [
  "memchr",
  "once_cell",
@@ -560,9 +569,9 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fe233b960f12f8007e3db2d136e3cb1c291bfd7396e384ee76025fc1a3932b4"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -573,9 +582,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "bytestring"
@@ -734,12 +743,12 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.32"
+version = "4.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7db700bc935f9e43e88d00b0850dae18a63773cfbec6d8e070fccf7fef89a39"
+checksum = "3339b77607ffdf358f6b1146107785d6cdb2b3f251e1920e96c45a0fc08a7b18"
 dependencies = [
  "bitflags",
- "clap_derive 4.0.21",
+ "clap_derive 4.1.0",
  "clap_lex 0.3.0",
  "is-terminal",
  "once_cell",
@@ -755,22 +764,22 @@ checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.0.21"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
+checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -797,9 +806,9 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df715824eb382e34b7afb7463b0247bf41538aeba731fba05241ecdb5dc3747"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1050,10 +1059,10 @@ checksum = "a784d2ccaf7c98501746bf0be29b2022ba41fd62a2e622af997a03e9f972859f"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
  "strsim",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1063,8 +1072,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
 dependencies = [
  "darling_core",
- "quote",
- "syn",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1083,9 +1092,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f91d4cfa921f1c05904dc3c57b4a32c38aed3340cce209f3a6fd1478babafc4"
 dependencies = [
  "darling",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1095,7 +1104,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f0314b72bed045f3a68671b3c86328386762c93f82d98c65c3cb5e5f573dd68"
 dependencies = [
  "derive_builder_core",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1105,10 +1114,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case 0.4.0",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
  "rustc_version",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1135,9 +1144,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c27246f8ca9eeba9dd70d614b664dc43b529251ed7bd9e633131010d340da4b9"
 dependencies = [
  "convert_case 0.5.0",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1200,14 +1209,14 @@ dependencies = [
  "tempfile",
  "thiserror",
  "time",
- "uuid 1.2.2",
+ "uuid 1.3.0",
 ]
 
 [[package]]
 name = "either"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 dependencies = [
  "serde",
 ]
@@ -1315,9 +1324,9 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "828de45d0ca18782232dfb8f3ea9cc428e8ced380eb26a520baaacfc70de39ce"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1380,9 +1389,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35c9bb4a2c13ffb3a93a39902aaf4e7190a1706a4779b6db0449aee433d26c4a"
 dependencies = [
  "darling",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
  "uuid 0.8.2",
 ]
 
@@ -1393,7 +1402,7 @@ dependencies = [
  "faux",
  "tempfile",
  "thiserror",
- "uuid 1.2.2",
+ "uuid 1.3.0",
 ]
 
 [[package]]
@@ -1459,9 +1468,9 @@ checksum = "7ab85b9b05e3978cc9a9cf8fea7f01b494e1a09ed3037e16ba39edc7a29eb61a"
 
 [[package]]
 name = "futures"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
+checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1474,9 +1483,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
+checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1484,15 +1493,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
+checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
+checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1501,38 +1510,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
+checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
+checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
+checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
 
 [[package]]
 name = "futures-task"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
+checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
 
 [[package]]
 name = "futures-util"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
+checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1585,9 +1594,9 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30ce01e8bbb3e7e0758dcf907fe799f5998a54368963f766ae94b84624ba60c8"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1642,9 +1651,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
 dependencies = [
  "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1931,7 +1940,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "time",
- "uuid 1.2.2",
+ "uuid 1.3.0",
 ]
 
 [[package]]
@@ -2393,9 +2402,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a9062912d7952c5588cc474795e0b9ee008e7e6781127945b85413d4b99d81"
 dependencies = [
  "log",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2415,9 +2424,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f08150cf2bab1fc47c2196f4f41173a27fcd0f684165e5458c0046b53a472e2f"
 dependencies = [
  "once_cell",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2457,11 +2466,11 @@ dependencies = [
  "async-trait",
  "atty",
  "brotli",
- "bstr 1.1.0",
+ "bstr 1.2.0",
  "byte-unit",
  "bytes",
  "cargo_toml",
- "clap 4.0.32",
+ "clap 4.1.5",
  "crossbeam-channel",
  "deserr",
  "dump",
@@ -2504,6 +2513,7 @@ dependencies = [
  "rustls-pemfile",
  "segment",
  "serde",
+ "serde-cs",
  "serde_json",
  "serde_urlencoded",
  "sha-1",
@@ -2522,7 +2532,7 @@ dependencies = [
  "tokio-stream",
  "toml",
  "urlencoding",
- "uuid 1.2.2",
+ "uuid 1.3.0",
  "vergen",
  "walkdir",
  "yaup",
@@ -2545,7 +2555,7 @@ dependencies = [
  "sha2",
  "thiserror",
  "time",
- "uuid 1.2.2",
+ "uuid 1.3.0",
 ]
 
 [[package]]
@@ -2566,6 +2576,8 @@ dependencies = [
  "meili-snap",
  "memmap2",
  "milli",
+ "proptest",
+ "proptest-derive",
  "roaring",
  "serde",
  "serde-cs",
@@ -2575,7 +2587,7 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
- "uuid 1.2.2",
+ "uuid 1.3.0",
 ]
 
 [[package]]
@@ -2609,7 +2621,7 @@ dependencies = [
  "big_s",
  "bimap",
  "bincode",
- "bstr 1.1.0",
+ "bstr 1.2.0",
  "byteorder",
  "charabia",
  "concat-arrays",
@@ -2650,7 +2662,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "time",
- "uuid 1.2.2",
+ "uuid 1.3.0",
 ]
 
 [[package]]
@@ -2712,9 +2724,9 @@ source = "git+https://github.com/meilisearch/nelson.git?rev=675f13885548fb415ead
 
 [[package]]
 name = "nom"
-version = "7.1.2"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5507769c4919c998e69e49c839d9dc6e693ede4cc4290d6ad8b41d4f09c548c"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
@@ -2722,9 +2734,9 @@ dependencies = [
 
 [[package]]
 name = "nom_locate"
-version = "4.0.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37794436ca3029a3089e0b95d42da1f0b565ad271e4d3bb4bad0c7bb70b10605"
+checksum = "b1e299bf5ea7b212e811e71174c5d1a5d065c4c0ad0c8691ecb1f97e3e66025e"
 dependencies = [
  "bytecount",
  "memchr",
@@ -2992,9 +3004,9 @@ checksum = "46b53634d8c8196302953c74d5352f33d0c512a9499bd2ce468fc9f4128fa27c"
 dependencies = [
  "pest",
  "pest_meta",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3120,9 +3132,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
  "version_check",
 ]
 
@@ -3132,9 +3144,18 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
  "version_check",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
+dependencies = [
+ "unicode-xid 0.1.0",
 ]
 
 [[package]]
@@ -3177,10 +3198,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29f1b898011ce9595050a68e60f90bad083ff2987a695a42357134c8381fba70"
+dependencies = [
+ "bit-set",
+ "bitflags",
+ "byteorder",
+ "lazy_static",
+ "num-traits",
+ "quick-error 2.0.1",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "proptest-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90b46295382dc76166cb7cf2bb4a97952464e4b7ed5a43e6cd34e1fec3349ddc"
+dependencies = [
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "syn 0.15.44",
+]
+
+[[package]]
 name = "protobuf"
 version = "2.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
+name = "quote"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
+dependencies = [
+ "proc-macro2 0.4.30",
+]
 
 [[package]]
 name = "quote"
@@ -3188,7 +3262,7 @@ version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
- "proc-macro2",
+ "proc-macro2 1.0.49",
 ]
 
 [[package]]
@@ -3219,6 +3293,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -3297,11 +3380,11 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
+checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.0",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3410,9 +3493,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.7"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "539a2bfe908f471bfa933876bd1eb6a19cf2176d375f82ef7f99530a40e48c2c"
+checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
 dependencies = [
  "log",
  "ring",
@@ -3434,6 +3517,18 @@ name = "rustversion"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -3510,16 +3605,16 @@ version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.91"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
+checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
 dependencies = [
  "indexmap",
  "itoa 1.0.5",
@@ -3709,12 +3804,23 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
+version = "0.15.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
+dependencies = [
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "unicode-xid 0.1.0",
+]
+
+[[package]]
+name = "syn"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
  "unicode-ident",
 ]
 
@@ -3733,10 +3839,10 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "unicode-xid",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
+ "unicode-xid 0.2.4",
 ]
 
 [[package]]
@@ -3818,9 +3924,9 @@ version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3877,9 +3983,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.24.2"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a12a59981d9e3c38d216785b0c37399f6e415e8d0712047620f189371b0bb"
+checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
 dependencies = [
  "autocfg",
  "bytes",
@@ -3901,9 +4007,9 @@ version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3944,9 +4050,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
 ]
@@ -3997,6 +4103,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4037,6 +4149,12 @@ name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
+name = "unicode-xid"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
 name = "unicode-xid"
@@ -4084,9 +4202,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
+checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
 dependencies = [
  "getrandom",
  "serde",
@@ -4119,6 +4237,15 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"
@@ -4177,9 +4304,9 @@ dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
  "wasm-bindgen-shared",
 ]
 
@@ -4201,7 +4328,7 @@ version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
 dependencies = [
- "quote",
+ "quote 1.0.23",
  "wasm-bindgen-macro-support",
 ]
 
@@ -4211,9 +4338,9 @@ version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4410,16 +4537,16 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d498dbd1fd7beb83c86709ae1c33ca50942889473473d287d56ce4770a18edfb"
 dependencies = [
- "proc-macro2",
- "syn",
+ "proc-macro2 1.0.49",
+ "syn 1.0.107",
  "synstructure",
 ]
 
 [[package]]
 name = "zip"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537ce7411d25e54e8ae21a7ce0b15840e7bfcff15b51d697ec3266cc76bdf080"
+checksum = "0445d0fbc924bb93539b4316c11afb121ea39296f99a3c4c9edad09e3658cdef"
 dependencies = [
  "aes",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,8 +80,8 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "465a6172cf69b960917811022d8f29bc0b7fa1398bc4f78b3c466673db1213b6"
 dependencies = [
- "quote 1.0.23",
- "syn 1.0.107",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -214,9 +214,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa9362663c8643d67b2d5eafba49e4cb2c8a053a29ed00a0bea121f17c76b13"
 dependencies = [
  "actix-router",
- "proc-macro2 1.0.49",
- "quote 1.0.23",
- "syn 1.0.107",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -308,45 +308,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "assert-json-diff"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "async-stream"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad5c83079eae9969be7fadefe640a1c566901f05ff91ab221de4b6f68d9507e"
-dependencies = [
- "async-stream-impl",
- "futures-core",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
-dependencies = [
- "proc-macro2 1.0.49",
- "quote 1.0.23",
- "syn 1.0.107",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
 dependencies = [
- "proc-macro2 1.0.49",
- "quote 1.0.23",
- "syn 1.0.107",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -449,15 +418,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec",
 ]
 
 [[package]]
@@ -569,9 +529,9 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fe233b960f12f8007e3db2d136e3cb1c291bfd7396e384ee76025fc1a3932b4"
 dependencies = [
- "proc-macro2 1.0.49",
- "quote 1.0.23",
- "syn 1.0.107",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -764,9 +724,9 @@ checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.49",
- "quote 1.0.23",
- "syn 1.0.107",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -777,9 +737,9 @@ checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.49",
- "quote 1.0.23",
- "syn 1.0.107",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -806,9 +766,9 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df715824eb382e34b7afb7463b0247bf41538aeba731fba05241ecdb5dc3747"
 dependencies = [
- "proc-macro2 1.0.49",
- "quote 1.0.23",
- "syn 1.0.107",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1042,82 +1002,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0dd3cd20dc6b5a876612a6e5accfe7f3dd883db6d07acfbf14c128f61550dfa"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a784d2ccaf7c98501746bf0be29b2022ba41fd62a2e622af997a03e9f972859f"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2 1.0.49",
- "quote 1.0.23",
- "strsim",
- "syn 1.0.107",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
-dependencies = [
- "darling_core",
- "quote 1.0.23",
- "syn 1.0.107",
-]
-
-[[package]]
-name = "derive_builder"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07adf7be193b71cc36b193d0f5fe60b918a3a9db4dad0449f57bcfd519704a3"
-dependencies = [
- "derive_builder_macro",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f91d4cfa921f1c05904dc3c57b4a32c38aed3340cce209f3a6fd1478babafc4"
-dependencies = [
- "darling",
- "proc-macro2 1.0.49",
- "quote 1.0.23",
- "syn 1.0.107",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f0314b72bed045f3a68671b3c86328386762c93f82d98c65c3cb5e5f573dd68"
-dependencies = [
- "derive_builder_core",
- "syn 1.0.107",
-]
-
-[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case 0.4.0",
- "proc-macro2 1.0.49",
- "quote 1.0.23",
+ "proc-macro2",
+ "quote",
  "rustc_version",
- "syn 1.0.107",
+ "syn",
 ]
 
 [[package]]
@@ -1144,9 +1038,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c27246f8ca9eeba9dd70d614b664dc43b529251ed7bd9e633131010d340da4b9"
 dependencies = [
  "convert_case 0.5.0",
- "proc-macro2 1.0.49",
- "quote 1.0.23",
- "syn 1.0.107",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1198,7 +1092,6 @@ dependencies = [
  "log",
  "maplit",
  "meili-snap",
- "meilisearch-auth",
  "meilisearch-types",
  "once_cell",
  "regex",
@@ -1209,7 +1102,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "time",
- "uuid 1.3.0",
+ "uuid",
 ]
 
 [[package]]
@@ -1324,9 +1217,9 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "828de45d0ca18782232dfb8f3ea9cc428e8ced380eb26a520baaacfc70de39ce"
 dependencies = [
- "proc-macro2 1.0.49",
- "quote 1.0.23",
- "syn 1.0.107",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1373,36 +1266,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "faux"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3b5e56a69ca67c241191cd9d484e14fb0fe89f5e539c2e8448eafd1f65c1f0"
-dependencies = [
- "faux_macros",
- "paste",
-]
-
-[[package]]
-name = "faux_macros"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35c9bb4a2c13ffb3a93a39902aaf4e7190a1706a4779b6db0449aee433d26c4a"
-dependencies = [
- "darling",
- "proc-macro2 1.0.49",
- "quote 1.0.23",
- "syn 1.0.107",
- "uuid 0.8.2",
-]
-
-[[package]]
 name = "file-store"
 version = "1.0.0"
 dependencies = [
- "faux",
  "tempfile",
  "thiserror",
- "uuid 1.3.0",
+ "uuid",
 ]
 
 [[package]]
@@ -1520,9 +1389,9 @@ version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
 dependencies = [
- "proc-macro2 1.0.49",
- "quote 1.0.23",
- "syn 1.0.107",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1594,9 +1463,9 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30ce01e8bbb3e7e0758dcf907fe799f5998a54368963f766ae94b84624ba60c8"
 dependencies = [
- "proc-macro2 1.0.49",
- "quote 1.0.23",
- "syn 1.0.107",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1651,9 +1520,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
 dependencies = [
  "proc-macro-error",
- "proc-macro2 1.0.49",
- "quote 1.0.23",
- "syn 1.0.107",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1899,12 +1768,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
 name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1923,7 +1786,6 @@ dependencies = [
  "bincode",
  "crossbeam",
  "csv",
- "derive_builder",
  "dump",
  "enum-iterator",
  "file-store",
@@ -1931,7 +1793,6 @@ dependencies = [
  "log",
  "meili-snap",
  "meilisearch-types",
- "nelson",
  "page_size 0.5.0",
  "roaring",
  "serde",
@@ -1940,7 +1801,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "time",
- "uuid 1.3.0",
+ "uuid",
 ]
 
 [[package]]
@@ -2402,9 +2263,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a9062912d7952c5588cc474795e0b9ee008e7e6781127945b85413d4b99d81"
 dependencies = [
  "log",
- "proc-macro2 1.0.49",
- "quote 1.0.23",
- "syn 1.0.107",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2424,9 +2285,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f08150cf2bab1fc47c2196f4f41173a27fcd0f684165e5458c0046b53a472e2f"
 dependencies = [
  "once_cell",
- "proc-macro2 1.0.49",
- "quote 1.0.23",
- "syn 1.0.107",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2461,9 +2322,6 @@ dependencies = [
  "actix-web",
  "actix-web-static-files",
  "anyhow",
- "assert-json-diff",
- "async-stream",
- "async-trait",
  "atty",
  "brotli",
  "bstr 1.2.0",
@@ -2529,12 +2387,10 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
- "tokio-stream",
  "toml",
  "urlencoding",
- "uuid 1.3.0",
+ "uuid",
  "vergen",
- "walkdir",
  "yaup",
  "zip",
 ]
@@ -2555,7 +2411,7 @@ dependencies = [
  "sha2",
  "thiserror",
  "time",
- "uuid 1.3.0",
+ "uuid",
 ]
 
 [[package]]
@@ -2576,8 +2432,6 @@ dependencies = [
  "meili-snap",
  "memmap2",
  "milli",
- "proptest",
- "proptest-derive",
  "roaring",
  "serde",
  "serde-cs",
@@ -2587,7 +2441,7 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
- "uuid 1.3.0",
+ "uuid",
 ]
 
 [[package]]
@@ -2662,7 +2516,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "time",
- "uuid 1.3.0",
+ "uuid",
 ]
 
 [[package]]
@@ -2716,11 +2570,6 @@ dependencies = [
  "wasi",
  "windows-sys",
 ]
-
-[[package]]
-name = "nelson"
-version = "0.1.0"
-source = "git+https://github.com/meilisearch/nelson.git?rev=675f13885548fb415ead8fbb447e9e6d9314000a#675f13885548fb415ead8fbb447e9e6d9314000a"
 
 [[package]]
 name = "nom"
@@ -3004,9 +2853,9 @@ checksum = "46b53634d8c8196302953c74d5352f33d0c512a9499bd2ce468fc9f4128fa27c"
 dependencies = [
  "pest",
  "pest_meta",
- "proc-macro2 1.0.49",
- "quote 1.0.23",
- "syn 1.0.107",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3132,9 +2981,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.49",
- "quote 1.0.23",
- "syn 1.0.107",
+ "proc-macro2",
+ "quote",
+ "syn",
  "version_check",
 ]
 
@@ -3144,18 +2993,9 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.49",
- "quote 1.0.23",
+ "proc-macro2",
+ "quote",
  "version_check",
-]
-
-[[package]]
-name = "proc-macro2"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-dependencies = [
- "unicode-xid 0.1.0",
 ]
 
 [[package]]
@@ -3198,63 +3038,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "proptest"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f1b898011ce9595050a68e60f90bad083ff2987a695a42357134c8381fba70"
-dependencies = [
- "bit-set",
- "bitflags",
- "byteorder",
- "lazy_static",
- "num-traits",
- "quick-error 2.0.1",
- "rand",
- "rand_chacha",
- "rand_xorshift",
- "regex-syntax",
- "rusty-fork",
- "tempfile",
- "unarray",
-]
-
-[[package]]
-name = "proptest-derive"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90b46295382dc76166cb7cf2bb4a97952464e4b7ed5a43e6cd34e1fec3349ddc"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "syn 0.15.44",
-]
-
-[[package]]
 name = "protobuf"
 version = "2.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
-name = "quick-error"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
-
-[[package]]
-name = "quote"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
-dependencies = [
- "proc-macro2 0.4.30",
-]
 
 [[package]]
 name = "quote"
@@ -3262,7 +3049,7 @@ version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
- "proc-macro2 1.0.49",
+ "proc-macro2",
 ]
 
 [[package]]
@@ -3293,15 +3080,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
-dependencies = [
- "rand_core",
 ]
 
 [[package]]
@@ -3519,18 +3297,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
 
 [[package]]
-name = "rusty-fork"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
-dependencies = [
- "fnv",
- "quick-error 1.2.3",
- "tempfile",
- "wait-timeout",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3605,9 +3371,9 @@ version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
- "proc-macro2 1.0.49",
- "quote 1.0.23",
- "syn 1.0.107",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3804,23 +3570,12 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "0.15.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "unicode-xid 0.1.0",
-]
-
-[[package]]
-name = "syn"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
- "proc-macro2 1.0.49",
- "quote 1.0.23",
+ "proc-macro2",
+ "quote",
  "unicode-ident",
 ]
 
@@ -3839,10 +3594,10 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.49",
- "quote 1.0.23",
- "syn 1.0.107",
- "unicode-xid 0.2.4",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -3924,9 +3679,9 @@ version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
- "proc-macro2 1.0.49",
- "quote 1.0.23",
- "syn 1.0.107",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -4007,9 +3762,9 @@ version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
- "proc-macro2 1.0.49",
- "quote 1.0.23",
- "syn 1.0.107",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -4021,17 +3776,6 @@ dependencies = [
  "rustls",
  "tokio",
  "webpki",
-]
-
-[[package]]
-name = "tokio-stream"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d660770404473ccd7bc9f8b28494a811bc18542b915c0855c51e8f419d5223ce"
-dependencies = [
- "futures-core",
- "pin-project-lite",
- "tokio",
 ]
 
 [[package]]
@@ -4103,12 +3847,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
-name = "unarray"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
-
-[[package]]
 name = "unicase"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4152,12 +3890,6 @@ checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unicode-xid"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-
-[[package]]
-name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
@@ -4190,15 +3922,6 @@ name = "utf8-width"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5190c9442dcdaf0ddd50f37420417d219ae5261bbf5db120d0f9bab996c9cba1"
-
-[[package]]
-name = "uuid"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
-dependencies = [
- "getrandom",
-]
 
 [[package]]
 name = "uuid"
@@ -4237,15 +3960,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "wait-timeout"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "walkdir"
@@ -4304,9 +4018,9 @@ dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.49",
- "quote 1.0.23",
- "syn 1.0.107",
+ "proc-macro2",
+ "quote",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -4328,7 +4042,7 @@ version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
 dependencies = [
- "quote 1.0.23",
+ "quote",
  "wasm-bindgen-macro-support",
 ]
 
@@ -4338,9 +4052,9 @@ version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
- "proc-macro2 1.0.49",
- "quote 1.0.23",
- "syn 1.0.107",
+ "proc-macro2",
+ "quote",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4537,8 +4251,8 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d498dbd1fd7beb83c86709ae1c33ca50942889473473d287d56ce4770a18edfb"
 dependencies = [
- "proc-macro2 1.0.49",
- "syn 1.0.107",
+ "proc-macro2",
+ "syn",
  "synstructure",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,7 +59,7 @@ dependencies = [
  "http",
  "httparse",
  "httpdate",
- "itoa 1.0.5",
+ "itoa",
  "language-tags",
  "local-channel",
  "mime",
@@ -191,7 +191,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http",
- "itoa 1.0.5",
+ "itoa",
  "language-tags",
  "log",
  "mime",
@@ -464,18 +464,6 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
-dependencies = [
- "lazy_static",
- "memchr",
- "regex-automata",
- "serde",
-]
-
-[[package]]
-name = "bstr"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f0778972c64420fdedc63f09919c8a88bda7b25135357fd25a5d9f3257e832"
@@ -703,9 +691,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.5"
+version = "4.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3339b77607ffdf358f6b1146107785d6cdb2b3f251e1920e96c45a0fc08a7b18"
+checksum = "ec0b0588d44d4d63a87dbd75c136c166bbfd9a86a31cb89e09906521c7d3f5e3"
 dependencies = [
  "bitflags",
  "clap_derive 4.1.0",
@@ -981,13 +969,12 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.1.6"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
+checksum = "af91f40b7355f82b0a891f50e70399475945bb0b0da4f1700ce60761c9d3e359"
 dependencies = [
- "bstr 0.2.17",
  "csv-core",
- "itoa 0.4.8",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -1204,9 +1191,9 @@ dependencies = [
 
 [[package]]
 name = "enum-iterator"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91a4ec26efacf4aeff80887a175a419493cb6f8b5480d26387eb0bd038976187"
+checksum = "9ea166b3f7dc1032f7866d13f8d8e02c8d87507b61750176b86554964dc6a7bf"
 dependencies = [
  "enum-iterator-derive",
 ]
@@ -1533,9 +1520,9 @@ checksum = "dec7af912d60cdbd3677c1af9352ebae6fb8394d165568a2234df0fa00f87793"
 
 [[package]]
 name = "git2"
-version = "0.15.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2994bee4a3a6a51eb90c218523be382fd7ea09b16380b9312e9dbe955ff7c7d1"
+checksum = "ccf7f68c2995f392c49fffb4f95ae2c873297830eb25c6bc4c114ce8f4562acc"
 dependencies = [
  "bitflags",
  "libc",
@@ -1698,7 +1685,7 @@ checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 1.0.5",
+ "itoa",
 ]
 
 [[package]]
@@ -1745,7 +1732,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 1.0.5",
+ "itoa",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1817,9 +1804,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.26.0"
+version = "1.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f0f08b46e4379744de2ab67aa8f7de3ffd1da3e275adc41fcc82053ede46ff"
+checksum = "fea5b3894afe466b4bcf0388630fc15e11938a6074af0cd637c825ba2ec8a099"
 dependencies = [
  "console",
  "lazy_static",
@@ -1876,12 +1863,6 @@ checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
-
-[[package]]
-name = "itoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
@@ -2324,11 +2305,11 @@ dependencies = [
  "anyhow",
  "atty",
  "brotli",
- "bstr 1.2.0",
+ "bstr",
  "byte-unit",
  "bytes",
  "cargo_toml",
- "clap 4.1.5",
+ "clap 4.1.6",
  "crossbeam-channel",
  "deserr",
  "dump",
@@ -2475,7 +2456,7 @@ dependencies = [
  "big_s",
  "bimap",
  "bincode",
- "bstr 1.2.0",
+ "bstr",
  "byteorder",
  "charabia",
  "concat-arrays",
@@ -2678,9 +2659,9 @@ checksum = "f69e48cd7c8e5bb52a1da1287fdbfd877c32673176583ce664cd63b201aba385"
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "oorandom"
@@ -3000,9 +2981,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.49"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
 dependencies = [
  "unicode-ident",
 ]
@@ -3383,7 +3364,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
 dependencies = [
  "indexmap",
- "itoa 1.0.5",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -3395,7 +3376,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.5",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -3651,9 +3632,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
 ]
@@ -3686,11 +3667,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
+checksum = "af0097eaf301d576d0b2aead7a59facab6d53cc636340f0291fab8446a2e8613"
 dependencies = [
- "itoa 1.0.5",
+ "itoa",
  "serde",
  "time-core",
  "time-macros",
@@ -3857,9 +3838,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.8"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
 
 [[package]]
 name = "unicode-ident"
@@ -3941,9 +3922,9 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vergen"
-version = "7.5.0"
+version = "7.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "571b69f690c855821462709b6f41d42ceccc316fbd17b60bd06d06928cfe6a99"
+checksum = "f21b881cd6636ece9735721cf03c1fe1e774fe258683d084bb2812ab67435749"
 dependencies = [
  "anyhow",
  "cfg-if",

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -5,11 +5,11 @@ edition = "2018"
 publish = false
 
 [dependencies]
-anyhow = "1.0.65"
+anyhow = "1.0.69"
 csv = "1.1.6"
 milli = { path = "../milli", default-features = false }
-mimalloc = { version = "0.1.29", default-features = false }
-serde_json = { version = "1.0.85", features = ["preserve_order"] }
+mimalloc = { version = "0.1.34", default-features = false }
+serde_json = { version = "1.0.92", features = ["preserve_order"] }
 
 [dev-dependencies]
 criterion = { version = "0.4.0", features = ["html_reports"] }
@@ -18,11 +18,11 @@ rand_chacha = "0.3.1"
 roaring = "0.10.1"
 
 [build-dependencies]
-anyhow = "1.0.65"
-bytes = "1.2.1"
+anyhow = "1.0.69"
+bytes = "1.4.0"
 convert_case = "0.6.0"
-flate2 = "1.0.24"
-reqwest = { version = "0.11.12", features = ["blocking", "rustls-tls"], default-features = false }
+flate2 = "1.0.25"
+reqwest = { version = "0.11.14", features = ["blocking", "rustls-tls"], default-features = false }
 
 [features]
 default = ["milli/default"]

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -6,10 +6,10 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.69"
-csv = "1.1.6"
+csv = "1.2.0"
 milli = { path = "../milli", default-features = false }
 mimalloc = { version = "0.1.34", default-features = false }
-serde_json = { version = "1.0.92", features = ["preserve_order"] }
+serde_json = { version = "1.0.93", features = ["preserve_order"] }
 
 [dev-dependencies]
 criterion = { version = "0.4.0", features = ["html_reports"] }

--- a/dump/Cargo.toml
+++ b/dump/Cargo.toml
@@ -4,22 +4,22 @@ version = "1.0.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0.65"
-flate2 = "1.0.22"
+anyhow = "1.0.68"
+flate2 = "1.0.25"
 http = "0.2.8"
 log = "0.4.17"
 meilisearch-auth = { path = "../meilisearch-auth" }
 meilisearch-types = { path = "../meilisearch-types" }
-once_cell = "1.15.0"
-regex = "1.6.0"
-roaring = { version = "0.10.0", features = ["serde"] }
-serde = { version = "1.0.136", features = ["derive"] }
-serde_json = { version = "1.0.85", features = ["preserve_order"] }
+once_cell = "1.17.0"
+regex = "1.7.1"
+roaring = { version = "0.10.1", features = ["serde"] }
+serde = { version = "1.0.152", features = ["derive"] }
+serde_json = { version = "1.0.91", features = ["preserve_order"] }
 tar = "0.4.38"
 tempfile = "3.3.0"
-thiserror = "1.0.30"
-time = { version = "0.3.7", features = ["serde-well-known", "formatting", "parsing", "macros"] }
-uuid = { version = "1.1.2", features = ["serde", "v4"] }
+thiserror = "1.0.38"
+time = { version = "0.3.17", features = ["serde-well-known", "formatting", "parsing", "macros"] }
+uuid = { version = "1.2.2", features = ["serde", "v4"] }
 
 [dev-dependencies]
 big_s = "1.0.2"

--- a/dump/Cargo.toml
+++ b/dump/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0.68"
+anyhow = "1.0.69"
 flate2 = "1.0.25"
 http = "0.2.8"
 log = "0.4.17"
@@ -14,12 +14,12 @@ once_cell = "1.17.0"
 regex = "1.7.1"
 roaring = { version = "0.10.1", features = ["serde"] }
 serde = { version = "1.0.152", features = ["derive"] }
-serde_json = { version = "1.0.91", features = ["preserve_order"] }
+serde_json = { version = "1.0.92", features = ["preserve_order"] }
 tar = "0.4.38"
 tempfile = "3.3.0"
 thiserror = "1.0.38"
 time = { version = "0.3.17", features = ["serde-well-known", "formatting", "parsing", "macros"] }
-uuid = { version = "1.2.2", features = ["serde", "v4"] }
+uuid = { version = "1.3.0", features = ["serde", "v4"] }
 
 [dev-dependencies]
 big_s = "1.0.2"

--- a/dump/Cargo.toml
+++ b/dump/Cargo.toml
@@ -8,7 +8,6 @@ anyhow = "1.0.69"
 flate2 = "1.0.25"
 http = "0.2.8"
 log = "0.4.17"
-meilisearch-auth = { path = "../meilisearch-auth" }
 meilisearch-types = { path = "../meilisearch-types" }
 once_cell = "1.17.0"
 regex = "1.7.1"

--- a/dump/Cargo.toml
+++ b/dump/Cargo.toml
@@ -9,15 +9,15 @@ flate2 = "1.0.25"
 http = "0.2.8"
 log = "0.4.17"
 meilisearch-types = { path = "../meilisearch-types" }
-once_cell = "1.17.0"
+once_cell = "1.17.1"
 regex = "1.7.1"
 roaring = { version = "0.10.1", features = ["serde"] }
 serde = { version = "1.0.152", features = ["derive"] }
-serde_json = { version = "1.0.92", features = ["preserve_order"] }
+serde_json = { version = "1.0.93", features = ["preserve_order"] }
 tar = "0.4.38"
 tempfile = "3.3.0"
 thiserror = "1.0.38"
-time = { version = "0.3.17", features = ["serde-well-known", "formatting", "parsing", "macros"] }
+time = { version = "0.3.18", features = ["serde-well-known", "formatting", "parsing", "macros"] }
 uuid = { version = "1.3.0", features = ["serde", "v4"] }
 
 [dev-dependencies]

--- a/file-store/Cargo.toml
+++ b/file-store/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 
 [dependencies]
 tempfile = "3.3.0"
-thiserror = "1.0.30"
-uuid = { version = "1.1.2", features = ["serde", "v4"] }
+thiserror = "1.0.38"
+uuid = { version = "1.2.2", features = ["serde", "v4"] }
 
 [dev-dependencies]
-faux = "0.1.8"
+faux = "0.1.9"

--- a/file-store/Cargo.toml
+++ b/file-store/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 tempfile = "3.3.0"
 thiserror = "1.0.38"
-uuid = { version = "1.2.2", features = ["serde", "v4"] }
+uuid = { version = "1.3.0", features = ["serde", "v4"] }
 
 [dev-dependencies]
 faux = "0.1.9"

--- a/file-store/Cargo.toml
+++ b/file-store/Cargo.toml
@@ -7,6 +7,3 @@ edition = "2021"
 tempfile = "3.3.0"
 thiserror = "1.0.38"
 uuid = { version = "1.3.0", features = ["serde", "v4"] }
-
-[dev-dependencies]
-faux = "0.1.9"

--- a/filter-parser/Cargo.toml
+++ b/filter-parser/Cargo.toml
@@ -6,8 +6,8 @@ description = "The parser for the Meilisearch filter syntax"
 publish = false
 
 [dependencies]
-nom = "7.1.1"
-nom_locate = "4.0.0"
+nom = "7.1.3"
+nom_locate = "4.1.0"
 
 [dev-dependencies]
-insta = "1.21.0"
+insta = "1.26.0"

--- a/filter-parser/Cargo.toml
+++ b/filter-parser/Cargo.toml
@@ -10,4 +10,4 @@ nom = "7.1.3"
 nom_locate = "4.1.0"
 
 [dev-dependencies]
-insta = "1.26.0"
+insta = "1.28.0"

--- a/index-scheduler/Cargo.toml
+++ b/index-scheduler/Cargo.toml
@@ -4,28 +4,28 @@ version = "1.0.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0.64"
+anyhow = "1.0.68"
 bincode = "1.3.3"
 csv = "1.1.6"
 derive_builder = "0.11.2"
 dump = { path = "../dump" }
-enum-iterator = "1.1.3"
+enum-iterator = "1.2.0"
 file-store = { path = "../file-store" }
-log = "0.4.14"
+log = "0.4.17"
 meilisearch-types = { path = "../meilisearch-types" }
 page_size = "0.5.0"
-roaring = { version = "0.10.0", features = ["serde"] }
-serde = { version = "1.0.136", features = ["derive"] }
-serde_json = { version = "1.0.85", features = ["preserve_order"] }
+roaring = { version = "0.10.1", features = ["serde"] }
+serde = { version = "1.0.152", features = ["derive"] }
+serde_json = { version = "1.0.91", features = ["preserve_order"] }
 synchronoise = "1.0.1"
 tempfile = "3.3.0"
-thiserror = "1.0.30"
-time = { version = "0.3.7", features = ["serde-well-known", "formatting", "parsing", "macros"] }
-uuid = { version = "1.1.2", features = ["serde", "v4"] }
+thiserror = "1.0.38"
+time = { version = "0.3.17", features = ["serde-well-known", "formatting", "parsing", "macros"] }
+uuid = { version = "1.2.2", features = ["serde", "v4"] }
 
 [dev-dependencies]
 big_s = "1.0.2"
 crossbeam = "0.8.2"
-insta = { version = "1.19.1", features = ["json", "redactions"] }
+insta = { version = "1.26.0", features = ["json", "redactions"] }
 meili-snap = { path = "../meili-snap" }
 nelson = { git = "https://github.com/meilisearch/nelson.git", rev = "675f13885548fb415ead8fbb447e9e6d9314000a"}

--- a/index-scheduler/Cargo.toml
+++ b/index-scheduler/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0.68"
+anyhow = "1.0.69"
 bincode = "1.3.3"
 csv = "1.1.6"
 derive_builder = "0.11.2"
@@ -16,12 +16,12 @@ meilisearch-types = { path = "../meilisearch-types" }
 page_size = "0.5.0"
 roaring = { version = "0.10.1", features = ["serde"] }
 serde = { version = "1.0.152", features = ["derive"] }
-serde_json = { version = "1.0.91", features = ["preserve_order"] }
+serde_json = { version = "1.0.92", features = ["preserve_order"] }
 synchronoise = "1.0.1"
 tempfile = "3.3.0"
 thiserror = "1.0.38"
 time = { version = "0.3.17", features = ["serde-well-known", "formatting", "parsing", "macros"] }
-uuid = { version = "1.2.2", features = ["serde", "v4"] }
+uuid = { version = "1.3.0", features = ["serde", "v4"] }
 
 [dev-dependencies]
 big_s = "1.0.2"

--- a/index-scheduler/Cargo.toml
+++ b/index-scheduler/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 anyhow = "1.0.69"
 bincode = "1.3.3"
 csv = "1.1.6"
-derive_builder = "0.11.2"
 dump = { path = "../dump" }
 enum-iterator = "1.2.0"
 file-store = { path = "../file-store" }
@@ -28,4 +27,3 @@ big_s = "1.0.2"
 crossbeam = "0.8.2"
 insta = { version = "1.26.0", features = ["json", "redactions"] }
 meili-snap = { path = "../meili-snap" }
-nelson = { git = "https://github.com/meilisearch/nelson.git", rev = "675f13885548fb415ead8fbb447e9e6d9314000a"}

--- a/index-scheduler/Cargo.toml
+++ b/index-scheduler/Cargo.toml
@@ -6,24 +6,24 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.69"
 bincode = "1.3.3"
-csv = "1.1.6"
+csv = "1.2.0"
 dump = { path = "../dump" }
-enum-iterator = "1.2.0"
+enum-iterator = "1.3.0"
 file-store = { path = "../file-store" }
 log = "0.4.17"
 meilisearch-types = { path = "../meilisearch-types" }
 page_size = "0.5.0"
 roaring = { version = "0.10.1", features = ["serde"] }
 serde = { version = "1.0.152", features = ["derive"] }
-serde_json = { version = "1.0.92", features = ["preserve_order"] }
+serde_json = { version = "1.0.93", features = ["preserve_order"] }
 synchronoise = "1.0.1"
 tempfile = "3.3.0"
 thiserror = "1.0.38"
-time = { version = "0.3.17", features = ["serde-well-known", "formatting", "parsing", "macros"] }
+time = { version = "0.3.18", features = ["serde-well-known", "formatting", "parsing", "macros"] }
 uuid = { version = "1.3.0", features = ["serde", "v4"] }
 
 [dev-dependencies]
 big_s = "1.0.2"
 crossbeam = "0.8.2"
-insta = { version = "1.26.0", features = ["json", "redactions"] }
+insta = { version = "1.28.0", features = ["json", "redactions"] }
 meili-snap = { path = "../meili-snap" }

--- a/meili-snap/Cargo.toml
+++ b/meili-snap/Cargo.toml
@@ -4,6 +4,6 @@ version = "1.0.0"
 edition = "2021"
 
 [dependencies]
-insta = { version = "^1.19.1", features = ["json", "redactions"] }
+insta = { version = "^1.26.0", features = ["json", "redactions"] }
 md5 = "0.7.0"
-once_cell = "1.15"
+once_cell = "1.17"

--- a/meili-snap/Cargo.toml
+++ b/meili-snap/Cargo.toml
@@ -4,6 +4,6 @@ version = "1.0.0"
 edition = "2021"
 
 [dependencies]
-insta = { version = "^1.26.0", features = ["json", "redactions"] }
+insta = { version = "^1.28.0", features = ["json", "redactions"] }
 md5 = "0.7.0"
 once_cell = "1.17"

--- a/meilisearch-auth/Cargo.toml
+++ b/meilisearch-auth/Cargo.toml
@@ -5,15 +5,15 @@ edition = "2021"
 
 [dependencies]
 base64 = "0.13.1"
-enum-iterator = "1.2.0"
+enum-iterator = "1.3.0"
 hmac = "0.12.1"
 maplit = "1.0.2"
 meilisearch-types = { path = "../meilisearch-types" }
 rand = "0.8.5"
 roaring = { version = "0.10.1", features = ["serde"] }
 serde = { version = "1.0.152", features = ["derive"] }
-serde_json = { version = "1.0.92", features = ["preserve_order"] }
+serde_json = { version = "1.0.93", features = ["preserve_order"] }
 sha2 = "0.10.6"
 thiserror = "1.0.38"
-time = { version = "0.3.17", features = ["serde-well-known", "formatting", "parsing", "macros"] }
+time = { version = "0.3.18", features = ["serde-well-known", "formatting", "parsing", "macros"] }
 uuid = { version = "1.3.0", features = ["serde", "v4"] }

--- a/meilisearch-auth/Cargo.toml
+++ b/meilisearch-auth/Cargo.toml
@@ -12,8 +12,8 @@ meilisearch-types = { path = "../meilisearch-types" }
 rand = "0.8.5"
 roaring = { version = "0.10.1", features = ["serde"] }
 serde = { version = "1.0.152", features = ["derive"] }
-serde_json = { version = "1.0.91", features = ["preserve_order"] }
+serde_json = { version = "1.0.92", features = ["preserve_order"] }
 sha2 = "0.10.6"
 thiserror = "1.0.38"
 time = { version = "0.3.17", features = ["serde-well-known", "formatting", "parsing", "macros"] }
-uuid = { version = "1.2.2", features = ["serde", "v4"] }
+uuid = { version = "1.3.0", features = ["serde", "v4"] }

--- a/meilisearch-auth/Cargo.toml
+++ b/meilisearch-auth/Cargo.toml
@@ -5,15 +5,15 @@ edition = "2021"
 
 [dependencies]
 base64 = "0.13.1"
-enum-iterator = "1.1.3"
+enum-iterator = "1.2.0"
 hmac = "0.12.1"
 maplit = "1.0.2"
 meilisearch-types = { path = "../meilisearch-types" }
 rand = "0.8.5"
-roaring = { version = "0.10.0", features = ["serde"] }
-serde = { version = "1.0.145", features = ["derive"] }
-serde_json = { version = "1.0.85", features = ["preserve_order"] }
+roaring = { version = "0.10.1", features = ["serde"] }
+serde = { version = "1.0.152", features = ["derive"] }
+serde_json = { version = "1.0.91", features = ["preserve_order"] }
 sha2 = "0.10.6"
-thiserror = "1.0.37"
-time = { version = "0.3.15", features = ["serde-well-known", "formatting", "parsing", "macros"] }
-uuid = { version = "1.1.2", features = ["serde", "v4"] }
+thiserror = "1.0.38"
+time = { version = "0.3.17", features = ["serde-well-known", "formatting", "parsing", "macros"] }
+uuid = { version = "1.2.2", features = ["serde", "v4"] }

--- a/meilisearch-types/Cargo.toml
+++ b/meilisearch-types/Cargo.toml
@@ -5,32 +5,36 @@ authors = ["marin <postma.marin@protonmail.com>"]
 edition = "2021"
 
 [dependencies]
-actix-web = { version = "4.2.1", default-features = false }
-anyhow = "1.0.68"
+actix-web = { version = "4.3.0", default-features = false }
+anyhow = "1.0.69"
 convert_case = "0.6.0"
 csv = "1.1.6"
 deserr = "0.4.1"
-either = { version = "1.8.0", features = ["serde"] }
+either = { version = "1.8.1", features = ["serde"] }
 enum-iterator = "1.2.0"
 file-store = { path = "../file-store" }
 flate2 = "1.0.25"
 fst = "0.4.7"
 memmap2 = "0.5.8"
 milli = { path = "../milli", default-features = false }
+proptest = { version = "1.1.0", optional = true }
+proptest-derive = { version = "0.3.0", optional = true }
 roaring = { version = "0.10.1", features = ["serde"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde-cs = "0.2.4"
-serde_json = "1.0.91"
+serde_json = "1.0.92"
 tar = "0.4.38"
 tempfile = "3.3.0"
 thiserror = "1.0.38"
 time = { version = "0.3.17", features = ["serde-well-known", "formatting", "parsing", "macros"] }
-tokio = "1.24"
-uuid = { version = "1.2.2", features = ["serde", "v4"] }
+tokio = "1.25"
+uuid = { version = "1.3.0", features = ["serde", "v4"] }
 
 [dev-dependencies]
 insta = "1.26.0"
 meili-snap = { path = "../meili-snap" }
+proptest = "1.1.0"
+proptest-derive = "0.3.0"
 
 [features]
 # all specialized tokenizations

--- a/meilisearch-types/Cargo.toml
+++ b/meilisearch-types/Cargo.toml
@@ -8,10 +8,10 @@ edition = "2021"
 actix-web = { version = "4.3.0", default-features = false }
 anyhow = "1.0.69"
 convert_case = "0.6.0"
-csv = "1.1.6"
+csv = "1.2.0"
 deserr = "0.4.1"
 either = { version = "1.8.1", features = ["serde"] }
-enum-iterator = "1.2.0"
+enum-iterator = "1.3.0"
 file-store = { path = "../file-store" }
 flate2 = "1.0.25"
 fst = "0.4.7"
@@ -20,16 +20,16 @@ milli = { path = "../milli", default-features = false }
 roaring = { version = "0.10.1", features = ["serde"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde-cs = "0.2.4"
-serde_json = "1.0.92"
+serde_json = "1.0.93"
 tar = "0.4.38"
 tempfile = "3.3.0"
 thiserror = "1.0.38"
-time = { version = "0.3.17", features = ["serde-well-known", "formatting", "parsing", "macros"] }
+time = { version = "0.3.18", features = ["serde-well-known", "formatting", "parsing", "macros"] }
 tokio = "1.25"
 uuid = { version = "1.3.0", features = ["serde", "v4"] }
 
 [dev-dependencies]
-insta = "1.26.0"
+insta = "1.28.0"
 meili-snap = { path = "../meili-snap" }
 
 [features]

--- a/meilisearch-types/Cargo.toml
+++ b/meilisearch-types/Cargo.toml
@@ -17,8 +17,6 @@ flate2 = "1.0.25"
 fst = "0.4.7"
 memmap2 = "0.5.8"
 milli = { path = "../milli", default-features = false }
-proptest = { version = "1.1.0", optional = true }
-proptest-derive = { version = "0.3.0", optional = true }
 roaring = { version = "0.10.1", features = ["serde"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde-cs = "0.2.4"
@@ -33,8 +31,6 @@ uuid = { version = "1.3.0", features = ["serde", "v4"] }
 [dev-dependencies]
 insta = "1.26.0"
 meili-snap = { path = "../meili-snap" }
-proptest = "1.1.0"
-proptest-derive = "0.3.0"
 
 [features]
 # all specialized tokenizations

--- a/meilisearch-types/Cargo.toml
+++ b/meilisearch-types/Cargo.toml
@@ -6,30 +6,30 @@ edition = "2021"
 
 [dependencies]
 actix-web = { version = "4.2.1", default-features = false }
-anyhow = "1.0.65"
+anyhow = "1.0.68"
 convert_case = "0.6.0"
 csv = "1.1.6"
 deserr = "0.4.1"
-either = { version = "1.6.1", features = ["serde"] }
-enum-iterator = "1.1.3"
+either = { version = "1.8.0", features = ["serde"] }
+enum-iterator = "1.2.0"
 file-store = { path = "../file-store" }
-flate2 = "1.0.24"
+flate2 = "1.0.25"
 fst = "0.4.7"
-memmap2 = "0.5.7"
+memmap2 = "0.5.8"
 milli = { path = "../milli", default-features = false }
-roaring = { version = "0.10.0", features = ["serde"] }
-serde = { version = "1.0.145", features = ["derive"] }
+roaring = { version = "0.10.1", features = ["serde"] }
+serde = { version = "1.0.152", features = ["derive"] }
 serde-cs = "0.2.4"
-serde_json = "1.0.85"
+serde_json = "1.0.91"
 tar = "0.4.38"
 tempfile = "3.3.0"
-thiserror = "1.0.30"
-time = { version = "0.3.7", features = ["serde-well-known", "formatting", "parsing", "macros"] }
+thiserror = "1.0.38"
+time = { version = "0.3.17", features = ["serde-well-known", "formatting", "parsing", "macros"] }
 tokio = "1.24"
-uuid = { version = "1.1.2", features = ["serde", "v4"] }
+uuid = { version = "1.2.2", features = ["serde", "v4"] }
 
 [dev-dependencies]
-insta = "1.19.1"
+insta = "1.26.0"
 meili-snap = { path = "../meili-snap" }
 
 [features]

--- a/meilisearch/Cargo.toml
+++ b/meilisearch/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = { version = "1.0.69", features = ["backtrace"] }
 bstr = "1.2.0"
 byte-unit = { version = "4.0.18", default-features = false, features = ["std", "serde"] }
 bytes = "1.4.0"
-clap = { version = "4.1.4", features = ["derive", "env"] }
+clap = { version = "4.1.6", features = ["derive", "env"] }
 crossbeam-channel = "0.5.6"
 deserr = "0.4.1"
 dump = { path = "../dump" }
@@ -39,7 +39,7 @@ mimalloc = { version = "0.1.34", default-features = false }
 mime = "0.3.16"
 num_cpus = "1.15.0"
 obkv = "0.2.0"
-once_cell = "1.17.0"
+once_cell = "1.17.1"
 parking_lot = "0.12.1"
 permissive-json-pointer = { path = "../permissive-json-pointer" }
 pin-project-lite = "0.2.9"
@@ -54,7 +54,7 @@ rustls-pemfile = "1.0.2"
 segment = { version = "0.2.2", optional = true }
 serde = { version = "1.0.152", features = ["derive"] }
 serde-cs = "0.2.4"
-serde_json = { version = "1.0.92", features = ["preserve_order"] }
+serde_json = { version = "1.0.93", features = ["preserve_order"] }
 sha2 = "0.10.6"
 siphasher = "0.3.10"
 slice-group-by = "0.3.0"
@@ -63,7 +63,7 @@ sysinfo = "0.26.9"
 tar = "0.4.38"
 tempfile = "3.3.0"
 thiserror = "1.0.38"
-time = { version = "0.3.17", features = ["serde-well-known", "formatting", "parsing", "macros"] }
+time = { version = "0.3.18", features = ["serde-well-known", "formatting", "parsing", "macros"] }
 tokio = { version = "1.25.0", features = ["full"] }
 toml = "0.5.11"
 uuid = { version = "1.3.0", features = ["serde", "v4"] }
@@ -71,12 +71,12 @@ yaup = "0.2.1"
 serde_urlencoded = "0.7.1"
 actix-utils = "3.0.1"
 atty = "0.2.14"
-termcolor = "1.1.3"
+termcolor = "1.2.0"
 
 [dev-dependencies]
 actix-rt = "2.8.0"
 brotli = "3.3.4"
-insta = "1.26.0"
+insta = "1.28.0"
 manifest-dir-macros = "0.1.16"
 maplit = "1.0.2"
 meili-snap = {path = "../meili-snap"}
@@ -92,7 +92,7 @@ reqwest = { version = "0.11.14", features = ["blocking", "rustls-tls"], default-
 sha-1 = { version = "0.10.1", optional = true }
 static-files = { version = "0.2.3", optional = true }
 tempfile = { version = "3.3.0", optional = true }
-vergen = { version = "7.5.0", default-features = false, features = ["git"] }
+vergen = { version = "7.5.1", default-features = false, features = ["git"] }
 zip = { version = "0.6.4", optional = true }
 
 [features]

--- a/meilisearch/Cargo.toml
+++ b/meilisearch/Cargo.toml
@@ -12,8 +12,6 @@ actix-http = { version = "3.3.0", default-features = false, features = ["compres
 actix-web = { version = "4.3.0", default-features = false, features = ["macros", "compress-brotli", "compress-gzip", "cookies", "rustls"] }
 actix-web-static-files = { git = "https://github.com/kilork/actix-web-static-files.git", rev = "2d3b6160", optional = true }
 anyhow = { version = "1.0.69", features = ["backtrace"] }
-async-stream = "0.3.3"
-async-trait = "0.1.64"
 bstr = "1.2.0"
 byte-unit = { version = "4.0.18", default-features = false, features = ["std", "serde"] }
 bytes = "1.4.0"
@@ -67,10 +65,8 @@ tempfile = "3.3.0"
 thiserror = "1.0.38"
 time = { version = "0.3.17", features = ["serde-well-known", "formatting", "parsing", "macros"] }
 tokio = { version = "1.25.0", features = ["full"] }
-tokio-stream = "0.1.11"
 toml = "0.5.11"
 uuid = { version = "1.3.0", features = ["serde", "v4"] }
-walkdir = "2.3.2"
 yaup = "0.2.1"
 serde_urlencoded = "0.7.1"
 actix-utils = "3.0.1"
@@ -79,7 +75,6 @@ termcolor = "1.1.3"
 
 [dev-dependencies]
 actix-rt = "2.8.0"
-assert-json-diff = "2.0.2"
 brotli = "3.3.4"
 insta = "1.26.0"
 manifest-dir-macros = "0.1.16"
@@ -104,7 +99,7 @@ zip = { version = "0.6.4", optional = true }
 default = ["analytics", "meilisearch-types/default", "mini-dashboard"]
 metrics = ["prometheus"]
 analytics = ["segment"]
-mini-dashboard = ["actix-web-static-files", "static-files", "anyhow", "cargo_toml", "hex", "reqwest", "sha-1", "tempfile", "zip"]
+mini-dashboard = ["static-files", "anyhow", "cargo_toml", "hex", "reqwest", "sha-1", "tempfile", "zip"]
 chinese = ["meilisearch-types/chinese"]
 hebrew = ["meilisearch-types/hebrew"]
 japanese = ["meilisearch-types/japanese"]

--- a/meilisearch/Cargo.toml
+++ b/meilisearch/Cargo.toml
@@ -7,70 +7,70 @@ name = "meilisearch"
 version = "1.0.0"
 
 [dependencies]
-actix-cors = "0.6.3"
+actix-cors = "0.6.4"
 actix-http = { version = "3.2.2", default-features = false, features = ["compress-brotli", "compress-gzip", "rustls"] }
 actix-web = { version = "4.2.1", default-features = false, features = ["macros", "compress-brotli", "compress-gzip", "cookies", "rustls"] }
 actix-web-static-files = { git = "https://github.com/kilork/actix-web-static-files.git", rev = "2d3b6160", optional = true }
-anyhow = { version = "1.0.65", features = ["backtrace"] }
+anyhow = { version = "1.0.68", features = ["backtrace"] }
 async-stream = "0.3.3"
-async-trait = "0.1.57"
-bstr = "1.0.1"
-byte-unit = { version = "4.0.14", default-features = false, features = ["std", "serde"] }
-bytes = "1.2.1"
-clap = { version = "4.0.9", features = ["derive", "env"] }
+async-trait = "0.1.61"
+bstr = "1.1.0"
+byte-unit = { version = "4.0.18", default-features = false, features = ["std", "serde"] }
+bytes = "1.3.0"
+clap = { version = "4.0.32", features = ["derive", "env"] }
 crossbeam-channel = "0.5.6"
 deserr = "0.4.1"
 dump = { path = "../dump" }
 either = "1.8.0"
-env_logger = "0.9.1"
+env_logger = "0.9.3"
 file-store = { path = "../file-store" }
-flate2 = "1.0.24"
+flate2 = "1.0.25"
 fst = "0.4.7"
-futures = "0.3.24"
-futures-util = "0.3.24"
+futures = "0.3.25"
+futures-util = "0.3.25"
 http = "0.2.8"
 index-scheduler = { path = "../index-scheduler" }
-indexmap = { version = "1.9.1", features = ["serde-1"] }
+indexmap = { version = "1.9.2", features = ["serde-1"] }
 itertools = "0.10.5"
-jsonwebtoken = "8.1.1"
+jsonwebtoken = "8.2.0"
 lazy_static = "1.4.0"
 log = "0.4.17"
 meilisearch-auth = { path = "../meilisearch-auth" }
 meilisearch-types = { path = "../meilisearch-types" }
-mimalloc = { version = "0.1.29", default-features = false }
+mimalloc = { version = "0.1.34", default-features = false }
 mime = "0.3.16"
-num_cpus = "1.13.1"
+num_cpus = "1.15.0"
 obkv = "0.2.0"
-once_cell = "1.15.0"
+once_cell = "1.17.0"
 parking_lot = "0.12.1"
 permissive-json-pointer = { path = "../permissive-json-pointer" }
 pin-project-lite = "0.2.9"
 platform-dirs = "0.3.0"
-prometheus = { version = "0.13.2", features = ["process"], optional = true }
+prometheus = { version = "0.13.3", features = ["process"], optional = true }
 rand = "0.8.5"
-rayon = "1.5.3"
-regex = "1.6.0"
-reqwest = { version = "0.11.12", features = ["rustls-tls", "json"], default-features = false }
-rustls = "0.20.6"
+rayon = "1.6.1"
+regex = "1.7.1"
+reqwest = { version = "0.11.13", features = ["rustls-tls", "json"], default-features = false }
+rustls = "0.20.7"
 rustls-pemfile = "1.0.1"
-segment = { version = "0.2.1", optional = true }
-serde = { version = "1.0.145", features = ["derive"] }
-serde_json = { version = "1.0.85", features = ["preserve_order"] }
+segment = { version = "0.2.2", optional = true }
+serde = { version = "1.0.152", features = ["derive"] }
+serde_json = { version = "1.0.91", features = ["preserve_order"] }
 sha2 = "0.10.6"
 siphasher = "0.3.10"
 slice-group-by = "0.3.0"
 static-files = { version = "0.2.3", optional = true }
-sysinfo = "0.26.4"
+sysinfo = "0.26.8"
 tar = "0.4.38"
 tempfile = "3.3.0"
-thiserror = "1.0.37"
-time = { version = "0.3.15", features = ["serde-well-known", "formatting", "parsing", "macros"] }
+thiserror = "1.0.38"
+time = { version = "0.3.17", features = ["serde-well-known", "formatting", "parsing", "macros"] }
 tokio = { version = "1.24.2", features = ["full"] }
-tokio-stream = "0.1.10"
-toml = "0.5.9"
-uuid = { version = "1.1.2", features = ["serde", "v4"] }
+tokio-stream = "0.1.11"
+toml = "0.5.10"
+uuid = { version = "1.2.2", features = ["serde", "v4"] }
 walkdir = "2.3.2"
-yaup = "0.2.0"
+yaup = "0.2.1"
 serde_urlencoded = "0.7.1"
 actix-utils = "3.0.1"
 atty = "0.2.14"
@@ -80,7 +80,7 @@ termcolor = "1.1.3"
 actix-rt = "2.7.0"
 assert-json-diff = "2.0.2"
 brotli = "3.3.4"
-insta = "1.19.1"
+insta = "1.26.0"
 manifest-dir-macros = "0.1.16"
 maplit = "1.0.2"
 meili-snap = {path = "../meili-snap"}
@@ -89,15 +89,15 @@ urlencoding = "2.1.2"
 yaup = "0.2.1"
 
 [build-dependencies]
-anyhow = { version = "1.0.65", optional = true }
-cargo_toml = { version = "0.13.0", optional = true }
+anyhow = { version = "1.0.68", optional = true }
+cargo_toml = { version = "0.13.3", optional = true }
 hex = { version = "0.4.3", optional = true }
-reqwest = { version = "0.11.12", features = ["blocking", "rustls-tls"], default-features = false, optional = true }
-sha-1 = { version = "0.10.0", optional = true }
+reqwest = { version = "0.11.13", features = ["blocking", "rustls-tls"], default-features = false, optional = true }
+sha-1 = { version = "0.10.1", optional = true }
 static-files = { version = "0.2.3", optional = true }
 tempfile = { version = "3.3.0", optional = true }
-vergen = { version = "7.4.2", default-features = false, features = ["git"] }
-zip = { version = "0.6.2", optional = true }
+vergen = { version = "7.5.0", default-features = false, features = ["git"] }
+zip = { version = "0.6.3", optional = true }
 
 [features]
 default = ["analytics", "meilisearch-types/default", "mini-dashboard"]

--- a/meilisearch/Cargo.toml
+++ b/meilisearch/Cargo.toml
@@ -8,26 +8,26 @@ version = "1.0.0"
 
 [dependencies]
 actix-cors = "0.6.4"
-actix-http = { version = "3.2.2", default-features = false, features = ["compress-brotli", "compress-gzip", "rustls"] }
-actix-web = { version = "4.2.1", default-features = false, features = ["macros", "compress-brotli", "compress-gzip", "cookies", "rustls"] }
+actix-http = { version = "3.3.0", default-features = false, features = ["compress-brotli", "compress-gzip", "rustls"] }
+actix-web = { version = "4.3.0", default-features = false, features = ["macros", "compress-brotli", "compress-gzip", "cookies", "rustls"] }
 actix-web-static-files = { git = "https://github.com/kilork/actix-web-static-files.git", rev = "2d3b6160", optional = true }
-anyhow = { version = "1.0.68", features = ["backtrace"] }
+anyhow = { version = "1.0.69", features = ["backtrace"] }
 async-stream = "0.3.3"
-async-trait = "0.1.61"
-bstr = "1.1.0"
+async-trait = "0.1.64"
+bstr = "1.2.0"
 byte-unit = { version = "4.0.18", default-features = false, features = ["std", "serde"] }
-bytes = "1.3.0"
-clap = { version = "4.0.32", features = ["derive", "env"] }
+bytes = "1.4.0"
+clap = { version = "4.1.4", features = ["derive", "env"] }
 crossbeam-channel = "0.5.6"
 deserr = "0.4.1"
 dump = { path = "../dump" }
-either = "1.8.0"
+either = "1.8.1"
 env_logger = "0.9.3"
 file-store = { path = "../file-store" }
 flate2 = "1.0.25"
 fst = "0.4.7"
-futures = "0.3.25"
-futures-util = "0.3.25"
+futures = "0.3.26"
+futures-util = "0.3.26"
 http = "0.2.8"
 index-scheduler = { path = "../index-scheduler" }
 indexmap = { version = "1.9.2", features = ["serde-1"] }
@@ -50,25 +50,26 @@ prometheus = { version = "0.13.3", features = ["process"], optional = true }
 rand = "0.8.5"
 rayon = "1.6.1"
 regex = "1.7.1"
-reqwest = { version = "0.11.13", features = ["rustls-tls", "json"], default-features = false }
-rustls = "0.20.7"
-rustls-pemfile = "1.0.1"
+reqwest = { version = "0.11.14", features = ["rustls-tls", "json"], default-features = false }
+rustls = "0.20.8"
+rustls-pemfile = "1.0.2"
 segment = { version = "0.2.2", optional = true }
 serde = { version = "1.0.152", features = ["derive"] }
-serde_json = { version = "1.0.91", features = ["preserve_order"] }
+serde-cs = "0.2.4"
+serde_json = { version = "1.0.92", features = ["preserve_order"] }
 sha2 = "0.10.6"
 siphasher = "0.3.10"
 slice-group-by = "0.3.0"
 static-files = { version = "0.2.3", optional = true }
-sysinfo = "0.26.8"
+sysinfo = "0.26.9"
 tar = "0.4.38"
 tempfile = "3.3.0"
 thiserror = "1.0.38"
 time = { version = "0.3.17", features = ["serde-well-known", "formatting", "parsing", "macros"] }
-tokio = { version = "1.24.2", features = ["full"] }
+tokio = { version = "1.25.0", features = ["full"] }
 tokio-stream = "0.1.11"
-toml = "0.5.10"
-uuid = { version = "1.2.2", features = ["serde", "v4"] }
+toml = "0.5.11"
+uuid = { version = "1.3.0", features = ["serde", "v4"] }
 walkdir = "2.3.2"
 yaup = "0.2.1"
 serde_urlencoded = "0.7.1"
@@ -77,7 +78,7 @@ atty = "0.2.14"
 termcolor = "1.1.3"
 
 [dev-dependencies]
-actix-rt = "2.7.0"
+actix-rt = "2.8.0"
 assert-json-diff = "2.0.2"
 brotli = "3.3.4"
 insta = "1.26.0"
@@ -89,15 +90,15 @@ urlencoding = "2.1.2"
 yaup = "0.2.1"
 
 [build-dependencies]
-anyhow = { version = "1.0.68", optional = true }
+anyhow = { version = "1.0.69", optional = true }
 cargo_toml = { version = "0.13.3", optional = true }
 hex = { version = "0.4.3", optional = true }
-reqwest = { version = "0.11.13", features = ["blocking", "rustls-tls"], default-features = false, optional = true }
+reqwest = { version = "0.11.14", features = ["blocking", "rustls-tls"], default-features = false, optional = true }
 sha-1 = { version = "0.10.1", optional = true }
 static-files = { version = "0.2.3", optional = true }
 tempfile = { version = "3.3.0", optional = true }
 vergen = { version = "7.5.0", default-features = false, features = ["git"] }
-zip = { version = "0.6.3", optional = true }
+zip = { version = "0.6.4", optional = true }
 
 [features]
 default = ["analytics", "meilisearch-types/default", "mini-dashboard"]

--- a/meilisearch/tests/auth/errors.rs
+++ b/meilisearch/tests/auth/errors.rs
@@ -60,7 +60,7 @@ async fn create_api_key_bad_uid() {
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
-      "message": "Invalid value at `.uid`: invalid character: expected an optional prefix of `urn:uuid:` followed by [0-9a-zA-Z], found `o` at 2",
+      "message": "Invalid value at `.uid`: invalid character: expected an optional prefix of `urn:uuid:` followed by [0-9a-fA-F-], found `o` at 2",
       "code": "invalid_api_key_uid",
       "type": "invalid_request",
       "link": "https://docs.meilisearch.com/errors#invalid_api_key_uid"

--- a/milli/Cargo.toml
+++ b/milli/Cargo.toml
@@ -24,20 +24,20 @@ json-depth-checker = { path = "../json-depth-checker" }
 levenshtein_automata = { version = "0.2.1", features = ["fst_automaton"] }
 memmap2 = "0.5.8"
 obkv = "0.2.0"
-once_cell = "1.17.0"
+once_cell = "1.17.1"
 ordered-float = "3.4.0"
 rayon = "1.6.1"
 roaring = "0.10.1"
 rstar = { version = "0.9.3", features = ["serde"] }
 serde = { version = "1.0.152", features = ["derive"] }
-serde_json = { version = "1.0.92", features = ["preserve_order"] }
+serde_json = { version = "1.0.93", features = ["preserve_order"] }
 slice-group-by = "0.3.0"
 smallstr =  { version = "0.3.0", features = ["serde"] }
 smallvec = "1.10.0"
 smartstring = "1.0.1"
 tempfile = "3.3.0"
 thiserror = "1.0.38"
-time = { version = "0.3.17", features = ["serde-well-known", "formatting", "parsing", "macros"] }
+time = { version = "0.3.18", features = ["serde-well-known", "formatting", "parsing", "macros"] }
 uuid = { version = "1.3.0", features = ["v4"] }
 
 filter-parser = { path = "../filter-parser" }
@@ -48,11 +48,11 @@ itertools = "0.10.5"
 # logging
 log = "0.4.17"
 logging_timer = "1.1.0"
-csv = "1.1.6"
+csv = "1.2.0"
 
 [dev-dependencies]
 big_s = "1.0.2"
-insta = "1.26.0"
+insta = "1.28.0"
 maplit = "1.0.2"
 md5 = "0.7.0"
 rand = {version = "0.8.5", features = ["small_rng"] }

--- a/milli/Cargo.toml
+++ b/milli/Cargo.toml
@@ -7,38 +7,38 @@ edition = "2018"
 [dependencies]
 bimap = { version = "0.6.2", features = ["serde"] }
 bincode = "1.3.3"
-bstr = "1.0.1"
+bstr = "1.2.0"
 byteorder = "1.4.3"
 charabia = { version = "0.7.0", default-features = false }
 concat-arrays = "0.1.2"
 crossbeam-channel = "0.5.6"
 deserr = "0.4.1"
-either = "1.8.0"
+either = "1.8.1"
 flatten-serde-json = { path = "../flatten-serde-json" }
 fst = "0.4.7"
 fxhash = "0.2.1"
 geoutils = "0.5.1"
-grenad = { version = "0.4.3", default-features = false, features = ["tempfile"] }
+grenad = { version = "0.4.4", default-features = false, features = ["tempfile"] }
 heed = { git = "https://github.com/meilisearch/heed", tag = "v0.12.5", default-features = false, features = ["lmdb", "sync-read-txn"] }
 json-depth-checker = { path = "../json-depth-checker" }
 levenshtein_automata = { version = "0.2.1", features = ["fst_automaton"] }
-memmap2 = "0.5.7"
+memmap2 = "0.5.8"
 obkv = "0.2.0"
-once_cell = "1.15.0"
-ordered-float = "3.2.0"
-rayon = "1.5.3"
+once_cell = "1.17.0"
+ordered-float = "3.4.0"
+rayon = "1.6.1"
 roaring = "0.10.1"
 rstar = { version = "0.9.3", features = ["serde"] }
-serde = { version = "1.0.145", features = ["derive"] }
-serde_json = { version = "1.0.85", features = ["preserve_order"] }
+serde = { version = "1.0.152", features = ["derive"] }
+serde_json = { version = "1.0.92", features = ["preserve_order"] }
 slice-group-by = "0.3.0"
 smallstr =  { version = "0.3.0", features = ["serde"] }
 smallvec = "1.10.0"
 smartstring = "1.0.1"
 tempfile = "3.3.0"
-thiserror = "1.0.37"
-time = { version = "0.3.15", features = ["serde-well-known", "formatting", "parsing", "macros"] }
-uuid = { version = "1.1.2", features = ["v4"] }
+thiserror = "1.0.38"
+time = { version = "0.3.17", features = ["serde-well-known", "formatting", "parsing", "macros"] }
+uuid = { version = "1.3.0", features = ["v4"] }
 
 filter-parser = { path = "../filter-parser" }
 
@@ -52,7 +52,7 @@ csv = "1.1.6"
 
 [dev-dependencies]
 big_s = "1.0.2"
-insta = "1.21.0"
+insta = "1.26.0"
 maplit = "1.0.2"
 md5 = "0.7.0"
 rand = {version = "0.8.5", features = ["small_rng"] }


### PR DESCRIPTION
This PR bumps most of the dependencies to the next compatible patch version. I fixed the previous issue of `vergen` [thanks to the maintainer who published version 7.5.0](https://github.com/rustyhorde/vergen/pull/146#issuecomment-1372334760) which allows us to bump `enum-iterator` to 1.2.0 🎉

```bash
✅ cargo upgrade
✅ cargo test -- --test-threads 4
```

<img width="325" alt="Capture d’écran 2023-01-10 à 11 56 17" src="https://user-images.githubusercontent.com/3610253/211533446-923386f9-2e9e-479c-b3ce-ace8a64f6278.png">