### PR TITLE
Lookup non-derived terms in exact DBs

### DIFF
--- a/milli/src/search/new/db_cache.rs
+++ b/milli/src/search/new/db_cache.rs
@@ -89,7 +89,7 @@ impl<'ctx> SearchContext<'ctx> {
     }
 
     /// Retrieve or insert the given value in the `word_docids` database.
-    pub fn get_db_word_docids(&mut self, word: Interned<String>) -> Result<Option<RoaringBitmap>> {
+    fn get_db_word_docids(&mut self, word: Interned<String>) -> Result<Option<RoaringBitmap>> {
         DatabaseCache::get_value(
             self.txn,
             word,

--- a/milli/src/search/new/db_cache.rs
+++ b/milli/src/search/new/db_cache.rs
@@ -138,7 +138,7 @@ impl<'ctx> SearchContext<'ctx> {
     }
 
     /// Retrieve or insert the given value in the `word_prefix_docids` database.
-    pub fn get_db_word_prefix_docids(
+    fn get_db_word_prefix_docids(
         &mut self,
         prefix: Interned<String>,
     ) -> Result<Option<RoaringBitmap>> {

--- a/milli/src/search/new/logger/detailed.rs
+++ b/milli/src/search/new/logger/detailed.rs
@@ -455,7 +455,7 @@ results.{cur_ranking_rule}{cur_activated_id} {{
                     writeln!(file, "{}: phrase", p.description(ctx)).unwrap();
                 }
                 if let Some(w) = term_subset.use_prefix_db(ctx) {
-                    let w = ctx.word_interner.get(w);
+                    let w = ctx.word_interner.get(w.interned());
                     writeln!(file, "{w}: prefix db").unwrap();
                 }
 

--- a/milli/src/search/new/logger/detailed.rs
+++ b/milli/src/search/new/logger/detailed.rs
@@ -448,7 +448,7 @@ results.{cur_ranking_rule}{cur_activated_id} {{
                 .unwrap();
 
                 for w in term_subset.all_single_words_except_prefix_db(ctx).unwrap() {
-                    let w = ctx.word_interner.get(w);
+                    let w = ctx.word_interner.get(w.interned());
                     writeln!(file, "{w}: word").unwrap();
                 }
                 for p in term_subset.all_phrases(ctx).unwrap() {

--- a/milli/src/search/new/mod.rs
+++ b/milli/src/search/new/mod.rs
@@ -42,7 +42,7 @@ use words::Words;
 use self::bucket_sort::BucketSortOutput;
 use self::exact_attribute::ExactAttribute;
 use self::graph_based_ranking_rule::Exactness;
-use self::interner::Interner;
+use self::interner::{Interned, Interner};
 use self::ranking_rules::{BoxRankingRule, RankingRule};
 use self::resolve_query_graph::compute_query_graph_docids;
 use self::sort::Sort;
@@ -72,6 +72,21 @@ impl<'ctx> SearchContext<'ctx> {
             phrase_interner: <_>::default(),
             term_interner: <_>::default(),
             phrase_docids: <_>::default(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, PartialOrd, Ord, Eq)]
+pub enum Word {
+    Original(Interned<String>),
+    Derived(Interned<String>),
+}
+
+impl Word {
+    pub fn interned(&self) -> Interned<String> {
+        match self {
+            Word::Original(word) => *word,
+            Word::Derived(word) => *word,
         }
     }
 }

--- a/milli/src/search/new/query_term/mod.rs
+++ b/milli/src/search/new/query_term/mod.rs
@@ -3,18 +3,18 @@ mod ntypo_subset;
 mod parse_query;
 mod phrase;
 
-use super::interner::{DedupInterner, Interned};
-use super::{limits, SearchContext};
-use crate::Result;
 use std::collections::BTreeSet;
 use std::ops::RangeInclusive;
 
+use compute_derivations::partially_initialized_term_from_word;
 use either::Either;
 pub use ntypo_subset::NTypoTermSubset;
 pub use parse_query::{located_query_terms_from_string, make_ngram, number_of_typos_allowed};
 pub use phrase::Phrase;
 
-use compute_derivations::partially_initialized_term_from_word;
+use super::interner::{DedupInterner, Interned};
+use super::{limits, SearchContext, Word};
+use crate::Result;
 
 /// A set of word derivations attached to a location in the search query.
 #[derive(Clone, PartialEq, Eq, Hash)]
@@ -180,7 +180,7 @@ impl QueryTermSubset {
     pub fn all_single_words_except_prefix_db(
         &self,
         ctx: &mut SearchContext,
-    ) -> Result<BTreeSet<Interned<String>>> {
+    ) -> Result<BTreeSet<Word>> {
         let mut result = BTreeSet::default();
         // TODO: a compute_partially funtion
         if !self.one_typo_subset.is_empty() || !self.two_typo_subset.is_empty() {
@@ -196,8 +196,14 @@ impl QueryTermSubset {
                 synonyms: _,
                 use_prefix_db: _,
             } = &original.zero_typo;
-            result.extend(zero_typo.iter().copied());
-            result.extend(prefix_of.iter().copied());
+            result.extend(zero_typo.iter().copied().map(|word| {
+                if original.ngram_words.is_some() {
+                    Word::Original(word)
+                } else {
+                    Word::Derived(word)
+                }
+            }));
+            result.extend(prefix_of.iter().copied().map(Word::Derived));
         };
 
         match &self.one_typo_subset {
@@ -205,13 +211,13 @@ impl QueryTermSubset {
                 let Lazy::Init(OneTypoTerm { split_words: _, one_typo }) = &original.one_typo else {
                     panic!()
                 };
-                result.extend(one_typo.iter().copied())
+                result.extend(one_typo.iter().copied().map(Word::Derived))
             }
             NTypoTermSubset::Subset { words, phrases: _ } => {
                 let Lazy::Init(OneTypoTerm { split_words: _, one_typo }) = &original.one_typo else {
                     panic!()
                 };
-                result.extend(one_typo.intersection(words));
+                result.extend(one_typo.intersection(words).copied().map(Word::Derived));
             }
             NTypoTermSubset::Nothing => {}
         };
@@ -221,13 +227,13 @@ impl QueryTermSubset {
                 let Lazy::Init(TwoTypoTerm { two_typos }) = &original.two_typo else {
                     panic!()
                 };
-                result.extend(two_typos.iter().copied());
+                result.extend(two_typos.iter().copied().map(Word::Derived));
             }
             NTypoTermSubset::Subset { words, phrases: _ } => {
                 let Lazy::Init(TwoTypoTerm { two_typos }) = &original.two_typo else {
                     panic!()
                 };
-                result.extend(two_typos.intersection(words));
+                result.extend(two_typos.intersection(words).copied().map(Word::Derived));
             }
             NTypoTermSubset::Nothing => {}
         };

--- a/milli/src/search/new/query_term/mod.rs
+++ b/milli/src/search/new/query_term/mod.rs
@@ -210,7 +210,13 @@ impl QueryTermSubset {
                     Word::Original(word)
                 }
             }));
-            result.extend(prefix_of.iter().copied().map(Word::Derived));
+            result.extend(prefix_of.iter().copied().map(|word| {
+                if original.ngram_words.is_some() {
+                    Word::Derived(word)
+                } else {
+                    Word::Original(word)
+                }
+            }));
         };
 
         match &self.one_typo_subset {

--- a/milli/src/search/new/query_term/mod.rs
+++ b/milli/src/search/new/query_term/mod.rs
@@ -205,9 +205,9 @@ impl QueryTermSubset {
             } = &original.zero_typo;
             result.extend(zero_typo.iter().copied().map(|word| {
                 if original.ngram_words.is_some() {
-                    Word::Original(word)
-                } else {
                     Word::Derived(word)
+                } else {
+                    Word::Original(word)
                 }
             }));
             result.extend(prefix_of.iter().copied().map(Word::Derived));

--- a/milli/src/search/new/query_term/parse_query.rs
+++ b/milli/src/search/new/query_term/parse_query.rs
@@ -1,8 +1,8 @@
-use charabia::{normalizer::NormalizedTokenIter, SeparatorKind, TokenKind};
-
-use crate::{Result, SearchContext, MAX_WORD_LENGTH};
+use charabia::normalizer::NormalizedTokenIter;
+use charabia::{SeparatorKind, TokenKind};
 
 use super::*;
+use crate::{Result, SearchContext, MAX_WORD_LENGTH};
 
 /// Convert the tokenised search query into a list of located query terms.
 // TODO: checking if the positions are correct for phrases, separators, ngrams
@@ -51,6 +51,7 @@ pub fn located_query_terms_from_string(
                                 word,
                                 nbr_typos(word),
                                 false,
+                                false,
                             )?;
                             let located_term = LocatedQueryTerm {
                                 value: ctx.term_interner.push(term),
@@ -62,8 +63,13 @@ pub fn located_query_terms_from_string(
                     }
                 } else {
                     let word = token.lemma();
-                    let term =
-                        partially_initialized_term_from_word(ctx, word, nbr_typos(word), true)?;
+                    let term = partially_initialized_term_from_word(
+                        ctx,
+                        word,
+                        nbr_typos(word),
+                        true,
+                        false,
+                    )?;
                     let located_term = LocatedQueryTerm {
                         value: ctx.term_interner.push(term),
                         positions: position..=position,
@@ -195,7 +201,8 @@ pub fn make_ngram(
     let max_nbr_typos =
         number_of_typos_allowed(ngram_str.as_str()).saturating_sub(terms.len() as u8 - 1);
 
-    let mut term = partially_initialized_term_from_word(ctx, &ngram_str, max_nbr_typos, is_prefix)?;
+    let mut term =
+        partially_initialized_term_from_word(ctx, &ngram_str, max_nbr_typos, is_prefix, true)?;
 
     // Now add the synonyms
     let index_synonyms = ctx.index.synonyms(ctx.txn)?;

--- a/milli/src/search/new/ranking_rule_graph/exactness/mod.rs
+++ b/milli/src/search/new/ranking_rule_graph/exactness/mod.rs
@@ -4,6 +4,7 @@ use super::{ComputedCondition, DeadEndsCache, RankingRuleGraph, RankingRuleGraph
 use crate::search::new::interner::{DedupInterner, Interned, MappedInterner};
 use crate::search::new::query_graph::{QueryGraph, QueryNode};
 use crate::search::new::query_term::{ExactTerm, LocatedQueryTermSubset};
+use crate::search::new::Word;
 use crate::{Result, SearchContext, SearchLogger};
 
 #[derive(Clone, PartialEq, Eq, Hash)]
@@ -27,7 +28,7 @@ fn compute_docids(
     let mut candidates = match exact_term {
         ExactTerm::Phrase(phrase) => ctx.get_phrase_docids(phrase)?.clone(),
         ExactTerm::Word(word) => {
-            if let Some(word_candidates) = ctx.get_db_word_docids(word)? {
+            if let Some(word_candidates) = ctx.word_docids(Word::Original(word))? {
                 word_candidates
             } else {
                 return Ok(Default::default());

--- a/milli/src/search/new/ranking_rule_graph/proximity/compute_docids.rs
+++ b/milli/src/search/new/ranking_rule_graph/proximity/compute_docids.rs
@@ -55,7 +55,7 @@ pub fn compute_docids(
             compute_prefix_edges(
                 ctx,
                 left_word.interned(),
-                right_prefix,
+                right_prefix.interned(),
                 left_phrase,
                 forward_proximity,
                 backward_proximity,

--- a/milli/src/search/new/ranking_rule_graph/proximity/compute_docids.rs
+++ b/milli/src/search/new/ranking_rule_graph/proximity/compute_docids.rs
@@ -9,7 +9,7 @@ use crate::search::new::interner::Interned;
 use crate::search::new::query_term::{Phrase, QueryTermSubset};
 use crate::search::new::ranking_rule_graph::ComputedCondition;
 use crate::search::new::resolve_query_graph::compute_query_term_subset_docids;
-use crate::search::new::SearchContext;
+use crate::search::new::{SearchContext, Word};
 use crate::Result;
 
 pub fn compute_docids(
@@ -54,7 +54,7 @@ pub fn compute_docids(
         {
             compute_prefix_edges(
                 ctx,
-                left_word,
+                left_word.interned(),
                 right_prefix,
                 left_phrase,
                 forward_proximity,
@@ -91,7 +91,7 @@ pub fn compute_docids(
                 if universe.is_disjoint(ctx.get_phrase_docids(left_phrase)?) {
                     continue;
                 }
-            } else if let Some(left_word_docids) = ctx.get_db_word_docids(left_word)? {
+            } else if let Some(left_word_docids) = ctx.word_docids(left_word)? {
                 if universe.is_disjoint(&left_word_docids) {
                     continue;
                 }
@@ -101,7 +101,7 @@ pub fn compute_docids(
         for (right_word, right_phrase) in right_derivs {
             compute_non_prefix_edges(
                 ctx,
-                left_word,
+                left_word.interned(),
                 right_word,
                 left_phrase,
                 right_phrase,
@@ -243,7 +243,7 @@ fn compute_non_prefix_edges(
 fn last_words_of_term_derivations(
     ctx: &mut SearchContext,
     t: &QueryTermSubset,
-) -> Result<BTreeSet<(Option<Interned<Phrase>>, Interned<String>)>> {
+) -> Result<BTreeSet<(Option<Interned<Phrase>>, Word)>> {
     let mut result = BTreeSet::new();
 
     for w in t.all_single_words_except_prefix_db(ctx)? {
@@ -253,7 +253,7 @@ fn last_words_of_term_derivations(
         let phrase = ctx.phrase_interner.get(p);
         let last_term_of_phrase = phrase.words.last().unwrap();
         if let Some(last_word) = last_term_of_phrase {
-            result.insert((Some(p), *last_word));
+            result.insert((Some(p), Word::Original(*last_word)));
         }
     }
 
@@ -266,7 +266,7 @@ fn first_word_of_term_iter(
     let mut result = BTreeSet::new();
     let all_words = t.all_single_words_except_prefix_db(ctx)?;
     for w in all_words {
-        result.insert((w, None));
+        result.insert((w.interned(), None));
     }
     for p in t.all_phrases(ctx)? {
         let phrase = ctx.phrase_interner.get(p);

--- a/milli/src/search/new/resolve_query_graph.rs
+++ b/milli/src/search/new/resolve_query_graph.rs
@@ -44,7 +44,7 @@ pub fn compute_query_term_subset_docids(
     }
 
     if let Some(prefix) = term.use_prefix_db(ctx) {
-        if let Some(prefix_docids) = ctx.get_db_word_prefix_docids(prefix)? {
+        if let Some(prefix_docids) = ctx.word_prefix_docids(prefix)? {
             docids |= prefix_docids;
         }
     }

--- a/milli/src/search/new/resolve_query_graph.rs
+++ b/milli/src/search/new/resolve_query_graph.rs
@@ -9,7 +9,7 @@ use super::interner::Interned;
 use super::query_graph::QueryNodeData;
 use super::query_term::{Phrase, QueryTermSubset};
 use super::small_bitmap::SmallBitmap;
-use super::{QueryGraph, SearchContext};
+use super::{QueryGraph, SearchContext, Word};
 use crate::search::new::query_term::LocatedQueryTermSubset;
 use crate::Result;
 
@@ -35,7 +35,7 @@ pub fn compute_query_term_subset_docids(
 ) -> Result<RoaringBitmap> {
     let mut docids = RoaringBitmap::new();
     for word in term.all_single_words_except_prefix_db(ctx)? {
-        if let Some(word_docids) = ctx.get_db_word_docids(word)? {
+        if let Some(word_docids) = ctx.word_docids(word)? {
             docids |= word_docids;
         }
     }
@@ -125,7 +125,7 @@ pub fn compute_phrase_docids(
     }
     if words.len() == 1 {
         if let Some(word) = &words[0] {
-            if let Some(word_docids) = ctx.get_db_word_docids(*word)? {
+            if let Some(word_docids) = ctx.word_docids(Word::Original(*word))? {
                 return Ok(word_docids);
             } else {
                 return Ok(RoaringBitmap::new());


### PR DESCRIPTION
# Pull Request

## Related issue
Related to the search refactor.

## What does this PR do?
- Introduces a `Word` enum that wraps an `Interned<String>` by adding whether the word is an `Original` word from the user query or a `Derived` one.
- `ngram`, prefixes, words with typos, split words, are all `Derived` words. Words from the query or from a phrase are all `Original` words.
- Introduces `SearchContext::word_docids` and `SearchContext::word_prefix_docids` that accept a `Word` and call either `SearchContext::get_db_word_docids` only or also `SearchContext::get_db_exact_word_docids` depending on if the word is original or derived.
- Update call sites, make `SearchContext::get_db_word_docids` and `SearchContext::get_prefix_word_docids` private.

## PR checklist
- [ ] Do at least some tests with `DisableTypoForAttributes` to check it works correctly.
- [ ] The prefix might be unexpectedly `None` when a term is initialized and we should look at the `exact_word_db`.
