### PR TITLE
Avoid fetching an LMDB value with an empty string

### DIFF
--- a/milli/src/search/query_tree.rs
+++ b/milli/src/search/query_tree.rs
@@ -792,6 +792,10 @@ where
 
     let mut peekable = query.peekable();
     while let Some(token) = peekable.next() {
+        if token.lemma().is_empty() {
+            continue;
+        }
+
         // early return if word limit is exceeded
         if primitive_query.len() >= parts_limit {
             return primitive_query;


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #3574 

## What does this PR do?
This PR fixes a bug where an empty key fetches an entry in the database. LMDB throws an error if an empty or too-long key is used to fetch an entry. This empty string seems to have been generated by the Charabia tokenizer.