### PR TITLE
fix cargo flaky

### DIFF
--- a/.github/workflows/flaky.yml
+++ b/.github/workflows/flaky.yml
@@ -22,5 +22,11 @@ jobs:
         override: true
     - name: Install cargo-flaky
       run: cargo install cargo-flaky
-    - name: Run cargo flaky 100 times
-      run: cargo flaky -i 100 --release
+    - name: Run cargo flaky in the dumps
+      run: cd dump; cargo flaky -i 100 --release
+    - name: Run cargo flaky in the index-scheduler
+      run: cd index-scheduler; cargo flaky -i 100 --release
+    - name: Run cargo flaky in the auth
+      run: cd meilisearch-auth; cargo flaky -i 100 --release
+    - name: Run cargo flaky in meilisearch
+      run: cd meilisearch; cargo flaky -i 100 --release


### PR DESCRIPTION
Related to https://github.com/meilisearch/meilisearch/issues/3273 but does not fix completely

Ideally, we should revert this commit and fix cargo-flaky directly to ensure we never forget to add a sub-crate to the CI.

-----

Here is an example of the CI running (and thus working); https://github.com/meilisearch/meilisearch/actions/runs/3932783699/jobs/6725755801