### PR TITLE
Extract creation and last updated timestamp for v3 dump

### DIFF
--- a/dump/src/reader/v3/mod.rs
+++ b/dump/src/reader/v3/mod.rs
@@ -113,7 +113,7 @@ impl V3Reader {
         Ok(self.index_uuid.iter().map(|index| -> Result<_> {
             V3IndexReader::new(
                 &self.dump.path().join("indexes").join(index.uuid.to_string()),
-                &index,
+                index,
                 BufReader::new(
                     File::open(self.dump.path().join("updates").join("data.jsonl")).unwrap(),
                 ),
@@ -150,7 +150,6 @@ impl V3Reader {
     }
 }
 
-#[derive(Debug)]
 pub struct V3IndexReader {
     metadata: IndexMetadata,
     settings: Settings<Checked>,
@@ -169,7 +168,7 @@ impl V3IndexReader {
         for line in tasks.lines() {
             let task: Task = serde_json::from_str(&line?)?;
 
-            if task.uuid != index_uuid.uuid || !task.is_finished() {
+            if !(task.uuid == index_uuid.uuid && task.is_finished()) {
                 continue;
             }
 

--- a/dump/src/reader/v3/updates.rs
+++ b/dump/src/reader/v3/updates.rs
@@ -77,11 +77,11 @@ impl UpdateStatus {
 
     pub fn enqueued_at(&self) -> Option<OffsetDateTime> {
         match self {
-            UpdateStatus::Processing(u) => Some(u.from.enqueued_at.clone()),
-            UpdateStatus::Enqueued(u) => Some(u.enqueued_at.clone()),
-            UpdateStatus::Processed(u) => Some(u.from.from.enqueued_at.clone()),
-            UpdateStatus::Aborted(u) => Some(u.from.enqueued_at.clone()),
-            UpdateStatus::Failed(u) => Some(u.from.from.enqueued_at.clone()),
+            UpdateStatus::Processing(u) => Some(u.from.enqueued_at),
+            UpdateStatus::Enqueued(u) => Some(u.enqueued_at),
+            UpdateStatus::Processed(u) => Some(u.from.from.enqueued_at),
+            UpdateStatus::Aborted(u) => Some(u.from.enqueued_at),
+            UpdateStatus::Failed(u) => Some(u.from.from.enqueued_at),
         }
     }
 
@@ -89,9 +89,9 @@ impl UpdateStatus {
         match self {
             UpdateStatus::Processing(_) => None,
             UpdateStatus::Enqueued(_) => None,
-            UpdateStatus::Processed(u) => Some(u.processed_at.clone()),
+            UpdateStatus::Processed(u) => Some(u.processed_at),
             UpdateStatus::Aborted(_) => None,
-            UpdateStatus::Failed(u) => Some(u.failed_at.clone()),
+            UpdateStatus::Failed(u) => Some(u.failed_at),
         }
     }
 }

--- a/dump/src/reader/v3/updates.rs
+++ b/dump/src/reader/v3/updates.rs
@@ -75,7 +75,7 @@ impl UpdateStatus {
         }
     }
 
-    pub fn created_at(&self) -> Option<OffsetDateTime> {
+    pub fn enqueued_at(&self) -> Option<OffsetDateTime> {
         match self {
             UpdateStatus::Processing(u) => Some(u.from.enqueued_at.clone()),
             UpdateStatus::Enqueued(u) => Some(u.enqueued_at.clone()),
@@ -85,9 +85,9 @@ impl UpdateStatus {
         }
     }
 
-    pub fn processed_at(&self) -> Option<OffsetDateTime> {
+    pub fn finished_at(&self) -> Option<OffsetDateTime> {
         match self {
-            UpdateStatus::Processing(u) => Some(u.started_processing_at.clone()),
+            UpdateStatus::Processing(_) => None,
             UpdateStatus::Enqueued(_) => None,
             UpdateStatus::Processed(u) => Some(u.processed_at.clone()),
             UpdateStatus::Aborted(_) => None,

--- a/dump/src/reader/v3/updates.rs
+++ b/dump/src/reader/v3/updates.rs
@@ -74,6 +74,26 @@ impl UpdateStatus {
             _ => None,
         }
     }
+
+    pub fn created_at(&self) -> Option<OffsetDateTime> {
+        match self {
+            UpdateStatus::Processing(u) => Some(u.from.enqueued_at.clone()),
+            UpdateStatus::Enqueued(u) => Some(u.enqueued_at.clone()),
+            UpdateStatus::Processed(u) => Some(u.from.from.enqueued_at.clone()),
+            UpdateStatus::Aborted(u) => Some(u.from.enqueued_at.clone()),
+            UpdateStatus::Failed(u) => Some(u.from.from.enqueued_at.clone()),
+        }
+    }
+
+    pub fn processed_at(&self) -> Option<OffsetDateTime> {
+        match self {
+            UpdateStatus::Processing(u) => Some(u.started_processing_at.clone()),
+            UpdateStatus::Enqueued(_) => None,
+            UpdateStatus::Processed(u) => Some(u.processed_at.clone()),
+            UpdateStatus::Aborted(_) => None,
+            UpdateStatus::Failed(u) => Some(u.failed_at.clone()),
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Clone)]


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #2988

## What does this PR do?

Inspired by the v4 dump implementation, this extracts the first `createdAt` and last `updatedAt` fields by parsing the task queue.

Questions:
- Should the parsing of the tasks be cached instead of being parsed for every index since it might add a performance penalty?
- I am not sure if the `created_at` and `processed_at` fields are correct 
- Should I assume the data is sorted in some order like with `uuid` or `updateId`? I assumed the list is unordered.
- I was planning to populate my dev instance with data and dump my data. Is there a way to dump with previous versions?

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
