### PR TITLE
Enhance Japanese language detection

### DIFF
--- a/meilisearch/src/routes/indexes/mod.rs
+++ b/meilisearch/src/routes/indexes/mod.rs
@@ -100,7 +100,6 @@ pub async fn list_indexes(
             Ok(Some(IndexView::new(uid.to_string(), index)?))
         })?;
     // Won't cause to open all indexes because IndexView doesn't keep the `Index` opened.
-    // error when trying to fix it: the trait `ExactSizeIterator` is not implemented for `Flatten<IntoIter<Option<IndexView>>>`
     let indexes: Vec<IndexView> = indexes.into_iter().flatten().collect();
     let ret = paginate.as_pagination().auto_paginate_sized(indexes.into_iter());
 

--- a/meilisearch/src/routes/indexes/mod.rs
+++ b/meilisearch/src/routes/indexes/mod.rs
@@ -101,7 +101,6 @@ pub async fn list_indexes(
         })?;
     // Won't cause to open all indexes because IndexView doesn't keep the `Index` opened.
     // error when trying to fix it: the trait `ExactSizeIterator` is not implemented for `Flatten<IntoIter<Option<IndexView>>>`
-    #[allow(clippy::needless_collect)]
     let indexes: Vec<IndexView> = indexes.into_iter().flatten().collect();
     let ret = paginate.as_pagination().auto_paginate_sized(indexes.into_iter());
 

--- a/meilisearch/src/routes/indexes/mod.rs
+++ b/meilisearch/src/routes/indexes/mod.rs
@@ -100,6 +100,8 @@ pub async fn list_indexes(
             Ok(Some(IndexView::new(uid.to_string(), index)?))
         })?;
     // Won't cause to open all indexes because IndexView doesn't keep the `Index` opened.
+    // error when trying to fix it: the trait `ExactSizeIterator` is not implemented for `Flatten<IntoIter<Option<IndexView>>>`
+    #[allow(clippy::needless_collect)]
     let indexes: Vec<IndexView> = indexes.into_iter().flatten().collect();
     let ret = paginate.as_pagination().auto_paginate_sized(indexes.into_iter());
 

--- a/meilisearch/src/search.rs
+++ b/meilisearch/src/search.rs
@@ -375,15 +375,15 @@ pub fn perform_search(
         &displayed_ids,
     );
 
-    let mut tokenizer_buidler = TokenizerBuilder::default();
-    tokenizer_buidler.create_char_map(true);
+    let mut tokenizer_builder = TokenizerBuilder::default();
+    tokenizer_builder.create_char_map(true);
 
     let script_lang_map = index.script_language(&rtxn)?;
     if !script_lang_map.is_empty() {
-        tokenizer_buidler.allow_list(&script_lang_map);
+        tokenizer_builder.allow_list(&script_lang_map);
     }
 
-    let mut formatter_builder = MatcherBuilder::new(matching_words, tokenizer_buidler.build());
+    let mut formatter_builder = MatcherBuilder::new(matching_words, tokenizer_builder.build());
     formatter_builder.crop_marker(query.crop_marker);
     formatter_builder.highlight_prefix(query.highlight_pre_tag);
     formatter_builder.highlight_suffix(query.highlight_post_tag);

--- a/meilisearch/src/search.rs
+++ b/meilisearch/src/search.rs
@@ -378,6 +378,11 @@ pub fn perform_search(
     let mut tokenizer_buidler = TokenizerBuilder::default();
     tokenizer_buidler.create_char_map(true);
 
+    let script_lang_map = index.script_language(&rtxn)?;
+    if !script_lang_map.is_empty() {
+        tokenizer_buidler.allow_list(&script_lang_map);
+    }
+
     let mut formatter_builder = MatcherBuilder::new(matching_words, tokenizer_buidler.build());
     formatter_builder.crop_marker(query.crop_marker);
     formatter_builder.highlight_prefix(query.highlight_pre_tag);

--- a/milli/src/index.rs
+++ b/milli/src/index.rs
@@ -1224,7 +1224,7 @@ impl Index {
             }
         }
 
-        let threshold = total / 20; // 5% (arbitrar)
+        let threshold = total / 20; // 5% (arbitrary)
         for (script, language, count) in script_language_doc_count {
             if count > threshold {
                 if let Some(languages) = script_language.get_mut(&script) {

--- a/milli/src/index.rs
+++ b/milli/src/index.rs
@@ -1211,11 +1211,22 @@ impl Index {
         let soft_deleted_documents = self.soft_deleted_documents_ids(rtxn)?;
 
         let mut script_language: HashMap<Script, Vec<Language>> = HashMap::new();
+        let mut script_language_doc_count: Vec<(Script, Language, u64)> = Vec::new();
+        let mut total = 0;
         for sl in self.script_language_docids.iter(rtxn)? {
             let ((script, language), docids) = sl?;
 
             // keep only Languages that contains at least 1 document.
-            if !soft_deleted_documents.is_superset(&docids) {
+            let remaining_documents_count = (docids - &soft_deleted_documents).len();
+            total += remaining_documents_count;
+            if remaining_documents_count > 0 {
+                script_language_doc_count.push((script, language, remaining_documents_count));
+            }
+        }
+
+        let threshold = total / 20; // 5% (arbitrar)
+        for (script, language, count) in script_language_doc_count {
+            if count > threshold {
                 if let Some(languages) = script_language.get_mut(&script) {
                     (*languages).push(language);
                 } else {

--- a/milli/src/update/index_documents/extract/extract_docid_word_positions.rs
+++ b/milli/src/update/index_documents/extract/extract_docid_word_positions.rs
@@ -288,5 +288,5 @@ fn most_frequent_languages(
 
 fn compute_laguage_frequency_threshold(languages_frequency: &[(Language, usize)]) -> usize {
     let total: usize = languages_frequency.iter().map(|(_, c)| c).sum();
-    total / 20 // 5% is a completely arbitrar value.
+    total / 10 // 10% is a completely arbitrar value.
 }

--- a/milli/src/update/index_documents/extract/extract_docid_word_positions.rs
+++ b/milli/src/update/index_documents/extract/extract_docid_word_positions.rs
@@ -89,7 +89,7 @@ pub fn extract_docid_word_positions<R: io::Read + io::Seek>(
             // if the allow list is empty, meaning that no Language is considered frequent,
             // then we don't rerun the extraction.
             if !script_language.is_empty() {
-                // build a new temporar tokenizer including the allow list.
+                // build a new temporary tokenizer including the allow list.
                 let mut tokenizer_builder = TokenizerBuilder::new();
                 if let Some(stop_words) = stop_words {
                     tokenizer_builder.stop_words(stop_words);
@@ -260,7 +260,7 @@ fn process_tokens<'a>(
 
 fn potential_language_detection_error(languages_frequency: &Vec<(Language, usize)>) -> bool {
     if languages_frequency.len() > 1 {
-        let threshold = compute_laguage_frequency_threshold(languages_frequency);
+        let threshold = compute_language_frequency_threshold(languages_frequency);
         languages_frequency.iter().any(|(_, c)| *c <= threshold)
     } else {
         false
@@ -271,7 +271,7 @@ fn most_frequent_languages(
     (script, languages_frequency): (&Script, &Vec<(Language, usize)>),
 ) -> Option<(Script, Vec<Language>)> {
     if languages_frequency.len() > 1 {
-        let threshold = compute_laguage_frequency_threshold(languages_frequency);
+        let threshold = compute_language_frequency_threshold(languages_frequency);
 
         let languages: Vec<_> =
             languages_frequency.iter().filter(|(_, c)| *c > threshold).map(|(l, _)| *l).collect();
@@ -286,7 +286,7 @@ fn most_frequent_languages(
     }
 }
 
-fn compute_laguage_frequency_threshold(languages_frequency: &[(Language, usize)]) -> usize {
+fn compute_language_frequency_threshold(languages_frequency: &[(Language, usize)]) -> usize {
     let total: usize = languages_frequency.iter().map(|(_, c)| c).sum();
-    total / 10 // 10% is a completely arbitrar value.
+    total / 10 // 10% is a completely arbitrary value.
 }

--- a/milli/src/update/index_documents/extract/extract_docid_word_positions.rs
+++ b/milli/src/update/index_documents/extract/extract_docid_word_positions.rs
@@ -3,12 +3,14 @@ use std::convert::TryInto;
 use std::fs::File;
 use std::{io, mem, str};
 
-use charabia::{Language, Script, SeparatorKind, Token, TokenKind, TokenizerBuilder};
+use charabia::{Language, Script, SeparatorKind, Token, TokenKind, Tokenizer, TokenizerBuilder};
+use obkv::KvReader;
 use roaring::RoaringBitmap;
 use serde_json::Value;
 
 use super::helpers::{concat_u32s_array, create_sorter, sorter_into_reader, GrenadParameters};
 use crate::error::{InternalError, SerializationError};
+use crate::update::index_documents::MergeFn;
 use crate::{
     absolute_from_relative_position, FieldId, Result, MAX_POSITION_PER_ATTRIBUTE, MAX_WORD_LENGTH,
 };
@@ -33,7 +35,7 @@ pub fn extract_docid_word_positions<R: io::Read + io::Seek>(
     let max_memory = indexer.max_memory_by_thread();
 
     let mut documents_ids = RoaringBitmap::new();
-    let mut script_language_pair = HashMap::new();
+    let mut script_language_docids = HashMap::new();
     let mut docid_word_positions_sorter = create_sorter(
         grenad::SortAlgorithm::Stable,
         concat_u32s_array,
@@ -45,11 +47,11 @@ pub fn extract_docid_word_positions<R: io::Read + io::Seek>(
 
     let mut key_buffer = Vec::new();
     let mut field_buffer = String::new();
-    let mut builder = TokenizerBuilder::new();
+    let mut tokenizer_builder = TokenizerBuilder::new();
     if let Some(stop_words) = stop_words {
-        builder.stop_words(stop_words);
+        tokenizer_builder.stop_words(stop_words);
     }
-    let tokenizer = builder.build();
+    let tokenizer = tokenizer_builder.build();
 
     let mut cursor = obkv_documents.into_cursor()?;
     while let Some((key, value)) = cursor.move_on_next()? {
@@ -57,49 +59,120 @@ pub fn extract_docid_word_positions<R: io::Read + io::Seek>(
             .try_into()
             .map(u32::from_be_bytes)
             .map_err(|_| SerializationError::InvalidNumberSerialization)?;
-        let obkv = obkv::KvReader::<FieldId>::new(value);
+        let obkv = KvReader::<FieldId>::new(value);
 
         documents_ids.push(document_id);
         key_buffer.clear();
         key_buffer.extend_from_slice(&document_id.to_be_bytes());
 
-        for (field_id, field_bytes) in obkv.iter() {
-            if searchable_fields.as_ref().map_or(true, |sf| sf.contains(&field_id)) {
-                let value =
-                    serde_json::from_slice(field_bytes).map_err(InternalError::SerdeJson)?;
-                field_buffer.clear();
-                if let Some(field) = json_to_string(&value, &mut field_buffer) {
-                    let tokens = process_tokens(tokenizer.tokenize(field))
-                        .take_while(|(p, _)| (*p as u32) < max_positions_per_attributes);
+        let mut script_language_word_count = HashMap::new();
 
-                    for (index, token) in tokens {
-                        if let Some(language) = token.language {
-                            let script = token.script;
-                            let entry = script_language_pair
-                                .entry((script, language))
-                                .or_insert_with(RoaringBitmap::new);
-                            entry.push(document_id);
-                        }
-                        let token = token.lemma().trim();
-                        if !token.is_empty() && token.len() <= MAX_WORD_LENGTH {
-                            key_buffer.truncate(mem::size_of::<u32>());
-                            key_buffer.extend_from_slice(token.as_bytes());
+        extract_tokens_from_document(
+            &obkv,
+            searchable_fields,
+            &tokenizer,
+            max_positions_per_attributes,
+            &mut key_buffer,
+            &mut field_buffer,
+            &mut script_language_word_count,
+            &mut docid_word_positions_sorter,
+        )?;
 
-                            let position: u16 = index
-                                .try_into()
-                                .map_err(|_| SerializationError::InvalidNumberSerialization)?;
-                            let position = absolute_from_relative_position(field_id, position);
-                            docid_word_positions_sorter
-                                .insert(&key_buffer, position.to_ne_bytes())?;
+        // if we detect a potetial mistake in the language detection,
+        // we rerun the extraction forcing the tokenizer to detect the most frequently detected Languages.
+        // context: https://github.com/meilisearch/meilisearch/issues/3565
+        if script_language_word_count.values().any(potential_language_detection_error) {
+            // build an allow list with the most frequent detected languages in the document.
+            let script_language: HashMap<_, _> =
+                script_language_word_count.iter().filter_map(most_frequent_languages).collect();
+
+            // if the allow list is empty, meaning that no Language is considered frequent,
+            // then we don't rerun the extraction.
+            if !script_language.is_empty() {
+                // build a new temporar tokenizer including the allow list.
+                let mut tokenizer_builder = TokenizerBuilder::new();
+                if let Some(stop_words) = stop_words {
+                    tokenizer_builder.stop_words(stop_words);
+                }
+                tokenizer_builder.allow_list(&script_language);
+                let tokenizer = tokenizer_builder.build();
+
+                script_language_word_count.clear();
+
+                // rerun the extraction.
+                extract_tokens_from_document(
+                    &obkv,
+                    searchable_fields,
+                    &tokenizer,
+                    max_positions_per_attributes,
+                    &mut key_buffer,
+                    &mut field_buffer,
+                    &mut script_language_word_count,
+                    &mut docid_word_positions_sorter,
+                )?;
+            }
+        }
+
+        for (script, languages_frequency) in script_language_word_count {
+            for (language, _) in languages_frequency {
+                let entry = script_language_docids
+                    .entry((script, language))
+                    .or_insert_with(RoaringBitmap::new);
+                entry.push(document_id);
+            }
+        }
+    }
+
+    sorter_into_reader(docid_word_positions_sorter, indexer)
+        .map(|reader| (documents_ids, reader, script_language_docids))
+}
+
+fn extract_tokens_from_document<T: AsRef<[u8]>>(
+    obkv: &KvReader<FieldId>,
+    searchable_fields: &Option<HashSet<FieldId>>,
+    tokenizer: &Tokenizer<T>,
+    max_positions_per_attributes: u32,
+    key_buffer: &mut Vec<u8>,
+    field_buffer: &mut String,
+    script_language_word_count: &mut HashMap<Script, Vec<(Language, usize)>>,
+    docid_word_positions_sorter: &mut grenad::Sorter<MergeFn>,
+) -> Result<()> {
+    for (field_id, field_bytes) in obkv.iter() {
+        if searchable_fields.as_ref().map_or(true, |sf| sf.contains(&field_id)) {
+            let value = serde_json::from_slice(field_bytes).map_err(InternalError::SerdeJson)?;
+            field_buffer.clear();
+            if let Some(field) = json_to_string(&value, field_buffer) {
+                let tokens = process_tokens(tokenizer.tokenize(field))
+                    .take_while(|(p, _)| (*p as u32) < max_positions_per_attributes);
+
+                for (index, token) in tokens {
+                    // if a language has been detected for the token, we update the counter.
+                    if let Some(language) = token.language {
+                        let script = token.script;
+                        let entry =
+                            script_language_word_count.entry(script).or_insert_with(Vec::new);
+                        match entry.iter_mut().find(|(l, _)| *l == language) {
+                            Some((_, n)) => *n += 1,
+                            None => entry.push((language, 1)),
                         }
+                    }
+                    let token = token.lemma().trim();
+                    if !token.is_empty() && token.len() <= MAX_WORD_LENGTH {
+                        key_buffer.truncate(mem::size_of::<u32>());
+                        key_buffer.extend_from_slice(token.as_bytes());
+
+                        let position: u16 = index
+                            .try_into()
+                            .map_err(|_| SerializationError::InvalidNumberSerialization)?;
+                        let position = absolute_from_relative_position(field_id, position);
+                        docid_word_positions_sorter.insert(&key_buffer, position.to_ne_bytes())?;
                     }
                 }
             }
         }
     }
 
-    sorter_into_reader(docid_word_positions_sorter, indexer)
-        .map(|reader| (documents_ids, reader, script_language_pair))
+    Ok(())
 }
 
 /// Transform a JSON value into a string that can be indexed.
@@ -182,4 +255,40 @@ fn process_tokens<'a>(
             Some((*offset, token))
         })
         .filter(|(_, t)| t.is_word())
+}
+
+fn potential_language_detection_error(languages_frequency: &Vec<(Language, usize)>) -> bool {
+    if languages_frequency.len() > 1 {
+        let threshold = compute_laguage_frequency_threshold(languages_frequency);
+        languages_frequency.iter().any(|(_, c)| *c <= threshold)
+    } else {
+        false
+    }
+}
+
+fn most_frequent_languages(
+    (script, languages_frequency): (&Script, &Vec<(Language, usize)>),
+) -> Option<(Script, Vec<Language>)> {
+    if languages_frequency.len() > 1 {
+        let threshold = compute_laguage_frequency_threshold(languages_frequency);
+
+        let languages: Vec<_> = languages_frequency
+            .iter()
+            .filter(|(_, c)| *c > threshold)
+            .map(|(l, _)| l.clone())
+            .collect();
+
+        if languages.is_empty() {
+            None
+        } else {
+            Some((script.clone(), languages))
+        }
+    } else {
+        None
+    }
+}
+
+fn compute_laguage_frequency_threshold(languages_frequency: &Vec<(Language, usize)>) -> usize {
+    let total: usize = languages_frequency.iter().map(|(_, c)| c).sum();
+    total / 20 // 5% is a completely arbitrar value.
 }

--- a/milli/src/update/index_documents/extract/extract_docid_word_positions.rs
+++ b/milli/src/update/index_documents/extract/extract_docid_word_positions.rs
@@ -127,6 +127,7 @@ pub fn extract_docid_word_positions<R: io::Read + io::Seek>(
         .map(|reader| (documents_ids, reader, script_language_docids))
 }
 
+#[allow(clippy::too_many_arguments)]
 fn extract_tokens_from_document<T: AsRef<[u8]>>(
     obkv: &KvReader<FieldId>,
     searchable_fields: &Option<HashSet<FieldId>>,
@@ -272,23 +273,20 @@ fn most_frequent_languages(
     if languages_frequency.len() > 1 {
         let threshold = compute_laguage_frequency_threshold(languages_frequency);
 
-        let languages: Vec<_> = languages_frequency
-            .iter()
-            .filter(|(_, c)| *c > threshold)
-            .map(|(l, _)| l.clone())
-            .collect();
+        let languages: Vec<_> =
+            languages_frequency.iter().filter(|(_, c)| *c > threshold).map(|(l, _)| *l).collect();
 
         if languages.is_empty() {
             None
         } else {
-            Some((script.clone(), languages))
+            Some((*script, languages))
         }
     } else {
         None
     }
 }
 
-fn compute_laguage_frequency_threshold(languages_frequency: &Vec<(Language, usize)>) -> usize {
+fn compute_laguage_frequency_threshold(languages_frequency: &[(Language, usize)]) -> usize {
     let total: usize = languages_frequency.iter().map(|(_, c)| c).sum();
     total / 20 // 5% is a completely arbitrar value.
 }


### PR DESCRIPTION
# Pull Request

This PR is a prototype and can be tested by downloading [the dedicated docker image](https://hub.docker.com/layers/getmeili/meilisearch/prototype-better-language-detection-0/images/sha256-a12847de00e21a71ab797879fd09777dadcb0881f65b5f810e7d1ed434d116ef?context=explore):

```bash
$ docker pull getmeili/meilisearch:prototype-better-language-detection-0
```

## Context
Some Languages are harder to detect than others, this miss-detection leads to bad tokenization making some words or even documents completely unsearchable. Japanese is the main Language affected and can be detected as Chinese which has a completely different way of tokenization.

A [first iteration has been implemented for v1.1.0](https://github.com/meilisearch/meilisearch/pull/3347) but is an insufficient enhancement to make Japanese work. This first implementation was detecting the Language during the indexing to avoid bad detections during the search.
Unfortunately, some documents (shorter ones) can be wrongly detected as Chinese running bad tokenization for these documents and making possible the detection of Chinese during the search because it has been detected during the indexing.

For instance, a Japanese document `{"id": 1, "name": "東京スカパラダイスオーケストラ"}` is detected as Japanese during indexing, during the search the query `東京` will be detected as Japanese because only Japanese documents have been detected during indexing despite the fact that v1.0.2 would detect it as Chinese.
However if in the dataset there is at least one document containing a field with only Kanjis like:
_A document with only 1 field containing only Kanjis:_
```json
{
 "id":4,
 "name": "東京特許許可局"
}
```
_A document with 1 field containing only Kanjis and 1 field containing several Japanese characters:_
```json
{
 "id":105,
 "name": "東京特許許可局",
 "desc": "日経平均株価は26日 に約8カ月ぶりに2万4000円の心理的な節目を上回った。株高を支える材料のひとつは、自民党総裁選で3選を決めた安倍晋三首相の経済政策への期待だ。恩恵が見込まれるとされる人材サービスや建設株の一角が買われている。ただ思惑が先行して資金が集まっている面 は否めない。実際に政策効果を取り込む企業はどこか、なお未知数だ。"
}
```

Then, in both cases, the field `name` will be detected as Chinese during indexing allowing the search to detect Chinese in queries. Therefore,  the query `東京` will be detected as Chinese and only the two last documents will be retrieved by Meilisearch.

## Technical Approach

The current PR partially fixes these issues by:
1) Adding a check over potential miss-detections and rerunning the extraction of the document forcing the tokenization over the main Languages detected in it.
 >  1) run a first extraction allowing the tokenizer to detect any Language in any Script
 >  2) generate a distribution of tokens by Script and Languages (`script_language`)
 >  3) if for a Script we have a token distribution of one of the Language that is under the threshold, then we rerun the extraction forbidding the tokenizer to detect the marginal Languages
 >  4) the tokenizer will fall back on the other available Languages to tokenize the text. For example, if the Chinese were marginally detected compared to the Japanese on the CJ script, then the second extraction will force Japanese tokenization for CJ text in the document. however, the text on another script like Latin will not be impacted by this restriction.

2) Adding a filtering threshold during the search over Languages that have been marginally detected in documents

## Limits
This PR introduces 2 arbitrary thresholds:
1) during the indexing, a Language is considered miss-detected if the number of detected tokens of this Language is under 10% of the tokens detected in the same Script (Japanese and Chinese are 2 different Languages sharing the "same" script "CJK").
2) during the search, a Language is considered marginal if less than 5% of documents are detected as this Language.

This PR only partially fixes these issues:
- ✅ the query `東京` now find Japanese documents if less than 5% of documents are detected as Chinese.
- ✅ the document with the id `105` containing the Japanese field `desc` but the miss-detected field `name` is now completely detected and tokenized as Japanese and is found with the query `東京`.
- ❌ the document with the id `4` no longer breaks the search Language detection but continues to be detected as a Chinese document and can't be found during the search.

## Related issue
Fixes #3565

## Possible future enhancements
- Change or contribute to the Library used to detect the Language
  - the related issue on Whatlang: https://github.com/greyblake/whatlang-rs/issues/122