### PR TITLE
Add git config about ownership in Docker CI

### DIFF
--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Set build-args for Docker buildx
         id: build-metadata
         run: |
+          # Define ownership
+          git config --global --add safe.directory /home/meili/actions-runner/_work/meilisearch/meilisearch
+
           # Extract commit date
           commit_date=$(git show -s --format=%cd --date=iso-strict ${{ github.sha }})
 


### PR DESCRIPTION
The docker CI si failing because of git usage: https://github.com/meilisearch/meilisearch/actions/runs/4053334082/jobs/6973827940

<img width="960" alt="Capture d’écran 2023-01-31 à 12 12 44" src="https://user-images.githubusercontent.com/20380692/215745119-b866bcf2-7077-48e4-b018-7a2085b23680.png">


> fatal: detected dubious ownership in repository at '/home/meili/actions-runner/_work/meilisearch/meilisearch'

I made some research and I found out this https://github.com/actions/runner-images/issues/6775