### PR TITLE
Fix metrics feature

### DIFF
--- a/meilisearch/src/analytics/segment_analytics.rs
+++ b/meilisearch/src/analytics/segment_analytics.rs
@@ -250,7 +250,7 @@ impl From<Opt> for Infos {
         // Thus we must not insert `..` at the end.
         let Opt {
             #[cfg(features = "metrics")]
-            enable_metrics_route: _,
+                enable_metrics_route: _,
             db_path,
             http_addr,
             master_key: _,

--- a/meilisearch/src/analytics/segment_analytics.rs
+++ b/meilisearch/src/analytics/segment_analytics.rs
@@ -249,6 +249,7 @@ impl From<Opt> for Infos {
         // to add analytics when we add a field in the Opt.
         // Thus we must not insert `..` at the end.
         let Opt {
+            #[cfg(features = "metrics")]
             enable_metrics_route: _,
             db_path,
             http_addr,

--- a/meilisearch/src/analytics/segment_analytics.rs
+++ b/meilisearch/src/analytics/segment_analytics.rs
@@ -249,6 +249,7 @@ impl From<Opt> for Infos {
         // to add analytics when we add a field in the Opt.
         // Thus we must not insert `..` at the end.
         let Opt {
+            enable_metrics_route: _,
             db_path,
             http_addr,
             master_key: _,

--- a/meilisearch/src/lib.rs
+++ b/meilisearch/src/lib.rs
@@ -92,7 +92,8 @@ pub fn create_app(
     let app = app.configure(|s| configure_metrics_route(s, opt.enable_metrics_route));
 
     #[cfg(feature = "metrics")]
-    let app = app.wrap(Condition::new(opt.enable_metrics_route, route_metrics::RouteMetrics));
+    let app =
+        app.wrap(middleware::Condition::new(opt.enable_metrics_route, route_metrics::RouteMetrics));
     app.wrap(
         Cors::default()
             .send_wildcard()

--- a/meilisearch/src/route_metrics.rs
+++ b/meilisearch/src/route_metrics.rs
@@ -4,9 +4,9 @@ use actix_web::dev::{self, Service, ServiceRequest, ServiceResponse, Transform};
 use actix_web::http::header;
 use actix_web::{Error, HttpResponse};
 use futures_util::future::LocalBoxFuture;
-use meilisearch_auth::actions;
 use meilisearch_lib::MeiliSearch;
 use meilisearch_types::error::ResponseError;
+use meilisearch_types::keys::actions;
 use prometheus::{Encoder, HistogramTimer, TextEncoder};
 
 use crate::extractors::authentication::policies::ActionPolicy;


### PR DESCRIPTION
# Pull Request

## Related issue

Resolves: #3469
See also: #2763

## What does this PR do?
As reported the metrics feature was broken by still using and old reference to `meilisearch_auth::actions`. This commit switches to the new location, `meilisearch_types::keys::actions`.

The original issue was not *that* clear as to exactly what was broken, and the build logs have disappeared, but it seemed to just be this one line fix. If this is not the case and I've missed the mark let me know, and i'll head back to the drawing board.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?