### PR TITLE
Add tests with rust stable and nightly in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,8 +27,19 @@ jobs:
       run: |
         apt-get update && apt-get install -y curl
         apt-get install build-essential -y
-    - uses: actions-rs/toolchain@v1
+    - name: Run test with Rust nightly
+      uses: actions-rs/toolchain@v1
       with:
+        profile: minimal
+        toolchain: nightly
+        override: true
+      on:
+          schedule:
+            - cron: '0 0 * * *' # Run daily at midnight (UTC)
+    - name: Run test with Rust stable
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
         toolchain: stable
         override: true
     # Disable cache due to disk space issues with Windows workers in CI


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #3402

## What does this PR do?
In the [test-linux](https://github.com/meilisearch/meilisearch/blob/b3166df7ea597beef798278e56d2a4b4c545c0da/.github/workflows/rust.yml#L18) job two tests are added : 

- one run with rust stable
- one with rust nightly that runs once a day

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
