### PR TITLE
Remove `--generate-master-key` option

### DIFF
--- a/meilisearch/src/analytics/segment_analytics.rs
+++ b/meilisearch/src/analytics/segment_analytics.rs
@@ -271,7 +271,6 @@ impl From<Opt> for Infos {
             log_level,
             indexer_options,
             config_file_path,
-            generate_master_key: _,
             #[cfg(all(not(debug_assertions), feature = "analytics"))]
                 no_analytics: _,
         } = options;

--- a/meilisearch/src/main.rs
+++ b/meilisearch/src/main.rs
@@ -29,11 +29,6 @@ async fn main() -> anyhow::Result<()> {
 
     setup(&opt)?;
 
-    if opt.generate_master_key {
-        println!("{}", generate_master_key());
-        return Ok(());
-    }
-
     match (opt.env.as_ref(), &opt.master_key) {
         ("production", Some(master_key)) if master_key.len() < MASTER_KEY_MIN_SIZE => {
             anyhow::bail!(
@@ -178,7 +173,6 @@ Anonymous telemetry:\t\"Enabled\""
                 eprintln!();
                 log::warn!("The provided master key is too short (< {MASTER_KEY_MIN_SIZE} bytes)");
                 eprintln!("A master key of at least {MASTER_KEY_MIN_SIZE} bytes will be required when switching to the production environment.");
-                eprintln!("Restart Meilisearch with the `--generate-master-key` flag to generate a secure master key you can use");
             }
         }
         ("development", None) => {

--- a/meilisearch/src/option.rs
+++ b/meilisearch/src/option.rs
@@ -47,7 +47,6 @@ const MEILI_IGNORE_MISSING_DUMP: &str = "MEILI_IGNORE_MISSING_DUMP";
 const MEILI_IGNORE_DUMP_IF_DB_EXISTS: &str = "MEILI_IGNORE_DUMP_IF_DB_EXISTS";
 const MEILI_DUMP_DIR: &str = "MEILI_DUMP_DIR";
 const MEILI_LOG_LEVEL: &str = "MEILI_LOG_LEVEL";
-const MEILI_GENERATE_MASTER_KEY: &str = "MEILI_GENERATE_MASTER_KEY";
 #[cfg(feature = "metrics")]
 const MEILI_ENABLE_METRICS_ROUTE: &str = "MEILI_ENABLE_METRICS_ROUTE";
 
@@ -284,13 +283,6 @@ pub struct Opt {
     #[serde(default)]
     pub log_level: LogLevel,
 
-    /// Generates a string of characters that can be used as a master key and exits.
-    ///
-    /// Pass the generated master key using the `--master-key` argument or the `MEILI_MASTER_KEY` environment variable in a subsequent Meilisearch invocation.
-    #[clap(long, env = MEILI_GENERATE_MASTER_KEY)]
-    #[serde(default)]
-    pub generate_master_key: bool,
-
     /// Enables Prometheus metrics and /metrics route.
     #[cfg(feature = "metrics")]
     #[clap(long, env = MEILI_ENABLE_METRICS_ROUTE)]
@@ -383,7 +375,6 @@ impl Opt {
             ignore_missing_snapshot: _,
             ignore_snapshot_if_db_exists: _,
             import_dump: _,
-            generate_master_key: _,
             ignore_missing_dump: _,
             ignore_dump_if_db_exists: _,
             config_file_path: _,


### PR DESCRIPTION
# Pull Request

## Related issue

Related to https://github.com/meilisearch/specifications/pull/210#issuecomment-1372035525

## What does this PR do?
- Remove the short-lived `--generate-master-key` flag that was too beautiful for this world :D.

Removal of this option proceeds of the following reasoning:

1. It is the only option that starts meilisearch and then immediately exits
2. We are unsure if we want to keep it under this form in the future or switch to a subcommand.
3. Releasing this option in v1 would make it insta-stable.
5. The option is only marginally useful, as users will be presented with freshly generated key directly in the error messages if their master key is absent/too short.
6. If we remove this option now, we can still add it back in a future v1 release. If we add it now, we won't be able to remove it in any future v1 version.

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [ ] Have you read the contributing guidelines?
- [ ] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
