### PR TITLE
stops receiving tasks once the task queue is full

### DIFF
--- a/index-scheduler/src/error.rs
+++ b/index-scheduler/src/error.rs
@@ -61,6 +61,8 @@ pub enum Error {
     SwapDuplicateIndexesFound(Vec<String>),
     #[error("Index `{0}` not found.")]
     SwapIndexNotFound(String),
+    #[error("No space left in database. Free some space by deleting tasks.")]
+    NoSpaceLeftInTaskQueue,
     #[error(
         "Indexes {} not found.",
         .0.iter().map(|s| format!("`{}`", s)).collect::<Vec<_>>().join(", ")
@@ -152,6 +154,8 @@ impl ErrorCode for Error {
             Error::TaskNotFound(_) => Code::TaskNotFound,
             Error::TaskDeletionWithEmptyQuery => Code::MissingTaskFilters,
             Error::TaskCancelationWithEmptyQuery => Code::MissingTaskFilters,
+            // TODO: not sure of the Code to use
+            Error::NoSpaceLeftInTaskQueue => Code::NoSpaceLeftOnDevice,
             Error::Dump(e) => e.error_code(),
             Error::Milli(e) => e.error_code(),
             Error::ProcessBatchPanicked => Code::Internal,

--- a/index-scheduler/src/error.rs
+++ b/index-scheduler/src/error.rs
@@ -61,7 +61,7 @@ pub enum Error {
     SwapDuplicateIndexesFound(Vec<String>),
     #[error("Index `{0}` not found.")]
     SwapIndexNotFound(String),
-    #[error("No space left in database. Free some space by deleting tasks.")]
+    #[error("Meilisearch cannot receive write operations because the limit of the task database has been reached. Please delete tasks to continue performing write operations.")]
     NoSpaceLeftInTaskQueue,
     #[error(
         "Indexes {} not found.",

--- a/index-scheduler/src/lib.rs
+++ b/index-scheduler/src/lib.rs
@@ -820,9 +820,9 @@ impl IndexScheduler {
     pub fn register(&self, kind: KindWithContent) -> Result<Task> {
         let mut wtxn = self.env.write_txn()?;
 
-        // if the task doesn't delete anything and 90% of the task queue is full, we must refuse to enqueue the incomming task
+        // if the task doesn't delete anything and 50% of the task queue is full, we must refuse to enqueue the incomming task
         if !matches!(&kind, KindWithContent::TaskDeletion { tasks, .. } if !tasks.is_empty())
-            && (self.env.real_disk_size()? * 100) / self.env.map_size()? as u64 > 90
+            && (self.env.real_disk_size()? * 100) / self.env.map_size()? as u64 > 50
         {
             return Err(Error::NoSpaceLeftInTaskQueue);
         }

--- a/meilisearch/src/option.rs
+++ b/meilisearch/src/option.rs
@@ -68,7 +68,7 @@ const DEFAULT_LOG_EVERY_N: usize = 100_000;
 // The actual size of the virtual address space is computed at startup to determine how many 2TiB indexes can be
 // opened simultaneously.
 pub const INDEX_SIZE: u64 = 2 * 1024 * 1024 * 1024 * 1024; // 2 TiB
-pub const TASK_DB_SIZE: u64 = 11 * 1024 * 1024 * 1024; // 11 GiB
+pub const TASK_DB_SIZE: u64 = 20 * 1024 * 1024 * 1024; // 20 GiB
 
 #[derive(Debug, Default, Clone, Copy, Serialize, Deserialize)]
 #[serde(rename_all = "UPPERCASE")]

--- a/meilisearch/src/option.rs
+++ b/meilisearch/src/option.rs
@@ -68,7 +68,7 @@ const DEFAULT_LOG_EVERY_N: usize = 100_000;
 // The actual size of the virtual address space is computed at startup to determine how many 2TiB indexes can be
 // opened simultaneously.
 pub const INDEX_SIZE: u64 = 2 * 1024 * 1024 * 1024 * 1024; // 2 TiB
-pub const TASK_DB_SIZE: u64 = 10 * 1024 * 1024 * 1024; // 10 GiB
+pub const TASK_DB_SIZE: u64 = 11 * 1024 * 1024 * 1024; // 11 GiB
 
 #[derive(Debug, Default, Clone, Copy, Serialize, Deserialize)]
 #[serde(rename_all = "UPPERCASE")]

--- a/meilisearch/tests/tasks/mod.rs
+++ b/meilisearch/tests/tasks/mod.rs
@@ -1042,7 +1042,7 @@ async fn test_task_queue_is_full() {
     snapshot!(code, @"422 Unprocessable Entity");
     snapshot!(json_string!(result), @r###"
     {
-      "message": "No space left in database. Free some space by deleting tasks.",
+      "message": "Meilisearch cannot receive write operations because the limit of the task database has been reached. Please delete tasks to continue performing write operations.",
       "code": "no_space_left_on_device",
       "type": "system",
       "link": "https://docs.meilisearch.com/errors#no_space_left_on_device"
@@ -1081,7 +1081,7 @@ async fn test_task_queue_is_full() {
     snapshot!(code, @"422 Unprocessable Entity");
     snapshot!(json_string!(result), @r###"
     {
-      "message": "No space left in database. Free some space by deleting tasks.",
+      "message": "Meilisearch cannot receive write operations because the limit of the task database has been reached. Please delete tasks to continue performing write operations.",
       "code": "no_space_left_on_device",
       "type": "system",
       "link": "https://docs.meilisearch.com/errors#no_space_left_on_device"

--- a/meilisearch/tests/tasks/mod.rs
+++ b/meilisearch/tests/tasks/mod.rs
@@ -1064,7 +1064,7 @@ async fn test_task_queue_is_full() {
 
     // we're going to fill up the queue once again
     loop {
-        let (res, code) = server.create_index(json!({ "uid": "doggo" })).await;
+        let (res, code) = server.delete_tasks("uids=0").await;
         if code == 422 {
             break;
         }

--- a/meilisearch/tests/tasks/mod.rs
+++ b/meilisearch/tests/tasks/mod.rs
@@ -1026,9 +1026,15 @@ async fn test_task_queue_is_full() {
     "###);
 
     loop {
-        let (res, _code) = server.create_index(json!({ "uid": "doggo" })).await;
-        if res["taskUid"] == json!(null) {
+        let (res, code) = server.create_index(json!({ "uid": "doggo" })).await;
+        if code == 422 {
             break;
+        }
+        if res["taskUid"] == json!(null) {
+            panic!(
+                "Encountered the strange case:\n{}",
+                serde_json::to_string_pretty(&res).unwrap()
+            );
         }
     }
 
@@ -1058,9 +1064,15 @@ async fn test_task_queue_is_full() {
 
     // we're going to fill up the queue once again
     loop {
-        let (res, _code) = server.create_index(json!({ "uid": "doggo" })).await;
-        if res["taskUid"] == json!(null) {
+        let (res, code) = server.create_index(json!({ "uid": "doggo" })).await;
+        if code == 422 {
             break;
+        }
+        if res["taskUid"] == json!(null) {
+            panic!(
+                "Encountered the strange case:\n{}",
+                serde_json::to_string_pretty(&res).unwrap()
+            );
         }
     }
 


### PR DESCRIPTION
Give 20GiB to the task queue + once 50% of the task queue is used, it blocks itself and only receives task deletion requests to ensure we never get in a state where we can’t do anything.

Also, create a new error message when we reach this case:
```
Meilisearch cannot receive write operations because the size limit of the tasks database has been reached. Please delete tasks to continue performing write operations.
```