### PR TITLE
Enable cache again in test suite CI

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -42,9 +42,8 @@ jobs:
         with:
           toolchain: nightly
           override: true
-      # Disable cache due to disk space issues with Windows workers in CI
-      # - name: Cache dependencies
-      #   uses: Swatinem/rust-cache@v2.2.0
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2.2.0
       - name: Run cargo check without any default features
         uses: actions-rs/cargo@v1
         with:
@@ -65,8 +64,8 @@ jobs:
         os: [macos-12, windows-2022]
     steps:
       - uses: actions/checkout@v3
-      #     - name: Cache dependencies
-      #       uses: Swatinem/rust-cache@v2.2.0
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2.2.0
       - name: Run cargo check without any default features
         uses: actions-rs/cargo@v1
         with:
@@ -123,8 +122,8 @@ jobs:
         with:
           toolchain: stable
           override: true
-      # - name: Cache dependencies
-      #   uses: Swatinem/rust-cache@v2.2.0
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2.2.0
       - name: Run tests in debug
         uses: actions-rs/cargo@v1
         with:
@@ -142,8 +141,8 @@ jobs:
           toolchain: 1.67.0
           override: true
           components: clippy
-      # - name: Cache dependencies
-      #   uses: Swatinem/rust-cache@v2.2.0
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2.2.0
       - name: Run cargo clippy
         uses: actions-rs/cargo@v1
         with:
@@ -162,8 +161,8 @@ jobs:
           toolchain: nightly
           override: true
           components: rustfmt
-      # - name: Cache dependencies
-      #   uses: Swatinem/rust-cache@v2.2.0
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2.2.0
       - name: Run cargo fmt
         # Since we never ran the `build.rs` script in the benchmark directory we are missing one auto-generated import file.
         # Since we want to trigger (and fail) this action as fast as possible, instead of building the benchmark crate


### PR DESCRIPTION
Following the change in this PR introduced in v1.1: https://github.com/meilisearch/meilisearch/pull/3422

The cache was removed due to failures (lack of space). Now the binary is smaller (from 250Mb to 50Mb) we want to try to enable the cache again.
Indeed, without the cache step, the CIs are wayyyy slower (45min instead of 20-30min).

For later: Rust 1.68 introduced a new way to fetch crates. Updating the rust version might also help in the future!