### PR TITLE
Csv delimiter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1113,9 +1113,9 @@ dependencies = [
 
 [[package]]
 name = "deserr"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eee2844f21cf7fb5693aae1fb8f1658127acfdb2fc072167d68a9152584ae64"
+checksum = "c71c14985c842bf1e520b1ebcd22daff6aeece32f510e11f063cecf9b308c04b"
 dependencies = [
  "actix-http",
  "actix-utils",
@@ -1130,9 +1130,9 @@ dependencies = [
 
 [[package]]
 name = "deserr-internal"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c27246f8ca9eeba9dd70d614b664dc43b529251ed7bd9e633131010d340da4b9"
+checksum = "cae1c51b191528c9e4e5d6cff671de94f61fcda1c206cc891251e0cf438c941a"
 dependencies = [
  "convert_case 0.5.0",
  "proc-macro2",

--- a/meilisearch-types/Cargo.toml
+++ b/meilisearch-types/Cargo.toml
@@ -9,7 +9,7 @@ actix-web = { version = "4.2.1", default-features = false }
 anyhow = "1.0.65"
 convert_case = "0.6.0"
 csv = "1.1.6"
-deserr = "0.4.1"
+deserr = "0.5.0"
 either = { version = "1.6.1", features = ["serde"] }
 enum-iterator = "1.1.3"
 file-store = { path = "../file-store" }

--- a/meilisearch-types/src/document_formats.rs
+++ b/meilisearch-types/src/document_formats.rs
@@ -19,7 +19,7 @@ type Result<T> = std::result::Result<T, DocumentFormatError>;
 pub enum PayloadType {
     Ndjson,
     Json,
-    Csv,
+    Csv(u8),
 }
 
 impl fmt::Display for PayloadType {
@@ -27,7 +27,7 @@ impl fmt::Display for PayloadType {
         match self {
             PayloadType::Ndjson => f.write_str("ndjson"),
             PayloadType::Json => f.write_str("json"),
-            PayloadType::Csv => f.write_str("csv"),
+            PayloadType::Csv(_) => f.write_str("csv"),
         }
     }
 }
@@ -105,11 +105,11 @@ impl ErrorCode for DocumentFormatError {
 }
 
 /// Reads CSV from input and write an obkv batch to writer.
-pub fn read_csv(file: &File, writer: impl Write + Seek) -> Result<u64> {
+pub fn read_csv(file: &File, writer: impl Write + Seek, delimiter: u8) -> Result<u64> {
     let mut builder = DocumentsBatchBuilder::new(writer);
     let mmap = unsafe { MmapOptions::new().map(file)? };
-    let csv = csv::Reader::from_reader(mmap.as_ref());
-    builder.append_csv(csv).map_err(|e| (PayloadType::Csv, e))?;
+    let csv = csv::ReaderBuilder::new().delimiter(delimiter).from_reader(mmap.as_ref());
+    builder.append_csv(csv).map_err(|e| (PayloadType::Csv(delimiter), e))?;
 
     let count = builder.documents_count();
     let _ = builder.into_inner().map_err(DocumentFormatError::Io)?;

--- a/meilisearch-types/src/error.rs
+++ b/meilisearch-types/src/error.rs
@@ -220,6 +220,7 @@ InvalidDocumentOffset                 , InvalidRequest       , BAD_REQUEST ;
 InvalidIndexLimit                     , InvalidRequest       , BAD_REQUEST ;
 InvalidIndexOffset                    , InvalidRequest       , BAD_REQUEST ;
 InvalidIndexPrimaryKey                , InvalidRequest       , BAD_REQUEST ;
+InvalidIndexCsvDelimiter              , InvalidRequest       , BAD_REQUEST ;
 InvalidIndexUid                       , InvalidRequest       , BAD_REQUEST ;
 InvalidSearchAttributesToCrop         , InvalidRequest       , BAD_REQUEST ;
 InvalidSearchAttributesToHighlight    , InvalidRequest       , BAD_REQUEST ;

--- a/meilisearch/Cargo.toml
+++ b/meilisearch/Cargo.toml
@@ -19,7 +19,7 @@ byte-unit = { version = "4.0.14", default-features = false, features = ["std", "
 bytes = "1.2.1"
 clap = { version = "4.0.9", features = ["derive", "env"] }
 crossbeam-channel = "0.5.6"
-deserr = "0.4.1"
+deserr = "0.5.0"
 dump = { path = "../dump" }
 either = "1.8.0"
 env_logger = "0.9.1"

--- a/meilisearch/src/error.rs
+++ b/meilisearch/src/error.rs
@@ -11,6 +11,8 @@ pub enum MeilisearchHttpError {
     #[error("A Content-Type header is missing. Accepted values for the Content-Type header are: {}",
             .0.iter().map(|s| format!("`{}`", s)).collect::<Vec<_>>().join(", "))]
     MissingContentType(Vec<String>),
+    #[error("The Content-Type `{0}` does not support the use of a csv delimiter. The csv delimiter can only be used with the Content-Type `text/csv`.")]
+    CsvDelimiterWithWrongContentType(String),
     #[error(
         "The Content-Type `{0}` is invalid. Accepted values for the Content-Type header are: {}",
         .1.iter().map(|s| format!("`{}`", s)).collect::<Vec<_>>().join(", ")
@@ -52,6 +54,7 @@ impl ErrorCode for MeilisearchHttpError {
     fn error_code(&self) -> Code {
         match self {
             MeilisearchHttpError::MissingContentType(_) => Code::MissingContentType,
+            MeilisearchHttpError::CsvDelimiterWithWrongContentType(_) => Code::InvalidContentType,
             MeilisearchHttpError::MissingPayload(_) => Code::MissingPayload,
             MeilisearchHttpError::InvalidContentType(_, _) => Code::InvalidContentType,
             MeilisearchHttpError::DocumentNotFound(_) => Code::DocumentNotFound,

--- a/meilisearch/src/routes/indexes/documents.rs
+++ b/meilisearch/src/routes/indexes/documents.rs
@@ -239,6 +239,7 @@ pub async fn update_documents(
     Ok(HttpResponse::Accepted().json(task))
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn document_addition(
     mime_type: Option<Mime>,
     index_scheduler: GuardedData<ActionPolicy<{ actions::DOCUMENTS_ADD }>, Data<IndexScheduler>>,

--- a/meilisearch/src/routes/indexes/documents.rs
+++ b/meilisearch/src/routes/indexes/documents.rs
@@ -256,8 +256,8 @@ async fn document_addition(
     ) {
         (Some(("application", "json")), None) => PayloadType::Json,
         (Some(("application", "x-ndjson")), None) => PayloadType::Ndjson,
-        (Some(("text", "csv")), None) => PayloadType::Csv(b','),
-        (Some(("text", "csv")), Some(delimiter)) => PayloadType::Csv(delimiter),
+        (Some(("text", "csv")), None) => PayloadType::Csv { delimiter: b',' },
+        (Some(("text", "csv")), Some(delimiter)) => PayloadType::Csv { delimiter },
 
         (Some(("application", "json")), Some(_)) => {
             return Err(MeilisearchHttpError::CsvDelimiterWithWrongContentType(String::from(
@@ -320,7 +320,9 @@ async fn document_addition(
     let documents_count = tokio::task::spawn_blocking(move || {
         let documents_count = match format {
             PayloadType::Json => read_json(&read_file, update_file.as_file_mut())?,
-            PayloadType::Csv(delim) => read_csv(&read_file, update_file.as_file_mut(), delim)?,
+            PayloadType::Csv { delimiter } => {
+                read_csv(&read_file, update_file.as_file_mut(), delimiter)?
+            }
             PayloadType::Ndjson => read_ndjson(&read_file, update_file.as_file_mut())?,
         };
         // we NEED to persist the file here because we moved the `udpate_file` in another task.

--- a/meilisearch/tests/common/index.rs
+++ b/meilisearch/tests/common/index.rs
@@ -30,7 +30,7 @@ impl Index<'_> {
             .post_str(
                 url,
                 include_str!("../assets/test_set.json"),
-                ("content-type", "application/json"),
+                vec![("content-type", "application/json")],
             )
             .await;
         assert_eq!(code, 202);
@@ -46,7 +46,7 @@ impl Index<'_> {
             .post_str(
                 url,
                 include_str!("../assets/test_set.ndjson"),
-                ("content-type", "application/x-ndjson"),
+                vec![("content-type", "application/x-ndjson")],
             )
             .await;
         assert_eq!(code, 202);
@@ -96,6 +96,21 @@ impl Index<'_> {
         self.service.post_encoded(url, documents, self.encoder).await
     }
 
+    pub async fn raw_add_documents(
+        &self,
+        payload: &str,
+        content_type: Option<&str>,
+        query_parameter: &str,
+    ) -> (Value, StatusCode) {
+        let url = format!("/indexes/{}/documents{}", urlencode(self.uid.as_ref()), query_parameter);
+
+        if let Some(content_type) = content_type {
+            self.service.post_str(url, payload, vec![("Content-Type", content_type)]).await
+        } else {
+            self.service.post_str(url, payload, Vec::new()).await
+        }
+    }
+
     pub async fn update_documents(
         &self,
         documents: Value,
@@ -108,6 +123,21 @@ impl Index<'_> {
             None => format!("/indexes/{}/documents", urlencode(self.uid.as_ref())),
         };
         self.service.put_encoded(url, documents, self.encoder).await
+    }
+
+    pub async fn raw_update_documents(
+        &self,
+        payload: &str,
+        content_type: Option<&str>,
+        query_parameter: &str,
+    ) -> (Value, StatusCode) {
+        let url = format!("/indexes/{}/documents{}", urlencode(self.uid.as_ref()), query_parameter);
+
+        if let Some(content_type) = content_type {
+            self.service.put_str(url, payload, vec![("Content-Type", content_type)]).await
+        } else {
+            self.service.put_str(url, payload, Vec::new()).await
+        }
     }
 
     pub async fn wait_task(&self, update_id: u64) -> Value {

--- a/meilisearch/tests/common/service.rs
+++ b/meilisearch/tests/common/service.rs
@@ -34,17 +34,18 @@ impl Service {
         self.request(req).await
     }
 
-    /// Send a test post request from a text body, with a `content-type:application/json` header.
+    /// Send a test post request from a text body.
     pub async fn post_str(
         &self,
         url: impl AsRef<str>,
         body: impl AsRef<str>,
-        header: (&str, &str),
+        headers: Vec<(&str, &str)>,
     ) -> (Value, StatusCode) {
-        let req = test::TestRequest::post()
-            .uri(url.as_ref())
-            .set_payload(body.as_ref().to_string())
-            .insert_header(header);
+        let mut req =
+            test::TestRequest::post().uri(url.as_ref()).set_payload(body.as_ref().to_string());
+        for header in headers {
+            req = req.insert_header(header);
+        }
         self.request(req).await
     }
 
@@ -55,6 +56,21 @@ impl Service {
 
     pub async fn put(&self, url: impl AsRef<str>, body: Value) -> (Value, StatusCode) {
         self.put_encoded(url, body, Encoder::Plain).await
+    }
+
+    /// Send a test put request from a text body.
+    pub async fn put_str(
+        &self,
+        url: impl AsRef<str>,
+        body: impl AsRef<str>,
+        headers: Vec<(&str, &str)>,
+    ) -> (Value, StatusCode) {
+        let mut req =
+            test::TestRequest::put().uri(url.as_ref()).set_payload(body.as_ref().to_string());
+        for header in headers {
+            req = req.insert_header(header);
+        }
+        self.request(req).await
     }
 
     pub async fn put_encoded(

--- a/meilisearch/tests/documents/add_documents.rs
+++ b/meilisearch/tests/documents/add_documents.rs
@@ -216,6 +216,133 @@ async fn add_single_document_with_every_encoding() {
     }
 }
 
+#[actix_rt::test]
+async fn add_csv_document() {
+    let server = Server::new().await;
+    let index = server.index("pets");
+
+    let document = "#id,name,race
+0,jean,bernese mountain
+1,jorts,orange cat";
+
+    let (response, code) = index.raw_update_documents(document, Some("text/csv"), "").await;
+    snapshot!(code, @"202 Accepted");
+    snapshot!(json_string!(response, { ".enqueuedAt" => "[date]" }), @r###"
+    {
+      "taskUid": 0,
+      "indexUid": "pets",
+      "status": "enqueued",
+      "type": "documentAdditionOrUpdate",
+      "enqueuedAt": "[date]"
+    }
+    "###);
+    let response = index.wait_task(response["taskUid"].as_u64().unwrap()).await;
+    snapshot!(json_string!(response, { ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]", ".duration" => "[duration]" }), @r###"
+    {
+      "uid": 0,
+      "indexUid": "pets",
+      "status": "succeeded",
+      "type": "documentAdditionOrUpdate",
+      "canceledBy": null,
+      "details": {
+        "receivedDocuments": 2,
+        "indexedDocuments": 2
+      },
+      "error": null,
+      "duration": "[duration]",
+      "enqueuedAt": "[date]",
+      "startedAt": "[date]",
+      "finishedAt": "[date]"
+    }
+    "###);
+
+    let (documents, code) = index.get_all_documents(GetAllDocumentsOptions::default()).await;
+    snapshot!(code, @"200 OK");
+    snapshot!(json_string!(documents), @r###"
+    {
+      "results": [
+        {
+          "#id": "0",
+          "name": "jean",
+          "race": "bernese mountain"
+        },
+        {
+          "#id": "1",
+          "name": "jorts",
+          "race": "orange cat"
+        }
+      ],
+      "offset": 0,
+      "limit": 20,
+      "total": 2
+    }
+    "###);
+}
+
+#[actix_rt::test]
+async fn add_csv_document_with_custom_delimiter() {
+    let server = Server::new().await;
+    let index = server.index("pets");
+
+    let document = "#id|name|race
+0|jean|bernese mountain
+1|jorts|orange cat";
+
+    let (response, code) =
+        index.raw_update_documents(document, Some("text/csv"), "?csvDelimiter=|").await;
+    snapshot!(code, @"202 Accepted");
+    snapshot!(json_string!(response, { ".enqueuedAt" => "[date]" }), @r###"
+    {
+      "taskUid": 0,
+      "indexUid": "pets",
+      "status": "enqueued",
+      "type": "documentAdditionOrUpdate",
+      "enqueuedAt": "[date]"
+    }
+    "###);
+    let response = index.wait_task(response["taskUid"].as_u64().unwrap()).await;
+    snapshot!(json_string!(response, { ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]", ".duration" => "[duration]" }), @r###"
+    {
+      "uid": 0,
+      "indexUid": "pets",
+      "status": "succeeded",
+      "type": "documentAdditionOrUpdate",
+      "canceledBy": null,
+      "details": {
+        "receivedDocuments": 2,
+        "indexedDocuments": 2
+      },
+      "error": null,
+      "duration": "[duration]",
+      "enqueuedAt": "[date]",
+      "startedAt": "[date]",
+      "finishedAt": "[date]"
+    }
+    "###);
+
+    let (documents, code) = index.get_all_documents(GetAllDocumentsOptions::default()).await;
+    snapshot!(code, @"200 OK");
+    snapshot!(json_string!(documents), @r###"
+    {
+      "results": [
+        {
+          "#id": "0",
+          "name": "jean",
+          "race": "bernese mountain"
+        },
+        {
+          "#id": "1",
+          "name": "jorts",
+          "race": "orange cat"
+        }
+      ],
+      "offset": 0,
+      "limit": 20,
+      "total": 2
+    }
+    "###);
+}
+
 /// any other content-type is must be refused
 #[actix_rt::test]
 async fn error_add_documents_test_bad_content_types() {

--- a/meilisearch/tests/documents/errors.rs
+++ b/meilisearch/tests/documents/errors.rs
@@ -298,8 +298,9 @@ async fn replace_documents_bad_csv_delimiter() {
     }
     "###);
 
-    let (response, code) =
-        index.raw_add_documents("", Some("application/json"), &format!("?csvDelimiter={}", encode("🍰"))).await;
+    let (response, code) = index
+        .raw_add_documents("", Some("application/json"), &format!("?csvDelimiter={}", encode("🍰")))
+        .await;
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
@@ -340,8 +341,13 @@ async fn update_documents_bad_csv_delimiter() {
     }
     "###);
 
-    let (response, code) =
-        index.raw_update_documents("", Some("application/json"), &format!("?csvDelimiter={}", encode("🍰"))).await;
+    let (response, code) = index
+        .raw_update_documents(
+            "",
+            Some("application/json"),
+            &format!("?csvDelimiter={}", encode("🍰")),
+        )
+        .await;
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {

--- a/milli/Cargo.toml
+++ b/milli/Cargo.toml
@@ -12,7 +12,7 @@ byteorder = "1.4.3"
 charabia = { version = "0.7.0", default-features = false }
 concat-arrays = "0.1.2"
 crossbeam-channel = "0.5.6"
-deserr = "0.4.1"
+deserr = "0.5.0"
 either = "1.8.0"
 flatten-serde-json = { path = "../flatten-serde-json" }
 fst = "0.4.7"


### PR DESCRIPTION
Fixes https://github.com/meilisearch/meilisearch/issues/3442
Closes https://github.com/meilisearch/meilisearch/pull/2803
Specified in https://github.com/meilisearch/specifications/pull/221

This PR is a reimplementation of https://github.com/meilisearch/meilisearch/pull/2803, on the new engine. Thanks for your idea and initial PR @MixusMinimax; sorry I couldn’t update/merge your PR. Way too many changes happened on the engine in the meantime.

**Attention to reviewer**; I had to update deserr to implement the support of deserializing `char`s

-------

It introduces four new error messages;
- Invalid value in parameter csvDelimiter: expected a string of one character, but found an empty string
- Invalid value in parameter csvDelimiter: expected a string of one character, but found the following string of 5 characters: doggo
- csv delimiter must be an ascii character. Found: 🍰 
- The Content-Type application/json does not support the use of a csv delimiter. The csv delimiter can only be used with the Content-Type text/csv.

And one error code;
- `invalid_index_csv_delimiter`

The `invalid_content_type` error code is now also used when we encounter the `csvDelimiter` query parameter with a non-csv content type.