### PR TITLE
Make clippy happy for Rust 1.67, allow uninlined_format_args

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -108,7 +108,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all-targets -- --deny warnings
+          args: --all-targets -- --deny warnings --allow clippy::uninlined_format_args
 
   fmt:
     name: Run Rustfmt

--- a/dump/src/lib.rs
+++ b/dump/src/lib.rs
@@ -198,7 +198,7 @@ impl From<KindWithContent> for KindDump {
 #[cfg(test)]
 pub(crate) mod test {
     use std::fs::File;
-    use std::io::{Seek, SeekFrom};
+    use std::io::Seek;
     use std::str::FromStr;
 
     use big_s::S;
@@ -410,7 +410,7 @@ pub(crate) mod test {
         // create the dump
         let mut file = tempfile::tempfile().unwrap();
         dump.persist_to(&mut file).unwrap();
-        file.seek(SeekFrom::Start(0)).unwrap();
+        file.rewind().unwrap();
 
         file
     }

--- a/dump/src/reader/v5/mod.rs
+++ b/dump/src/reader/v5/mod.rs
@@ -33,7 +33,7 @@
 //!
 
 use std::fs::{self, File};
-use std::io::{BufRead, BufReader, ErrorKind, Seek, SeekFrom};
+use std::io::{BufRead, BufReader, ErrorKind, Seek};
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
@@ -178,7 +178,7 @@ impl V5Reader {
     }
 
     pub fn keys(&mut self) -> Result<Box<dyn Iterator<Item = Result<Key>> + '_>> {
-        self.keys.seek(SeekFrom::Start(0))?;
+        self.keys.rewind()?;
         Ok(Box::new(
             (&mut self.keys).lines().map(|line| -> Result<_> { Ok(serde_json::from_str(&line?)?) }),
         ))

--- a/index-scheduler/src/batch.rs
+++ b/index-scheduler/src/batch.rs
@@ -960,9 +960,9 @@ impl IndexScheduler {
     ///
     /// ## Return
     /// The list of processed tasks.
-    fn apply_index_operation<'txn, 'i>(
+    fn apply_index_operation<'i>(
         &self,
-        index_wtxn: &'txn mut RwTxn<'i, '_>,
+        index_wtxn: &mut RwTxn<'i, '_>,
         index: &'i Index,
         operation: IndexOperation,
     ) -> Result<Vec<Task>> {

--- a/meilisearch/src/search.rs
+++ b/meilisearch/src/search.rs
@@ -473,10 +473,10 @@ fn make_document(
     Ok(document)
 }
 
-fn format_fields<'a, A: AsRef<[u8]>>(
+fn format_fields<A: AsRef<[u8]>>(
     document: &Document,
     field_ids_map: &FieldsIdsMap,
-    builder: &MatcherBuilder<'a, A>,
+    builder: &MatcherBuilder<'_, A>,
     formatted_options: &BTreeMap<FieldId, FormatOptions>,
     compute_matches: bool,
     displayable_ids: &BTreeSet<FieldId>,
@@ -521,9 +521,9 @@ fn format_fields<'a, A: AsRef<[u8]>>(
     Ok((matches_position, document))
 }
 
-fn format_value<'a, A: AsRef<[u8]>>(
+fn format_value<A: AsRef<[u8]>>(
     value: Value,
-    builder: &MatcherBuilder<'a, A>,
+    builder: &MatcherBuilder<'_, A>,
     format_options: Option<FormatOptions>,
     infos: &mut Vec<MatchBounds>,
     compute_matches: bool,

--- a/permissive-json-pointer/src/lib.rs
+++ b/permissive-json-pointer/src/lib.rs
@@ -72,9 +72,9 @@ pub fn map_leaf_values<'a>(
     map_leaf_values_in_object(value, &selectors, "", &mut mapper);
 }
 
-pub fn map_leaf_values_in_object<'a>(
+pub fn map_leaf_values_in_object(
     value: &mut Map<String, Value>,
-    selectors: &[&'a str],
+    selectors: &[&str],
     base_key: &str,
     mapper: &mut impl FnMut(&str, &mut Value),
 ) {


### PR DESCRIPTION
# Pull Request

This PR is the equivalent of #3434 for the `release-v1.0.0` branch.

See #3434 for more information.