### PR TITLE
Add boolean support for csv documents

### DIFF
--- a/milli/src/documents/builder.rs
+++ b/milli/src/documents/builder.rs
@@ -114,9 +114,9 @@ impl<W: Write> DocumentsBatchBuilder<W> {
                 self.value_buffer.clear();
 
                 let value = &record[*i];
+                let trimmed_value = value.trim();
                 match type_ {
                     AllowedType::Number => {
-                        let trimmed_value = value.trim();
                         if trimmed_value.is_empty() {
                             to_writer(&mut self.value_buffer, &Value::Null)?;
                         } else if let Ok(integer) = trimmed_value.parse::<i64>() {
@@ -137,7 +137,6 @@ impl<W: Write> DocumentsBatchBuilder<W> {
                         }
                     }
                     AllowedType::Boolean => {
-                        let trimmed_value = value.trim();
                         if trimmed_value.is_empty() {
                             to_writer(&mut self.value_buffer, &Value::Null)?;
                         } else {


### PR DESCRIPTION
Fixes https://github.com/meilisearch/meilisearch/issues/3572

## What does this PR do?
Add support for the boolean types in csv documents.
The type definition is `boolean` and the possible values are
- `true` for true
- `false` for false
- ` ` for null

Here is an example:
```csv
#id,cute:boolean
0,true
1,false
2,
```