### PR TITLE
Add missingneeds: to the git latest tag workflow

### DIFF
--- a/.github/workflows/latest-git-tag.yml
+++ b/.github/workflows/latest-git-tag.yml
@@ -17,6 +17,7 @@ jobs:
 
   update-latest-tag:
     runs-on: ubuntu-latest
+    needs: check-version
     steps:
       - uses: actions/checkout@v3
       - uses: rickstaa/action-create-tag@v1


### PR DESCRIPTION
Fixes this problem: the workflow to update the latest git tag was triggered despite the first check failed

<img width="580" alt="Capture d’écran 2023-01-12 à 15 07 00" src="https://user-images.githubusercontent.com/20380692/212087926-975eb387-c8c9-4789-8a62-a56143b9bbd4.png">


These leads to update our latest git tag: our latest git tag corresponds to the `v1.0.0-rc.0` tag instead of `v0.30.5`. (I'm fixing this right now)

<img width="586" alt="Capture d’écran 2023-01-12 à 15 08 15" src="https://user-images.githubusercontent.com/20380692/212088136-f4bc2e9c-d824-4c23-8213-52598c742ebd.png">
