### PR TITLE
CI: attempt to use apt-mirror-updater

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,6 +25,8 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install needed dependencies
       run: |
+        pip3 install apt-mirror-updater
+        apt-mirror-updater --auto-change-mirror
         apt-get update && apt-get install -y curl
         apt-get install build-essential -y
     - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
Ubuntu mirrors are not responding.

This PR attempts to fix that for the time being, just in case situation doesn't return to normal shortly.