### PR TITLE
Search refactor exhaustive distinct hits

### DIFF
--- a/milli/src/search/mod.rs
+++ b/milli/src/search/mod.rs
@@ -1,3 +1,9 @@
+use std::fmt;
+
+use levenshtein_automata::{LevenshteinAutomatonBuilder as LevBuilder, DFA};
+use once_cell::sync::Lazy;
+use roaring::bitmap::RoaringBitmap;
+
 pub use self::facet::{FacetDistribution, Filter, DEFAULT_VALUES_PER_FACET};
 pub use self::matches::{
     FormatOptions, MatchBounds, Matcher, MatcherBuilder, MatchingWord, MatchingWords,
@@ -5,10 +11,6 @@ pub use self::matches::{
 use crate::{
     execute_search, AscDesc, DefaultSearchLogger, DocumentId, Index, Result, SearchContext,
 };
-use levenshtein_automata::{LevenshteinAutomatonBuilder as LevBuilder, DFA};
-use once_cell::sync::Lazy;
-use roaring::bitmap::RoaringBitmap;
-use std::fmt;
 
 // Building these factories is not free.
 static LEVDIST0: Lazy<LevBuilder> = Lazy::new(|| LevBuilder::new(0, true));
@@ -112,6 +114,7 @@ impl<'a> Search<'a> {
             &mut ctx,
             &self.query,
             self.terms_matching_strategy,
+            self.exhaustive_number_hits,
             &self.filter,
             &self.sort_criteria,
             self.offset,

--- a/milli/src/search/new/mod.rs
+++ b/milli/src/search/new/mod.rs
@@ -34,6 +34,7 @@ use words::Words;
 
 use self::ranking_rules::{BoxRankingRule, RankingRule};
 use self::sort::Sort;
+use crate::search::new::distinct::{apply_distinct_rule, DistinctOutput};
 use crate::{
     AscDesc, Filter, Index, MatchingWords, Member, Result, SearchResult, TermsMatchingStrategy,
     UserError,
@@ -286,6 +287,7 @@ pub fn execute_search(
     ctx: &mut SearchContext,
     query: &Option<String>,
     terms_matching_strategy: TermsMatchingStrategy,
+    exhaustive_number_hits: bool,
     filters: &Option<Filter>,
     sort_criteria: &Option<Vec<AscDesc>>,
     from: usize,
@@ -347,11 +349,21 @@ pub fn execute_search(
         )?
     };
 
+    // The candidates is the universe unless the exhaustive number of hits
+    // is requested and a distinct attribute is set.
+    let mut candidates = universe;
+    if exhaustive_number_hits {
+        if let Some(f) = ctx.index.distinct_field(ctx.txn)? {
+            if let Some(distinct_fid) = ctx.index.fields_ids_map(ctx.txn)?.id(f) {
+                candidates = apply_distinct_rule(ctx, distinct_fid, &candidates)?.remaining;
+            }
+        }
+    }
+
     Ok(SearchResult {
         // TODO: correct matching words
         matching_words: MatchingWords::default(),
-        // TODO: candidates with distinct
-        candidates: universe,
+        candidates,
         documents_ids,
     })
 }


### PR DESCRIPTION
# Pull Request
This PR implements an exhaustive number of hits for when it is requested and a distinct is set. It can be slow as it will iterate over all of the exhaustive candidates, but the user requested it explicitly. However, we would like to work on a faster algorithm in the future, this will involve product and design questions.

## Related issue
It's about the search refactor.