### PR TITLE
Experimental features

### DIFF
--- a/dump/src/lib.rs
+++ b/dump/src/lib.rs
@@ -412,6 +412,8 @@ pub(crate) mod test {
         }
         keys.flush().unwrap();
 
+        // ========== TODO: create features here
+
         // create the dump
         let mut file = tempfile::tempfile().unwrap();
         dump.persist_to(&mut file).unwrap();

--- a/dump/src/reader/compat/v5_to_v6.rs
+++ b/dump/src/reader/compat/v5_to_v6.rs
@@ -191,6 +191,10 @@ impl CompatV5ToV6 {
             })
         })))
     }
+
+    pub fn features(&self) -> Result<Option<v6::RuntimeTogglableFeatures>> {
+        Ok(None)
+    }
 }
 
 pub enum CompatIndexV5ToV6 {

--- a/dump/src/reader/mod.rs
+++ b/dump/src/reader/mod.rs
@@ -107,6 +107,13 @@ impl DumpReader {
             DumpReader::Compat(compat) => compat.keys(),
         }
     }
+
+    pub fn features(&self) -> Result<Option<v6::RuntimeTogglableFeatures>> {
+        match self {
+            DumpReader::Current(current) => Ok(current.features()),
+            DumpReader::Compat(compat) => compat.features(),
+        }
+    }
 }
 
 impl From<V6Reader> for DumpReader {
@@ -188,6 +195,8 @@ pub(crate) mod test {
     use meili_snap::insta;
 
     use super::*;
+
+    // TODO: add `features` to tests
 
     #[test]
     fn import_dump_v5() {

--- a/dump/src/writer.rs
+++ b/dump/src/writer.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 
 use flate2::write::GzEncoder;
 use flate2::Compression;
+use meilisearch_types::features::RuntimeTogglableFeatures;
 use meilisearch_types::keys::Key;
 use meilisearch_types::settings::{Checked, Settings};
 use serde_json::{Map, Value};
@@ -51,6 +52,13 @@ impl DumpWriter {
 
     pub fn create_tasks_queue(&self) -> Result<TaskWriter> {
         TaskWriter::new(self.dir.path().join("tasks"))
+    }
+
+    pub fn create_experimental_features(&self, features: RuntimeTogglableFeatures) -> Result<()> {
+        Ok(std::fs::write(
+            self.dir.path().join("experimental-features.json"),
+            serde_json::to_string(&features)?,
+        )?)
     }
 
     pub fn persist_to(self, mut writer: impl Write) -> Result<()> {

--- a/index-scheduler/src/batch.rs
+++ b/index-scheduler/src/batch.rs
@@ -839,6 +839,10 @@ impl IndexScheduler {
                     Ok(())
                 })?;
 
+                // 4. Dump experimental feature settings
+                let features = self.features()?.runtime_features();
+                dump.create_experimental_features(features)?;
+
                 let dump_uid = started_at.format(format_description!(
                     "[year repr:full][month repr:numerical][day padding:zero]-[hour padding:zero][minute padding:zero][second padding:zero][subsecond digits:3]"
                 )).unwrap();

--- a/index-scheduler/src/features.rs
+++ b/index-scheduler/src/features.rs
@@ -1,0 +1,98 @@
+use meilisearch_types::features::{InstanceTogglableFeatures, RuntimeTogglableFeatures};
+use meilisearch_types::heed::types::{SerdeJson, Str};
+use meilisearch_types::heed::{Database, Env, RoTxn, RwTxn};
+
+use crate::error::FeatureNotEnabledError;
+use crate::Result;
+
+const EXPERIMENTAL_FEATURES: &str = "experimental-features";
+
+#[derive(Clone)]
+pub(crate) struct FeatureData {
+    runtime: Database<Str, SerdeJson<RuntimeTogglableFeatures>>,
+    instance: InstanceTogglableFeatures,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct RoFeatures {
+    runtime: RuntimeTogglableFeatures,
+    instance: InstanceTogglableFeatures,
+}
+
+impl RoFeatures {
+    fn new(txn: RoTxn<'_>, data: &FeatureData) -> Result<Self> {
+        let runtime = data.runtime_features(txn)?;
+        Ok(Self { runtime, instance: data.instance })
+    }
+
+    pub fn runtime_features(&self) -> RuntimeTogglableFeatures {
+        self.runtime
+    }
+
+    pub fn check_score_details(&self) -> Result<()> {
+        if self.runtime.score_details {
+            Ok(())
+        } else {
+            Err(FeatureNotEnabledError {
+                disabled_action: "Computing score details",
+                feature: "score details",
+                issue_link: "https://github.com/meilisearch/product/discussions/674",
+            }
+            .into())
+        }
+    }
+
+    pub fn check_metrics(&self) -> Result<()> {
+        if self.instance.metrics {
+            Ok(())
+        } else {
+            Err(FeatureNotEnabledError {
+                disabled_action: "Getting metrics",
+                feature: "metrics",
+                issue_link: "https://github.com/meilisearch/meilisearch/discussions/3518",
+            }
+            .into())
+        }
+    }
+
+    pub fn check_vector(&self) -> Result<()> {
+        if self.runtime.vector_store {
+            Ok(())
+        } else {
+            Err(FeatureNotEnabledError {
+                disabled_action: "Passing `vector` as a query parameter",
+                feature: "vector store",
+                issue_link: "https://github.com/meilisearch/meilisearch/discussions/TODO",
+            }
+            .into())
+        }
+    }
+}
+
+impl FeatureData {
+    pub fn new(env: &Env, instance_features: InstanceTogglableFeatures) -> Result<Self> {
+        let mut wtxn = env.write_txn()?;
+        let runtime_features = env.create_database(&mut wtxn, Some(EXPERIMENTAL_FEATURES))?;
+        wtxn.commit()?;
+
+        Ok(Self { runtime: runtime_features, instance: instance_features })
+    }
+
+    pub fn put_runtime_features(
+        &self,
+        mut wtxn: RwTxn,
+        features: RuntimeTogglableFeatures,
+    ) -> Result<()> {
+        self.runtime.put(&mut wtxn, EXPERIMENTAL_FEATURES, &features)?;
+        wtxn.commit()?;
+        Ok(())
+    }
+
+    fn runtime_features(&self, txn: RoTxn) -> Result<RuntimeTogglableFeatures> {
+        Ok(self.runtime.get(&txn, EXPERIMENTAL_FEATURES)?.unwrap_or_default())
+    }
+
+    pub fn features(&self, txn: RoTxn) -> Result<RoFeatures> {
+        RoFeatures::new(txn, self)
+    }
+}

--- a/index-scheduler/src/insta_snapshot.rs
+++ b/index-scheduler/src/insta_snapshot.rs
@@ -28,6 +28,7 @@ pub fn snapshot_index_scheduler(scheduler: &IndexScheduler) -> String {
         started_at,
         finished_at,
         index_mapper,
+        features: _,
         max_number_of_tasks: _,
         wake_up: _,
         dumps_path: _,

--- a/meilisearch-types/src/error.rs
+++ b/meilisearch-types/src/error.rs
@@ -271,6 +271,7 @@ InvalidTaskStatuses                   , InvalidRequest       , BAD_REQUEST ;
 InvalidTaskTypes                      , InvalidRequest       , BAD_REQUEST ;
 InvalidTaskUids                       , InvalidRequest       , BAD_REQUEST  ;
 IoError                               , System               , UNPROCESSABLE_ENTITY;
+FeatureNotEnabled                     , InvalidRequest       , BAD_REQUEST ;
 MalformedPayload                      , InvalidRequest       , BAD_REQUEST ;
 MaxFieldsLimitExceeded                , InvalidRequest       , BAD_REQUEST ;
 MissingApiKeyActions                  , InvalidRequest       , BAD_REQUEST ;

--- a/meilisearch-types/src/features.rs
+++ b/meilisearch-types/src/features.rs
@@ -1,0 +1,13 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, Default)]
+#[serde(rename_all = "camelCase", default)]
+pub struct RuntimeTogglableFeatures {
+    pub score_details: bool,
+    pub vector_store: bool,
+}
+
+#[derive(Default, Debug, Clone, Copy)]
+pub struct InstanceTogglableFeatures {
+    pub metrics: bool,
+}

--- a/meilisearch-types/src/keys.rs
+++ b/meilisearch-types/src/keys.rs
@@ -274,6 +274,12 @@ pub enum Action {
     #[serde(rename = "keys.delete")]
     #[deserr(rename = "keys.delete")]
     KeysDelete,
+    #[serde(rename = "experimental.get")]
+    #[deserr(rename = "experimental.get")]
+    ExperimentalFeaturesGet,
+    #[serde(rename = "experimental.update")]
+    #[deserr(rename = "experimental.update")]
+    ExperimentalFeaturesUpdate,
 }
 
 impl Action {
@@ -310,6 +316,8 @@ impl Action {
             KEYS_GET => Some(Self::KeysGet),
             KEYS_UPDATE => Some(Self::KeysUpdate),
             KEYS_DELETE => Some(Self::KeysDelete),
+            EXPERIMENTAL_FEATURES_GET => Some(Self::ExperimentalFeaturesGet),
+            EXPERIMENTAL_FEATURES_UPDATE => Some(Self::ExperimentalFeaturesUpdate),
             _otherwise => None,
         }
     }
@@ -352,4 +360,6 @@ pub mod actions {
     pub const KEYS_GET: u8 = KeysGet.repr();
     pub const KEYS_UPDATE: u8 = KeysUpdate.repr();
     pub const KEYS_DELETE: u8 = KeysDelete.repr();
+    pub const EXPERIMENTAL_FEATURES_GET: u8 = ExperimentalFeaturesGet.repr();
+    pub const EXPERIMENTAL_FEATURES_UPDATE: u8 = ExperimentalFeaturesUpdate.repr();
 }

--- a/meilisearch-types/src/lib.rs
+++ b/meilisearch-types/src/lib.rs
@@ -2,6 +2,7 @@ pub mod compression;
 pub mod deserr;
 pub mod document_formats;
 pub mod error;
+pub mod features;
 pub mod index_uid;
 pub mod index_uid_pattern;
 pub mod keys;

--- a/meilisearch/src/lib.rs
+++ b/meilisearch/src/lib.rs
@@ -221,6 +221,7 @@ fn open_or_create_database_unchecked(
     // we don't want to create anything in the data.ms yet, thus we
     // wrap our two builders in a closure that'll be executed later.
     let auth_controller = AuthController::new(&opt.db_path, &opt.master_key);
+    let instance_features = opt.to_instance_features();
     let index_scheduler_builder = || -> anyhow::Result<_> {
         Ok(IndexScheduler::new(IndexSchedulerOptions {
             version_file_path: opt.db_path.join(VERSION_FILE_NAME),
@@ -238,6 +239,7 @@ fn open_or_create_database_unchecked(
             max_number_of_tasks: 1_000_000,
             index_growth_amount: byte_unit::Byte::from_str("10GiB").unwrap().get_bytes() as usize,
             index_count: DEFAULT_INDEX_COUNT,
+            instance_features,
         })?)
     };
 

--- a/meilisearch/src/lib.rs
+++ b/meilisearch/src/lib.rs
@@ -111,7 +111,7 @@ pub fn create_app(
                 analytics.clone(),
             )
         })
-        .configure(|cfg| routes::configure(cfg, opt.experimental_enable_metrics))
+        .configure(routes::configure)
         .configure(|s| dashboard(s, enable_dashboard));
 
     let app = app.wrap(actix_web::middleware::Condition::new(

--- a/meilisearch/src/option.rs
+++ b/meilisearch/src/option.rs
@@ -12,6 +12,7 @@ use std::{env, fmt, fs};
 
 use byte_unit::{Byte, ByteError};
 use clap::Parser;
+use meilisearch_types::features::InstanceTogglableFeatures;
 use meilisearch_types::milli::update::IndexerConfig;
 use rustls::server::{
     AllowAnyAnonymousOrAuthenticatedClient, AllowAnyAuthenticatedClient, ServerSessionMemoryCache,
@@ -485,6 +486,10 @@ impl Opt {
         } else {
             Ok(None)
         }
+    }
+
+    pub(crate) fn to_instance_features(&self) -> InstanceTogglableFeatures {
+        InstanceTogglableFeatures { metrics: self.experimental_enable_metrics }
     }
 }
 

--- a/meilisearch/src/routes/features.rs
+++ b/meilisearch/src/routes/features.rs
@@ -1,0 +1,102 @@
+use actix_web::web::{self, Data};
+use actix_web::{HttpRequest, HttpResponse};
+use deserr::actix_web::AwebJson;
+use deserr::Deserr;
+use index_scheduler::IndexScheduler;
+use log::debug;
+use meilisearch_types::deserr::DeserrJsonError;
+use meilisearch_types::error::ResponseError;
+use meilisearch_types::keys::actions;
+use serde_json::json;
+
+use crate::analytics::Analytics;
+use crate::extractors::authentication::policies::ActionPolicy;
+use crate::extractors::authentication::GuardedData;
+use crate::extractors::sequential_extractor::SeqHandler;
+
+pub fn configure(cfg: &mut web::ServiceConfig) {
+    cfg.service(
+        web::resource("")
+            .route(web::get().to(SeqHandler(get_features)))
+            .route(web::patch().to(SeqHandler(patch_features)))
+            .route(web::delete().to(SeqHandler(delete_features)))
+            .route(web::post().to(SeqHandler(post_features))),
+    );
+}
+
+async fn get_features(
+    index_scheduler: GuardedData<
+        ActionPolicy<{ actions::EXPERIMENTAL_FEATURES_GET }>,
+        Data<IndexScheduler>,
+    >,
+    req: HttpRequest,
+    analytics: Data<dyn Analytics>,
+) -> Result<HttpResponse, ResponseError> {
+    let features = index_scheduler.features()?;
+
+    analytics.publish("Experimental features Seen".to_string(), json!(null), Some(&req));
+    debug!("returns: {:?}", features.runtime_features());
+    Ok(HttpResponse::Ok().json(features.runtime_features()))
+}
+
+#[derive(Debug, Deserr)]
+#[deserr(error = DeserrJsonError, rename_all = camelCase, deny_unknown_fields)]
+pub struct RuntimeTogglableFeatures {
+    #[deserr(default)]
+    pub score_details: Option<bool>,
+    #[deserr(default)]
+    pub vector_store: Option<bool>,
+}
+
+async fn patch_features(
+    index_scheduler: GuardedData<
+        ActionPolicy<{ actions::EXPERIMENTAL_FEATURES_UPDATE }>,
+        Data<IndexScheduler>,
+    >,
+    new_features: AwebJson<RuntimeTogglableFeatures, DeserrJsonError>,
+    analytics: Data<dyn Analytics>,
+) -> Result<HttpResponse, ResponseError> {
+    let features = index_scheduler.features()?;
+
+    let old_features = features.runtime_features();
+
+    let new_features = meilisearch_types::features::RuntimeTogglableFeatures {
+        score_details: new_features.0.score_details.unwrap_or(old_features.score_details),
+        vector_store: new_features.0.vector_store.unwrap_or(old_features.vector_store),
+    };
+
+    analytics.publish("Experimental features PATCH".to_string(), json!(new_features), None);
+    index_scheduler.put_runtime_features(new_features)?;
+    Ok(HttpResponse::Ok().json(new_features))
+}
+
+async fn post_features(
+    index_scheduler: GuardedData<
+        ActionPolicy<{ actions::EXPERIMENTAL_FEATURES_UPDATE }>,
+        Data<IndexScheduler>,
+    >,
+    new_features: AwebJson<RuntimeTogglableFeatures, DeserrJsonError>,
+    analytics: Data<dyn Analytics>,
+) -> Result<HttpResponse, ResponseError> {
+    let new_features = meilisearch_types::features::RuntimeTogglableFeatures {
+        score_details: new_features.0.score_details.unwrap_or(false),
+        vector_store: new_features.0.vector_store.unwrap_or(false),
+    };
+
+    analytics.publish("Experimental features POST".to_string(), json!(new_features), None);
+    index_scheduler.put_runtime_features(new_features)?;
+    Ok(HttpResponse::Ok().json(new_features))
+}
+
+async fn delete_features(
+    index_scheduler: GuardedData<
+        ActionPolicy<{ actions::EXPERIMENTAL_FEATURES_UPDATE }>,
+        Data<IndexScheduler>,
+    >,
+    analytics: Data<dyn Analytics>,
+) -> Result<HttpResponse, ResponseError> {
+    let deleted_features = Default::default();
+    analytics.publish("Experimental features DELETE".to_string(), json!(null), None);
+    index_scheduler.put_runtime_features(deleted_features)?;
+    Ok(HttpResponse::Ok().json(deleted_features))
+}

--- a/meilisearch/src/routes/indexes/search.rs
+++ b/meilisearch/src/routes/indexes/search.rs
@@ -151,7 +151,9 @@ pub async fn search_with_url_query(
     let mut aggregate = SearchAggregator::from_query(&query, &req);
 
     let index = index_scheduler.index(&index_uid)?;
-    let search_result = tokio::task::spawn_blocking(move || perform_search(&index, query)).await?;
+    let features = index_scheduler.features()?;
+    let search_result =
+        tokio::task::spawn_blocking(move || perform_search(&index, query, features)).await?;
     if let Ok(ref search_result) = search_result {
         aggregate.succeed(search_result);
     }
@@ -183,7 +185,10 @@ pub async fn search_with_post(
     let mut aggregate = SearchAggregator::from_query(&query, &req);
 
     let index = index_scheduler.index(&index_uid)?;
-    let search_result = tokio::task::spawn_blocking(move || perform_search(&index, query)).await?;
+
+    let features = index_scheduler.features()?;
+    let search_result =
+        tokio::task::spawn_blocking(move || perform_search(&index, query, features)).await?;
     if let Ok(ref search_result) = search_result {
         aggregate.succeed(search_result);
     }

--- a/meilisearch/src/routes/metrics.rs
+++ b/meilisearch/src/routes/metrics.rs
@@ -19,6 +19,7 @@ pub async fn get_metrics(
     index_scheduler: GuardedData<ActionPolicy<{ actions::METRICS_GET }>, Data<IndexScheduler>>,
     auth_controller: Data<AuthController>,
 ) -> Result<HttpResponse, ResponseError> {
+    index_scheduler.features()?.check_metrics()?;
     let auth_filters = index_scheduler.filters();
     if !auth_filters.all_indexes_authorized() {
         let mut error = ResponseError::from(AuthenticationError::InvalidToken);

--- a/meilisearch/src/routes/mod.rs
+++ b/meilisearch/src/routes/mod.rs
@@ -20,6 +20,7 @@ const PAGINATION_DEFAULT_LIMIT: usize = 20;
 
 mod api_key;
 mod dump;
+pub mod features;
 pub mod indexes;
 mod metrics;
 mod multi_search;
@@ -35,7 +36,8 @@ pub fn configure(cfg: &mut web::ServiceConfig, enable_metrics: bool) {
         .service(web::resource("/version").route(web::get().to(get_version)))
         .service(web::scope("/indexes").configure(indexes::configure))
         .service(web::scope("/multi-search").configure(multi_search::configure))
-        .service(web::scope("/swap-indexes").configure(swap_indexes::configure));
+        .service(web::scope("/swap-indexes").configure(swap_indexes::configure))
+        .service(web::scope("/experimental-features").configure(features::configure));
 
     if enable_metrics {
         cfg.service(web::scope("/metrics").configure(metrics::configure));

--- a/meilisearch/src/routes/mod.rs
+++ b/meilisearch/src/routes/mod.rs
@@ -27,7 +27,7 @@ mod multi_search;
 mod swap_indexes;
 pub mod tasks;
 
-pub fn configure(cfg: &mut web::ServiceConfig, enable_metrics: bool) {
+pub fn configure(cfg: &mut web::ServiceConfig) {
     cfg.service(web::scope("/tasks").configure(tasks::configure))
         .service(web::resource("/health").route(web::get().to(get_health)))
         .service(web::scope("/keys").configure(api_key::configure))
@@ -37,11 +37,8 @@ pub fn configure(cfg: &mut web::ServiceConfig, enable_metrics: bool) {
         .service(web::scope("/indexes").configure(indexes::configure))
         .service(web::scope("/multi-search").configure(multi_search::configure))
         .service(web::scope("/swap-indexes").configure(swap_indexes::configure))
+        .service(web::scope("/metrics").configure(metrics::configure))
         .service(web::scope("/experimental-features").configure(features::configure));
-
-    if enable_metrics {
-        cfg.service(web::scope("/metrics").configure(metrics::configure));
-    }
 }
 
 #[derive(Debug, Serialize)]

--- a/meilisearch/src/routes/multi_search.rs
+++ b/meilisearch/src/routes/multi_search.rs
@@ -41,6 +41,7 @@ pub async fn multi_search_with_post(
     let queries = params.into_inner().queries;
 
     let mut multi_aggregate = MultiSearchAggregator::from_queries(&queries, &req);
+    let features = index_scheduler.features()?;
 
     // Explicitly expect a `(ResponseError, usize)` for the error type rather than `ResponseError` only,
     // so that `?` doesn't work if it doesn't use `with_index`, ensuring that it is not forgotten in case of code
@@ -74,8 +75,9 @@ pub async fn multi_search_with_post(
                         err
                     })
                     .with_index(query_index)?;
+
                 let search_result =
-                    tokio::task::spawn_blocking(move || perform_search(&index, query))
+                    tokio::task::spawn_blocking(move || perform_search(&index, query, features))
                         .await
                         .with_index(query_index)?;
 

--- a/meilisearch/tests/auth/api_keys.rs
+++ b/meilisearch/tests/auth/api_keys.rs
@@ -422,7 +422,7 @@ async fn error_add_api_key_invalid_parameters_actions() {
     meili_snap::snapshot!(code, @"400 Bad Request");
     meili_snap::snapshot!(meili_snap::json_string!(response, { ".createdAt" => "[ignored]", ".updatedAt" => "[ignored]" }), @r###"
     {
-      "message": "Unknown value `doc.add` at `.actions[0]`: expected one of `*`, `search`, `documents.*`, `documents.add`, `documents.get`, `documents.delete`, `indexes.*`, `indexes.create`, `indexes.get`, `indexes.update`, `indexes.delete`, `indexes.swap`, `tasks.*`, `tasks.cancel`, `tasks.delete`, `tasks.get`, `settings.*`, `settings.get`, `settings.update`, `stats.*`, `stats.get`, `metrics.*`, `metrics.get`, `dumps.*`, `dumps.create`, `version`, `keys.create`, `keys.get`, `keys.update`, `keys.delete`",
+      "message": "Unknown value `doc.add` at `.actions[0]`: expected one of `*`, `search`, `documents.*`, `documents.add`, `documents.get`, `documents.delete`, `indexes.*`, `indexes.create`, `indexes.get`, `indexes.update`, `indexes.delete`, `indexes.swap`, `tasks.*`, `tasks.cancel`, `tasks.delete`, `tasks.get`, `settings.*`, `settings.get`, `settings.update`, `stats.*`, `stats.get`, `metrics.*`, `metrics.get`, `dumps.*`, `dumps.create`, `version`, `keys.create`, `keys.get`, `keys.update`, `keys.delete`, `experimental.get`, `experimental.update`",
       "code": "invalid_api_key_actions",
       "type": "invalid_request",
       "link": "https://docs.meilisearch.com/errors#invalid_api_key_actions"

--- a/meilisearch/tests/auth/errors.rs
+++ b/meilisearch/tests/auth/errors.rs
@@ -90,7 +90,7 @@ async fn create_api_key_bad_actions() {
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
-      "message": "Unknown value `doggo` at `.actions[0]`: expected one of `*`, `search`, `documents.*`, `documents.add`, `documents.get`, `documents.delete`, `indexes.*`, `indexes.create`, `indexes.get`, `indexes.update`, `indexes.delete`, `indexes.swap`, `tasks.*`, `tasks.cancel`, `tasks.delete`, `tasks.get`, `settings.*`, `settings.get`, `settings.update`, `stats.*`, `stats.get`, `metrics.*`, `metrics.get`, `dumps.*`, `dumps.create`, `version`, `keys.create`, `keys.get`, `keys.update`, `keys.delete`",
+      "message": "Unknown value `doggo` at `.actions[0]`: expected one of `*`, `search`, `documents.*`, `documents.add`, `documents.get`, `documents.delete`, `indexes.*`, `indexes.create`, `indexes.get`, `indexes.update`, `indexes.delete`, `indexes.swap`, `tasks.*`, `tasks.cancel`, `tasks.delete`, `tasks.get`, `settings.*`, `settings.get`, `settings.update`, `stats.*`, `stats.get`, `metrics.*`, `metrics.get`, `dumps.*`, `dumps.create`, `version`, `keys.create`, `keys.get`, `keys.update`, `keys.delete`, `experimental.get`, `experimental.update`",
       "code": "invalid_api_key_actions",
       "type": "invalid_request",
       "link": "https://docs.meilisearch.com/errors#invalid_api_key_actions"


### PR DESCRIPTION
# Pull Request

## Related issue

- Fixes https://github.com/meilisearch/meilisearch/issues/3857
- Related to https://github.com/meilisearch/meilisearch/issues/3771
## What does this PR do?

### Example

<details>
<summary>Using the feature to enable `scoreDetails`</summary>

```json
❯ curl \
  -X POST 'http://localhost:7700/indexes/index-word-count-10-count/search' \
  -H 'Content-Type: application/json' \
  --data-binary '{ "q": "Batman", "limit": 1, "showRankingScoreDetails": true, "attributesToRetrieve": ["title"]}' | jsonxf

{
  "message": "Computing score details requires enabling the `score details` experimental feature. See https://github.com/meilisearch/product/discussions/674",
  "code": "feature_not_enabled",
  "type": "invalid_request",
  "link": "https://docs.meilisearch.com/errors#feature_not_enabled"
}
```

```json
❯ curl \
  -X PATCH 'http://localhost:7700/experimental-features/' \
  -H 'Content-Type: application/json'  \
--data-binary '{
    "scoreDetails": true
  }'
{"scoreDetails":true,"vectorSearch":false}
```

```json
❯ curl \
  -X POST 'http://localhost:7700/indexes/index-word-count-10-count/search' \
  -H 'Content-Type: application/json' \
  --data-binary '{ "q": "Batman", "limit": 1, "showRankingScoreDetails": true, "attributesToRetrieve": ["title"]}' | jsonxf
{
  "hits": [
    {
      "title": "Batman",
      "_rankingScoreDetails": {
        "words": {
          "order": 0,
          "matchingWords": 1,
          "maxMatchingWords": 1,
          "score": 1.0
        },
        "typo": {
          "order": 1,
          "typoCount": 0,
          "maxTypoCount": 1,
          "score": 1.0
        },
        "proximity": {
          "order": 2,
          "score": 1.0
        },
        "attribute": {
          "order": 3,
          "attribute_ranking_order_score": 1.0,
          "query_word_distance_score": 1.0,
          "score": 1.0
        },
        "exactness": {
          "order": 4,
          "matchType": "exactMatch",
          "score": 1.0
        }
      }
    }
  ],
  "query": "Batman",
  "processingTimeMs": 3,
  "limit": 1,
  "offset": 0,
  "estimatedTotalHits": 46
}
```


</details>

### User standpoint

- Add new route GET/POST/PATCH/DELETE `/experimental-features` to switch on or off some of the experimental features in a manner persistent between instance restarts
- Use these new routes to allow setting on/off the following experimental features:
  - vector store **TODO:** fill in issue 
  - score details (related to https://github.com/meilisearch/meilisearch/issues/3771)
- Make the way of checking feature availability and error message uniform for the Prometheus metrics experimental feature
- Save the enabled features in dump, restore from dumps
- **TODO:** tests:
  - Test new security permissions (do they allow access with ALL, do they prevent access when missing)
  - Test dump behavior, in particular ability to import existing v6 dumps
  - Test basic behavior when calling the rule 

### Implementation standpoint

- New DB "experimental-features"
- dumps are modified to save the state of that new DB as a `experimental-features.json` file, that is then loaded back when importing the dump. This doesn't change the dump version, as the file is optional and it missing will not cause the dump to fail