### PR TITLE
Extract creation and updated dates from v2 dump

### DIFF
--- a/dump/src/reader/v2/updates.rs
+++ b/dump/src/reader/v2/updates.rs
@@ -227,4 +227,14 @@ impl UpdateStatus {
             _ => None,
         }
     }
+
+    pub fn finished_at(&self) -> Option<OffsetDateTime> {
+        match self {
+            UpdateStatus::Processing(_) => None,
+            UpdateStatus::Enqueued(_) => None,
+            UpdateStatus::Processed(u) => Some(u.processed_at),
+            UpdateStatus::Aborted(_) => None,
+            UpdateStatus::Failed(u) => Some(u.failed_at),
+        }
+    }
 }


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #2989

## What does this PR do?
This PR extracts the creation and updated dates from v2 dumps. The changes made in this PR are largely referenced from https://github.com/meilisearch/meilisearch/blob/798aa4ee9204ce20ab90054cad3e7a2243544aa3/dump/src/reader/v3/mod.rs#L165-L188

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x]  Have you made sure that the title is accurate and descriptive of the changes?
