### PR TITLE
Add sprint issue to the template issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/sprint_issue.md
+++ b/.github/ISSUE_TEMPLATE/sprint_issue.md
@@ -1,0 +1,34 @@
+---
+name: New sprint issue
+about: ⚠️ Should only be used by the engine team ⚠️
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+Related product team resources: [roadmap card]() (_internal only_) and [PRD]() (_internal only_)
+Related product discussion:
+Related spec: WIP
+
+## Motivation
+
+<!---Copy/paste the information in the roadmap resources or briefly detail the product motivation. Ask product team if any hesitation.-->
+
+## Usage
+
+<!---Write a quick description of the usage if the usage has already been defined-->
+
+Refer to the final spec to know the details and the final decisions about the usage.
+
+## TODO
+
+<!---Feel free to adapt this list with more technical/product steps-->
+
+- [ ] Release a prototype
+- [ ] If prototype validated, merge changes into `main`
+- [ ] Update the spec
+
+## Impacted teams
+
+<!---Ping the related teams. Ask for the engine manager if any hesitation-->


### PR DESCRIPTION
Following our [internal guide](https://www.notion.so/meilisearch/Delivery-synchronization-policy-b4ec15c3e56a49539fa02d2f1d381de3) presentation, I put the template here