### PR TITLE
Bump milli to v0.41.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1300,8 +1300,8 @@ dependencies = [
 
 [[package]]
 name = "filter-parser"
-version = "0.40.0"
-source = "git+https://github.com/meilisearch/milli.git?tag=v0.41.0#4e4d8dfda72e9301d66a637dabaee619ec0d1a02"
+version = "0.41.1"
+source = "git+https://github.com/meilisearch/milli.git?tag=v0.41.1#758b4acea7cecd689650bee65949b49cf09ddaa3"
 dependencies = [
  "nom",
  "nom_locate",
@@ -1319,8 +1319,8 @@ dependencies = [
 
 [[package]]
 name = "flatten-serde-json"
-version = "0.40.0"
-source = "git+https://github.com/meilisearch/milli.git?tag=v0.41.0#4e4d8dfda72e9301d66a637dabaee619ec0d1a02"
+version = "0.41.1"
+source = "git+https://github.com/meilisearch/milli.git?tag=v0.41.1#758b4acea7cecd689650bee65949b49cf09ddaa3"
 dependencies = [
  "serde_json",
 ]
@@ -1884,8 +1884,8 @@ dependencies = [
 
 [[package]]
 name = "json-depth-checker"
-version = "0.40.0"
-source = "git+https://github.com/meilisearch/milli.git?tag=v0.41.0#4e4d8dfda72e9301d66a637dabaee619ec0d1a02"
+version = "0.41.1"
+source = "git+https://github.com/meilisearch/milli.git?tag=v0.41.1#758b4acea7cecd689650bee65949b49cf09ddaa3"
 dependencies = [
  "serde_json",
 ]
@@ -2433,8 +2433,8 @@ dependencies = [
 
 [[package]]
 name = "milli"
-version = "0.40.0"
-source = "git+https://github.com/meilisearch/milli.git?tag=v0.41.0#4e4d8dfda72e9301d66a637dabaee619ec0d1a02"
+version = "0.41.1"
+source = "git+https://github.com/meilisearch/milli.git?tag=v0.41.1#758b4acea7cecd689650bee65949b49cf09ddaa3"
 dependencies = [
  "bimap",
  "bincode",

--- a/meilisearch-types/Cargo.toml
+++ b/meilisearch-types/Cargo.toml
@@ -16,7 +16,7 @@ file-store = { path = "../file-store" }
 flate2 = "1.0.24"
 fst = "0.4.7"
 memmap2 = "0.5.7"
-milli = { git = "https://github.com/meilisearch/milli.git", tag = "v0.41.0", default-features = false }
+milli = { git = "https://github.com/meilisearch/milli.git", tag = "v0.41.1", default-features = false }
 roaring = { version = "0.10.0", features = ["serde"] }
 serde = { version = "1.0.145", features = ["derive"] }
 serde-cs = "0.2.4"


### PR DESCRIPTION
# Pull Request

## Related issue

Fixes #3438.

## What does this PR do?
- Bump milli to [v0.41.1](https://github.com/meilisearch/milli/releases/tag/v0.41.1) that includes a bugfix for #3438 