### PR TITLE
Fix attributes set candidates

### DIFF
--- a/milli/src/search/criteria/attribute.rs
+++ b/milli/src/search/criteria/attribute.rs
@@ -123,7 +123,7 @@ impl<'t> Criterion for Attribute<'t> {
                             None => {
                                 return Ok(Some(CriterionResult {
                                     query_tree: Some(query_tree),
-                                    candidates: Some(RoaringBitmap::new()),
+                                    candidates: Some(allowed_candidates),
                                     filtered_candidates: None,
                                     initial_candidates: Some(self.initial_candidates.take()),
                                 }));


### PR DESCRIPTION
# Pull Request

Fix attributes set candidates for v1.1.0

## details

The attribute criterion was not returning the remaining candidates when its internal algorithm was been exhausted.
We had a loss of candidates by the attribute criterion leading to the bug reported in the issue linked below.
After some investigation, it seems that it was the only criterion that had this behavior.

We are now returning the remaining candidates instead of an empty bitmap.

## Related issue

Fixes #3483
PR on milli for v1.0.1: https://github.com/meilisearch/milli/pull/777
