### PR TITLE
Add `custom-static-files` option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-files"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d832782fac6ca7369a70c9ee9a20554623c5e51c76e190ad151780ebea1cf689"
+dependencies = [
+ "actix-http",
+ "actix-service",
+ "actix-utils",
+ "actix-web",
+ "askama_escape",
+ "bitflags",
+ "bytes",
+ "derive_more",
+ "futures-core",
+ "http-range",
+ "log",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "actix-http"
 version = "3.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,6 +326,12 @@ checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
 dependencies = [
  "backtrace",
 ]
+
+[[package]]
+name = "askama_escape"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
 
 [[package]]
 name = "assert-json-diff"
@@ -1826,6 +1855,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
+
+[[package]]
 name = "httparse"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2437,6 +2472,7 @@ name = "meilisearch"
 version = "1.0.0"
 dependencies = [
  "actix-cors",
+ "actix-files",
  "actix-http",
  "actix-rt",
  "actix-utils",

--- a/meilisearch/Cargo.toml
+++ b/meilisearch/Cargo.toml
@@ -11,6 +11,7 @@ actix-cors = "0.6.3"
 actix-http = { version = "3.2.2", default-features = false, features = ["compress-brotli", "compress-gzip", "rustls"] }
 actix-web = { version = "4.2.1", default-features = false, features = ["macros", "compress-brotli", "compress-gzip", "cookies", "rustls"] }
 actix-web-static-files = { git = "https://github.com/kilork/actix-web-static-files.git", rev = "2d3b6160", optional = true }
+actix-files = { version = "0.6" }
 anyhow = { version = "1.0.65", features = ["backtrace"] }
 async-stream = "0.3.3"
 async-trait = "0.1.57"

--- a/meilisearch/src/lib.rs
+++ b/meilisearch/src/lib.rs
@@ -86,7 +86,7 @@ pub fn create_app(
                 analytics.clone(),
             )
         })
-        .configure(routes::configure)
+        .configure(|s|routes::configure(s, &opt))
         .configure(|s| dashboard(s, enable_dashboard));
     #[cfg(feature = "metrics")]
     let app = app.configure(|s| configure_metrics_route(s, opt.enable_metrics_route));

--- a/meilisearch/src/option.rs
+++ b/meilisearch/src/option.rs
@@ -301,6 +301,12 @@ pub struct Opt {
     /// Format must be TOML.
     #[clap(long)]
     pub config_file_path: Option<PathBuf>,
+
+    /// Instead of hosting meili's own static assets (the mini-dashboard), use a custom directory to host files.
+    /// Use this if you want to customize the front-end.
+    #[clap(long)]
+    #[serde(default)]
+    pub custom_static_files: Option<PathBuf>,
 }
 
 impl Opt {
@@ -386,6 +392,7 @@ impl Opt {
             no_analytics,
             #[cfg(feature = "metrics")]
             enable_metrics_route,
+            custom_static_files: _,
         } = self;
         export_to_env_if_not_present(MEILI_DB_PATH, db_path);
         export_to_env_if_not_present(MEILI_HTTP_ADDR, http_addr);

--- a/meilisearch/src/routes/mod.rs
+++ b/meilisearch/src/routes/mod.rs
@@ -23,7 +23,7 @@ pub mod indexes;
 mod swap_indexes;
 pub mod tasks;
 
-pub fn configure(cfg: &mut web::ServiceConfig) {
+pub fn configure(cfg: &mut web::ServiceConfig, opt: &crate::Opt) {
     cfg.service(web::scope("/tasks").configure(tasks::configure))
         .service(web::resource("/health").route(web::get().to(get_health)))
         .service(web::scope("/keys").configure(api_key::configure))
@@ -32,6 +32,9 @@ pub fn configure(cfg: &mut web::ServiceConfig) {
         .service(web::resource("/version").route(web::get().to(get_version)))
         .service(web::scope("/indexes").configure(indexes::configure))
         .service(web::scope("/swap-indexes").configure(swap_indexes::configure));
+    if let Some(path) = &opt.custom_static_files {
+        cfg.service(actix_files::Files::new("/", path).index_file("index.html").show_files_listing());
+    }
 }
 
 const PAGINATION_DEFAULT_LIMIT: usize = 20;


### PR DESCRIPTION
Just a draft proposal to toy around with. Probably not a good idea, but it's useful in my usecase: wanting one less component in my setup for a customer.

- Adds the `--custom-static-files` CLI option that allows users to use their own static files, instead of the dashboard. Makes it easier to host a custom front-end.
- Adds the `actix_files` crate as dependency. The impact of this is pretty low, as by far [most](https://github.com/meilisearch/meilisearch/pull/3478/files#diff-13ee4b2252c9e516a0547f2891aa2105c3ca71c6d7a1e682c69be97998dfc87e) of the sub-dependencies are already used.

See https://github.com/meilisearch/product/discussions/610