### PR TITLE
Return `invalid_search_facets` rather than `bad_request` when using facet on a non filterable attribute

### DIFF
--- a/meilisearch-types/src/error.rs
+++ b/meilisearch-types/src/error.rs
@@ -327,7 +327,7 @@ impl ErrorCode for milli::Error {
                     }
                     UserError::PrimaryKeyCannotBeChanged(_) => Code::IndexPrimaryKeyAlreadyExists,
                     UserError::SortRankingRuleMissing => Code::InvalidSearchSort,
-                    UserError::InvalidFacetsDistribution { .. } => Code::BadRequest,
+                    UserError::InvalidFacetsDistribution { .. } => Code::InvalidSearchFacets,
                     UserError::InvalidSortableAttribute { .. } => Code::InvalidSearchSort,
                     UserError::CriterionError(_) => Code::InvalidSettingsRankingRules,
                     UserError::InvalidGeoField { .. } => Code::InvalidDocumentGeoField,


### PR DESCRIPTION
# Pull Request

## Related issue

Fixes https://github.com/meilisearch/meilisearch/issues/3384

## What does the PR does

- title
- also adds a test

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
