### PR TITLE
Exactness missing field

### DIFF
--- a/milli/src/score_details.rs
+++ b/milli/src/score_details.rs
@@ -10,7 +10,7 @@ pub enum ScoreDetails {
     Fid(Rank),
     Position(Rank),
     ExactAttribute(ExactAttribute),
-    Exactness(Rank),
+    ExactWords(ExactWords),
     Sort(Sort),
     GeoSort(GeoSort),
 }
@@ -28,7 +28,7 @@ impl ScoreDetails {
             ScoreDetails::Fid(details) => Some(*details),
             ScoreDetails::Position(details) => Some(*details),
             ScoreDetails::ExactAttribute(details) => Some(details.rank()),
-            ScoreDetails::Exactness(details) => Some(*details),
+            ScoreDetails::ExactWords(details) => Some(details.rank()),
             ScoreDetails::Sort(_) => None,
             ScoreDetails::GeoSort(_) => None,
         }
@@ -117,7 +117,7 @@ impl ScoreDetails {
                     details_map.insert("exactness".into(), exactness_details);
                     order += 1;
                 }
-                ScoreDetails::Exactness(details) => {
+                ScoreDetails::ExactWords(details) => {
                     // For now, exactness is a virtual rule always preceded by the "ExactAttribute" rule
                     let exactness_details = details_map
                         .get_mut("exactness")
@@ -129,9 +129,16 @@ impl ScoreDetails {
                         == &serde_json::json!(ExactAttribute::NoExactMatch)
                     {
                         let score = Rank::global_score(
-                            [ExactAttribute::NoExactMatch.rank(), *details].iter().copied(),
+                            [ExactAttribute::NoExactMatch.rank(), details.rank()].iter().copied(),
                         );
-                        *exactness_details.get_mut("score").expect("missing score") = score.into();
+                        // tiny detail, but we want the score to be the last displayed field,
+                        // so we're removing it here, adding the other fields, then adding the new score
+                        exactness_details.remove("score");
+                        exactness_details
+                            .insert("matchingWords".into(), details.matching_words.into());
+                        exactness_details
+                            .insert("maxMatchingWords".into(), details.max_matching_words.into());
+                        exactness_details.insert("score".into(), score.into());
                     }
                     // do not update the order since this was already done by exactAttribute
                 }
@@ -209,8 +216,34 @@ impl Words {
         Rank { rank: self.matching_words, max_rank: self.max_matching_words }
     }
 
-    pub(crate) fn from_rank(rank: Rank) -> Words {
-        Words { matching_words: rank.rank, max_matching_words: rank.max_rank }
+    pub(crate) fn from_rank(rank: Rank) -> Self {
+        Self { matching_words: rank.rank, max_matching_words: rank.max_rank }
+    }
+}
+
+/// Structure that is super similar to [`Words`], but whose semantics is a bit distinct.
+///
+/// In exactness, the number of matching words can actually be 0 with a non-zero score,
+/// if no words from the query appear exactly in the document.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ExactWords {
+    pub matching_words: u32,
+    pub max_matching_words: u32,
+}
+
+impl ExactWords {
+    pub fn rank(&self) -> Rank {
+        // 0 matching words means last rank (1)
+        Rank { rank: self.matching_words + 1, max_rank: self.max_matching_words + 1 }
+    }
+
+    pub(crate) fn from_rank(rank: Rank) -> Self {
+        // last rank (1) means that 0 words from the query appear exactly in the document.
+        // first rank (max_rank) means that (max_rank - 1) words from the query appear exactly in the document.
+        Self {
+            matching_words: rank.rank.saturating_sub(1),
+            max_matching_words: rank.max_rank.saturating_sub(1),
+        }
     }
 }
 
@@ -223,7 +256,7 @@ pub struct Typo {
 impl Typo {
     pub fn rank(&self) -> Rank {
         Rank {
-            rank: self.max_typo_count - self.typo_count + 1,
+            rank: (self.max_typo_count + 1).saturating_sub(self.typo_count),
             max_rank: (self.max_typo_count + 1),
         }
     }
@@ -236,7 +269,10 @@ impl Typo {
     // rank + typo = max_rank
     // typo = max_rank - rank
     pub fn from_rank(rank: Rank) -> Typo {
-        Typo { typo_count: rank.max_rank - rank.rank, max_typo_count: rank.max_rank - 1 }
+        Typo {
+            typo_count: rank.max_rank.saturating_sub(rank.rank),
+            max_typo_count: rank.max_rank.saturating_sub(1),
+        }
     }
 }
 

--- a/milli/src/search/new/ranking_rule_graph/exactness/mod.rs
+++ b/milli/src/search/new/ranking_rule_graph/exactness/mod.rs
@@ -1,7 +1,7 @@
 use roaring::RoaringBitmap;
 
 use super::{ComputedCondition, RankingRuleGraphTrait};
-use crate::score_details::{Rank, ScoreDetails};
+use crate::score_details::{self, Rank, ScoreDetails};
 use crate::search::new::interner::{DedupInterner, Interned};
 use crate::search::new::query_term::{ExactTerm, LocatedQueryTermSubset};
 use crate::search::new::resolve_query_graph::compute_query_term_subset_docids;
@@ -87,6 +87,6 @@ impl RankingRuleGraphTrait for ExactnessGraph {
     }
 
     fn rank_to_score(rank: Rank) -> ScoreDetails {
-        ScoreDetails::Exactness(rank)
+        ScoreDetails::ExactWords(score_details::ExactWords::from_rank(rank))
     }
 }

--- a/milli/src/search/new/tests/snapshots/milli__search__new__tests__exactness__exactness_after_words.snap
+++ b/milli/src/search/new/tests/snapshots/milli__search__new__tests__exactness__exactness_after_words.snap
@@ -15,10 +15,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 ExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 10,
-                    max_rank: 10,
+            ExactWords(
+                ExactWords {
+                    matching_words: 9,
+                    max_matching_words: 9,
                 },
             ),
         ],
@@ -35,10 +35,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 7,
-                    max_rank: 10,
+            ExactWords(
+                ExactWords {
+                    matching_words: 6,
+                    max_matching_words: 9,
                 },
             ),
         ],
@@ -55,10 +55,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 ExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 9,
-                    max_rank: 9,
+            ExactWords(
+                ExactWords {
+                    matching_words: 8,
+                    max_matching_words: 8,
                 },
             ),
         ],
@@ -75,10 +75,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 6,
-                    max_rank: 9,
+            ExactWords(
+                ExactWords {
+                    matching_words: 5,
+                    max_matching_words: 8,
                 },
             ),
         ],
@@ -95,10 +95,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 ExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 8,
-                    max_rank: 8,
+            ExactWords(
+                ExactWords {
+                    matching_words: 7,
+                    max_matching_words: 7,
                 },
             ),
         ],
@@ -115,10 +115,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 8,
-                    max_rank: 8,
+            ExactWords(
+                ExactWords {
+                    matching_words: 7,
+                    max_matching_words: 7,
                 },
             ),
         ],
@@ -135,10 +135,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 5,
-                    max_rank: 8,
+            ExactWords(
+                ExactWords {
+                    matching_words: 4,
+                    max_matching_words: 7,
                 },
             ),
         ],
@@ -155,10 +155,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 5,
-                    max_rank: 8,
+            ExactWords(
+                ExactWords {
+                    matching_words: 4,
+                    max_matching_words: 7,
                 },
             ),
         ],
@@ -175,10 +175,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 ExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 6,
-                    max_rank: 6,
+            ExactWords(
+                ExactWords {
+                    matching_words: 5,
+                    max_matching_words: 5,
                 },
             ),
         ],
@@ -195,10 +195,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 3,
-                    max_rank: 6,
+            ExactWords(
+                ExactWords {
+                    matching_words: 2,
+                    max_matching_words: 5,
                 },
             ),
         ],
@@ -215,10 +215,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 ExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 5,
-                    max_rank: 5,
+            ExactWords(
+                ExactWords {
+                    matching_words: 4,
+                    max_matching_words: 4,
                 },
             ),
         ],
@@ -235,10 +235,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 3,
-                    max_rank: 5,
+            ExactWords(
+                ExactWords {
+                    matching_words: 2,
+                    max_matching_words: 4,
                 },
             ),
         ],
@@ -255,10 +255,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 ExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 4,
-                    max_rank: 4,
+            ExactWords(
+                ExactWords {
+                    matching_words: 3,
+                    max_matching_words: 3,
                 },
             ),
         ],
@@ -275,10 +275,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 2,
-                    max_rank: 4,
+            ExactWords(
+                ExactWords {
+                    matching_words: 1,
+                    max_matching_words: 3,
                 },
             ),
         ],
@@ -295,10 +295,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 ExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 3,
-                    max_rank: 3,
+            ExactWords(
+                ExactWords {
+                    matching_words: 2,
+                    max_matching_words: 2,
                 },
             ),
         ],
@@ -315,10 +315,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 2,
-                    max_rank: 3,
+            ExactWords(
+                ExactWords {
+                    matching_words: 1,
+                    max_matching_words: 2,
                 },
             ),
         ],
@@ -335,10 +335,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 ExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 2,
-                    max_rank: 2,
+            ExactWords(
+                ExactWords {
+                    matching_words: 1,
+                    max_matching_words: 1,
                 },
             ),
         ],
@@ -355,10 +355,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 ExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 2,
-                    max_rank: 2,
+            ExactWords(
+                ExactWords {
+                    matching_words: 1,
+                    max_matching_words: 1,
                 },
             ),
         ],

--- a/milli/src/search/new/tests/snapshots/milli__search__new__tests__exactness__exactness_all_candidates_with_typo.snap
+++ b/milli/src/search/new/tests/snapshots/milli__search__new__tests__exactness__exactness_all_candidates_with_typo.snap
@@ -15,10 +15,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 7,
-                    max_rank: 8,
+            ExactWords(
+                ExactWords {
+                    matching_words: 6,
+                    max_matching_words: 7,
                 },
             ),
         ],
@@ -35,10 +35,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 7,
-                    max_rank: 8,
+            ExactWords(
+                ExactWords {
+                    matching_words: 6,
+                    max_matching_words: 7,
                 },
             ),
         ],
@@ -55,10 +55,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 7,
-                    max_rank: 8,
+            ExactWords(
+                ExactWords {
+                    matching_words: 6,
+                    max_matching_words: 7,
                 },
             ),
         ],
@@ -75,10 +75,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 4,
-                    max_rank: 5,
+            ExactWords(
+                ExactWords {
+                    matching_words: 3,
+                    max_matching_words: 4,
                 },
             ),
         ],
@@ -95,10 +95,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 1,
-                    max_rank: 2,
+            ExactWords(
+                ExactWords {
+                    matching_words: 0,
+                    max_matching_words: 1,
                 },
             ),
         ],

--- a/milli/src/search/new/tests/snapshots/milli__search__new__tests__exactness__exactness_attribute_starts_with_phrase-3.snap
+++ b/milli/src/search/new/tests/snapshots/milli__search__new__tests__exactness__exactness_attribute_starts_with_phrase-3.snap
@@ -15,10 +15,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 ExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 8,
-                    max_rank: 8,
+            ExactWords(
+                ExactWords {
+                    matching_words: 7,
+                    max_matching_words: 7,
                 },
             ),
         ],
@@ -35,10 +35,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 MatchesStart,
             ),
-            Exactness(
-                Rank {
-                    rank: 8,
-                    max_rank: 8,
+            ExactWords(
+                ExactWords {
+                    matching_words: 7,
+                    max_matching_words: 7,
                 },
             ),
         ],
@@ -55,10 +55,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 8,
-                    max_rank: 8,
+            ExactWords(
+                ExactWords {
+                    matching_words: 7,
+                    max_matching_words: 7,
                 },
             ),
         ],
@@ -75,10 +75,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 7,
-                    max_rank: 8,
+            ExactWords(
+                ExactWords {
+                    matching_words: 6,
+                    max_matching_words: 7,
                 },
             ),
         ],
@@ -95,10 +95,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 5,
-                    max_rank: 5,
+            ExactWords(
+                ExactWords {
+                    matching_words: 4,
+                    max_matching_words: 4,
                 },
             ),
         ],
@@ -115,10 +115,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 ExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 2,
-                    max_rank: 2,
+            ExactWords(
+                ExactWords {
+                    matching_words: 1,
+                    max_matching_words: 1,
                 },
             ),
         ],

--- a/milli/src/search/new/tests/snapshots/milli__search__new__tests__exactness__exactness_attribute_starts_with_phrase.snap
+++ b/milli/src/search/new/tests/snapshots/milli__search__new__tests__exactness__exactness_attribute_starts_with_phrase.snap
@@ -15,10 +15,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 ExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 6,
-                    max_rank: 6,
+            ExactWords(
+                ExactWords {
+                    matching_words: 5,
+                    max_matching_words: 5,
                 },
             ),
         ],
@@ -35,10 +35,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 MatchesStart,
             ),
-            Exactness(
-                Rank {
-                    rank: 6,
-                    max_rank: 6,
+            ExactWords(
+                ExactWords {
+                    matching_words: 5,
+                    max_matching_words: 5,
                 },
             ),
         ],
@@ -55,10 +55,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 6,
-                    max_rank: 6,
+            ExactWords(
+                ExactWords {
+                    matching_words: 5,
+                    max_matching_words: 5,
                 },
             ),
         ],
@@ -75,10 +75,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 3,
-                    max_rank: 3,
+            ExactWords(
+                ExactWords {
+                    matching_words: 2,
+                    max_matching_words: 2,
                 },
             ),
         ],

--- a/milli/src/search/new/tests/snapshots/milli__search__new__tests__exactness__exactness_attribute_starts_with_simple.snap
+++ b/milli/src/search/new/tests/snapshots/milli__search__new__tests__exactness__exactness_attribute_starts_with_simple.snap
@@ -15,10 +15,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 ExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 3,
-                    max_rank: 3,
+            ExactWords(
+                ExactWords {
+                    matching_words: 2,
+                    max_matching_words: 2,
                 },
             ),
         ],
@@ -35,10 +35,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 MatchesStart,
             ),
-            Exactness(
-                Rank {
-                    rank: 3,
-                    max_rank: 3,
+            ExactWords(
+                ExactWords {
+                    matching_words: 2,
+                    max_matching_words: 2,
                 },
             ),
         ],
@@ -55,10 +55,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 3,
-                    max_rank: 3,
+            ExactWords(
+                ExactWords {
+                    matching_words: 2,
+                    max_matching_words: 2,
                 },
             ),
         ],

--- a/milli/src/search/new/tests/snapshots/milli__search__new__tests__exactness__exactness_followed_by_typo_prefer_no_typo_prefix.snap
+++ b/milli/src/search/new/tests/snapshots/milli__search__new__tests__exactness__exactness_followed_by_typo_prefer_no_typo_prefix.snap
@@ -15,10 +15,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 5,
-                    max_rank: 5,
+            ExactWords(
+                ExactWords {
+                    matching_words: 4,
+                    max_matching_words: 4,
                 },
             ),
             Typo(
@@ -41,10 +41,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 4,
-                    max_rank: 5,
+            ExactWords(
+                ExactWords {
+                    matching_words: 3,
+                    max_matching_words: 4,
                 },
             ),
             Typo(
@@ -67,10 +67,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 4,
-                    max_rank: 5,
+            ExactWords(
+                ExactWords {
+                    matching_words: 3,
+                    max_matching_words: 4,
                 },
             ),
             Typo(
@@ -93,10 +93,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 4,
-                    max_rank: 5,
+            ExactWords(
+                ExactWords {
+                    matching_words: 3,
+                    max_matching_words: 4,
                 },
             ),
             Typo(
@@ -119,10 +119,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 3,
-                    max_rank: 5,
+            ExactWords(
+                ExactWords {
+                    matching_words: 2,
+                    max_matching_words: 4,
                 },
             ),
             Typo(

--- a/milli/src/search/new/tests/snapshots/milli__search__new__tests__exactness__exactness_simple_ordered.snap
+++ b/milli/src/search/new/tests/snapshots/milli__search__new__tests__exactness__exactness_simple_ordered.snap
@@ -15,10 +15,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 ExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 10,
-                    max_rank: 10,
+            ExactWords(
+                ExactWords {
+                    matching_words: 9,
+                    max_matching_words: 9,
                 },
             ),
         ],
@@ -35,10 +35,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 ExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 9,
-                    max_rank: 9,
+            ExactWords(
+                ExactWords {
+                    matching_words: 8,
+                    max_matching_words: 8,
                 },
             ),
         ],
@@ -55,10 +55,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 ExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 8,
-                    max_rank: 8,
+            ExactWords(
+                ExactWords {
+                    matching_words: 7,
+                    max_matching_words: 7,
                 },
             ),
         ],
@@ -75,10 +75,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 8,
-                    max_rank: 8,
+            ExactWords(
+                ExactWords {
+                    matching_words: 7,
+                    max_matching_words: 7,
                 },
             ),
         ],
@@ -95,10 +95,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 ExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 6,
-                    max_rank: 6,
+            ExactWords(
+                ExactWords {
+                    matching_words: 5,
+                    max_matching_words: 5,
                 },
             ),
         ],
@@ -115,10 +115,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 ExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 5,
-                    max_rank: 5,
+            ExactWords(
+                ExactWords {
+                    matching_words: 4,
+                    max_matching_words: 4,
                 },
             ),
         ],
@@ -135,10 +135,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 ExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 4,
-                    max_rank: 4,
+            ExactWords(
+                ExactWords {
+                    matching_words: 3,
+                    max_matching_words: 3,
                 },
             ),
         ],
@@ -155,10 +155,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 ExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 3,
-                    max_rank: 3,
+            ExactWords(
+                ExactWords {
+                    matching_words: 2,
+                    max_matching_words: 2,
                 },
             ),
         ],
@@ -175,10 +175,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 ExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 2,
-                    max_rank: 2,
+            ExactWords(
+                ExactWords {
+                    matching_words: 1,
+                    max_matching_words: 1,
                 },
             ),
         ],

--- a/milli/src/search/new/tests/snapshots/milli__search__new__tests__exactness__exactness_simple_random.snap
+++ b/milli/src/search/new/tests/snapshots/milli__search__new__tests__exactness__exactness_simple_random.snap
@@ -15,10 +15,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 10,
-                    max_rank: 10,
+            ExactWords(
+                ExactWords {
+                    matching_words: 9,
+                    max_matching_words: 9,
                 },
             ),
         ],
@@ -35,10 +35,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 4,
-                    max_rank: 4,
+            ExactWords(
+                ExactWords {
+                    matching_words: 3,
+                    max_matching_words: 3,
                 },
             ),
         ],
@@ -55,10 +55,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 3,
-                    max_rank: 3,
+            ExactWords(
+                ExactWords {
+                    matching_words: 2,
+                    max_matching_words: 2,
                 },
             ),
         ],
@@ -75,10 +75,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 3,
-                    max_rank: 3,
+            ExactWords(
+                ExactWords {
+                    matching_words: 2,
+                    max_matching_words: 2,
                 },
             ),
         ],
@@ -95,10 +95,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 2,
-                    max_rank: 2,
+            ExactWords(
+                ExactWords {
+                    matching_words: 1,
+                    max_matching_words: 1,
                 },
             ),
         ],
@@ -115,10 +115,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 2,
-                    max_rank: 2,
+            ExactWords(
+                ExactWords {
+                    matching_words: 1,
+                    max_matching_words: 1,
                 },
             ),
         ],

--- a/milli/src/search/new/tests/snapshots/milli__search__new__tests__exactness__exactness_simple_reversed-3.snap
+++ b/milli/src/search/new/tests/snapshots/milli__search__new__tests__exactness__exactness_simple_reversed-3.snap
@@ -15,10 +15,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 ExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 10,
-                    max_rank: 10,
+            ExactWords(
+                ExactWords {
+                    matching_words: 9,
+                    max_matching_words: 9,
                 },
             ),
         ],
@@ -35,10 +35,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 10,
-                    max_rank: 10,
+            ExactWords(
+                ExactWords {
+                    matching_words: 9,
+                    max_matching_words: 9,
                 },
             ),
         ],
@@ -55,10 +55,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 MatchesStart,
             ),
-            Exactness(
-                Rank {
-                    rank: 2,
-                    max_rank: 2,
+            ExactWords(
+                ExactWords {
+                    matching_words: 1,
+                    max_matching_words: 1,
                 },
             ),
         ],
@@ -75,10 +75,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 2,
-                    max_rank: 2,
+            ExactWords(
+                ExactWords {
+                    matching_words: 1,
+                    max_matching_words: 1,
                 },
             ),
         ],
@@ -95,10 +95,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 2,
-                    max_rank: 2,
+            ExactWords(
+                ExactWords {
+                    matching_words: 1,
+                    max_matching_words: 1,
                 },
             ),
         ],
@@ -115,10 +115,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 2,
-                    max_rank: 2,
+            ExactWords(
+                ExactWords {
+                    matching_words: 1,
+                    max_matching_words: 1,
                 },
             ),
         ],
@@ -135,10 +135,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 2,
-                    max_rank: 2,
+            ExactWords(
+                ExactWords {
+                    matching_words: 1,
+                    max_matching_words: 1,
                 },
             ),
         ],

--- a/milli/src/search/new/tests/snapshots/milli__search__new__tests__exactness__exactness_simple_reversed.snap
+++ b/milli/src/search/new/tests/snapshots/milli__search__new__tests__exactness__exactness_simple_reversed.snap
@@ -15,10 +15,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 ExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 10,
-                    max_rank: 10,
+            ExactWords(
+                ExactWords {
+                    matching_words: 9,
+                    max_matching_words: 9,
                 },
             ),
         ],
@@ -35,10 +35,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 10,
-                    max_rank: 10,
+            ExactWords(
+                ExactWords {
+                    matching_words: 9,
+                    max_matching_words: 9,
                 },
             ),
         ],
@@ -55,10 +55,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 MatchesStart,
             ),
-            Exactness(
-                Rank {
-                    rank: 2,
-                    max_rank: 2,
+            ExactWords(
+                ExactWords {
+                    matching_words: 1,
+                    max_matching_words: 1,
                 },
             ),
         ],
@@ -75,10 +75,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 2,
-                    max_rank: 2,
+            ExactWords(
+                ExactWords {
+                    matching_words: 1,
+                    max_matching_words: 1,
                 },
             ),
         ],
@@ -95,10 +95,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 2,
-                    max_rank: 2,
+            ExactWords(
+                ExactWords {
+                    matching_words: 1,
+                    max_matching_words: 1,
                 },
             ),
         ],
@@ -115,10 +115,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 2,
-                    max_rank: 2,
+            ExactWords(
+                ExactWords {
+                    matching_words: 1,
+                    max_matching_words: 1,
                 },
             ),
         ],
@@ -135,10 +135,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 2,
-                    max_rank: 2,
+            ExactWords(
+                ExactWords {
+                    matching_words: 1,
+                    max_matching_words: 1,
                 },
             ),
         ],

--- a/milli/src/search/new/tests/snapshots/milli__search__new__tests__exactness__proximity_after_exactness-4.snap
+++ b/milli/src/search/new/tests/snapshots/milli__search__new__tests__exactness__proximity_after_exactness-4.snap
@@ -15,10 +15,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 10,
-                    max_rank: 10,
+            ExactWords(
+                ExactWords {
+                    matching_words: 9,
+                    max_matching_words: 9,
                 },
             ),
             Proximity(
@@ -41,10 +41,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 10,
-                    max_rank: 10,
+            ExactWords(
+                ExactWords {
+                    matching_words: 9,
+                    max_matching_words: 9,
                 },
             ),
             Proximity(
@@ -67,10 +67,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 10,
-                    max_rank: 10,
+            ExactWords(
+                ExactWords {
+                    matching_words: 9,
+                    max_matching_words: 9,
                 },
             ),
             Proximity(

--- a/milli/src/search/new/tests/snapshots/milli__search__new__tests__exactness__proximity_after_exactness.snap
+++ b/milli/src/search/new/tests/snapshots/milli__search__new__tests__exactness__proximity_after_exactness.snap
@@ -15,10 +15,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 ExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 10,
-                    max_rank: 10,
+            ExactWords(
+                ExactWords {
+                    matching_words: 9,
+                    max_matching_words: 9,
                 },
             ),
             Proximity(
@@ -41,10 +41,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 10,
-                    max_rank: 10,
+            ExactWords(
+                ExactWords {
+                    matching_words: 9,
+                    max_matching_words: 9,
                 },
             ),
             Proximity(
@@ -67,10 +67,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 10,
-                    max_rank: 10,
+            ExactWords(
+                ExactWords {
+                    matching_words: 9,
+                    max_matching_words: 9,
                 },
             ),
             Proximity(
@@ -93,10 +93,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 MatchesStart,
             ),
-            Exactness(
-                Rank {
-                    rank: 5,
-                    max_rank: 5,
+            ExactWords(
+                ExactWords {
+                    matching_words: 4,
+                    max_matching_words: 4,
                 },
             ),
             Proximity(
@@ -119,10 +119,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 MatchesStart,
             ),
-            Exactness(
-                Rank {
-                    rank: 5,
-                    max_rank: 5,
+            ExactWords(
+                ExactWords {
+                    matching_words: 4,
+                    max_matching_words: 4,
                 },
             ),
             Proximity(
@@ -145,10 +145,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 MatchesStart,
             ),
-            Exactness(
-                Rank {
-                    rank: 5,
-                    max_rank: 5,
+            ExactWords(
+                ExactWords {
+                    matching_words: 4,
+                    max_matching_words: 4,
                 },
             ),
             Proximity(
@@ -171,10 +171,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 5,
-                    max_rank: 5,
+            ExactWords(
+                ExactWords {
+                    matching_words: 4,
+                    max_matching_words: 4,
                 },
             ),
             Proximity(
@@ -197,10 +197,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 5,
-                    max_rank: 5,
+            ExactWords(
+                ExactWords {
+                    matching_words: 4,
+                    max_matching_words: 4,
                 },
             ),
             Proximity(
@@ -223,10 +223,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 5,
-                    max_rank: 5,
+            ExactWords(
+                ExactWords {
+                    matching_words: 4,
+                    max_matching_words: 4,
                 },
             ),
             Proximity(

--- a/milli/src/search/new/tests/snapshots/milli__search__new__tests__exactness__typo_followed_by_exactness.snap
+++ b/milli/src/search/new/tests/snapshots/milli__search__new__tests__exactness__typo_followed_by_exactness.snap
@@ -21,10 +21,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 ExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 5,
-                    max_rank: 5,
+            ExactWords(
+                ExactWords {
+                    matching_words: 4,
+                    max_matching_words: 4,
                 },
             ),
         ],
@@ -47,10 +47,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 4,
-                    max_rank: 5,
+            ExactWords(
+                ExactWords {
+                    matching_words: 3,
+                    max_matching_words: 4,
                 },
             ),
         ],
@@ -73,10 +73,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 4,
-                    max_rank: 5,
+            ExactWords(
+                ExactWords {
+                    matching_words: 3,
+                    max_matching_words: 4,
                 },
             ),
         ],
@@ -99,10 +99,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 3,
-                    max_rank: 5,
+            ExactWords(
+                ExactWords {
+                    matching_words: 2,
+                    max_matching_words: 4,
                 },
             ),
         ],

--- a/milli/src/search/new/tests/snapshots/milli__search__new__tests__exactness__words_after_exactness.snap
+++ b/milli/src/search/new/tests/snapshots/milli__search__new__tests__exactness__words_after_exactness.snap
@@ -15,10 +15,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 ExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 10,
-                    max_rank: 10,
+            ExactWords(
+                ExactWords {
+                    matching_words: 9,
+                    max_matching_words: 9,
                 },
             ),
         ],
@@ -35,10 +35,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 7,
-                    max_rank: 10,
+            ExactWords(
+                ExactWords {
+                    matching_words: 6,
+                    max_matching_words: 9,
                 },
             ),
         ],
@@ -55,10 +55,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 ExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 9,
-                    max_rank: 9,
+            ExactWords(
+                ExactWords {
+                    matching_words: 8,
+                    max_matching_words: 8,
                 },
             ),
         ],
@@ -75,10 +75,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 6,
-                    max_rank: 9,
+            ExactWords(
+                ExactWords {
+                    matching_words: 5,
+                    max_matching_words: 8,
                 },
             ),
         ],
@@ -95,10 +95,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 ExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 8,
-                    max_rank: 8,
+            ExactWords(
+                ExactWords {
+                    matching_words: 7,
+                    max_matching_words: 7,
                 },
             ),
         ],
@@ -115,10 +115,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 8,
-                    max_rank: 8,
+            ExactWords(
+                ExactWords {
+                    matching_words: 7,
+                    max_matching_words: 7,
                 },
             ),
         ],
@@ -135,10 +135,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 5,
-                    max_rank: 8,
+            ExactWords(
+                ExactWords {
+                    matching_words: 4,
+                    max_matching_words: 7,
                 },
             ),
         ],
@@ -155,10 +155,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 5,
-                    max_rank: 8,
+            ExactWords(
+                ExactWords {
+                    matching_words: 4,
+                    max_matching_words: 7,
                 },
             ),
         ],
@@ -175,10 +175,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 ExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 6,
-                    max_rank: 6,
+            ExactWords(
+                ExactWords {
+                    matching_words: 5,
+                    max_matching_words: 5,
                 },
             ),
         ],
@@ -195,10 +195,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 3,
-                    max_rank: 6,
+            ExactWords(
+                ExactWords {
+                    matching_words: 2,
+                    max_matching_words: 5,
                 },
             ),
         ],
@@ -215,10 +215,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 ExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 5,
-                    max_rank: 5,
+            ExactWords(
+                ExactWords {
+                    matching_words: 4,
+                    max_matching_words: 4,
                 },
             ),
         ],
@@ -235,10 +235,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 3,
-                    max_rank: 5,
+            ExactWords(
+                ExactWords {
+                    matching_words: 2,
+                    max_matching_words: 4,
                 },
             ),
         ],
@@ -255,10 +255,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 ExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 4,
-                    max_rank: 4,
+            ExactWords(
+                ExactWords {
+                    matching_words: 3,
+                    max_matching_words: 3,
                 },
             ),
         ],
@@ -275,10 +275,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 2,
-                    max_rank: 4,
+            ExactWords(
+                ExactWords {
+                    matching_words: 1,
+                    max_matching_words: 3,
                 },
             ),
         ],
@@ -295,10 +295,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 ExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 3,
-                    max_rank: 3,
+            ExactWords(
+                ExactWords {
+                    matching_words: 2,
+                    max_matching_words: 2,
                 },
             ),
         ],
@@ -315,10 +315,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 2,
-                    max_rank: 3,
+            ExactWords(
+                ExactWords {
+                    matching_words: 1,
+                    max_matching_words: 2,
                 },
             ),
         ],
@@ -335,10 +335,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 ExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 2,
-                    max_rank: 2,
+            ExactWords(
+                ExactWords {
+                    matching_words: 1,
+                    max_matching_words: 1,
                 },
             ),
         ],
@@ -355,10 +355,10 @@ expression: "format!(\"{document_ids_scores:#?}\")"
             ExactAttribute(
                 ExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 2,
-                    max_rank: 2,
+            ExactWords(
+                ExactWords {
+                    matching_words: 1,
+                    max_matching_words: 1,
                 },
             ),
         ],

--- a/milli/src/search/new/tests/snapshots/milli__search__new__tests__stop_words__stop_words_in_phrase-6.snap
+++ b/milli/src/search/new/tests/snapshots/milli__search__new__tests__stop_words__stop_words_in_phrase-6.snap
@@ -37,10 +37,10 @@ expression: "format!(\"{document_scores:#?}\")"
         ExactAttribute(
             NoExactMatch,
         ),
-        Exactness(
-            Rank {
-                rank: 4,
-                max_rank: 4,
+        ExactWords(
+            ExactWords {
+                matching_words: 3,
+                max_matching_words: 3,
             },
         ),
     ],
@@ -78,10 +78,10 @@ expression: "format!(\"{document_scores:#?}\")"
         ExactAttribute(
             NoExactMatch,
         ),
-        Exactness(
-            Rank {
-                rank: 4,
-                max_rank: 4,
+        ExactWords(
+            ExactWords {
+                matching_words: 3,
+                max_matching_words: 3,
             },
         ),
     ],
@@ -119,10 +119,10 @@ expression: "format!(\"{document_scores:#?}\")"
         ExactAttribute(
             NoExactMatch,
         ),
-        Exactness(
-            Rank {
-                rank: 4,
-                max_rank: 4,
+        ExactWords(
+            ExactWords {
+                matching_words: 3,
+                max_matching_words: 3,
             },
         ),
     ],

--- a/milli/src/search/new/tests/stop_words.rs
+++ b/milli/src/search/new/tests/stop_words.rs
@@ -120,10 +120,10 @@ fn test_ignore_stop_words() {
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 2,
-                    max_rank: 2,
+            ExactWords(
+                ExactWords {
+                    matching_words: 1,
+                    max_matching_words: 1,
                 },
             ),
         ],
@@ -173,10 +173,10 @@ fn test_ignore_stop_words() {
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 2,
-                    max_rank: 2,
+            ExactWords(
+                ExactWords {
+                    matching_words: 1,
+                    max_matching_words: 1,
                 },
             ),
         ],
@@ -226,10 +226,10 @@ fn test_ignore_stop_words() {
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 2,
-                    max_rank: 2,
+            ExactWords(
+                ExactWords {
+                    matching_words: 1,
+                    max_matching_words: 1,
                 },
             ),
         ],
@@ -278,10 +278,10 @@ fn test_ignore_stop_words() {
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 3,
-                    max_rank: 3,
+            ExactWords(
+                ExactWords {
+                    matching_words: 2,
+                    max_matching_words: 2,
                 },
             ),
         ],
@@ -337,10 +337,10 @@ fn test_stop_words_in_phrase() {
             ExactAttribute(
                 MatchesStart,
             ),
-            Exactness(
-                Rank {
-                    rank: 2,
-                    max_rank: 2,
+            ExactWords(
+                ExactWords {
+                    matching_words: 1,
+                    max_matching_words: 1,
                 },
             ),
         ],
@@ -378,10 +378,10 @@ fn test_stop_words_in_phrase() {
             ExactAttribute(
                 MatchesStart,
             ),
-            Exactness(
-                Rank {
-                    rank: 2,
-                    max_rank: 2,
+            ExactWords(
+                ExactWords {
+                    matching_words: 1,
+                    max_matching_words: 1,
                 },
             ),
         ],
@@ -430,10 +430,10 @@ fn test_stop_words_in_phrase() {
             ExactAttribute(
                 NoExactMatch,
             ),
-            Exactness(
-                Rank {
-                    rank: 4,
-                    max_rank: 4,
+            ExactWords(
+                ExactWords {
+                    matching_words: 3,
+                    max_matching_words: 3,
                 },
             ),
         ],


### PR DESCRIPTION
# Pull Request

Adds fields to score details that were [specified](https://github.com/meilisearch/specifications/blob/c25d7582643b520e1bf6d1166d007a4c778422de/text/0195-ranking-score.md#322-ranking-rule-specific-fields), but missing in the implementation:

- `exactness.matchingWords`
- `exactness.maxMatchingWords` 
