### PR TITLE
Add `publish-post-release.yml` CI workflow

### DIFF
--- a/.github/workflows/latest-git-tag.yml
+++ b/.github/workflows/latest-git-tag.yml
@@ -1,9 +1,9 @@
 # Create or update a latest git tag when releasing a stable version of Meilisearch
 name: Update latest git tag
 on:
-  workflow_dispatch:
   release:
     types: [released]
+  workflow_dispatch:
 
 jobs:
   check-version:

--- a/.github/workflows/publish-apt-brew-pkg.yml
+++ b/.github/workflows/publish-apt-brew-pkg.yml
@@ -14,7 +14,7 @@ jobs:
         run: bash .github/scripts/check-release.sh
 
   debian:
-    name: Publish debian packagge
+    name: Publish debian package
     runs-on: ubuntu-latest
     needs: check-version
     container:

--- a/.github/workflows/publish-apt-brew-pkg.yml
+++ b/.github/workflows/publish-apt-brew-pkg.yml
@@ -1,8 +1,9 @@
 name: Publish to APT & Homebrew
 
 on:
-  release:
-    types: [released]
+  # This workflow is reusable, i.e. it may be called from another workflow.
+  # See https://docs.github.com/en/actions/using-workflows/reusing-workflows
+  workflow_call:
 
 jobs:
   check-version:
@@ -14,7 +15,7 @@ jobs:
         run: bash .github/scripts/check-release.sh
 
   debian:
-    name: Publish debian package
+    name: Publish Debian package
     runs-on: ubuntu-latest
     needs: check-version
     container:
@@ -41,7 +42,7 @@ jobs:
         file: target/debian/meilisearch.deb
         asset_name: meilisearch.deb
         tag: ${{ github.ref }}
-    - name: Upload debian pkg to apt repository
+    - name: Upload Debian package to apt repository
       run: curl -F package=@target/debian/meilisearch.deb https://${{ secrets.GEMFURY_PUSH_TOKEN }}@push.fury.io/meilisearch/
 
   homebrew:

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -1,11 +1,14 @@
 name: Publish binaries to GitHub release
 
 on:
-  workflow_dispatch:
   schedule:
     - cron: '0 2 * * *' # Every day at 2:00am
   release:
     types: [published]
+  # This workflow is reusable, i.e. it may be called from another workflow.
+  # See https://docs.github.com/en/actions/using-workflows/reusing-workflows
+  workflow_call:
+  workflow_dispatch:
 
 jobs:
   check-version:

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -11,6 +11,9 @@ on:
   # Both `schedule` and `workflow_dispatch` build the nightly tag
   schedule:
     - cron: '0 23 * * *' # Every day at 11:00pm
+  # This workflow is reusable, i.e. it may be called from another workflow.
+  # See https://docs.github.com/en/actions/using-workflows/reusing-workflows
+  workflow_call:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/publish-post-release.yml
+++ b/.github/workflows/publish-post-release.yml
@@ -1,0 +1,15 @@
+name: Publish binaries, images, and packages
+
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+
+jobs:
+  publish-binaries:
+    uses: ./.github/workflows/publish-binaries.yml
+  publish-images:
+    uses: ./.github/workflows/publish-docker-images.yml
+  publish-packages:
+    needs: [publish-binaries, publish-images]
+    uses: ./.github/workflows/publish-apt-brew-pkg.yml

--- a/.github/workflows/sdks-tests.yml
+++ b/.github/workflows/sdks-tests.yml
@@ -145,7 +145,7 @@ jobs:
       - name: Install pipenv
         uses: dschep/install-pipenv-action@v1
       - name: Install dependencies
-        run: pipenv install --dev --python=${{ matrix.python-version }}
+        run: pipenv install --dev
       - name: Test with pytest
         run: pipenv run pytest
 


### PR DESCRIPTION
New CI workflow is triggered when a release is published, or a pre-release
is changed to a released. It can also be triggered manually.
`publish-post-release.yml` calls `publish-binaries.yml` and
`publish-docker-images.yml` --- they are made reusable for this purpose.
Once both workflows succeed, `publish-apt-brew-pkg.yml` is called.

Closes #3146

### Other changes

- Remove stray `matrix` reference in `.github/workflows/sdks-tests.yml`.
