### PR TITLE
Make clippy happy for Rust 1.67, allow `uninlined_format_args`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -109,7 +109,8 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all-targets -- --deny warnings
+          # allow unlined_format_args https://github.com/rust-lang/rust-clippy/issues/10087
+          args: --all-targets -- --deny warnings --allow clippy::uninlined_format_args
 
   fmt:
     name: Run Rustfmt

--- a/dump/src/lib.rs
+++ b/dump/src/lib.rs
@@ -198,7 +198,7 @@ impl From<KindWithContent> for KindDump {
 #[cfg(test)]
 pub(crate) mod test {
     use std::fs::File;
-    use std::io::{Seek, SeekFrom};
+    use std::io::Seek;
     use std::str::FromStr;
 
     use big_s::S;
@@ -410,7 +410,7 @@ pub(crate) mod test {
         // create the dump
         let mut file = tempfile::tempfile().unwrap();
         dump.persist_to(&mut file).unwrap();
-        file.seek(SeekFrom::Start(0)).unwrap();
+        file.rewind().unwrap();
 
         file
     }

--- a/dump/src/reader/v5/mod.rs
+++ b/dump/src/reader/v5/mod.rs
@@ -33,7 +33,7 @@
 //!
 
 use std::fs::{self, File};
-use std::io::{BufRead, BufReader, ErrorKind, Seek, SeekFrom};
+use std::io::{BufRead, BufReader, ErrorKind, Seek};
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
@@ -178,7 +178,7 @@ impl V5Reader {
     }
 
     pub fn keys(&mut self) -> Result<Box<dyn Iterator<Item = Result<Key>> + '_>> {
-        self.keys.seek(SeekFrom::Start(0))?;
+        self.keys.rewind()?;
         Ok(Box::new(
             (&mut self.keys).lines().map(|line| -> Result<_> { Ok(serde_json::from_str(&line?)?) }),
         ))

--- a/index-scheduler/src/batch.rs
+++ b/index-scheduler/src/batch.rs
@@ -947,9 +947,9 @@ impl IndexScheduler {
     ///
     /// ## Return
     /// The list of processed tasks.
-    fn apply_index_operation<'txn, 'i>(
+    fn apply_index_operation<'i>(
         &self,
-        index_wtxn: &'txn mut RwTxn<'i, '_>,
+        index_wtxn: &'_ mut RwTxn<'i, '_>,
         index: &'i Index,
         operation: IndexOperation,
     ) -> Result<Vec<Task>> {

--- a/meilisearch/src/search.rs
+++ b/meilisearch/src/search.rs
@@ -474,10 +474,10 @@ fn make_document(
     Ok(document)
 }
 
-fn format_fields<'a, A: AsRef<[u8]>>(
+fn format_fields<A: AsRef<[u8]>>(
     document: &Document,
     field_ids_map: &FieldsIdsMap,
-    builder: &MatcherBuilder<'a, A>,
+    builder: &MatcherBuilder<'_, A>,
     formatted_options: &BTreeMap<FieldId, FormatOptions>,
     compute_matches: bool,
     displayable_ids: &BTreeSet<FieldId>,
@@ -522,9 +522,9 @@ fn format_fields<'a, A: AsRef<[u8]>>(
     Ok((matches_position, document))
 }
 
-fn format_value<'a, A: AsRef<[u8]>>(
+fn format_value<A: AsRef<[u8]>>(
     value: Value,
-    builder: &MatcherBuilder<'a, A>,
+    builder: &MatcherBuilder<'_, A>,
     format_options: Option<FormatOptions>,
     infos: &mut Vec<MatchBounds>,
     compute_matches: bool,

--- a/milli/src/index.rs
+++ b/milli/src/index.rs
@@ -348,10 +348,10 @@ impl Index {
     /* external documents ids */
 
     /// Writes the external documents ids and internal ids (i.e. `u32`).
-    pub(crate) fn put_external_documents_ids<'a>(
+    pub(crate) fn put_external_documents_ids(
         &self,
         wtxn: &mut RwTxn,
-        external_documents_ids: &ExternalDocumentsIds<'a>,
+        external_documents_ids: &ExternalDocumentsIds<'_>,
     ) -> heed::Result<()> {
         let ExternalDocumentsIds { hard, soft, .. } = external_documents_ids;
         let hard = hard.as_fst().as_bytes();
@@ -426,7 +426,7 @@ impl Index {
     }
 
     /// Returns the `rtree` which associates coordinates to documents ids.
-    pub fn geo_rtree<'t>(&self, rtxn: &'t RoTxn) -> Result<Option<RTree<GeoPoint>>> {
+    pub fn geo_rtree(&self, rtxn: &'_ RoTxn) -> Result<Option<RTree<GeoPoint>>> {
         match self
             .main
             .get::<_, Str, SerdeBincode<RTree<GeoPoint>>>(rtxn, main_key::GEO_RTREE_KEY)?

--- a/milli/src/search/criteria/proximity.rs
+++ b/milli/src/search/criteria/proximity.rs
@@ -182,15 +182,15 @@ impl<'t> Criterion for Proximity<'t> {
     }
 }
 
-fn resolve_candidates<'t>(
-    ctx: &'t dyn Context,
+fn resolve_candidates(
+    ctx: &'_ dyn Context,
     query_tree: &Operation,
     proximity: u8,
     cache: &mut Cache,
     wdcache: &mut WordDerivationsCache,
 ) -> Result<RoaringBitmap> {
-    fn resolve_operation<'t>(
-        ctx: &'t dyn Context,
+    fn resolve_operation(
+        ctx: &'_ dyn Context,
         query_tree: &Operation,
         proximity: u8,
         cache: &mut Cache,
@@ -243,8 +243,8 @@ fn resolve_candidates<'t>(
         Ok(result)
     }
 
-    fn mdfs_pair<'t>(
-        ctx: &'t dyn Context,
+    fn mdfs_pair(
+        ctx: &'_ dyn Context,
         left: &Operation,
         right: &Operation,
         proximity: u8,
@@ -298,8 +298,8 @@ fn resolve_candidates<'t>(
         Ok(output)
     }
 
-    fn mdfs<'t>(
-        ctx: &'t dyn Context,
+    fn mdfs(
+        ctx: &'_ dyn Context,
         branches: &[Operation],
         proximity: u8,
         cache: &mut Cache,

--- a/milli/src/search/criteria/typo.rs
+++ b/milli/src/search/criteria/typo.rs
@@ -239,15 +239,15 @@ fn alterate_query_tree(
     Ok(query_tree)
 }
 
-fn resolve_candidates<'t>(
-    ctx: &'t dyn Context,
+fn resolve_candidates(
+    ctx: &'_ dyn Context,
     query_tree: &Operation,
     number_typos: u8,
     cache: &mut HashMap<(Operation, u8), RoaringBitmap>,
     wdcache: &mut WordDerivationsCache,
 ) -> Result<RoaringBitmap> {
-    fn resolve_operation<'t>(
-        ctx: &'t dyn Context,
+    fn resolve_operation(
+        ctx: &'_ dyn Context,
         query_tree: &Operation,
         number_typos: u8,
         cache: &mut HashMap<(Operation, u8), RoaringBitmap>,
@@ -276,8 +276,8 @@ fn resolve_candidates<'t>(
         }
     }
 
-    fn mdfs<'t>(
-        ctx: &'t dyn Context,
+    fn mdfs(
+        ctx: &'_ dyn Context,
         branches: &[Operation],
         mana: u8,
         cache: &mut HashMap<(Operation, u8), RoaringBitmap>,

--- a/milli/src/update/delete_documents.rs
+++ b/milli/src/update/delete_documents.rs
@@ -574,9 +574,9 @@ fn remove_from_word_docids(
     Ok(())
 }
 
-fn remove_docids_from_field_id_docid_facet_value<'i, 'a>(
-    index: &'i Index,
-    wtxn: &'a mut heed::RwTxn,
+fn remove_docids_from_field_id_docid_facet_value(
+    index: &'_ Index,
+    wtxn: &'_ mut heed::RwTxn,
     facet_type: FacetType,
     field_id: FieldId,
     to_remove: &RoaringBitmap,

--- a/milli/src/update/facet/incremental.rs
+++ b/milli/src/update/facet/incremental.rs
@@ -157,9 +157,9 @@ impl FacetsUpdateIncrementalInner {
     ///
     /// ## Return
     /// See documentation of `insert_in_level`
-    fn insert_in_level_0<'t>(
+    fn insert_in_level_0(
         &self,
-        txn: &'t mut RwTxn,
+        txn: &'_ mut RwTxn,
         field_id: u16,
         facet_value: &[u8],
         docids: &RoaringBitmap,
@@ -211,9 +211,9 @@ impl FacetsUpdateIncrementalInner {
     /// - `InsertionResult::Insert` means that inserting the `facet_value` into the `level` resulted
     /// in the addition of a new key in that level, and that therefore the number of children
     /// of the parent node should be incremented.
-    fn insert_in_level<'t>(
+    fn insert_in_level(
         &self,
-        txn: &'t mut RwTxn,
+        txn: &'_ mut RwTxn,
         field_id: u16,
         level: u8,
         facet_value: &[u8],
@@ -348,9 +348,9 @@ impl FacetsUpdateIncrementalInner {
     }
 
     /// Insert the given facet value and corresponding document ids in the database.
-    pub fn insert<'t>(
+    pub fn insert(
         &self,
-        txn: &'t mut RwTxn,
+        txn: &'_ mut RwTxn,
         field_id: u16,
         facet_value: &[u8],
         docids: &RoaringBitmap,
@@ -470,9 +470,9 @@ impl FacetsUpdateIncrementalInner {
     /// in level 1, the key with the left bound `3` had to be changed to the next facet value (e.g. 4).
     /// In that case `DeletionResult::Reduce` is returned. The parent of the reduced key may need to adjust
     /// its left bound as well.
-    fn delete_in_level<'t>(
+    fn delete_in_level(
         &self,
-        txn: &'t mut RwTxn,
+        txn: &'_ mut RwTxn,
         field_id: u16,
         level: u8,
         facet_value: &[u8],
@@ -529,9 +529,9 @@ impl FacetsUpdateIncrementalInner {
         }
     }
 
-    fn delete_in_level_0<'t>(
+    fn delete_in_level_0(
         &self,
-        txn: &'t mut RwTxn,
+        txn: &'_ mut RwTxn,
         field_id: u16,
         facet_value: &[u8],
         docids: &RoaringBitmap,
@@ -557,9 +557,9 @@ impl FacetsUpdateIncrementalInner {
         }
     }
 
-    pub fn delete<'t>(
+    pub fn delete(
         &self,
-        txn: &'t mut RwTxn,
+        txn: &'_ mut RwTxn,
         field_id: u16,
         facet_value: &[u8],
         docids: &RoaringBitmap,

--- a/milli/src/update/index_documents/helpers/grenad_helpers.rs
+++ b/milli/src/update/index_documents/helpers/grenad_helpers.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 use std::fs::File;
-use std::io::{self, Seek, SeekFrom};
+use std::io::{self, Seek};
 use std::time::Instant;
 
 use grenad::{CompressionType, Sorter};
@@ -66,7 +66,7 @@ pub fn sorter_into_reader(
 
 pub fn writer_into_reader(writer: grenad::Writer<File>) -> Result<grenad::Reader<File>> {
     let mut file = writer.into_inner()?;
-    file.seek(SeekFrom::Start(0))?;
+    file.rewind()?;
     grenad::Reader::new(file).map_err(Into::into)
 }
 

--- a/milli/src/update/index_documents/transform.rs
+++ b/milli/src/update/index_documents/transform.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
-use std::io::{Read, Seek, SeekFrom};
+use std::io::{Read, Seek};
 
 use fxhash::FxHashMap;
 use heed::RoTxn;
@@ -510,7 +510,7 @@ impl<'a, 'i> Transform<'a, 'i> {
 
         let mut original_documents = writer.into_inner()?;
         // We then extract the file and reset the seek to be able to read it again.
-        original_documents.seek(SeekFrom::Start(0))?;
+        original_documents.rewind()?;
 
         // We create a final writer to write the new documents in order from the sorter.
         let mut writer = create_writer(
@@ -522,7 +522,7 @@ impl<'a, 'i> Transform<'a, 'i> {
         // into this writer, extract the file and reset the seek to be able to read it again.
         self.flattened_sorter.write_into_stream_writer(&mut writer)?;
         let mut flattened_documents = writer.into_inner()?;
-        flattened_documents.seek(SeekFrom::Start(0))?;
+        flattened_documents.rewind()?;
 
         let mut new_external_documents_ids_builder: Vec<_> =
             self.new_external_documents_ids_builder.into_iter().collect();
@@ -650,10 +650,10 @@ impl<'a, 'i> Transform<'a, 'i> {
         // Once we have written all the documents, we extract
         // the file and reset the seek to be able to read it again.
         let mut original_documents = original_writer.into_inner()?;
-        original_documents.seek(SeekFrom::Start(0))?;
+        original_documents.rewind()?;
 
         let mut flattened_documents = flattened_writer.into_inner()?;
-        flattened_documents.seek(SeekFrom::Start(0))?;
+        flattened_documents.rewind()?;
 
         let output = TransformOutput {
             primary_key,


### PR DESCRIPTION
# Pull Request

This PR allows `uninlined_format_args` in CI for clippy.

This is due to https://github.com/rust-lang/rust-clippy/issues/10087, which in particular has correctness issues wrt edition 2018 crates, and is a big change altogether. https://github.com/rust-lang/rust-clippy/pull/10265 is already open in order to change the category of this lint to "pedantic", meaning that if this latter PR merges, a future Rust release will accept our code unmodified wrt uninlined format arguments.

As a result, this PR introduces the following changes:

1. Allow `uninlined_format_args` in the clippy command in CI.
2. Use rewind rather than seek(0)
3. Remove lifetimes that clippy deems needless.