### PR TITLE
Use the new version of grenad with glidesort experiments in it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1667,6 +1667,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glidesort"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2e102e6eb644d3e0b186fc161e4460417880a0a0b87d235f2e5b8fb30f2e9e0"
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1675,11 +1681,11 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "grenad"
 version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5232b2d157b7bf63d7abe1b12177039e58db2f29e377517c0cdee1578cca4c93"
+source = "git+https://github.com/meilisearch/grenad?branch=glidesort-experiments#3b08b4278ceaac7e49e547ff66235167e6f80771"
 dependencies = [
  "bytemuck",
  "byteorder",
+ "glidesort",
  "tempfile",
 ]
 

--- a/milli/Cargo.toml
+++ b/milli/Cargo.toml
@@ -18,7 +18,8 @@ flatten-serde-json = { path = "../flatten-serde-json" }
 fst = "0.4.7"
 fxhash = "0.2.1"
 geoutils = "0.5.1"
-grenad = { version = "0.4.3", default-features = false, features = ["tempfile"] }
+# grenad = { version = "0.4.3", default-features = false, features = ["tempfile"] }
+grenad = { git = "https://github.com/meilisearch/grenad", branch = "glidesort-experiments", default-features = false, features = ["tempfile", "glidesort-stable"] }
 heed = { git = "https://github.com/meilisearch/heed", tag = "v0.12.5", default-features = false, features = ["lmdb", "sync-read-txn"] }
 json-depth-checker = { path = "../json-depth-checker" }
 levenshtein_automata = { version = "0.2.1", features = ["fst_automaton"] }


### PR DESCRIPTION
This PR experiments with using glidesort as the new algorithm in the Sorter. According to the graphs it should show incredible performance gains. It is based on https://github.com/meilisearch/grenad/pull/39.
 - [Here is the GitHub Action](https://github.com/meilisearch/meilisearch/actions/runs/4184904101) for the baseline (main, 91ce8a5e67553803ea74c26013659acad1a6e274).
 - And [the GitHub Action for this PR](https://github.com/meilisearch/meilisearch/actions/runs/4184919250) where we only replace the stable sort operation.
 - We will see if we try to also replace the unstable sort with glidesort too, the issue is that glidesort allocates and not the std unstable sort.