### PR TITLE
config: case `experimental_enable_metrics` in snake_case

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -123,7 +123,7 @@ ssl_tickets = false
 ### Experimental features ###
 #############################
 
-experimental-enable-metrics = false
+experimental_enable_metrics = false
 # Experimental metrics feature. For more information, see: <https://github.com/meilisearch/meilisearch/discussions/3518>
 # Enables the Prometheus metrics on the `GET /metrics` endpoint.
 


### PR DESCRIPTION
# Pull Request

Avoids "Error: unknown field `experimental-enable-metrics` at line 1 column 1" error when using the default config file.