### PR TITLE
Replace published by released

### DIFF
--- a/.github/workflows/latest-git-tag.yml
+++ b/.github/workflows/latest-git-tag.yml
@@ -3,7 +3,7 @@ name: Update latest git tag
 on:
   workflow_dispatch:
   release:
-    types: [published]
+    types: [released]
 
 jobs:
   check-version:

--- a/.github/workflows/publish-deb-brew-pkg.yml
+++ b/.github/workflows/publish-deb-brew-pkg.yml
@@ -2,7 +2,7 @@ name: Publish to APT repository & Homebrew
 
 on:
   release:
-    types: [published]
+    types: [released]
 
 jobs:
   check-version:


### PR DESCRIPTION
Fix a bug introduced here: https://github.com/meilisearch/meilisearch/pull/3229

Regarding this line:

> * In multiple CIs: replace the `released` type by `published`, see [here](https://stackoverflow.com/questions/59319281/github-action-different-between-release-created-and-published) why. Will not impact anything, but will prevent to fail our future automation

I made mistakes by replacing some un-relevant lines in the 
- latest git workflow
- APT and brew workflow

-> the consequence was the workflow ran when releasing `rc0` but they shouldn't have. Luckily the check inside the workflow prevent any release.

<img width="1366" alt="Capture d’écran 2023-01-11 à 10 36 52" src="https://user-images.githubusercontent.com/20380692/211771382-d716ff16-0d53-41a9-90de-0d93e01e45fa.png">

This fix is not mandatory thanks to the check inside the workflow, but I would rather roll back to avoid any issues when releasing the official v1 release.