### PR TITLE
Avoid deleting all task invalid canceled by

### DIFF
--- a/meilisearch/tests/common/index.rs
+++ b/meilisearch/tests/common/index.rs
@@ -132,13 +132,21 @@ impl Index<'_> {
         self.service.get(url).await
     }
 
-    pub async fn filtered_tasks(&self, types: &[&str], statuses: &[&str]) -> (Value, StatusCode) {
+    pub async fn filtered_tasks(
+        &self,
+        types: &[&str],
+        statuses: &[&str],
+        canceled_by: &[&str],
+    ) -> (Value, StatusCode) {
         let mut url = format!("/tasks?indexUids={}", self.uid);
         if !types.is_empty() {
             let _ = write!(url, "&types={}", types.join(","));
         }
         if !statuses.is_empty() {
             let _ = write!(url, "&statuses={}", statuses.join(","));
+        }
+        if !canceled_by.is_empty() {
+            let _ = write!(url, "&canceledBy={}", canceled_by.join(","));
         }
         self.service.get(url).await
     }

--- a/meilisearch/tests/documents/add_documents.rs
+++ b/meilisearch/tests/documents/add_documents.rs
@@ -1077,7 +1077,7 @@ async fn batch_several_documents_addition() {
     futures::future::join_all(waiter).await;
     index.wait_task(9).await;
 
-    let (response, _code) = index.filtered_tasks(&[], &["failed"]).await;
+    let (response, _code) = index.filtered_tasks(&[], &["failed"], &[]).await;
 
     // Check if only the 6th task failed
     println!("{}", &response);

--- a/meilisearch/tests/tasks/mod.rs
+++ b/meilisearch/tests/tasks/mod.rs
@@ -152,6 +152,21 @@ async fn list_tasks_type_filtered() {
 }
 
 #[actix_rt::test]
+async fn list_tasks_invalid_canceled_by_filter() {
+    let server = Server::new().await;
+    let index = server.index("test");
+    index.create(None).await;
+    index.wait_task(0).await;
+    index
+        .add_documents(serde_json::from_str(include_str!("../assets/test_set.json")).unwrap(), None)
+        .await;
+
+    let (response, code) = index.filtered_tasks(&[], &[], &["0"]).await;
+    assert_eq!(code, 200, "{}", response);
+    assert_eq!(response["results"].as_array().unwrap().len(), 0);
+}
+
+#[actix_rt::test]
 async fn list_tasks_status_and_type_filtered() {
     let server = Server::new().await;
     let index = server.index("test");

--- a/meilisearch/tests/tasks/mod.rs
+++ b/meilisearch/tests/tasks/mod.rs
@@ -115,7 +115,7 @@ async fn list_tasks_status_filtered() {
         .add_documents(serde_json::from_str(include_str!("../assets/test_set.json")).unwrap(), None)
         .await;
 
-    let (response, code) = index.filtered_tasks(&[], &["succeeded"]).await;
+    let (response, code) = index.filtered_tasks(&[], &["succeeded"], &[]).await;
     assert_eq!(code, 200, "{}", response);
     assert_eq!(response["results"].as_array().unwrap().len(), 1);
 
@@ -126,7 +126,7 @@ async fn list_tasks_status_filtered() {
 
     index.wait_task(1).await;
 
-    let (response, code) = index.filtered_tasks(&[], &["succeeded"]).await;
+    let (response, code) = index.filtered_tasks(&[], &["succeeded"], &[]).await;
     assert_eq!(code, 200, "{}", response);
     assert_eq!(response["results"].as_array().unwrap().len(), 2);
 }
@@ -141,12 +141,12 @@ async fn list_tasks_type_filtered() {
         .add_documents(serde_json::from_str(include_str!("../assets/test_set.json")).unwrap(), None)
         .await;
 
-    let (response, code) = index.filtered_tasks(&["indexCreation"], &[]).await;
+    let (response, code) = index.filtered_tasks(&["indexCreation"], &[], &[]).await;
     assert_eq!(code, 200, "{}", response);
     assert_eq!(response["results"].as_array().unwrap().len(), 1);
 
     let (response, code) =
-        index.filtered_tasks(&["indexCreation", "documentAdditionOrUpdate"], &[]).await;
+        index.filtered_tasks(&["indexCreation", "documentAdditionOrUpdate"], &[], &[]).await;
     assert_eq!(code, 200, "{}", response);
     assert_eq!(response["results"].as_array().unwrap().len(), 2);
 }
@@ -161,7 +161,7 @@ async fn list_tasks_status_and_type_filtered() {
         .add_documents(serde_json::from_str(include_str!("../assets/test_set.json")).unwrap(), None)
         .await;
 
-    let (response, code) = index.filtered_tasks(&["indexCreation"], &["failed"]).await;
+    let (response, code) = index.filtered_tasks(&["indexCreation"], &["failed"], &[]).await;
     assert_eq!(code, 200, "{}", response);
     assert_eq!(response["results"].as_array().unwrap().len(), 0);
 
@@ -169,6 +169,7 @@ async fn list_tasks_status_and_type_filtered() {
         .filtered_tasks(
             &["indexCreation", "documentAdditionOrUpdate"],
             &["succeeded", "processing", "enqueued"],
+            &[],
         )
         .await;
     assert_eq!(code, 200, "{}", response);


### PR DESCRIPTION
Fixes #3369 by making sure that at least one `canceledBy` task filter parameter matches something.