### PR TITLE
Remove cache from test CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,8 +53,8 @@ jobs:
         os: [macos-12, windows-2022]
     steps:
     - uses: actions/checkout@v3
-    - name: Cache dependencies
-      uses: Swatinem/rust-cache@v2.2.0
+#     - name: Cache dependencies
+#       uses: Swatinem/rust-cache@v2.2.0
     - name: Run cargo check without any default features
       uses: actions-rs/cargo@v1
       with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         toolchain: stable
         override: true
+    # Disable cache due to disk space issues with Windows workers in CI
     # - name: Cache dependencies
     #   uses: Swatinem/rust-cache@v2.2.0
     - name: Run cargo check without any default features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,8 +31,8 @@ jobs:
       with:
         toolchain: stable
         override: true
-    - name: Cache dependencies
-      uses: Swatinem/rust-cache@v2.2.0
+    # - name: Cache dependencies
+    #   uses: Swatinem/rust-cache@v2.2.0
     - name: Run cargo check without any default features
       uses: actions-rs/cargo@v1
       with:
@@ -83,8 +83,8 @@ jobs:
         with:
           toolchain: stable
           override: true
-      - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2.2.0
+      # - name: Cache dependencies
+      #   uses: Swatinem/rust-cache@v2.2.0
       - name: Run tests in debug
         uses: actions-rs/cargo@v1
         with:
@@ -102,8 +102,8 @@ jobs:
           toolchain: stable
           override: true
           components: clippy
-      - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2.2.0
+      # - name: Cache dependencies
+      #   uses: Swatinem/rust-cache@v2.2.0
       - name: Run cargo clippy
         uses: actions-rs/cargo@v1
         with:
@@ -121,8 +121,8 @@ jobs:
           toolchain: nightly
           override: true
           components: rustfmt
-      - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2.2.0
+      # - name: Cache dependencies
+      #   uses: Swatinem/rust-cache@v2.2.0
       - name: Run cargo fmt
         # Since we never ran the `build.rs` script in the benchmark directory we are missing one auto-generated import file.
         # Since we want to trigger (and fail) this action as fast as possible, instead of building the benchmark crate


### PR DESCRIPTION
Comment the lines in CIs where we use the test CIs
We indeed have cache issues (lack of space on the machine) when running our test CIs
https://github.com/meilisearch/meilisearch/pull/3403