### PR TITLE
Search refactor: DB returns bitmaps instead of untyped byte slices

### DIFF
--- a/milli/src/search/new/exact_attribute.rs
+++ b/milli/src/search/new/exact_attribute.rs
@@ -1,11 +1,10 @@
-use heed::BytesDecode;
 use roaring::{MultiOps, RoaringBitmap};
 
 use super::query_graph::QueryGraph;
 use super::ranking_rules::{RankingRule, RankingRuleOutput};
 use crate::search::new::query_graph::QueryNodeData;
 use crate::search::new::query_term::ExactTerm;
-use crate::{CboRoaringBitmapCodec, Result, SearchContext, SearchLogger};
+use crate::{Result, SearchContext, SearchLogger};
 
 /// A ranking rule that produces 3 disjoint buckets:
 ///
@@ -161,10 +160,8 @@ impl State {
                 // Note: Since the position is stored bucketed in word_position_docids, for queries with a lot of
                 // longer phrases we'll be losing on precision here.
                 let bucketed_position = crate::bucketed_position(position + offset);
-                let word_position_docids = CboRoaringBitmapCodec::bytes_decode(
-                    ctx.get_db_word_position_docids(*word, bucketed_position)?.unwrap_or_default(),
-                )
-                .unwrap_or_default();
+                let word_position_docids =
+                    ctx.get_db_word_position_docids(*word, bucketed_position)?.unwrap_or_default();
                 candidates &= word_position_docids;
                 if candidates.is_empty() {
                     return Ok(State::Empty(query_graph.clone()));
@@ -191,11 +188,7 @@ impl State {
                     // ignore stop words words in phrases
                     .flatten()
                     .map(|word| -> Result<_> {
-                        Ok(ctx
-                            .get_db_word_fid_docids(*word, fid)?
-                            .map(CboRoaringBitmapCodec::bytes_decode)
-                            .unwrap_or_default()
-                            .unwrap_or_default())
+                        Ok(ctx.get_db_word_fid_docids(*word, fid)?.unwrap_or_default())
                     }),
             )?;
             intersection &= &candidates;

--- a/milli/src/search/new/logger/mod.rs
+++ b/milli/src/search/new/logger/mod.rs
@@ -1,8 +1,6 @@
 // #[cfg(test)]
 pub mod detailed;
 
-pub mod test_logger;
-
 use roaring::RoaringBitmap;
 
 use super::interner::{Interned, MappedInterner};

--- a/milli/src/search/new/query_term/compute_derivations.rs
+++ b/milli/src/search/new/query_term/compute_derivations.rs
@@ -1,17 +1,17 @@
-use fst::automaton::Str;
-use fst::{Automaton, IntoStreamer, Streamer};
-use heed::types::DecodeIgnore;
-use heed::BytesDecode;
 use std::borrow::Cow;
 use std::collections::BTreeSet;
 use std::ops::ControlFlow;
+
+use fst::automaton::Str;
+use fst::{Automaton, IntoStreamer, Streamer};
+use heed::types::DecodeIgnore;
 
 use super::*;
 use crate::search::fst_utils::{Complement, Intersection, StartsWith, Union};
 use crate::search::new::query_term::TwoTypoTerm;
 use crate::search::new::{limits, SearchContext};
 use crate::search::{build_dfa, get_first};
-use crate::{CboRoaringBitmapLenCodec, Result, MAX_WORD_LENGTH};
+use crate::{Result, MAX_WORD_LENGTH};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum NumberOfTypos {
@@ -385,9 +385,7 @@ fn split_best_frequency(
         let left = ctx.word_interner.insert(left.to_owned());
         let right = ctx.word_interner.insert(right.to_owned());
 
-        if let Some(docid_bytes) = ctx.get_db_word_pair_proximity_docids(left, right, 1)? {
-            let frequency =
-                CboRoaringBitmapLenCodec::bytes_decode(docid_bytes).ok_or(heed::Error::Decoding)?;
+        if let Some(frequency) = ctx.get_db_word_pair_proximity_docids_len(left, right, 1)? {
             if best.map_or(true, |(old, _, _)| frequency > old) {
                 best = Some((frequency, left, right));
             }

--- a/milli/src/search/new/ranking_rule_graph/exactness/mod.rs
+++ b/milli/src/search/new/ranking_rule_graph/exactness/mod.rs
@@ -1,11 +1,10 @@
-use heed::BytesDecode;
 use roaring::RoaringBitmap;
 
 use super::{ComputedCondition, DeadEndsCache, RankingRuleGraph, RankingRuleGraphTrait};
 use crate::search::new::interner::{DedupInterner, Interned, MappedInterner};
 use crate::search::new::query_graph::{QueryGraph, QueryNode};
 use crate::search::new::query_term::{ExactTerm, LocatedQueryTermSubset};
-use crate::{Result, RoaringBitmapCodec, SearchContext, SearchLogger};
+use crate::{Result, SearchContext, SearchLogger};
 
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub enum ExactnessCondition {
@@ -29,7 +28,7 @@ fn compute_docids(
         ExactTerm::Phrase(phrase) => ctx.get_phrase_docids(phrase)?.clone(),
         ExactTerm::Word(word) => {
             if let Some(word_candidates) = ctx.get_db_word_docids(word)? {
-                RoaringBitmapCodec::bytes_decode(word_candidates).ok_or(heed::Error::Decoding)?
+                word_candidates
             } else {
                 return Ok(Default::default());
             }


### PR DESCRIPTION
# Pull Request

## Related issue
Related to search refactor

## What does this PR do?
- Change the `ctx.get_db_xxx` methods to return a `RoaringBitmap` instead of a byte slice
- Add a new `ctx.get_db_word_pair_proximity_docids_len` method to return the len of the `RoaringBitmap`. The original `ctx.get_db_word_pair_proximity_docids` was used sometimes with a `CboRoaringBitmapCodec` and sometimes with `CboRoaringBitmapLenCodec`, so this accounts for that.
