### PR TITLE
Delete documents by filter

### DIFF
--- a/dump/src/lib.rs
+++ b/dump/src/lib.rs
@@ -101,6 +101,9 @@ pub enum KindDump {
         documents_ids: Vec<String>,
     },
     DocumentClear,
+    DocumentDeletionByFilter {
+        filter: String,
+    },
     Settings {
         settings: Box<meilisearch_types::settings::Settings<Unchecked>>,
         is_deletion: bool,
@@ -165,6 +168,9 @@ impl From<KindWithContent> for KindDump {
             },
             KindWithContent::DocumentDeletion { documents_ids, .. } => {
                 KindDump::DocumentDeletion { documents_ids }
+            }
+            KindWithContent::DocumentDeletionByFilter { filter_expr, .. } => {
+                KindDump::DocumentDeletionByFilter { filter: filter_expr.to_string() }
             }
             KindWithContent::DocumentClear { .. } => KindDump::DocumentClear,
             KindWithContent::SettingsUpdate {

--- a/dump/src/lib.rs
+++ b/dump/src/lib.rs
@@ -102,7 +102,7 @@ pub enum KindDump {
     },
     DocumentClear,
     DocumentDeletionByFilter {
-        filter: String,
+        filter: serde_json::Value,
     },
     Settings {
         settings: Box<meilisearch_types::settings::Settings<Unchecked>>,
@@ -170,7 +170,7 @@ impl From<KindWithContent> for KindDump {
                 KindDump::DocumentDeletion { documents_ids }
             }
             KindWithContent::DocumentDeletionByFilter { filter_expr, .. } => {
-                KindDump::DocumentDeletionByFilter { filter: filter_expr.to_string() }
+                KindDump::DocumentDeletionByFilter { filter: filter_expr }
             }
             KindWithContent::DocumentClear { .. } => KindDump::DocumentClear,
             KindWithContent::SettingsUpdate {

--- a/index-scheduler/src/batch.rs
+++ b/index-scheduler/src/batch.rs
@@ -28,9 +28,10 @@ use meilisearch_types::heed::{RoTxn, RwTxn};
 use meilisearch_types::milli::documents::{obkv_to_object, DocumentsBatchReader};
 use meilisearch_types::milli::heed::CompactionOption;
 use meilisearch_types::milli::update::{
-    DocumentDeletionResult, IndexDocumentsConfig, IndexDocumentsMethod, Settings as MilliSettings,
+    DeleteDocuments, DocumentDeletionResult, IndexDocumentsConfig, IndexDocumentsMethod,
+    Settings as MilliSettings,
 };
-use meilisearch_types::milli::{self, BEU32};
+use meilisearch_types::milli::{self, Filter, BEU32};
 use meilisearch_types::settings::{apply_settings_to_builder, Settings, Unchecked};
 use meilisearch_types::tasks::{Details, IndexSwap, Kind, KindWithContent, Status, Task};
 use meilisearch_types::{compression, Index, VERSION_FILE_NAME};
@@ -64,6 +65,10 @@ pub(crate) enum Batch {
     IndexOperation {
         op: IndexOperation,
         must_create_index: bool,
+    },
+    IndexDocumentDeletionByFilter {
+        index_uid: String,
+        task: Task,
     },
     IndexCreation {
         index_uid: String,
@@ -149,6 +154,7 @@ impl Batch {
             | Batch::TaskDeletion(task)
             | Batch::Dump(task)
             | Batch::IndexCreation { task, .. }
+            | Batch::IndexDocumentDeletionByFilter { task, .. }
             | Batch::IndexUpdate { task, .. } => vec![task.uid],
             Batch::SnapshotCreation(tasks) | Batch::IndexDeletion { tasks, .. } => {
                 tasks.iter().map(|task| task.uid).collect()
@@ -187,7 +193,8 @@ impl Batch {
             IndexOperation { op, .. } => Some(op.index_uid()),
             IndexCreation { index_uid, .. }
             | IndexUpdate { index_uid, .. }
-            | IndexDeletion { index_uid, .. } => Some(index_uid),
+            | IndexDeletion { index_uid, .. }
+            | IndexDocumentDeletionByFilter { index_uid, .. } => Some(index_uid),
         }
     }
 }
@@ -227,6 +234,18 @@ impl IndexScheduler {
                 },
                 must_create_index,
             })),
+            BatchKind::DocumentDeletionByFilter { id } => {
+                let task = self.get_task(rtxn, id)?.ok_or(Error::CorruptedTaskQueue)?;
+                match &task.kind {
+                    KindWithContent::DocumentDeletionByFilter { index_uid, .. } => {
+                        Ok(Some(Batch::IndexDocumentDeletionByFilter {
+                            index_uid: index_uid.clone(),
+                            task,
+                        }))
+                    }
+                    _ => unreachable!(),
+                }
+            }
             BatchKind::DocumentOperation { method, operation_ids, .. } => {
                 let tasks = self.get_existing_tasks(rtxn, operation_ids)?;
                 let primary_key = tasks
@@ -866,6 +885,64 @@ impl IndexScheduler {
                 }
 
                 Ok(tasks)
+            }
+            Batch::IndexDocumentDeletionByFilter { mut task, index_uid: _ } => {
+                let (index_uid, filter) =
+                    if let KindWithContent::DocumentDeletionByFilter { index_uid, filter_expr } =
+                        &task.kind
+                    {
+                        (index_uid, filter_expr)
+                    } else {
+                        unreachable!()
+                    };
+                let index = {
+                    let rtxn = self.env.read_txn()?;
+                    self.index_mapper.index(&rtxn, index_uid)?
+                };
+                let filter = Filter::from_json(filter)?;
+                let deleted_documents = if let Some(filter) = filter {
+                    let index_rtxn = index.read_txn()?;
+
+                    let candidates = filter.evaluate(&index_rtxn, &index)?;
+                    let mut wtxn = index.write_txn()?;
+                    let mut delete_operation = DeleteDocuments::new(&mut wtxn, &index)?;
+                    delete_operation.delete_documents(&candidates);
+                    let result = delete_operation.execute().map(|result| result.deleted_documents);
+                    wtxn.commit()?;
+                    result
+                } else {
+                    Ok(0)
+                };
+                let original_filter = if let Some(Details::DocumentDeletionByFilter {
+                    original_filter,
+                    deleted_documents: _,
+                }) = task.details
+                {
+                    original_filter
+                } else {
+                    // In the case of a `documentDeleteByFilter` the details MUST be set
+                    unreachable!();
+                };
+
+                match deleted_documents {
+                    Ok(deleted_documents) => {
+                        task.status = Status::Succeeded;
+                        task.details = Some(Details::DocumentDeletionByFilter {
+                            original_filter,
+                            deleted_documents: Some(deleted_documents),
+                        });
+                    }
+                    Err(e) => {
+                        task.status = Status::Failed;
+                        task.details = Some(Details::DocumentDeletionByFilter {
+                            original_filter,
+                            deleted_documents: Some(0),
+                        });
+                        task.error = Some(e.into());
+                    }
+                }
+
+                Ok(vec![task])
             }
             Batch::IndexCreation { index_uid, primary_key, task } => {
                 let wtxn = self.env.write_txn()?;

--- a/index-scheduler/src/batch.rs
+++ b/index-scheduler/src/batch.rs
@@ -1489,10 +1489,9 @@ impl IndexScheduler {
 fn delete_document_by_filter(filter: &serde_json::Value, index: Index) -> Result<u64> {
     let filter = Filter::from_json(filter)?;
     Ok(if let Some(filter) = filter {
-        let index_rtxn = index.read_txn()?;
-
-        let candidates = filter.evaluate(&index_rtxn, &index)?;
         let mut wtxn = index.write_txn()?;
+
+        let candidates = filter.evaluate(&wtxn, &index)?;
         let mut delete_operation = DeleteDocuments::new(&mut wtxn, &index)?;
         delete_operation.delete_documents(&candidates);
         let deleted_documents =

--- a/index-scheduler/src/insta_snapshot.rs
+++ b/index-scheduler/src/insta_snapshot.rs
@@ -183,6 +183,9 @@ fn snapshot_details(d: &Details) -> String {
             provided_ids: received_document_ids,
             deleted_documents,
         } => format!("{{ received_document_ids: {received_document_ids}, deleted_documents: {deleted_documents:?} }}"),
+        Details::DocumentDeletionByFilter { original_filter, deleted_documents } => format!(
+           "{{ original_filter: {original_filter}, deleted_documents: {deleted_documents:?} }}"
+        ),
         Details::ClearAll { deleted_documents } => {
             format!("{{ deleted_documents: {deleted_documents:?} }}")
         },

--- a/index-scheduler/src/lib.rs
+++ b/index-scheduler/src/lib.rs
@@ -1208,6 +1208,13 @@ impl<'a> Dump<'a> {
                     documents_ids,
                     index_uid: task.index_uid.ok_or(Error::CorruptedDump)?,
                 },
+                KindDump::DocumentDeletionByFilter { filter } => {
+                    KindWithContent::DocumentDeletionByFilter {
+                        filter_expr: serde_json::from_str(&filter)
+                            .map_err(|_| Error::CorruptedDump)?,
+                        index_uid: task.index_uid.ok_or(Error::CorruptedDump)?,
+                    }
+                }
                 KindDump::DocumentClear => KindWithContent::DocumentClear {
                     index_uid: task.index_uid.ok_or(Error::CorruptedDump)?,
                 },

--- a/index-scheduler/src/lib.rs
+++ b/index-scheduler/src/lib.rs
@@ -1210,8 +1210,7 @@ impl<'a> Dump<'a> {
                 },
                 KindDump::DocumentDeletionByFilter { filter } => {
                     KindWithContent::DocumentDeletionByFilter {
-                        filter_expr: serde_json::from_str(&filter)
-                            .map_err(|_| Error::CorruptedDump)?,
+                        filter_expr: filter,
                         index_uid: task.index_uid.ok_or(Error::CorruptedDump)?,
                     }
                 }

--- a/meilisearch-types/src/error.rs
+++ b/meilisearch-types/src/error.rs
@@ -315,6 +315,7 @@ impl ErrorCode for milli::Error {
                     UserError::MaxDatabaseSizeReached => Code::DatabaseSizeLimitReached,
                     UserError::AttributeLimitReached => Code::MaxFieldsLimitExceeded,
                     UserError::InvalidFilter(_) => Code::InvalidSearchFilter,
+                    UserError::InvalidFilterExpression(..) => Code::InvalidSearchFilter,
                     UserError::MissingDocumentId { .. } => Code::MissingDocumentId,
                     UserError::InvalidDocumentId { .. } | UserError::TooManyDocumentIds { .. } => {
                         Code::InvalidDocumentId

--- a/meilisearch-types/src/error.rs
+++ b/meilisearch-types/src/error.rs
@@ -218,6 +218,7 @@ InvalidDocumentGeoField               , InvalidRequest       , BAD_REQUEST ;
 InvalidDocumentId                     , InvalidRequest       , BAD_REQUEST ;
 InvalidDocumentLimit                  , InvalidRequest       , BAD_REQUEST ;
 InvalidDocumentOffset                 , InvalidRequest       , BAD_REQUEST ;
+InvalidDocumentDeleteFilter           , InvalidRequest       , BAD_REQUEST ;
 InvalidIndexLimit                     , InvalidRequest       , BAD_REQUEST ;
 InvalidIndexOffset                    , InvalidRequest       , BAD_REQUEST ;
 InvalidIndexPrimaryKey                , InvalidRequest       , BAD_REQUEST ;

--- a/meilisearch-types/src/tasks.rs
+++ b/meilisearch-types/src/tasks.rs
@@ -83,11 +83,6 @@ impl Task {
     }
 }
 
-pub enum DocumentDeletionContent {
-    ByDocumentIds(Vec<String>),
-    ByFilter(serde_json::Value),
-}
-
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum KindWithContent {

--- a/meilisearch/src/analytics/mod.rs
+++ b/meilisearch/src/analytics/mod.rs
@@ -64,6 +64,7 @@ pub enum DocumentDeletionKind {
     PerDocumentId,
     ClearAll,
     PerBatch,
+    PerFilter,
 }
 
 pub trait Analytics: Sync + Send {

--- a/meilisearch/src/analytics/segment_analytics.rs
+++ b/meilisearch/src/analytics/segment_analytics.rs
@@ -949,6 +949,7 @@ pub struct DocumentsDeletionAggregator {
     per_document_id: bool,
     clear_all: bool,
     per_batch: bool,
+    per_filter: bool,
 }
 
 impl DocumentsDeletionAggregator {
@@ -962,6 +963,7 @@ impl DocumentsDeletionAggregator {
             DocumentDeletionKind::PerDocumentId => ret.per_document_id = true,
             DocumentDeletionKind::ClearAll => ret.clear_all = true,
             DocumentDeletionKind::PerBatch => ret.per_batch = true,
+            DocumentDeletionKind::PerFilter => ret.per_batch = true,
         }
 
         ret
@@ -981,6 +983,7 @@ impl DocumentsDeletionAggregator {
         self.per_document_id |= other.per_document_id;
         self.clear_all |= other.clear_all;
         self.per_batch |= other.per_batch;
+        self.per_filter |= other.per_filter;
     }
 
     pub fn into_event(self, user: &User, event_name: &str) -> Option<Track> {

--- a/meilisearch/src/analytics/segment_analytics.rs
+++ b/meilisearch/src/analytics/segment_analytics.rs
@@ -963,7 +963,7 @@ impl DocumentsDeletionAggregator {
             DocumentDeletionKind::PerDocumentId => ret.per_document_id = true,
             DocumentDeletionKind::ClearAll => ret.clear_all = true,
             DocumentDeletionKind::PerBatch => ret.per_batch = true,
-            DocumentDeletionKind::PerFilter => ret.per_batch = true,
+            DocumentDeletionKind::PerFilter => ret.per_filter = true,
         }
 
         ret

--- a/meilisearch/src/error.rs
+++ b/meilisearch/src/error.rs
@@ -20,6 +20,8 @@ pub enum MeilisearchHttpError {
     InvalidContentType(String, Vec<String>),
     #[error("Document `{0}` not found.")]
     DocumentNotFound(String),
+    #[error("Sending an empty filter is forbidden.")]
+    EmptyFilter,
     #[error("Invalid syntax for the filter parameter: `expected {}, found: {1}`.", .0.join(", "))]
     InvalidExpression(&'static [&'static str], Value),
     #[error("A {0} payload is missing.")]
@@ -58,6 +60,7 @@ impl ErrorCode for MeilisearchHttpError {
             MeilisearchHttpError::MissingPayload(_) => Code::MissingPayload,
             MeilisearchHttpError::InvalidContentType(_, _) => Code::InvalidContentType,
             MeilisearchHttpError::DocumentNotFound(_) => Code::DocumentNotFound,
+            MeilisearchHttpError::EmptyFilter => Code::InvalidDocumentDeleteFilter,
             MeilisearchHttpError::InvalidExpression(_, _) => Code::InvalidSearchFilter,
             MeilisearchHttpError::PayloadTooLarge => Code::PayloadTooLarge,
             MeilisearchHttpError::SwapIndexPayloadWrongLength(_) => Code::InvalidSwapIndexes,

--- a/meilisearch/src/routes/indexes/documents.rs
+++ b/meilisearch/src/routes/indexes/documents.rs
@@ -17,6 +17,7 @@ use meilisearch_types::error::{Code, ResponseError};
 use meilisearch_types::heed::RoTxn;
 use meilisearch_types::index_uid::IndexUid;
 use meilisearch_types::milli::update::IndexDocumentsMethod;
+use meilisearch_types::milli::InternalError;
 use meilisearch_types::star_or::OptionStarOrList;
 use meilisearch_types::tasks::KindWithContent;
 use meilisearch_types::{milli, Document, Index};
@@ -373,22 +374,96 @@ async fn document_addition(
     Ok(task.into())
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum DocumentDeletionQuery {
+    Ids(Vec<Value>),
+    Object { filter: Option<Value> },
+}
+
+/// Parses a Json encoded document id and validate it, returning a user error when it is one.
+/// FIXME: stolen from milli
+fn validate_document_id_value(document_id: Value) -> String {
+    match document_id {
+        Value::String(string) => match validate_document_id(&string) {
+            Some(s) if s.len() == string.len() => string,
+            Some(s) => s.to_string(),
+            None => panic!(),
+        },
+        Value::Number(number) if number.is_i64() => number.to_string(),
+        _content => panic!(),
+    }
+}
+
+/// FIXME: stolen from milli
+fn validate_document_id(document_id: &str) -> Option<&str> {
+    if !document_id.is_empty()
+        && document_id.chars().all(|c| matches!(c, 'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_'))
+    {
+        Some(document_id)
+    } else {
+        None
+    }
+}
+
 pub async fn delete_documents(
     index_scheduler: GuardedData<ActionPolicy<{ actions::DOCUMENTS_DELETE }>, Data<IndexScheduler>>,
     index_uid: web::Path<String>,
-    body: web::Json<Vec<Value>>,
+    body: web::Json<DocumentDeletionQuery>,
     req: HttpRequest,
     analytics: web::Data<dyn Analytics>,
 ) -> Result<HttpResponse, ResponseError> {
     debug!("called with params: {:?}", body);
     let index_uid = IndexUid::try_from(index_uid.into_inner())?;
+    let index_uid = index_uid.into_inner();
 
     analytics.delete_documents(DocumentDeletionKind::PerBatch, &req);
 
-    let ids = body
-        .iter()
-        .map(|v| v.as_str().map(String::from).unwrap_or_else(|| v.to_string()))
-        .collect();
+    let ids = match body.into_inner() {
+        DocumentDeletionQuery::Ids(body) => body
+            .iter()
+            .map(|v| v.as_str().map(String::from).unwrap_or_else(|| v.to_string()))
+            .collect(),
+        DocumentDeletionQuery::Object { filter } => {
+            debug!("filter: {:?}", filter);
+
+            // FIXME: spawn_blocking
+            if let Some(ref filter) = filter {
+                if let Some(facets) = crate::search::parse_filter(filter)? {
+                    debug!("facets: {:?}", facets);
+
+                    let index = index_scheduler.index(&index_uid)?;
+                    let rtxn = index.read_txn()?;
+                    let filtered_candidates = facets.evaluate(&rtxn, &index)?;
+                    debug!("filtered_candidates.len(): {:?}", filtered_candidates.len());
+
+                    // FIXME: unwraps
+                    let primary_key = index.primary_key(&rtxn)?.unwrap();
+                    let primary_key = index.fields_ids_map(&rtxn)?.id(primary_key).unwrap();
+
+                    let documents = index.documents(&rtxn, filtered_candidates.into_iter())?;
+                    debug!("documents.len(): {:?}", documents.len());
+                    let documents: Vec<String> = documents
+                        .into_iter()
+                        .map(|(_, document)| {
+                            let value = document.get(primary_key).unwrap();
+                            let value: Value = serde_json::from_slice(value)
+                                .map_err(InternalError::SerdeJson)
+                                .unwrap();
+
+                            validate_document_id_value(value)
+                        })
+                        .collect();
+                    debug!("documents: {:?}", documents);
+                    documents
+                } else {
+                    vec![]
+                }
+            } else {
+                vec![]
+            }
+        }
+    };
 
     let task =
         KindWithContent::DocumentDeletion { index_uid: index_uid.to_string(), documents_ids: ids };

--- a/meilisearch/src/routes/indexes/documents.rs
+++ b/meilisearch/src/routes/indexes/documents.rs
@@ -71,7 +71,7 @@ pub fn configure(cfg: &mut web::ServiceConfig) {
             .route(web::put().to(SeqHandler(update_documents)))
             .route(web::delete().to(SeqHandler(clear_all_documents))),
     )
-    // these routes needs to be before the /documents/{document_id} to match properly
+    // these routes need to be before the /documents/{document_id} to match properly
     .service(
         web::resource("/delete-batch").route(web::post().to(SeqHandler(delete_documents_batch))),
     )

--- a/meilisearch/src/routes/tasks.rs
+++ b/meilisearch/src/routes/tasks.rs
@@ -133,6 +133,13 @@ impl From<Details> for DetailsView {
                 deleted_documents: Some(deleted_documents),
                 ..DetailsView::default()
             },
+            Details::DocumentDeletionByFilter { original_filter, deleted_documents } => {
+                DetailsView {
+                    original_filter: Some(original_filter),
+                    deleted_documents: Some(deleted_documents),
+                    ..DetailsView::default()
+                }
+            }
             Details::ClearAll { deleted_documents } => {
                 DetailsView { deleted_documents: Some(deleted_documents), ..DetailsView::default() }
             }

--- a/meilisearch/src/routes/tasks.rs
+++ b/meilisearch/src/routes/tasks.rs
@@ -728,7 +728,7 @@ mod tests {
             let err = deserr_query_params::<TaskDeletionOrCancelationQuery>(params).unwrap_err();
             snapshot!(meili_snap::json_string!(err), @r###"
             {
-              "message": "Invalid value in parameter `types`: `createIndex` is not a valid task type. Available types are `documentAdditionOrUpdate`, `documentDeletion`, `settingsUpdate`, `indexCreation`, `indexDeletion`, `indexUpdate`, `indexSwap`, `taskCancelation`, `taskDeletion`, `dumpCreation`, `snapshotCreation`.",
+              "message": "Invalid value in parameter `types`: `createIndex` is not a valid task type. Available types are `documentAdditionOrUpdate`, `documentDeletion`, `documentDeletionByFilter`, `settingsUpdate`, `indexCreation`, `indexDeletion`, `indexUpdate`, `indexSwap`, `taskCancelation`, `taskDeletion`, `dumpCreation`, `snapshotCreation`.",
               "code": "invalid_task_types",
               "type": "invalid_request",
               "link": "https://docs.meilisearch.com/errors#invalid_task_types"

--- a/meilisearch/src/routes/tasks.rs
+++ b/meilisearch/src/routes/tasks.rs
@@ -135,6 +135,7 @@ impl From<Details> for DetailsView {
             },
             Details::DocumentDeletionByFilter { original_filter, deleted_documents } => {
                 DetailsView {
+                    provided_ids: Some(0),
                     original_filter: Some(original_filter),
                     deleted_documents: Some(deleted_documents),
                     ..DetailsView::default()

--- a/meilisearch/src/search.rs
+++ b/meilisearch/src/search.rs
@@ -745,7 +745,7 @@ fn format_value<A: AsRef<[u8]>>(
     }
 }
 
-fn parse_filter(facets: &Value) -> Result<Option<Filter>, MeilisearchHttpError> {
+pub fn parse_filter(facets: &Value) -> Result<Option<Filter>, MeilisearchHttpError> {
     match facets {
         Value::String(expr) => {
             let condition = Filter::from_str(expr)?;

--- a/meilisearch/tests/common/index.rs
+++ b/meilisearch/tests/common/index.rs
@@ -226,7 +226,7 @@ impl Index<'_> {
     }
 
     pub async fn delete_document_by_filter(&self, body: Value) -> (Value, StatusCode) {
-        let url = format!("/indexes/{}/documents/delete-batch", urlencode(self.uid.as_ref()));
+        let url = format!("/indexes/{}/documents/delete", urlencode(self.uid.as_ref()));
         self.service.post_encoded(url, body, self.encoder).await
     }
 

--- a/meilisearch/tests/common/index.rs
+++ b/meilisearch/tests/common/index.rs
@@ -225,6 +225,11 @@ impl Index<'_> {
         self.service.delete(url).await
     }
 
+    pub async fn delete_document_by_filter(&self, body: Value) -> (Value, StatusCode) {
+        let url = format!("/indexes/{}/documents/delete-batch", urlencode(self.uid.as_ref()));
+        self.service.post_encoded(url, body, self.encoder).await
+    }
+
     pub async fn clear_all_documents(&self) -> (Value, StatusCode) {
         let url = format!("/indexes/{}/documents", urlencode(self.uid.as_ref()));
         self.service.delete(url).await

--- a/meilisearch/tests/documents/delete_documents.rs
+++ b/meilisearch/tests/documents/delete_documents.rs
@@ -220,18 +220,18 @@ async fn delete_document_by_filter() {
     }
     "###);
 
-    let response = index.wait_task(2).await;
+    let response = index.wait_task(3).await;
     snapshot!(json_string!(response, { ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]", ".duration" => "[duration]" }), @r###"
     {
-      "uid": 2,
+      "uid": 3,
       "indexUid": "doggo",
       "status": "succeeded",
       "type": "documentDeletion",
       "canceledBy": null,
       "details": {
         "providedIds": 0,
-        "deletedDocuments": 2,
-        "originalFilter": "\"color = blue\""
+        "deletedDocuments": 1,
+        "originalFilter": "\"color NOT EXISTS\""
       },
       "error": null,
       "duration": "[duration]",

--- a/meilisearch/tests/documents/delete_documents.rs
+++ b/meilisearch/tests/documents/delete_documents.rs
@@ -247,11 +247,14 @@ async fn delete_document_by_filter() {
         {
           "id": 0,
           "color": "red"
+        },
+        {
+          "id": 3
         }
       ],
       "offset": 0,
       "limit": 20,
-      "total": 1
+      "total": 2
     }
     "###);
 }

--- a/meilisearch/tests/documents/delete_documents.rs
+++ b/meilisearch/tests/documents/delete_documents.rs
@@ -159,10 +159,11 @@ async fn delete_document_by_filter() {
     // snapshot!(code, @"202 Accepted");
     snapshot!(json_string!(response, { ".enqueuedAt" => "[date]" }), @r###"
     {
-      "message": "Missing fied `filter`",
-      "code": "bad_request",
-      "type": "invalid_request",
-      "link": "https://docs.meilisearch.com/errors#bad_request"
+      "taskUid": 2,
+      "indexUid": "doggo",
+      "status": "enqueued",
+      "type": "documentDeletion",
+      "enqueuedAt": "[date]"
     }
     "###);
 

--- a/meilisearch/tests/documents/delete_documents.rs
+++ b/meilisearch/tests/documents/delete_documents.rs
@@ -156,7 +156,7 @@ async fn delete_document_by_filter() {
     index.wait_task(1).await;
     let (response, code) =
         index.delete_document_by_filter(json!({ "filter": "color = blue"})).await;
-    // snapshot!(code, @"202 Accepted");
+    snapshot!(code, @"202 Accepted");
     snapshot!(json_string!(response, { ".enqueuedAt" => "[date]" }), @r###"
     {
       "taskUid": 2,
@@ -247,14 +247,11 @@ async fn delete_document_by_filter() {
         {
           "id": 0,
           "color": "red"
-        },
-        {
-          "id": 3
         }
       ],
       "offset": 0,
       "limit": 20,
-      "total": 2
+      "total": 1
     }
     "###);
 }

--- a/meilisearch/tests/documents/delete_documents.rs
+++ b/meilisearch/tests/documents/delete_documents.rs
@@ -176,6 +176,7 @@ async fn delete_document_by_filter() {
       "type": "documentDeletion",
       "canceledBy": null,
       "details": {
+        "providedIds": 0,
         "deletedDocuments": 2,
         "originalFilter": "\"color = blue\""
       },
@@ -228,6 +229,7 @@ async fn delete_document_by_filter() {
       "type": "documentDeletion",
       "canceledBy": null,
       "details": {
+        "providedIds": 0,
         "deletedDocuments": 2,
         "originalFilter": "\"color = blue\""
       },

--- a/meilisearch/tests/documents/delete_documents.rs
+++ b/meilisearch/tests/documents/delete_documents.rs
@@ -1,3 +1,4 @@
+use meili_snap::{json_string, snapshot};
 use serde_json::json;
 
 use crate::common::{GetAllDocumentsOptions, Server};
@@ -134,4 +135,123 @@ async fn delete_no_document_batch() {
     let (response, code) = index.get_all_documents(GetAllDocumentsOptions::default()).await;
     assert_eq!(code, 200);
     assert_eq!(response["results"].as_array().unwrap().len(), 3);
+}
+
+#[actix_rt::test]
+async fn delete_document_by_filter() {
+    let server = Server::new().await;
+    let index = server.index("doggo");
+    index.update_settings_filterable_attributes(json!(["color"])).await;
+    index
+        .add_documents(
+            json!([
+                { "id": 0, "color": "red" },
+                { "id": 1, "color": "blue" },
+                { "id": 2, "color": "blue" },
+                { "id": 3 },
+            ]),
+            Some("id"),
+        )
+        .await;
+    index.wait_task(1).await;
+    let (response, code) =
+        index.delete_document_by_filter(json!({ "filter": "color = blue"})).await;
+    snapshot!(code, @"202 Accepted");
+    snapshot!(json_string!(response, { ".enqueuedAt" => "[date]" }), @r###"
+    {
+      "taskUid": 2,
+      "indexUid": "doggo",
+      "status": "enqueued",
+      "type": "documentDeletion",
+      "enqueuedAt": "[date]"
+    }
+    "###);
+
+    let response = index.wait_task(2).await;
+    snapshot!(json_string!(response, { ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]", ".duration" => "[duration]" }), @r###"
+    {
+      "uid": 2,
+      "indexUid": "doggo",
+      "status": "succeeded",
+      "type": "documentDeletion",
+      "canceledBy": null,
+      "details": {
+        "deletedDocuments": 2,
+        "originalFilter": "\"color = blue\""
+      },
+      "error": null,
+      "duration": "[duration]",
+      "enqueuedAt": "[date]",
+      "startedAt": "[date]",
+      "finishedAt": "[date]"
+    }
+    "###);
+
+    let (documents, code) = index.get_all_documents(GetAllDocumentsOptions::default()).await;
+    snapshot!(code, @"200 OK");
+    snapshot!(json_string!(documents), @r###"
+    {
+      "results": [
+        {
+          "id": 0,
+          "color": "red"
+        },
+        {
+          "id": 3
+        }
+      ],
+      "offset": 0,
+      "limit": 20,
+      "total": 2
+    }
+    "###);
+
+    let (response, code) =
+        index.delete_document_by_filter(json!({ "filter": "color NOT EXISTS"})).await;
+    snapshot!(code, @"202 Accepted");
+    snapshot!(json_string!(response, { ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]", ".duration" => "[duration]" }), @r###"
+    {
+      "taskUid": 3,
+      "indexUid": "doggo",
+      "status": "enqueued",
+      "type": "documentDeletion",
+      "enqueuedAt": "[date]"
+    }
+    "###);
+
+    let response = index.wait_task(2).await;
+    snapshot!(json_string!(response, { ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]", ".duration" => "[duration]" }), @r###"
+    {
+      "uid": 2,
+      "indexUid": "doggo",
+      "status": "succeeded",
+      "type": "documentDeletion",
+      "canceledBy": null,
+      "details": {
+        "deletedDocuments": 2,
+        "originalFilter": "\"color = blue\""
+      },
+      "error": null,
+      "duration": "[duration]",
+      "enqueuedAt": "[date]",
+      "startedAt": "[date]",
+      "finishedAt": "[date]"
+    }
+    "###);
+
+    let (documents, code) = index.get_all_documents(GetAllDocumentsOptions::default()).await;
+    snapshot!(code, @"200 OK");
+    snapshot!(json_string!(documents), @r###"
+    {
+      "results": [
+        {
+          "id": 0,
+          "color": "red"
+        }
+      ],
+      "offset": 0,
+      "limit": 20,
+      "total": 1
+    }
+    "###);
 }

--- a/meilisearch/tests/documents/delete_documents.rs
+++ b/meilisearch/tests/documents/delete_documents.rs
@@ -257,3 +257,133 @@ async fn delete_document_by_filter() {
     }
     "###);
 }
+
+#[actix_rt::test]
+async fn delete_document_by_complex_filter() {
+    let server = Server::new().await;
+    let index = server.index("doggo");
+    index.update_settings_filterable_attributes(json!(["color"])).await;
+    index
+        .add_documents(
+            json!([
+                { "id": 0, "color": "red" },
+                { "id": 1, "color": "blue" },
+                { "id": 2, "color": "blue" },
+                { "id": 3, "color": "green" },
+                { "id": 4 },
+            ]),
+            Some("id"),
+        )
+        .await;
+    index.wait_task(1).await;
+    let (response, code) = index
+        .delete_document_by_filter(
+            json!({ "filter": ["color != red", "color != green", "color EXISTS"] }),
+        )
+        .await;
+    snapshot!(code, @"202 Accepted");
+    snapshot!(json_string!(response, { ".enqueuedAt" => "[date]" }), @r###"
+    {
+      "taskUid": 2,
+      "indexUid": "doggo",
+      "status": "enqueued",
+      "type": "documentDeletion",
+      "enqueuedAt": "[date]"
+    }
+    "###);
+
+    let response = index.wait_task(2).await;
+    snapshot!(json_string!(response, { ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]", ".duration" => "[duration]" }), @r###"
+    {
+      "uid": 2,
+      "indexUid": "doggo",
+      "status": "succeeded",
+      "type": "documentDeletion",
+      "canceledBy": null,
+      "details": {
+        "providedIds": 0,
+        "deletedDocuments": 2,
+        "originalFilter": "[\"color != red\",\"color != green\",\"color EXISTS\"]"
+      },
+      "error": null,
+      "duration": "[duration]",
+      "enqueuedAt": "[date]",
+      "startedAt": "[date]",
+      "finishedAt": "[date]"
+    }
+    "###);
+
+    let (documents, code) = index.get_all_documents(GetAllDocumentsOptions::default()).await;
+    snapshot!(code, @"200 OK");
+    snapshot!(json_string!(documents), @r###"
+    {
+      "results": [
+        {
+          "id": 0,
+          "color": "red"
+        },
+        {
+          "id": 3,
+          "color": "green"
+        },
+        {
+          "id": 4
+        }
+      ],
+      "offset": 0,
+      "limit": 20,
+      "total": 3
+    }
+    "###);
+
+    let (response, code) = index
+        .delete_document_by_filter(json!({ "filter": [["color = green", "color NOT EXISTS"]] }))
+        .await;
+    snapshot!(code, @"202 Accepted");
+    snapshot!(json_string!(response, { ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]", ".duration" => "[duration]" }), @r###"
+    {
+      "taskUid": 3,
+      "indexUid": "doggo",
+      "status": "enqueued",
+      "type": "documentDeletion",
+      "enqueuedAt": "[date]"
+    }
+    "###);
+
+    let response = index.wait_task(3).await;
+    snapshot!(json_string!(response, { ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]", ".duration" => "[duration]" }), @r###"
+    {
+      "uid": 3,
+      "indexUid": "doggo",
+      "status": "succeeded",
+      "type": "documentDeletion",
+      "canceledBy": null,
+      "details": {
+        "providedIds": 0,
+        "deletedDocuments": 4,
+        "originalFilter": "[[\"color = green\",\"color NOT EXISTS\"]]"
+      },
+      "error": null,
+      "duration": "[duration]",
+      "enqueuedAt": "[date]",
+      "startedAt": "[date]",
+      "finishedAt": "[date]"
+    }
+    "###);
+
+    let (documents, code) = index.get_all_documents(GetAllDocumentsOptions::default()).await;
+    snapshot!(code, @"200 OK");
+    snapshot!(json_string!(documents), @r###"
+    {
+      "results": [
+        {
+          "id": 0,
+          "color": "red"
+        }
+      ],
+      "offset": 0,
+      "limit": 20,
+      "total": 1
+    }
+    "###);
+}

--- a/meilisearch/tests/documents/delete_documents.rs
+++ b/meilisearch/tests/documents/delete_documents.rs
@@ -156,14 +156,13 @@ async fn delete_document_by_filter() {
     index.wait_task(1).await;
     let (response, code) =
         index.delete_document_by_filter(json!({ "filter": "color = blue"})).await;
-    snapshot!(code, @"202 Accepted");
+    // snapshot!(code, @"202 Accepted");
     snapshot!(json_string!(response, { ".enqueuedAt" => "[date]" }), @r###"
     {
-      "taskUid": 2,
-      "indexUid": "doggo",
-      "status": "enqueued",
-      "type": "documentDeletion",
-      "enqueuedAt": "[date]"
+      "message": "Missing fied `filter`",
+      "code": "bad_request",
+      "type": "invalid_request",
+      "link": "https://docs.meilisearch.com/errors#bad_request"
     }
     "###);
 

--- a/meilisearch/tests/documents/errors.rs
+++ b/meilisearch/tests/documents/errors.rs
@@ -429,10 +429,10 @@ async fn delete_document_by_filter() {
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
-      "message": "Json deserialize error: data did not match any variant of untagged enum DocumentDeletionQuery",
-      "code": "bad_request",
+      "message": "Invalid syntax for the filter parameter: `expected String, Array, found: null`.",
+      "code": "invalid_search_filter",
       "type": "invalid_request",
-      "link": "https://docs.meilisearch.com/errors#bad_request"
+      "link": "https://docs.meilisearch.com/errors#invalid_search_filter"
     }
     "###);
 

--- a/meilisearch/tests/documents/errors.rs
+++ b/meilisearch/tests/documents/errors.rs
@@ -436,15 +436,39 @@ async fn delete_document_by_filter() {
     }
     "###);
 
+    // send bad payload type
+    let (response, code) = index.delete_document_by_filter(json!({ "filter": true })).await;
+    snapshot!(code, @"400 Bad Request");
+    snapshot!(json_string!(response), @r###"
+    {
+      "message": "Invalid syntax for the filter parameter: `expected String, Array, found: true`.",
+      "code": "invalid_document_delete_filter",
+      "type": "invalid_request",
+      "link": "https://docs.meilisearch.com/errors#invalid_document_delete_filter"
+    }
+    "###);
+
     // send bad filter
     let (response, code) = index.delete_document_by_filter(json!({ "filter": "hello"})).await;
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
       "message": "Was expecting an operation `=`, `!=`, `>=`, `>`, `<=`, `<`, `IN`, `NOT IN`, `TO`, `EXISTS`, `NOT EXISTS`, `_geoRadius`, or `_geoBoundingBox` at `hello`.\n1:6 hello",
-      "code": "invalid_search_filter",
+      "code": "invalid_document_delete_filter",
       "type": "invalid_request",
-      "link": "https://docs.meilisearch.com/errors#invalid_search_filter"
+      "link": "https://docs.meilisearch.com/errors#invalid_document_delete_filter"
+    }
+    "###);
+
+    // send empty filter
+    let (response, code) = index.delete_document_by_filter(json!({ "filter": ""})).await;
+    snapshot!(code, @"400 Bad Request");
+    snapshot!(json_string!(response), @r###"
+    {
+      "message": "Sending an empty filter is forbidden.",
+      "code": "invalid_document_delete_filter",
+      "type": "invalid_request",
+      "link": "https://docs.meilisearch.com/errors#invalid_document_delete_filter"
     }
     "###);
 

--- a/meilisearch/tests/documents/errors.rs
+++ b/meilisearch/tests/documents/errors.rs
@@ -485,6 +485,7 @@ async fn delete_document_by_filter() {
       "type": "documentDeletion",
       "canceledBy": null,
       "details": {
+        "providedIds": 0,
         "deletedDocuments": 0,
         "originalFilter": "\"doggo = bernese\""
       },
@@ -518,6 +519,7 @@ async fn delete_document_by_filter() {
       "type": "documentDeletion",
       "canceledBy": null,
       "details": {
+        "providedIds": 0,
         "deletedDocuments": 0,
         "originalFilter": "\"doggo = bernese\""
       },
@@ -551,6 +553,7 @@ async fn delete_document_by_filter() {
       "type": "documentDeletion",
       "canceledBy": null,
       "details": {
+        "providedIds": 0,
         "deletedDocuments": 0,
         "originalFilter": "\"catto = jorts\""
       },

--- a/meilisearch/tests/documents/errors.rs
+++ b/meilisearch/tests/documents/errors.rs
@@ -453,7 +453,7 @@ async fn delete_document_by_filter() {
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
-      "message": "Was expecting an operation `=`, `!=`, `>=`, `>`, `<=`, `<`, `IN`, `NOT IN`, `TO`, `EXISTS`, `NOT EXISTS`, `_geoRadius`, or `_geoBoundingBox` at `hello`.\n1:6 hello",
+      "message": "Was expecting an operation `=`, `!=`, `>=`, `>`, `<=`, `<`, `IN`, `NOT IN`, `TO`, `EXISTS`, `NOT EXISTS`, `IS NULL`, `IS NOT NULL`, `IS EMPTY`, `IS NOT EMPTY`, `_geoRadius`, or `_geoBoundingBox` at `hello`.\n1:6 hello",
       "code": "invalid_document_delete_filter",
       "type": "invalid_request",
       "link": "https://docs.meilisearch.com/errors#invalid_document_delete_filter"

--- a/meilisearch/tests/documents/errors.rs
+++ b/meilisearch/tests/documents/errors.rs
@@ -429,10 +429,10 @@ async fn delete_document_by_filter() {
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
-      "message": "Invalid syntax for the filter parameter: `expected String, Array, found: null`.",
-      "code": "invalid_search_filter",
+      "message": "Invalid value type: expected an object, but found a string: `\"hello\"`",
+      "code": "bad_request",
       "type": "invalid_request",
-      "link": "https://docs.meilisearch.com/errors#invalid_search_filter"
+      "link": "https://docs.meilisearch.com/errors#bad_request"
     }
     "###);
 

--- a/meilisearch/tests/tasks/errors.rs
+++ b/meilisearch/tests/tasks/errors.rs
@@ -97,7 +97,7 @@ async fn task_bad_types() {
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
-      "message": "Invalid value in parameter `types`: `doggo` is not a valid task type. Available types are `documentAdditionOrUpdate`, `documentDeletion`, `settingsUpdate`, `indexCreation`, `indexDeletion`, `indexUpdate`, `indexSwap`, `taskCancelation`, `taskDeletion`, `dumpCreation`, `snapshotCreation`.",
+      "message": "Invalid value in parameter `types`: `doggo` is not a valid task type. Available types are `documentAdditionOrUpdate`, `documentDeletion`, `documentDeletionByFilter`, `settingsUpdate`, `indexCreation`, `indexDeletion`, `indexUpdate`, `indexSwap`, `taskCancelation`, `taskDeletion`, `dumpCreation`, `snapshotCreation`.",
       "code": "invalid_task_types",
       "type": "invalid_request",
       "link": "https://docs.meilisearch.com/errors#invalid_task_types"
@@ -108,7 +108,7 @@ async fn task_bad_types() {
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
-      "message": "Invalid value in parameter `types`: `doggo` is not a valid task type. Available types are `documentAdditionOrUpdate`, `documentDeletion`, `settingsUpdate`, `indexCreation`, `indexDeletion`, `indexUpdate`, `indexSwap`, `taskCancelation`, `taskDeletion`, `dumpCreation`, `snapshotCreation`.",
+      "message": "Invalid value in parameter `types`: `doggo` is not a valid task type. Available types are `documentAdditionOrUpdate`, `documentDeletion`, `documentDeletionByFilter`, `settingsUpdate`, `indexCreation`, `indexDeletion`, `indexUpdate`, `indexSwap`, `taskCancelation`, `taskDeletion`, `dumpCreation`, `snapshotCreation`.",
       "code": "invalid_task_types",
       "type": "invalid_request",
       "link": "https://docs.meilisearch.com/errors#invalid_task_types"
@@ -119,7 +119,7 @@ async fn task_bad_types() {
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
-      "message": "Invalid value in parameter `types`: `doggo` is not a valid task type. Available types are `documentAdditionOrUpdate`, `documentDeletion`, `settingsUpdate`, `indexCreation`, `indexDeletion`, `indexUpdate`, `indexSwap`, `taskCancelation`, `taskDeletion`, `dumpCreation`, `snapshotCreation`.",
+      "message": "Invalid value in parameter `types`: `doggo` is not a valid task type. Available types are `documentAdditionOrUpdate`, `documentDeletion`, `documentDeletionByFilter`, `settingsUpdate`, `indexCreation`, `indexDeletion`, `indexUpdate`, `indexSwap`, `taskCancelation`, `taskDeletion`, `dumpCreation`, `snapshotCreation`.",
       "code": "invalid_task_types",
       "type": "invalid_request",
       "link": "https://docs.meilisearch.com/errors#invalid_task_types"

--- a/milli/src/error.rs
+++ b/milli/src/error.rs
@@ -112,6 +112,8 @@ only composed of alphanumeric characters (a-z A-Z 0-9), hyphens (-) and undersco
     InvalidGeoField(#[from] GeoError),
     #[error("{0}")]
     InvalidFilter(String),
+    #[error("Invalid type for filter subexpression: `expected {}, found: {1}`.", .0.join(", "))]
+    InvalidFilterExpression(&'static [&'static str], Value),
     #[error("Attribute `{}` is not sortable. {}",
         .field,
         match .valid_fields.is_empty() {


### PR DESCRIPTION
# Prototype `prototype-delete-by-filter-0`

Usage:
A new route is available under `POST /indexes/{index_uid}/documents/delete` that allows you to delete your documents by filter.
The expected payload looks like that:
```json
{
  "filter": "doggo = bernese",
}
```

It'll then enqueue a task in your task queue that'll delete all the documents matching this filter once it's processed.
Here is an example of the associated details;
```json
  "details": {
    "deletedDocuments": 53,
    "originalFilter": "\"doggo = bernese\""
  }
```

----------


# Pull Request

## Related issue
Related to https://github.com/meilisearch/meilisearch/issues/3477

## What does this PR do?

### User standpoint

- Modifies the `/indexes/{:indexUid}/documents/delete-batch` route to accept either the existing array of documents ids, or a JSON object with a `filter` field representing a filter to apply. If that latter variant is used, any document matching the filter will be deleted.

### Implementation standpoint

- (processing time version) Adds a new BatchKind that is not autobatchable and that performs the delete by filter
- Reuse the `documentDeletion` task with a new `originalFilter` detail that replaces the `providedIds` detail.

## Example

<details>
<summary>Sample request, response and task result</summary>

Request:

```
curl \
  -X POST 'http://localhost:7700/indexes/index-10/documents/delete-batch' \
  -H 'Content-Type: application/json' \
  --data-binary '{ "filter" : "mass = 600"}'
```

Response:

```
{
  "taskUid": 3902,
  "indexUid": "index-10",
  "status": "enqueued",
  "type": "documentDeletion",
  "enqueuedAt": "2023-02-28T20:50:31.667502Z"
}
```

Task log:

```json
    {
      "uid": 3906,
      "indexUid": "index-12",
      "status": "succeeded",
      "type": "documentDeletion",
      "canceledBy": null,
      "details": {
        "deletedDocuments": 3,
        "originalFilter": "\"mass = 600\""
      },
      "error": null,
      "duration": "PT0.001819S",
      "enqueuedAt": "2023-03-07T08:57:20.11387Z",
      "startedAt": "2023-03-07T08:57:20.115895Z",
      "finishedAt": "2023-03-07T08:57:20.117714Z"
    }
```

</details>

## Draft status

- [ ] Error handling
- [ ] Analytics
- [ ] Do we want to reuse the `delete-batch` route in this way, or create a new route instead?
- [ ] Should the filter be applied at request time or when the deletion task is processed? 
  - The first commit in this PR applies the filter at request time, meaning that even if a document is modified in a way that no longer matches the filter in a later update, it will be deleted as long as the deletion task is processed after that update. 
  - The other commits in this PR apply the filter only when the asynchronous deletion task is processed, meaning that documents that match the filter at processing time are deleted even if they didn't match the filter at request time.
- [ ] If keeping the filter at request time, find a more elegant way to recover the user document ids from the internal document ids. The current way implemented in the first commit of this PR involves getting all the documents matching the filter, looking for the value of their primary key, and turning it into a string by copy-pasting routines found in milli...
- [ ] Security consideration, if any
- [ ] Fix the tests (but waiting until product questions are resolved)
- [ ] Add delete by filter specific tests

