### PR TITLE
Increase the default tasks queue size to 100 GiB

### DIFF
--- a/meilisearch/src/option.rs
+++ b/meilisearch/src/option.rs
@@ -68,7 +68,7 @@ const DEFAULT_LOG_EVERY_N: usize = 100_000;
 // The actual size of the virtual address space is computed at startup to determine how many 2TiB indexes can be
 // opened simultaneously.
 pub const INDEX_SIZE: u64 = 2 * 1024 * 1024 * 1024 * 1024; // 2 TiB
-pub const TASK_DB_SIZE: u64 = 10 * 1024 * 1024 * 1024; // 10 GiB
+pub const TASK_DB_SIZE: u64 = 100 * 1024 * 1024 * 1024; // 100 GiB
 
 #[derive(Debug, Default, Clone, Copy, Serialize, Deserialize)]
 #[serde(rename_all = "UPPERCASE")]


### PR DESCRIPTION
This PR introduces a quick fix to avoid filling the tasks queue by increasing its size from _10 GiB_ to _100 GiB_. This is a temporary fix, as we are planning another real fix in [this product squad](https://github.com/meilisearch/product/discussions/641) (please give your feedback there).


