### PR TITLE
Introduce the filter syntax for `CONTAINS`, `STARTS` and `ENDS WITH`

### DIFF
--- a/filter-parser/src/condition.rs
+++ b/filter-parser/src/condition.rs
@@ -26,6 +26,9 @@ pub enum Condition<'a> {
     LowerThan(Token<'a>),
     LowerThanOrEqual(Token<'a>),
     Between { from: Token<'a>, to: Token<'a> },
+    StartsWith(Token<'a>),
+    EndsWith(Token<'a>),
+    Contains(Token<'a>),
 }
 
 /// condition      = value ("==" | ">" ...) value
@@ -44,6 +47,29 @@ pub fn parse_condition(input: Span) -> IResult<FilterCondition> {
     };
 
     Ok((input, condition))
+}
+
+/// contains        = value "CONTAINS" value
+pub fn parse_contains(input: Span) -> IResult<FilterCondition> {
+    let (input, (fid, _, value)) = tuple((parse_value, tag("CONTAINS"), cut(parse_value)))(input)?;
+
+    Ok((input, FilterCondition::Condition { fid, op: Contains(value) }))
+}
+
+/// starts with     = value "STARTS" WS+ "WITH" value
+pub fn parse_starts_with(input: Span) -> IResult<FilterCondition> {
+    let keyword = tuple((tag("STARTS"), multispace1, tag("WITH")));
+    let (input, (fid, _, value)) = tuple((parse_value, keyword, cut(parse_value)))(input)?;
+
+    Ok((input, FilterCondition::Condition { fid, op: StartsWith(value) }))
+}
+
+/// ends with       = value "ENDS" WS+ "WITH" value
+pub fn parse_ends_with(input: Span) -> IResult<FilterCondition> {
+    let keyword = tuple((tag("ENDS"), multispace1, tag("WITH")));
+    let (input, (fid, _, value)) = tuple((parse_value, keyword, cut(parse_value)))(input)?;
+
+    Ok((input, FilterCondition::Condition { fid, op: EndsWith(value) }))
 }
 
 /// null          = value "IS" WS+ "NULL"

--- a/filter-parser/src/error.rs
+++ b/filter-parser/src/error.rs
@@ -145,7 +145,7 @@ impl<'a> Display for Error<'a> {
             }
             ErrorKind::InvalidPrimary => {
                 let text = if input.trim().is_empty() { "but instead got nothing.".to_string() } else { format!("at `{}`.", escaped_input) };
-                writeln!(f, "Was expecting an operation `=`, `!=`, `>=`, `>`, `<=`, `<`, `IN`, `NOT IN`, `TO`, `EXISTS`, `NOT EXISTS`, `IS NULL`, `IS NOT NULL`, `IS EMPTY`, `IS NOT EMPTY`, `_geoRadius`, or `_geoBoundingBox` {}", text)?
+                writeln!(f, "Was expecting an operation `=`, `!=`, `>=`, `>`, `<=`, `<`, `IN`, `NOT IN`, `TO`, `EXISTS`, `NOT EXISTS`, `IS NULL`, `IS NOT NULL`, `IS EMPTY`, `IS NOT EMPTY`, `CONTAINS`, `STARTS WITH`, `ENDS WITH`, `_geoRadius`, or `_geoBoundingBox` {}", text)?
             }
             ErrorKind::ExpectedEof => {
                 writeln!(f, "Found unexpected characters at the end of the filter: `{}`. You probably forgot an `OR` or an `AND` rule.", escaped_input)?

--- a/filter-parser/src/value.rs
+++ b/filter-parser/src/value.rs
@@ -196,6 +196,10 @@ fn is_keyword(s: &str) -> bool {
             | "EMPTY"
             | "_geoRadius"
             | "_geoBoundingBox"
+            | "CONTAINS"
+            | "STARTS"
+            | "ENDS"
+            | "WITH"
     )
 }
 

--- a/meilisearch/tests/search/errors.rs
+++ b/meilisearch/tests/search/errors.rs
@@ -547,7 +547,7 @@ async fn filter_invalid_syntax_object() {
     index.wait_task(1).await;
 
     let expected_response = json!({
-        "message": "Was expecting an operation `=`, `!=`, `>=`, `>`, `<=`, `<`, `IN`, `NOT IN`, `TO`, `EXISTS`, `NOT EXISTS`, `IS NULL`, `IS NOT NULL`, `IS EMPTY`, `IS NOT EMPTY`, `_geoRadius`, or `_geoBoundingBox` at `title & Glass`.\n1:14 title & Glass",
+        "message": "Was expecting an operation `=`, `!=`, `>=`, `>`, `<=`, `<`, `IN`, `NOT IN`, `TO`, `EXISTS`, `NOT EXISTS`, `IS NULL`, `IS NOT NULL`, `IS EMPTY`, `IS NOT EMPTY`, `CONTAINS`, `STARTS WITH`, `ENDS WITH`, `_geoRadius`, or `_geoBoundingBox` at `title & Glass`.\n1:14 title & Glass",
         "code": "invalid_search_filter",
         "type": "invalid_request",
         "link": "https://docs.meilisearch.com/errors#invalid_search_filter"
@@ -572,7 +572,7 @@ async fn filter_invalid_syntax_array() {
     index.wait_task(1).await;
 
     let expected_response = json!({
-        "message": "Was expecting an operation `=`, `!=`, `>=`, `>`, `<=`, `<`, `IN`, `NOT IN`, `TO`, `EXISTS`, `NOT EXISTS`, `IS NULL`, `IS NOT NULL`, `IS EMPTY`, `IS NOT EMPTY`, `_geoRadius`, or `_geoBoundingBox` at `title & Glass`.\n1:14 title & Glass",
+        "message": "Was expecting an operation `=`, `!=`, `>=`, `>`, `<=`, `<`, `IN`, `NOT IN`, `TO`, `EXISTS`, `NOT EXISTS`, `IS NULL`, `IS NOT NULL`, `IS EMPTY`, `IS NOT EMPTY`, `CONTAINS`, `STARTS WITH`, `ENDS WITH`, `_geoRadius`, or `_geoBoundingBox` at `title & Glass`.\n1:14 title & Glass",
         "code": "invalid_search_filter",
         "type": "invalid_request",
         "link": "https://docs.meilisearch.com/errors#invalid_search_filter"

--- a/milli/src/search/facet/filter.rs
+++ b/milli/src/search/facet/filter.rs
@@ -298,6 +298,15 @@ impl<'a> Filter<'a> {
                 let all_ids = index.documents_ids(rtxn)?;
                 return Ok(all_ids - docids);
             }
+            Condition::Contains(val) => {
+                todo!()
+            }
+            Condition::StartsWith(val) => {
+                todo!()
+            }
+            Condition::EndsWith(val) => {
+                todo!()
+            }
         };
 
         let mut output = RoaringBitmap::new();


### PR DESCRIPTION
This PR introduces three filters:
 - `CONTAINS` which returns documents that have a facet value that contains the given string
 - `STARTS WITH` which returns documents that have a facet value that starts with the given string
 - `ENDS WITH` which returns documents that have a facet value that ends with the given string

Related to https://github.com/meilisearch/product/discussions/544.

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [ ] Have you read the contributing guidelines?
- [ ] Have you made sure that the title is accurate and descriptive of the changes?