### PR TITLE
Force japanese v1.2.0

### DIFF
--- a/meilisearch/tests/search/formatted.rs
+++ b/meilisearch/tests/search/formatted.rs
@@ -443,7 +443,7 @@ async fn displayedattr_2_smol() {
         .await;
 }
 
-#[cfg(feature = "default")]
+#[cfg(feature = "chinese")]
 #[actix_rt::test]
 async fn test_cjk_highlight() {
     let server = Server::new().await;

--- a/meilisearch/tests/search/japanese.rs
+++ b/meilisearch/tests/search/japanese.rs
@@ -1,0 +1,64 @@
+use crate::common::Server;
+use serde_json::json;
+
+async fn setup() -> Server {
+    let server = Server::new().await;
+    let index = server.index("test");
+
+    let documents = json!([
+        { "id": 0, "title": "東京医科歯科大学" },
+        { "id": 1, "title": "東京のお寿司。" },
+        { "id": 2, "title": "東京オペラシティ" },
+        { "id": 3, "title": "東京スカイツリー" },
+        { "id": 4, "title": "東京時代まつり" },
+        { "id": 5, "title": "アッー!!" }
+    ]);
+
+    index.add_documents(documents, None).await;
+    index.wait_task(0).await;
+
+    server
+}
+
+async fn test_search(server: &Server, query: &str, expected_hits: usize) {
+    let index = server.index("test");
+    index
+        .search(json!({ "q": query }), |response, code| {
+            assert_eq!(code, 200, "{}", response);
+            assert_eq!(response["hits"].as_array().unwrap().len(), expected_hits);
+        })
+        .await;
+}
+
+#[actix_rt::test]
+async fn prototype_test_search_japanese_empty() {
+    // Index check for "ッー" (ref: https://github.com/meilisearch/meilisearch/pull/3588#issuecomment-1529169147)
+    let server = setup().await;
+    test_search(&server, "", 6).await;
+}
+
+#[actix_rt::test]
+async fn prototype_test_search_japanese_tokyo() {
+    // Test for kanji
+    // If unforce Japanese, the number of hits will be 1
+    let server = setup().await;
+    test_search(&server, "東京", 5).await;
+}
+
+#[actix_rt::test]
+async fn prototype_test_search_japanese_katakana() {
+    // Test for katakana
+    // Test that it is possible to search by katakana or hiragana by wana_kana
+    let server = setup().await;
+    test_search(&server, "オペラ", 1).await;
+    test_search(&server, "おぺら", 1).await;
+}
+
+#[actix_rt::test]
+async fn prototype_test_search_japanese_hiragana() {
+    // Test for hiragana
+    // Test that it is possible to search by katakana or hiragana by wana_kana
+    let server = setup().await;
+    test_search(&server, "まつり", 1).await;
+    test_search(&server, "マツリ", 1).await;
+}

--- a/meilisearch/tests/search/mod.rs
+++ b/meilisearch/tests/search/mod.rs
@@ -3,6 +3,7 @@
 
 mod errors;
 mod formatted;
+mod japanese;
 mod multi;
 mod pagination;
 

--- a/milli/Cargo.toml
+++ b/milli/Cargo.toml
@@ -79,7 +79,7 @@ rand = { version = "0.8.5", features = ["small_rng"] }
 fuzzcheck = "0.12.1"
 
 [features]
-all-tokenizations = ["charabia/default"]
+all-tokenizations = [ "charabia/japanese", "charabia/hebrew", "charabia/korean", "charabia/thai", "charabia/greek" ]
 
 # Use POSIX semaphores instead of SysV semaphores in LMDB
 # For more information on this feature, see heed's Cargo.toml

--- a/milli/src/update/delete_documents.rs
+++ b/milli/src/update/delete_documents.rs
@@ -1152,6 +1152,7 @@ mod tests {
         stats_should_not_return_deleted_documents_(DeletionStrategy::AlwaysSoft);
     }
 
+    #[cfg(feature = "chinese")]
     fn stored_detected_script_and_language_should_not_return_deleted_documents_(
         deletion_strategy: DeletionStrategy,
     ) {
@@ -1190,6 +1191,7 @@ mod tests {
         assert_eq!(cj_cmn_docs, expected_cj_cmn_docids);
     }
 
+    #[cfg(feature = "chinese")]
     #[test]
     fn stored_detected_script_and_language_should_not_return_deleted_documents() {
         stored_detected_script_and_language_should_not_return_deleted_documents_(

--- a/milli/src/update/index_documents/mod.rs
+++ b/milli/src/update/index_documents/mod.rs
@@ -2108,7 +2108,7 @@ mod tests {
         index.add_documents(doc1).unwrap();
     }
 
-    #[cfg(feature = "default")]
+    #[cfg(feature = "chinese")]
     #[test]
     fn store_detected_script_and_language_per_document_during_indexing() {
         use charabia::{Language, Script};


### PR DESCRIPTION
# Pull Request

> ⚠️ this PR is not meant to be merged.

This PR deactivates Chinese tokenization forcing Japanese tokenization to be used by Meilisearch.
It's a hotfix provided to Japanese users allowing them to use Meilisearch without having language detection issues before a final fix is released.

- Prepared for v1.2.0 what was in [v1.1.0](https://github.com/meilisearch/meilisearch/pull/3588)
- Added test code for Japanese

## How to use this prototype?

?

## Related issues and discussions

- meilisearch/product/discussions/532#discussioncomment-3806543
- meilisearch/meilisearch/issues/3565
- meilisearch/meilisearch/pull/3569
- meilisearch/meilisearch/pull/3588
