### PR TITLE
Force exhaustive search when faceting is requested

### DIFF
--- a/meilisearch/src/search.rs
+++ b/meilisearch/src/search.rs
@@ -144,14 +144,17 @@ pub fn perform_search(
     }
 
     let is_finite_pagination = query.is_finite_pagination();
+    let has_facet_distribution =
+        if let Some(facets) = query.facets.as_deref() { !facets.is_empty() } else { false };
+
+    search.exhaustive_number_hits(is_finite_pagination || has_facet_distribution);
+
     search.terms_matching_strategy(query.matching_strategy.into());
 
     let max_total_hits = index
         .pagination_max_total_hits(&rtxn)
         .map_err(milli::Error::from)?
         .unwrap_or(DEFAULT_PAGINATION_MAX_TOTAL_HITS);
-
-    search.exhaustive_number_hits(is_finite_pagination);
 
     // compute the offset on the limit depending on the pagination mode.
     let (offset, limit) = if is_finite_pagination {

--- a/milli/src/search/mod.rs
+++ b/milli/src/search/mod.rs
@@ -112,7 +112,7 @@ impl<'a> Search<'a> {
         self
     }
 
-    /// Force the search to exhastivelly compute the number of candidates,
+    /// Force the search to exhaustively compute the number of candidates,
     /// this will increase the search time but allows finite pagination.
     pub fn exhaustive_number_hits(&mut self, exhaustive_number_hits: bool) -> &mut Search<'a> {
         self.exhaustive_number_hits = exhaustive_number_hits;


### PR DESCRIPTION
# Pull Request

## Related issue

Related to #3426.

## What does this PR do?

When not using pagination mode, the search is not exhaustive. This can result in incomplete results for facet distribution and wrong results for facet stats (as implemented in #3423).

This PR forces the search to be as exhaustive as possible[^1], even when not using pagination mode, as soon as a facet distribution (or facet stats) is required.

## Tests

Unfortunately, I was not able to come up with a test case that demonstrates how the search is not exhaustive by default. I'm still opening the PR should the issue pop up.

[^1]: My understanding is that we can still have differences in distribution/stats when distinct attributes are used in the query.