### PR TITLE
Unify "Bad latitude" & "Bad longitude" errors

### DIFF
--- a/milli/src/asc_desc.rs
+++ b/milli/src/asc_desc.rs
@@ -280,7 +280,10 @@ mod tests {
             ("_geoPoint(18):asc", ReservedKeyword { name: S("_geoPoint(18)") }),
             ("_geoPoint(200, 200):asc", InvalidLatitude(ParseGeoError::BadGeoLat(200.))),
             ("_geoPoint(90.000001, 0):asc", InvalidLatitude(ParseGeoError::BadGeoLat(90.000001))),
-            ("_geoPoint(0, -180.000001):desc", InvalidLongitude(ParseGeoError::BadGeoLng(-180.000001))),
+            (
+                "_geoPoint(0, -180.000001):desc",
+                InvalidLongitude(ParseGeoError::BadGeoLng(-180.000001)),
+            ),
             ("_geoPoint(159.256, 130):asc", InvalidLatitude(ParseGeoError::BadGeoLat(159.256))),
             ("_geoPoint(12, -2021):desc", InvalidLongitude(ParseGeoError::BadGeoLng(-2021.))),
         ];

--- a/milli/src/asc_desc.rs
+++ b/milli/src/asc_desc.rs
@@ -165,7 +165,7 @@ impl FromStr for AscDesc {
 
 #[derive(Error, Debug)]
 pub enum SortError {
-    #[error("{}", error)]
+    #[error(transparent)]
     ParseGeoError { error: ParseGeoError },
     #[error("Invalid syntax for the geo parameter: expected expression formated like \
                     `_geoPoint(latitude, longitude)` and ending by `:asc` or `:desc`, found `{name}`.")]

--- a/milli/src/asc_desc.rs
+++ b/milli/src/asc_desc.rs
@@ -12,10 +12,13 @@ use crate::{CriterionError, Error, UserError};
 
 /// This error type is never supposed to be shown to the end user.
 /// You must always cast it to a sort error or a criterion error.
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum AscDescError {
+    #[error(transparent)]
     GeoError(ParseGeoError),
+    #[error("Invalid syntax for the asc/desc parameter: expected expression ending by `:asc` or `:desc`, found `{name}`.")]
     InvalidSyntax { name: String },
+    #[error("`{name}` is a reserved keyword and thus can't be used as a asc/desc rule.")]
     ReservedKeyword { name: String },
 }
 
@@ -25,25 +28,6 @@ impl From<ParseGeoError> for AscDescError {
     }
 }
 
-impl fmt::Display for AscDescError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Self::GeoError(error) => {
-                write!(f, "{error}",)
-            }
-            Self::InvalidSyntax { name } => {
-                write!(f, "Invalid syntax for the asc/desc parameter: expected expression ending by `:asc` or `:desc`, found `{}`.", name)
-            }
-            Self::ReservedKeyword { name } => {
-                write!(
-                    f,
-                    "`{}` is a reserved keyword and thus can't be used as a asc/desc rule.",
-                    name
-                )
-            }
-        }
-    }
-}
 
 impl From<AscDescError> for CriterionError {
     fn from(error: AscDescError) -> Self {

--- a/milli/src/asc_desc.rs
+++ b/milli/src/asc_desc.rs
@@ -28,7 +28,6 @@ impl From<BadGeoError> for AscDescError {
     }
 }
 
-
 impl From<AscDescError> for CriterionError {
     fn from(error: AscDescError) -> Self {
         match error {

--- a/milli/src/search/facet/filter.rs
+++ b/milli/src/search/facet/filter.rs
@@ -22,7 +22,7 @@ pub struct Filter<'a> {
 }
 
 #[derive(Debug)]
-enum ParseGeoError {
+pub enum ParseGeoError {
     BadGeo(String),
     BadGeoLat(f64),
     BadGeoLng(f64),

--- a/milli/src/search/facet/filter.rs
+++ b/milli/src/search/facet/filter.rs
@@ -389,14 +389,10 @@ impl<'a> Filter<'a> {
                     let base_point: [f64; 2] =
                         [point[0].parse_finite_float()?, point[1].parse_finite_float()?];
                     if !(-90.0..=90.0).contains(&base_point[0]) {
-                        return Err(
-                            point[0].as_external_error(BadGeoError::Lat(base_point[0]))
-                        )?;
+                        return Err(point[0].as_external_error(BadGeoError::Lat(base_point[0])))?;
                     }
                     if !(-180.0..=180.0).contains(&base_point[1]) {
-                        return Err(
-                            point[1].as_external_error(BadGeoError::Lng(base_point[1]))
-                        )?;
+                        return Err(point[1].as_external_error(BadGeoError::Lng(base_point[1])))?;
                     }
                     let radius = radius.parse_finite_float()?;
                     let rtree = match index.geo_rtree(rtxn)? {
@@ -434,12 +430,14 @@ impl<'a> Filter<'a> {
                         bottom_right_point[1].parse_finite_float()?,
                     ];
                     if !(-90.0..=90.0).contains(&top_left[0]) {
-                        return Err(top_left_point[0]
-                            .as_external_error(BadGeoError::Lat(top_left[0])))?;
+                        return Err(
+                            top_left_point[0].as_external_error(BadGeoError::Lat(top_left[0]))
+                        )?;
                     }
                     if !(-180.0..=180.0).contains(&top_left[1]) {
-                        return Err(top_left_point[1]
-                            .as_external_error(BadGeoError::Lng(top_left[1])))?;
+                        return Err(
+                            top_left_point[1].as_external_error(BadGeoError::Lng(top_left[1]))
+                        )?;
                     }
                     if !(-90.0..=90.0).contains(&bottom_right[0]) {
                         return Err(bottom_right_point[0]
@@ -451,10 +449,7 @@ impl<'a> Filter<'a> {
                     }
                     if top_left[0] < bottom_right[0] {
                         return Err(bottom_right_point[1].as_external_error(
-                            BadGeoError::BoundingBoxTopIsBelowBottom(
-                                top_left[0],
-                                bottom_right[0],
-                            ),
+                            BadGeoError::BoundingBoxTopIsBelowBottom(top_left[0], bottom_right[0]),
                         ))?;
                     }
 

--- a/milli/src/search/facet/mod.rs
+++ b/milli/src/search/facet/mod.rs
@@ -4,7 +4,7 @@ use heed::types::{ByteSlice, DecodeIgnore};
 use heed::{BytesDecode, RoTxn};
 
 pub use self::facet_distribution::{FacetDistribution, DEFAULT_VALUES_PER_FACET};
-pub use self::filter::Filter;
+pub use self::filter::{Filter, ParseGeoError};
 use crate::heed_codec::facet::{FacetGroupKeyCodec, FacetGroupValueCodec};
 use crate::heed_codec::ByteSliceRefCodec;
 mod facet_distribution;

--- a/milli/src/search/facet/mod.rs
+++ b/milli/src/search/facet/mod.rs
@@ -4,7 +4,7 @@ use heed::types::{ByteSlice, DecodeIgnore};
 use heed::{BytesDecode, RoTxn};
 
 pub use self::facet_distribution::{FacetDistribution, DEFAULT_VALUES_PER_FACET};
-pub use self::filter::{Filter, ParseGeoError};
+pub use self::filter::{Filter, BadGeoError};
 use crate::heed_codec::facet::{FacetGroupKeyCodec, FacetGroupValueCodec};
 use crate::heed_codec::ByteSliceRefCodec;
 mod facet_distribution;

--- a/milli/src/search/facet/mod.rs
+++ b/milli/src/search/facet/mod.rs
@@ -4,7 +4,7 @@ use heed::types::{ByteSlice, DecodeIgnore};
 use heed::{BytesDecode, RoTxn};
 
 pub use self::facet_distribution::{FacetDistribution, DEFAULT_VALUES_PER_FACET};
-pub use self::filter::{Filter, BadGeoError};
+pub use self::filter::{BadGeoError, Filter};
 use crate::heed_codec::facet::{FacetGroupKeyCodec, FacetGroupValueCodec};
 use crate::heed_codec::ByteSliceRefCodec;
 mod facet_distribution;


### PR DESCRIPTION
# Pull Request

## Related issue
Fix part of #3006

## What does this PR do?
- Moved out `BadGeoLat`, `BadGeoLng`, `BadGeoBoundingBoxTopIsBelowBottom` from `FilterError` into newly introduced error type `ParseGeoError`. 
- Renamed `BadGeo` error  to `ReservedGeo`
- Used new `ParseGeoError` type in `FilterError` and `AscDescError`

Screenshot: 
![image](https://user-images.githubusercontent.com/2981598/217927231-fe23b6a3-2ea8-4145-98af-38eb61c4ff16.png)

I ran `cargo test --package milli -- --test-threads 1` and tests passed.
`--test-threads` was set to 1 because my OS complained about too many opened files.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [ ] Have you made sure that the title is accurate and descriptive of the changes?
