### PR TITLE
Use bincode to store the tasks in the task queue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,6 +452,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "2.0.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb50c5a2ef4b9b1e7ae73e3a73b52ea24b20312d629f9c4df28260b7ad2c3c4"
+dependencies = [
+ "bincode_derive",
+ "serde",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a45a23389446d2dd25dc8e73a7a3b3c43522b630cac068927f0649d43d719d2"
+dependencies = [
+ "virtue",
+]
+
+[[package]]
 name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1755,7 +1774,7 @@ name = "heed-types"
 version = "0.7.2"
 source = "git+https://github.com/meilisearch/heed?tag=v0.12.5#4158a6c484752afaaf9e2530a6ee0e7ab0f24ee8"
 dependencies = [
- "bincode",
+ "bincode 1.3.3",
  "heed-traits",
  "serde",
  "serde_json",
@@ -1894,7 +1913,7 @@ version = "1.1.0"
 dependencies = [
  "anyhow",
  "big_s",
- "bincode",
+ "bincode 2.0.0-rc.2",
  "crossbeam",
  "csv",
  "derive_builder",
@@ -2152,7 +2171,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f33a20bb9cbf95572b2d2f40d7040c8d8c7ad09ae20e1f6513db6ef2564dfc5"
 dependencies = [
  "anyhow",
- "bincode",
+ "bincode 1.3.3",
  "byteorder",
  "encoding",
  "kanaria",
@@ -2180,7 +2199,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60c3b379251edadbac7a5fdb31e482274e11dae6ab6cc789d0d86cf34369cf49"
 dependencies = [
  "anyhow",
- "bincode",
+ "bincode 1.3.3",
  "byteorder",
  "csv",
  "encoding",
@@ -2210,7 +2229,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2281747b98fdd46bcc54ce7fdb6870dad9f67ddb3dc086c47b6704f3e1178cd5"
 dependencies = [
  "anyhow",
- "bincode",
+ "bincode 1.3.3",
  "byteorder",
  "encoding_rs",
  "log",
@@ -2238,7 +2257,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1c6668848f1d30d216c99093a3ed3fe125c105fa12a4aeed5a1861dc01dd52"
 dependencies = [
  "anyhow",
- "bincode",
+ "bincode 1.3.3",
  "byteorder",
  "lindera-core",
 ]
@@ -2249,7 +2268,7 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "693098007200fa43fd5cdc9ca8740f371327369672ce812cd87a1f6344971e31"
 dependencies = [
- "bincode",
+ "bincode 1.3.3",
  "byteorder",
  "encoding",
  "flate2",
@@ -2267,7 +2286,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b6b7240d097a8fc37ee8f90ebff02c4db0ba5325ecb0dacb6da3724596798c9"
 dependencies = [
  "anyhow",
- "bincode",
+ "bincode 1.3.3",
  "byteorder",
  "csv",
  "encoding_rs",
@@ -2288,7 +2307,7 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abd3c5a4addeb61ca66788a3dd1fd51093e6cd8fea1d997042ada5aa60e8cc5e"
 dependencies = [
- "bincode",
+ "bincode 1.3.3",
  "byteorder",
  "encoding",
  "flate2",
@@ -2306,7 +2325,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512bb1393a9281e0b13704319d1343b7931416865852d9d7b7c0178431518326"
 dependencies = [
  "anyhow",
- "bincode",
+ "bincode 1.3.3",
  "byteorder",
  "csv",
  "encoding",
@@ -2326,7 +2345,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f575a27f8ba67c15fe16ebf7d277a0ac04e8c8a0f72670ebc2443da9d41c450"
 dependencies = [
  "anyhow",
- "bincode",
+ "bincode 1.3.3",
  "byteorder",
  "csv",
  "encoding",
@@ -2565,6 +2584,7 @@ version = "1.1.0"
 dependencies = [
  "actix-web",
  "anyhow",
+ "bincode 2.0.0-rc.2",
  "convert_case 0.6.0",
  "csv",
  "deserr",
@@ -2619,7 +2639,8 @@ version = "1.1.0"
 dependencies = [
  "big_s",
  "bimap",
- "bincode",
+ "bincode 1.3.3",
+ "bincode 2.0.0-rc.2",
  "bstr 1.1.0",
  "byteorder",
  "charabia",
@@ -4136,6 +4157,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "virtue"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b60dcd6a64dd45abf9bd426970c9843726da7fc08f44cd6fcebf68c21220a63"
 
 [[package]]
 name = "walkdir"

--- a/index-scheduler/Cargo.toml
+++ b/index-scheduler/Cargo.toml
@@ -12,7 +12,7 @@ license.workspace = true
 
 [dependencies]
 anyhow = "1.0.64"
-bincode = "1.3.3"
+bincode = "2.0.0-rc.2"
 csv = "1.1.6"
 derive_builder = "0.11.2"
 dump = { path = "../dump" }

--- a/index-scheduler/src/insta_snapshot.rs
+++ b/index-scheduler/src/insta_snapshot.rs
@@ -1,14 +1,14 @@
 use std::collections::BTreeSet;
 use std::fmt::Write;
 
-use meilisearch_types::heed::types::{OwnedType, SerdeBincode, SerdeJson, Str};
+use meilisearch_types::heed::types::{OwnedType, SerdeBincode, Str};
 use meilisearch_types::heed::{Database, RoTxn};
 use meilisearch_types::milli::{CboRoaringBitmapCodec, RoaringBitmapCodec, BEU32};
 use meilisearch_types::tasks::{Details, Task};
 use roaring::RoaringBitmap;
 
 use crate::index_mapper::IndexMapper;
-use crate::{IndexScheduler, Kind, Status, BEI128};
+use crate::{Bincode, IndexScheduler, Kind, Status, BEI128};
 
 pub fn snapshot_index_scheduler(scheduler: &IndexScheduler) -> String {
     scheduler.assert_internally_consistent();
@@ -111,7 +111,7 @@ pub fn snapshot_bitmap(r: &RoaringBitmap) -> String {
     snap
 }
 
-pub fn snapshot_all_tasks(rtxn: &RoTxn, db: Database<OwnedType<BEU32>, SerdeJson<Task>>) -> String {
+pub fn snapshot_all_tasks(rtxn: &RoTxn, db: Database<OwnedType<BEU32>, Bincode<Task>>) -> String {
     let mut snap = String::new();
     let iter = db.iter(rtxn).unwrap();
     for next in iter {

--- a/index-scheduler/src/lib.rs
+++ b/index-scheduler/src/lib.rs
@@ -43,7 +43,7 @@ use dump::{KindDump, TaskDump, UpdateFile};
 pub use error::Error;
 use file_store::FileStore;
 use meilisearch_types::error::ResponseError;
-use meilisearch_types::heed::types::{OwnedType, SerdeBincode, SerdeJson, Str};
+use meilisearch_types::heed::types::{OwnedType, SerdeBincode, Str};
 use meilisearch_types::heed::{self, Database, Env, RoTxn, RwTxn};
 use meilisearch_types::milli::documents::DocumentsBatchBuilder;
 use meilisearch_types::milli::update::IndexerConfig;
@@ -52,7 +52,9 @@ use meilisearch_types::tasks::{Kind, KindWithContent, Status, Task};
 use roaring::RoaringBitmap;
 use synchronoise::SignalEvent;
 use time::OffsetDateTime;
-use utils::{filter_out_references_to_newer_tasks, keep_tasks_within_datetimes, map_bound};
+use utils::{
+    filter_out_references_to_newer_tasks, keep_tasks_within_datetimes, map_bound, Bincode,
+};
 use uuid::Uuid;
 
 use crate::index_mapper::IndexMapper;
@@ -259,7 +261,7 @@ pub struct IndexScheduler {
     pub(crate) file_store: FileStore,
 
     // The main database, it contains all the tasks accessible by their Id.
-    pub(crate) all_tasks: Database<OwnedType<BEU32>, SerdeJson<Task>>,
+    pub(crate) all_tasks: Database<OwnedType<BEU32>, Bincode<Task>>,
 
     /// All the tasks ids grouped by their status.
     // TODO we should not be able to serialize a `Status::Processing` in this database.

--- a/meilisearch-types/Cargo.toml
+++ b/meilisearch-types/Cargo.toml
@@ -13,6 +13,7 @@ license.workspace = true
 [dependencies]
 actix-web = { version = "4.2.1", default-features = false }
 anyhow = "1.0.65"
+bincode = { version = "2.0.0-rc.2", features = ["serde"] }
 convert_case = "0.6.0"
 csv = "1.1.6"
 deserr = "0.5.0"

--- a/meilisearch-types/src/index_uid_pattern.rs
+++ b/meilisearch-types/src/index_uid_pattern.rs
@@ -4,6 +4,7 @@ use std::fmt;
 use std::ops::Deref;
 use std::str::FromStr;
 
+use bincode::{Decode, Encode};
 use deserr::Deserr;
 use serde::{Deserialize, Serialize};
 
@@ -12,7 +13,7 @@ use crate::index_uid::{IndexUid, IndexUidFormatError};
 
 /// An index uid pattern is composed of only ascii alphanumeric characters, - and _, between 1 and 400
 /// bytes long and optionally ending with a *.
-#[derive(Serialize, Deserialize, Deserr, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Serialize, Deserialize, Deserr, Debug, Clone, PartialEq, Eq, Hash, Encode, Decode)]
 #[deserr(try_from(&String) = FromStr::from_str -> IndexUidPatternFormatError)]
 pub struct IndexUidPattern(String);
 

--- a/meilisearch-types/src/keys.rs
+++ b/meilisearch-types/src/keys.rs
@@ -2,6 +2,7 @@ use std::convert::Infallible;
 use std::hash::Hash;
 use std::str::FromStr;
 
+use bincode::{Decode, Encode};
 use deserr::{DeserializeError, Deserr, MergeWithError, ValuePointerRef};
 use enum_iterator::Sequence;
 use milli::update::Setting;
@@ -95,20 +96,24 @@ pub struct PatchApiKey {
     pub name: Setting<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, Encode, Decode)]
 pub struct Key {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+    #[bincode(with_serde)]
     pub uid: KeyId,
     pub actions: Vec<Action>,
     pub indexes: Vec<IndexUidPattern>,
     #[serde(with = "time::serde::rfc3339::option")]
+    #[bincode(with_serde)]
     pub expires_at: Option<OffsetDateTime>,
     #[serde(with = "time::serde::rfc3339")]
+    #[bincode(with_serde)]
     pub created_at: OffsetDateTime,
     #[serde(with = "time::serde::rfc3339")]
+    #[bincode(with_serde)]
     pub updated_at: OffsetDateTime,
 }
 
@@ -181,7 +186,8 @@ fn parse_expiration_date(
     }
 }
 
-#[derive(Copy, Clone, Serialize, Deserialize, Debug, Eq, PartialEq, Hash, Sequence, Deserr)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Sequence)] // Basic derive
+#[derive(Serialize, Deserialize, Deserr, Encode, Decode)] // Serialize derive
 #[repr(u8)]
 pub enum Action {
     #[serde(rename = "*")]

--- a/meilisearch-types/src/settings.rs
+++ b/meilisearch-types/src/settings.rs
@@ -6,6 +6,7 @@ use std::num::NonZeroUsize;
 use std::ops::ControlFlow;
 use std::str::FromStr;
 
+use bincode::{Decode, Encode};
 use deserr::{DeserializeError, Deserr, ErrorKind, MergeWithError, ValuePointerRef};
 use fst::IntoStreamer;
 use milli::update::Setting;
@@ -35,10 +36,10 @@ where
     .serialize(s)
 }
 
-#[derive(Clone, Default, Debug, Serialize, PartialEq, Eq)]
+#[derive(Clone, Default, Debug, Serialize, PartialEq, Eq, Encode, Decode)]
 pub struct Checked;
 
-#[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq, Encode, Decode)]
 pub struct Unchecked;
 
 impl<E> Deserr<E> for Unchecked
@@ -65,7 +66,7 @@ fn validate_min_word_size_for_typo_setting<E: DeserializeError>(
     Ok(s)
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq, Deserr)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq, Deserr, Encode, Decode)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 #[deserr(deny_unknown_fields, rename_all = camelCase, validate = validate_min_word_size_for_typo_setting -> DeserrJsonError<InvalidSettingsTypoTolerance>)]
 pub struct MinWordSizeTyposSetting {
@@ -77,7 +78,7 @@ pub struct MinWordSizeTyposSetting {
     pub two_typos: Setting<u8>,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq, Deserr)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq, Deserr, Encode, Decode)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 #[deserr(deny_unknown_fields, rename_all = camelCase, where_predicate = __Deserr_E: deserr::MergeWithError<DeserrJsonError<InvalidSettingsTypoTolerance>>)]
 pub struct TypoSettings {
@@ -95,7 +96,7 @@ pub struct TypoSettings {
     pub disable_on_attributes: Setting<BTreeSet<String>>,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq, Deserr)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq, Deserr, Encode, Decode)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 #[deserr(rename_all = camelCase, deny_unknown_fields)]
 pub struct FacetingSettings {
@@ -104,7 +105,7 @@ pub struct FacetingSettings {
     pub max_values_per_facet: Setting<usize>,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq, Deserr)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq, Deserr, Encode, Decode)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 #[deserr(rename_all = camelCase, deny_unknown_fields)]
 pub struct PaginationSettings {
@@ -130,7 +131,7 @@ impl MergeWithError<milli::CriterionError> for DeserrJsonError<InvalidSettingsRa
 /// Holds all the settings for an index. `T` can either be `Checked` if they represents settings
 /// whose validity is guaranteed, or `Unchecked` if they need to be validated. In the later case, a
 /// call to `check` will return a `Settings<Checked>` from a `Settings<Unchecked>`.
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq, Deserr)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq, Deserr, Encode, Decode)]
 #[serde(
     deny_unknown_fields,
     rename_all = "camelCase",
@@ -509,7 +510,7 @@ pub fn settings(
     })
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Deserr)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserr, Encode, Decode)]
 #[deserr(try_from(&String) = FromStr::from_str -> CriterionError)]
 pub enum RankingRuleView {
     /// Sorted by decreasing number of matched query terms.

--- a/milli/Cargo.toml
+++ b/milli/Cargo.toml
@@ -13,7 +13,8 @@ license.workspace = true
 
 [dependencies]
 bimap = { version = "0.6.2", features = ["serde"] }
-bincode = "1.3.3"
+bincodev1 = { package = "bincode", version = "1.3.3" }
+bincode = { package = "bincode", version = "2.0.0-rc.2" }
 bstr = "1.0.1"
 byteorder = "1.4.3"
 charabia = { version = "0.7.1", default-features = false }

--- a/milli/src/update/index_documents/mod.rs
+++ b/milli/src/update/index_documents/mod.rs
@@ -52,7 +52,8 @@ pub struct DocumentAdditionResult {
     pub number_of_documents: u64,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)] // Basic derive
+#[derive(Serialize, Deserialize, bincode::Encode, bincode::Decode)] // Serialize derive
 #[non_exhaustive]
 pub enum IndexDocumentsMethod {
     /// Replace the previous document with the new one,

--- a/milli/src/update/settings.rs
+++ b/milli/src/update/settings.rs
@@ -16,7 +16,7 @@ use crate::update::index_documents::IndexDocumentsMethod;
 use crate::update::{IndexDocuments, UpdateIndexingStep};
 use crate::{FieldsIdsMap, Index, Result};
 
-#[derive(Debug, Clone, PartialEq, Eq, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy, bincode::Encode, bincode::Decode)]
 pub enum Setting<T> {
     Set(T),
     Reset,


### PR DESCRIPTION
Mitigate but does not fix the task queue issue https://github.com/meilisearch/meilisearch/issues/3622

This is one of the multiple « fixes/mitigation » we can work on to reduce the issue of the task queue being full.

Here are some measures of the impact of moving to bincode
| db size/branch              | main                              | bincode                     | Percentage change |
|-----------------------|------------------------|---------------------|--------------------|
| db size for 100k tasks |               80MiB               |        24MiB                |    -70%                    |
| db size for 1M tasks    |              506MiB              |        100MiB              |    -79%                     |
| time to import 1M tasks |           3m36s                 |         3m37s             |         0%                   |
| db size for 10M tasks    |              4.9GiB               |        987MiB             |        -80%                |
| time to import 10M tasks |           1m05s                 |         55s                 |         0%                   |

As we can see, it roughly divides the size of the task database by a factor of 5.