### PR TITLE
Use the workspace inheritance

### DIFF
--- a/.github/scripts/check-release.sh
+++ b/.github/scripts/check-release.sh
@@ -3,7 +3,7 @@
 # check_tag $current_tag $file_tag $file_name
 function check_tag {
   if [[ "$1" != "$2" ]]; then
-      echo "Error: the current tag does not match the version in $3: found $2 - expected $1"
+      echo "Error: the current tag does not match the version in Cargo.toml: found $2 - expected $1"
       ret=1
   fi
 }
@@ -11,12 +11,8 @@ function check_tag {
 ret=0
 current_tag=${GITHUB_REF#'refs/tags/v'}
 
-toml_files='*/Cargo.toml'
-for toml_file in $toml_files;
-do
-    file_tag="$(grep '^version = ' $toml_file | cut -d '=' -f 2 | tr -d '"' | tr -d ' ')"
-    check_tag $current_tag $file_tag $toml_file
-done
+file_tag="$(grep '^version = ' Cargo.toml | cut -d '=' -f 2 | tr -d '"' | tr -d ' ')"
+check_tag $current_tag $file_tag
 
 lock_file='Cargo.lock'
 lock_tag=$(grep -A 1 'name = "meilisearch-auth"' $lock_file | grep version | cut -d '=' -f 2 | tr -d '"' | tr -d ' ')

--- a/.github/workflows/update-cargo-toml-version.yml
+++ b/.github/workflows/update-cargo-toml-version.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           raw_new_version=$(echo $NEW_VERSION | cut -d 'v' -f 2)
           new_string="version = \"$raw_new_version\""
-          sd '^version = "\d+.\d+.\w+"$' "$new_string" */Cargo.toml
+          sd '^version = "\d+.\d+.\w+"$' "$new_string" Cargo.toml
       - name: Build Meilisearch to update Cargo.lock
         run: cargo build
       - name: Commit and push the changes to the ${{ env.NEW_BRANCH }} branch

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -609,9 +609,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_toml"
-version = "0.13.3"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497049e9477329f8f6a559972ee42e117487d01d1e8c2cc9f836ea6fa23a9e1a"
+checksum = "2bfbc36312494041e2cdd5f06697b7e89d4b76f42773a0b5556ac290ff22acc2"
 dependencies = [
  "serde",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,15 @@ members = [
     "benchmarks"
 ]
 
+[workspace.package]
+version = "1.0.0"
+authors = ["Quentin de Quelen <quentin@dequelen.me>", "Clément Renault <clement@meilisearch.com>"]
+description = "Meilisearch HTTP server"
+homepage = "https://meilisearch.com"
+readme = "README.md"
+edition = "2021"
+license = "MIT"
+
 [profile.release]
 codegen-units = 1
 

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -1,8 +1,14 @@
 [package]
 name = "benchmarks"
-version = "1.0.0"
-edition = "2018"
 publish = false
+
+version.workspace = true
+authors.workspace = true
+description.workspace = true
+homepage.workspace = true
+readme.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 anyhow = "1.0.65"

--- a/dump/Cargo.toml
+++ b/dump/Cargo.toml
@@ -1,7 +1,14 @@
 [package]
 name = "dump"
-version = "1.0.0"
-edition = "2021"
+publish = false
+
+version.workspace = true
+authors.workspace = true
+description.workspace = true
+edition.workspace = true
+homepage.workspace = true
+readme.workspace = true
+license.workspace = true
 
 [dependencies]
 anyhow = "1.0.65"

--- a/file-store/Cargo.toml
+++ b/file-store/Cargo.toml
@@ -1,7 +1,14 @@
 [package]
 name = "file-store"
-version = "1.0.0"
-edition = "2021"
+publish = false
+
+version.workspace = true
+authors.workspace = true
+description.workspace = true
+homepage.workspace = true
+readme.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 tempfile = "3.3.0"

--- a/filter-parser/Cargo.toml
+++ b/filter-parser/Cargo.toml
@@ -1,9 +1,15 @@
 [package]
 name = "filter-parser"
-version = "1.0.0"
-edition = "2021"
 description = "The parser for the Meilisearch filter syntax"
 publish = false
+
+version.workspace = true
+authors.workspace = true
+# description.workspace = true
+homepage.workspace = true
+readme.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 nom = "7.1.1"

--- a/flatten-serde-json/Cargo.toml
+++ b/flatten-serde-json/Cargo.toml
@@ -1,10 +1,16 @@
 [package]
 name = "flatten-serde-json"
-version = "1.0.0"
-edition = "2021"
 description = "Flatten serde-json objects like elastic search"
 readme = "README.md"
 publish = false
+
+version.workspace = true
+authors.workspace = true
+# description.workspace = true
+homepage.workspace = true
+# readme.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 serde_json = "1.0"

--- a/index-scheduler/Cargo.toml
+++ b/index-scheduler/Cargo.toml
@@ -1,7 +1,14 @@
 [package]
 name = "index-scheduler"
-version = "1.0.0"
-edition = "2021"
+publish = false
+
+version.workspace = true
+authors.workspace = true
+description.workspace = true
+homepage.workspace = true
+readme.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 anyhow = "1.0.64"

--- a/json-depth-checker/Cargo.toml
+++ b/json-depth-checker/Cargo.toml
@@ -1,9 +1,15 @@
 [package]
 name = "json-depth-checker"
-version = "1.0.0"
-edition = "2021"
 description = "A library that indicates if a JSON must be flattened"
 publish = false
+
+version.workspace = true
+authors.workspace = true
+# description.workspace = true
+homepage.workspace = true
+readme.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 serde_json = "1.0"

--- a/meili-snap/Cargo.toml
+++ b/meili-snap/Cargo.toml
@@ -1,7 +1,14 @@
 [package]
 name = "meili-snap"
-version = "1.0.0"
-edition = "2021"
+publish = false
+
+version.workspace = true
+authors.workspace = true
+description.workspace = true
+homepage.workspace = true
+readme.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 insta = { version = "^1.19.1", features = ["json", "redactions"] }

--- a/meilisearch-auth/Cargo.toml
+++ b/meilisearch-auth/Cargo.toml
@@ -1,7 +1,14 @@
 [package]
 name = "meilisearch-auth"
-version = "1.0.0"
-edition = "2021"
+publish = false
+
+version.workspace = true
+authors.workspace = true
+description.workspace = true
+homepage.workspace = true
+readme.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 base64 = "0.13.1"

--- a/meilisearch-types/Cargo.toml
+++ b/meilisearch-types/Cargo.toml
@@ -1,8 +1,14 @@
 [package]
 name = "meilisearch-types"
-version = "1.0.0"
-authors = ["marin <postma.marin@protonmail.com>"]
-edition = "2021"
+publish = false
+
+version.workspace = true
+authors.workspace = true
+description.workspace = true
+homepage.workspace = true
+readme.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 actix-web = { version = "4.2.1", default-features = false }

--- a/meilisearch/Cargo.toml
+++ b/meilisearch/Cargo.toml
@@ -1,10 +1,14 @@
 [package]
-authors = ["Quentin de Quelen <quentin@dequelen.me>", "Clément Renault <clement@meilisearch.com>"]
-description = "Meilisearch HTTP server"
-edition = "2021"
-license = "MIT"
 name = "meilisearch"
-version = "1.0.0"
+publish = false
+
+version.workspace = true
+authors.workspace = true
+description.workspace = true
+homepage.workspace = true
+readme.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 actix-cors = "0.6.3"
@@ -90,7 +94,7 @@ yaup = "0.2.1"
 
 [build-dependencies]
 anyhow = { version = "1.0.65", optional = true }
-cargo_toml = { version = "0.13.0", optional = true }
+cargo_toml = { version = "0.14.0", optional = true }
 hex = { version = "0.4.3", optional = true }
 reqwest = { version = "0.11.12", features = ["blocking", "rustls-tls"], default-features = false, optional = true }
 sha-1 = { version = "0.10.0", optional = true }

--- a/meilisearch/Cargo.toml
+++ b/meilisearch/Cargo.toml
@@ -10,6 +10,8 @@ readme.workspace = true
 edition.workspace = true
 license.workspace = true
 
+default-run = "meilisearch"
+
 [dependencies]
 actix-cors = "0.6.3"
 actix-http = { version = "3.2.2", default-features = false, features = ["compress-brotli", "compress-gzip", "rustls"] }

--- a/milli/Cargo.toml
+++ b/milli/Cargo.toml
@@ -1,8 +1,15 @@
 [package]
 name = "milli"
-version = "1.0.0"
-authors = ["Kerollmops <clement@meilisearch.com>"]
 edition = "2018"
+publish = false
+
+version.workspace = true
+authors.workspace = true
+description.workspace = true
+homepage.workspace = true
+readme.workspace = true
+# edition.workspace = true
+license.workspace = true
 
 [dependencies]
 bimap = { version = "0.6.2", features = ["serde"] }

--- a/permissive-json-pointer/Cargo.toml
+++ b/permissive-json-pointer/Cargo.toml
@@ -1,9 +1,16 @@
 [package]
 name = "permissive-json-pointer"
-version = "1.0.0"
-edition = "2021"
 description = "A permissive json pointer"
 readme = "README.md"
+publish = false
+
+version.workspace = true
+authors.workspace = true
+# description.workspace = true
+homepage.workspace = true
+# readme.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 serde_json = "1.0"


### PR DESCRIPTION
Use the workspace inheritance [introduced in rust 1.64](https://blog.rust-lang.org/2022/09/22/Rust-1.64.0.html#cargo-improvements-workspace-inheritance-and-multi-target-builds).

It allows us to define the version of meilisearch once in the main `Cargo.toml` and let all the other `Cargo.toml` uses this version.

@curquiza I added you as a reviewer because I had to patch some CI scripts

And @Kerollmops, I had to bump the `cargo_toml` crates because our version was getting old and didn't support the feature yet.

Also, in another PR, I would like to unify some of our dependencies to ensure we always stay in sync between all our crates.