### PR TITLE
Remove CLI changes for clippy

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -147,8 +147,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          # allow unlined_format_args https://github.com/rust-lang/rust-clippy/issues/10087
-          args: --all-targets -- --deny warnings --allow clippy::uninlined_format_args
+          args: --all-targets -- --deny warnings
 
   fmt:
     name: Run Rustfmt


### PR DESCRIPTION
# Pull Request

## Related issue

Reverts #3434, which was linked to https://github.com/rust-lang/rust-clippy/issues/10087, as putting the lint in the pedantic group [is being uplifted to Rust 1.67.1](https://github.com/rust-lang/rust/pull/107743#issue-1573438821) (my thanks to everyone involved in this work :tada:).

## Motivation

- Using "standard issue" clippy in the CI spares our contributors and us from knowing/remembering to add the lint when running clippy locally
- In particular, spares us from configuring tools like rust-analyzer to take the lint into account.
- Should this lint come back in another form in the future, we won't blindly ignore it, and we will be able to reassess it, which will be good wrt writing idiomatic Rust. By the time this occurs, lints might be configurable through `clippy.toml` too, which would make disabling one globally much more convenient if needs be.

## Note

We should wait for the release of Rust 1.67.1 and its propagation to our CI before merging this. The PR won't pass CI before this.
