### PR TITLE
update the geoBoundingBox feature

### DIFF
--- a/filter-parser/src/lib.rs
+++ b/filter-parser/src/lib.rs
@@ -141,7 +141,7 @@ pub enum FilterCondition<'a> {
     Or(Vec<Self>),
     And(Vec<Self>),
     GeoLowerThan { point: [Token<'a>; 2], radius: Token<'a> },
-    GeoBoundingBox { top_left_point: [Token<'a>; 2], bottom_right_point: [Token<'a>; 2] },
+    GeoBoundingBox { top_right_point: [Token<'a>; 2], bottom_left_point: [Token<'a>; 2] },
 }
 
 impl<'a> FilterCondition<'a> {
@@ -362,8 +362,8 @@ fn parse_geo_bounding_box(input: Span) -> IResult<FilterCondition> {
     }
 
     let res = FilterCondition::GeoBoundingBox {
-        top_left_point: [args[0][0].into(), args[0][1].into()],
-        bottom_right_point: [args[1][0].into(), args[1][1].into()],
+        top_right_point: [args[0][0].into(), args[0][1].into()],
+        bottom_left_point: [args[1][0].into(), args[1][1].into()],
     };
     Ok((input, res))
 }
@@ -780,7 +780,10 @@ impl<'a> std::fmt::Display for FilterCondition<'a> {
             FilterCondition::GeoLowerThan { point, radius } => {
                 write!(f, "_geoRadius({}, {}, {})", point[0], point[1], radius)
             }
-            FilterCondition::GeoBoundingBox { top_left_point, bottom_right_point } => {
+            FilterCondition::GeoBoundingBox {
+                top_right_point: top_left_point,
+                bottom_left_point: bottom_right_point,
+            } => {
                 write!(
                     f,
                     "_geoBoundingBox([{}, {}], [{}, {}])",

--- a/milli/src/index.rs
+++ b/milli/src/index.rs
@@ -1586,35 +1586,35 @@ pub(crate) mod tests {
 
         // match a document in the middle of the rectangle
         let search_result = search
-            .filter(Filter::from_str("_geoBoundingBox([10, -10], [-10, 10])").unwrap().unwrap())
+            .filter(Filter::from_str("_geoBoundingBox([10, 10], [-10, -10])").unwrap().unwrap())
             .execute()
             .unwrap();
         insta::assert_debug_snapshot!(search_result.candidates, @"RoaringBitmap<[0]>");
 
         // select everything
         let search_result = search
-            .filter(Filter::from_str("_geoBoundingBox([90, -180], [-90, 180])").unwrap().unwrap())
+            .filter(Filter::from_str("_geoBoundingBox([90, 180], [-90, -180])").unwrap().unwrap())
             .execute()
             .unwrap();
         insta::assert_debug_snapshot!(search_result.candidates, @"RoaringBitmap<[0, 1, 2, 3, 4]>");
 
         // go on the edge of the longitude
         let search_result = search
-            .filter(Filter::from_str("_geoBoundingBox([0, 180], [0, -170])").unwrap().unwrap())
+            .filter(Filter::from_str("_geoBoundingBox([0, -170], [0, 180])").unwrap().unwrap())
             .execute()
             .unwrap();
         insta::assert_debug_snapshot!(search_result.candidates, @"RoaringBitmap<[1]>");
 
         // go on the other edge of the longitude
         let search_result = search
-            .filter(Filter::from_str("_geoBoundingBox([0, 170], [0, -180])").unwrap().unwrap())
+            .filter(Filter::from_str("_geoBoundingBox([0, -180], [0, 170])").unwrap().unwrap())
             .execute()
             .unwrap();
         insta::assert_debug_snapshot!(search_result.candidates, @"RoaringBitmap<[2]>");
 
         // wrap around the longitude
         let search_result = search
-            .filter(Filter::from_str("_geoBoundingBox([0, 170], [0, -170])").unwrap().unwrap())
+            .filter(Filter::from_str("_geoBoundingBox([0, -170], [0, 170])").unwrap().unwrap())
             .execute()
             .unwrap();
         insta::assert_debug_snapshot!(search_result.candidates, @"RoaringBitmap<[1, 2]>");
@@ -1640,20 +1640,26 @@ pub(crate) mod tests {
             .filter(Filter::from_str("_geoBoundingBox([-80, 0], [80, 0])").unwrap().unwrap())
             .execute()
             .unwrap_err();
-        insta::assert_display_snapshot!(error, @r###"
+        insta::assert_display_snapshot!(
+            error,
+            @r###"
         The top latitude `-80` is below the bottom latitude `80`.
         32:33 _geoBoundingBox([-80, 0], [80, 0])
-        "###);
+        "###
+        );
 
         // send a top latitude lower than the bottow latitude
         let error = search
             .filter(Filter::from_str("_geoBoundingBox([-10, 0], [10, 0])").unwrap().unwrap())
             .execute()
             .unwrap_err();
-        insta::assert_display_snapshot!(error, @r###"
+        insta::assert_display_snapshot!(
+            error,
+            @r###"
         The top latitude `-10` is below the bottom latitude `10`.
         32:33 _geoBoundingBox([-10, 0], [10, 0])
-        "###);
+        "###
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closing #3616
Implementing this change in the spec: https://github.com/meilisearch/specifications/pull/223/commits/38a715c0721f7ffce57cc85d2f2f90889d2f077b


Now instead of using the (top_left, bottom_right) corners of the bounding box, it’s using the (top_right, bottom_left) corners.