### PR TITLE
Display the total number of tasks matching a filter/query

### DIFF
--- a/index-scheduler/src/lib.rs
+++ b/index-scheduler/src/lib.rs
@@ -2797,43 +2797,43 @@ mod tests {
 
         let rtxn = index_scheduler.env.read_txn().unwrap();
         let query = Query { limit: Some(0), ..Default::default() };
-        let tasks = index_scheduler
+        let (tasks, _) = index_scheduler
             .get_task_ids_from_authorized_indexes(&rtxn, &query, &AuthFilter::default())
             .unwrap();
         snapshot!(snapshot_bitmap(&tasks), @"[]");
 
         let query = Query { limit: Some(1), ..Default::default() };
-        let tasks = index_scheduler
+        let (tasks, _) = index_scheduler
             .get_task_ids_from_authorized_indexes(&rtxn, &query, &AuthFilter::default())
             .unwrap();
         snapshot!(snapshot_bitmap(&tasks), @"[2,]");
 
         let query = Query { limit: Some(2), ..Default::default() };
-        let tasks = index_scheduler
+        let (tasks, _) = index_scheduler
             .get_task_ids_from_authorized_indexes(&rtxn, &query, &AuthFilter::default())
             .unwrap();
         snapshot!(snapshot_bitmap(&tasks), @"[1,2,]");
 
         let query = Query { from: Some(1), ..Default::default() };
-        let tasks = index_scheduler
+        let (tasks, _) = index_scheduler
             .get_task_ids_from_authorized_indexes(&rtxn, &query, &AuthFilter::default())
             .unwrap();
         snapshot!(snapshot_bitmap(&tasks), @"[0,1,]");
 
         let query = Query { from: Some(2), ..Default::default() };
-        let tasks = index_scheduler
+        let (tasks, _) = index_scheduler
             .get_task_ids_from_authorized_indexes(&rtxn, &query, &AuthFilter::default())
             .unwrap();
         snapshot!(snapshot_bitmap(&tasks), @"[0,1,2,]");
 
         let query = Query { from: Some(1), limit: Some(1), ..Default::default() };
-        let tasks = index_scheduler
+        let (tasks, _) = index_scheduler
             .get_task_ids_from_authorized_indexes(&rtxn, &query, &AuthFilter::default())
             .unwrap();
         snapshot!(snapshot_bitmap(&tasks), @"[1,]");
 
         let query = Query { from: Some(1), limit: Some(2), ..Default::default() };
-        let tasks = index_scheduler
+        let (tasks, _) = index_scheduler
             .get_task_ids_from_authorized_indexes(&rtxn, &query, &AuthFilter::default())
             .unwrap();
         snapshot!(snapshot_bitmap(&tasks), @"[0,1,]");
@@ -2860,13 +2860,13 @@ mod tests {
         let rtxn = index_scheduler.env.read_txn().unwrap();
 
         let query = Query { statuses: Some(vec![Status::Processing]), ..Default::default() };
-        let tasks = index_scheduler
+        let (tasks, _) = index_scheduler
             .get_task_ids_from_authorized_indexes(&rtxn, &query, &AuthFilter::default())
             .unwrap();
         snapshot!(snapshot_bitmap(&tasks), @"[0,]"); // only the processing tasks in the first tick
 
         let query = Query { statuses: Some(vec![Status::Enqueued]), ..Default::default() };
-        let tasks = index_scheduler
+        let (tasks, _) = index_scheduler
             .get_task_ids_from_authorized_indexes(&rtxn, &query, &AuthFilter::default())
             .unwrap();
         snapshot!(snapshot_bitmap(&tasks), @"[1,2,]"); // only the enqueued tasks in the first tick
@@ -2875,7 +2875,7 @@ mod tests {
             statuses: Some(vec![Status::Enqueued, Status::Processing]),
             ..Default::default()
         };
-        let tasks = index_scheduler
+        let (tasks, _) = index_scheduler
             .get_task_ids_from_authorized_indexes(&rtxn, &query, &AuthFilter::default())
             .unwrap();
         snapshot!(snapshot_bitmap(&tasks), @"[0,1,2,]"); // both enqueued and processing tasks in the first tick
@@ -2885,7 +2885,7 @@ mod tests {
             after_started_at: Some(start_time),
             ..Default::default()
         };
-        let tasks = index_scheduler
+        let (tasks, _) = index_scheduler
             .get_task_ids_from_authorized_indexes(&rtxn, &query, &AuthFilter::default())
             .unwrap();
         // both enqueued and processing tasks in the first tick, but limited to those with a started_at
@@ -2897,7 +2897,7 @@ mod tests {
             before_started_at: Some(start_time),
             ..Default::default()
         };
-        let tasks = index_scheduler
+        let (tasks, _) = index_scheduler
             .get_task_ids_from_authorized_indexes(&rtxn, &query, &AuthFilter::default())
             .unwrap();
         // both enqueued and processing tasks in the first tick, but limited to those with a started_at
@@ -2910,7 +2910,7 @@ mod tests {
             before_started_at: Some(start_time + Duration::minutes(1)),
             ..Default::default()
         };
-        let tasks = index_scheduler
+        let (tasks, _) = index_scheduler
             .get_task_ids_from_authorized_indexes(&rtxn, &query, &AuthFilter::default())
             .unwrap();
         // both enqueued and processing tasks in the first tick, but limited to those with a started_at
@@ -2937,7 +2937,7 @@ mod tests {
             before_started_at: Some(start_time + Duration::minutes(1)),
             ..Default::default()
         };
-        let tasks = index_scheduler
+        let (tasks, _) = index_scheduler
             .get_task_ids_from_authorized_indexes(&rtxn, &query, &AuthFilter::default())
             .unwrap();
         // both succeeded and processing tasks in the first tick, but limited to those with a started_at
@@ -2950,7 +2950,7 @@ mod tests {
             before_started_at: Some(start_time),
             ..Default::default()
         };
-        let tasks = index_scheduler
+        let (tasks, _) = index_scheduler
             .get_task_ids_from_authorized_indexes(&rtxn, &query, &AuthFilter::default())
             .unwrap();
         // both succeeded and processing tasks in the first tick, but limited to those with a started_at
@@ -2963,7 +2963,7 @@ mod tests {
             before_started_at: Some(second_start_time + Duration::minutes(1)),
             ..Default::default()
         };
-        let tasks = index_scheduler
+        let (tasks, _) = index_scheduler
             .get_task_ids_from_authorized_indexes(&rtxn, &query, &AuthFilter::default())
             .unwrap();
         // both succeeded and processing tasks in the first tick, but limited to those with a started_at
@@ -2983,7 +2983,7 @@ mod tests {
 
         let rtxn = index_scheduler.env.read_txn().unwrap();
 
-        let tasks = index_scheduler
+        let (tasks, _) = index_scheduler
             .get_task_ids_from_authorized_indexes(&rtxn, &query, &AuthFilter::default())
             .unwrap();
         // we run the same query to verify that, and indeed find that the last task is matched
@@ -2995,7 +2995,7 @@ mod tests {
             before_started_at: Some(second_start_time + Duration::minutes(1)),
             ..Default::default()
         };
-        let tasks = index_scheduler
+        let (tasks, _) = index_scheduler
             .get_task_ids_from_authorized_indexes(&rtxn, &query, &AuthFilter::default())
             .unwrap();
         // enqueued, succeeded, or processing tasks started after the second part of the test, should
@@ -3007,7 +3007,7 @@ mod tests {
 
         // now the last task should have failed
         snapshot!(snapshot_index_scheduler(&index_scheduler), name: "end");
-        let tasks = index_scheduler
+        let (tasks, _) = index_scheduler
             .get_task_ids_from_authorized_indexes(&rtxn, &query, &AuthFilter::default())
             .unwrap();
         // so running the last query should return nothing
@@ -3019,7 +3019,7 @@ mod tests {
             before_started_at: Some(second_start_time + Duration::minutes(1)),
             ..Default::default()
         };
-        let tasks = index_scheduler
+        let (tasks, _) = index_scheduler
             .get_task_ids_from_authorized_indexes(&rtxn, &query, &AuthFilter::default())
             .unwrap();
         // but the same query on failed tasks should return the last task
@@ -3031,7 +3031,7 @@ mod tests {
             before_started_at: Some(second_start_time + Duration::minutes(1)),
             ..Default::default()
         };
-        let tasks = index_scheduler
+        let (tasks, _) = index_scheduler
             .get_task_ids_from_authorized_indexes(&rtxn, &query, &AuthFilter::default())
             .unwrap();
         // but the same query on failed tasks should return the last task
@@ -3044,7 +3044,7 @@ mod tests {
             before_started_at: Some(second_start_time + Duration::minutes(1)),
             ..Default::default()
         };
-        let tasks = index_scheduler
+        let (tasks, _) = index_scheduler
             .get_task_ids_from_authorized_indexes(&rtxn, &query, &AuthFilter::default())
             .unwrap();
         // same query but with an invalid uid
@@ -3057,7 +3057,7 @@ mod tests {
             before_started_at: Some(second_start_time + Duration::minutes(1)),
             ..Default::default()
         };
-        let tasks = index_scheduler
+        let (tasks, _) = index_scheduler
             .get_task_ids_from_authorized_indexes(&rtxn, &query, &AuthFilter::default())
             .unwrap();
         // same query but with a valid uid
@@ -3089,14 +3089,14 @@ mod tests {
         let rtxn = index_scheduler.env.read_txn().unwrap();
 
         let query = Query { index_uids: Some(vec!["catto".to_owned()]), ..Default::default() };
-        let tasks = index_scheduler
+        let (tasks, _) = index_scheduler
             .get_task_ids_from_authorized_indexes(&rtxn, &query, &AuthFilter::default())
             .unwrap();
         // only the first task associated with catto is returned, the indexSwap tasks are excluded!
         snapshot!(snapshot_bitmap(&tasks), @"[0,]");
 
         let query = Query { index_uids: Some(vec!["catto".to_owned()]), ..Default::default() };
-        let tasks = index_scheduler
+        let (tasks, _) = index_scheduler
             .get_task_ids_from_authorized_indexes(
                 &rtxn,
                 &query,
@@ -3110,7 +3110,7 @@ mod tests {
         snapshot!(snapshot_bitmap(&tasks), @"[]");
 
         let query = Query::default();
-        let tasks = index_scheduler
+        let (tasks, _) = index_scheduler
             .get_task_ids_from_authorized_indexes(
                 &rtxn,
                 &query,
@@ -3124,7 +3124,7 @@ mod tests {
         snapshot!(snapshot_bitmap(&tasks), @"[1,]");
 
         let query = Query::default();
-        let tasks = index_scheduler
+        let (tasks, _) = index_scheduler
             .get_task_ids_from_authorized_indexes(
                 &rtxn,
                 &query,
@@ -3143,7 +3143,7 @@ mod tests {
         snapshot!(snapshot_bitmap(&tasks), @"[0,1,]");
 
         let query = Query::default();
-        let tasks = index_scheduler
+        let (tasks, _) = index_scheduler
             .get_task_ids_from_authorized_indexes(&rtxn, &query, &AuthFilter::default())
             .unwrap();
         // we asked for all the tasks with all index authorized -> all tasks returned
@@ -3176,7 +3176,7 @@ mod tests {
 
         let rtxn = index_scheduler.read_txn().unwrap();
         let query = Query { canceled_by: Some(vec![task_cancelation.uid]), ..Query::default() };
-        let tasks = index_scheduler
+        let (tasks, _) = index_scheduler
             .get_task_ids_from_authorized_indexes(&rtxn, &query, &AuthFilter::default())
             .unwrap();
         // 0 is not returned because it was not canceled, 3 is not returned because it is the uid of the
@@ -3184,7 +3184,7 @@ mod tests {
         snapshot!(snapshot_bitmap(&tasks), @"[1,2,]");
 
         let query = Query { canceled_by: Some(vec![task_cancelation.uid]), ..Query::default() };
-        let tasks = index_scheduler
+        let (tasks, _) = index_scheduler
             .get_task_ids_from_authorized_indexes(
                 &rtxn,
                 &query,

--- a/meilisearch/tests/dumps/mod.rs
+++ b/meilisearch/tests/dumps/mod.rs
@@ -43,7 +43,7 @@ async fn import_dump_v1_movie_raw() {
     assert_eq!(code, 200);
     assert_eq!(
         tasks,
-        json!({ "results": [{"uid": 0, "indexUid": "indexUID", "status": "succeeded", "type": "documentAdditionOrUpdate", "canceledBy": null, "details": { "receivedDocuments": 0, "indexedDocuments": 31968 }, "error": null, "duration": "PT9.317060500S", "enqueuedAt": "2021-09-08T09:08:45.153219Z", "startedAt": "2021-09-08T09:08:45.3961665Z", "finishedAt": "2021-09-08T09:08:54.713227Z" }], "limit": 20, "from": 0, "next": null })
+        json!({ "results": [{"uid": 0, "indexUid": "indexUID", "status": "succeeded", "type": "documentAdditionOrUpdate", "canceledBy": null, "details": { "receivedDocuments": 0, "indexedDocuments": 31968 }, "error": null, "duration": "PT9.317060500S", "enqueuedAt": "2021-09-08T09:08:45.153219Z", "startedAt": "2021-09-08T09:08:45.3961665Z", "finishedAt": "2021-09-08T09:08:54.713227Z" }], "total": 1,  "limit": 20, "from": 0, "next": null })
     );
 
     // finally we're just going to check that we can still get a few documents by id
@@ -135,7 +135,7 @@ async fn import_dump_v1_movie_with_settings() {
     assert_eq!(code, 200);
     assert_eq!(
         tasks,
-        json!({ "results": [{ "uid": 1, "indexUid": "indexUID", "status": "succeeded", "type": "settingsUpdate", "canceledBy": null, "details": { "displayedAttributes": ["genres", "id", "overview", "poster", "release_date", "title"], "searchableAttributes": ["title", "overview"], "filterableAttributes": ["genres"], "sortableAttributes": ["genres"], "stopWords": ["of", "the"] }, "error": null, "duration": "PT7.288826907S", "enqueuedAt": "2021-09-08T09:34:40.882977Z", "startedAt": "2021-09-08T09:34:40.883073093Z", "finishedAt": "2021-09-08T09:34:48.1719Z"}, { "uid": 0, "indexUid": "indexUID", "status": "succeeded", "type": "documentAdditionOrUpdate", "canceledBy": null, "details": { "receivedDocuments": 0, "indexedDocuments": 31968 }, "error": null, "duration": "PT9.090735774S", "enqueuedAt": "2021-09-08T09:34:16.036101Z", "startedAt": "2021-09-08T09:34:16.261191226Z", "finishedAt": "2021-09-08T09:34:25.351927Z" }], "limit": 20, "from": 1, "next": null })
+        json!({ "results": [{ "uid": 1, "indexUid": "indexUID", "status": "succeeded", "type": "settingsUpdate", "canceledBy": null, "details": { "displayedAttributes": ["genres", "id", "overview", "poster", "release_date", "title"], "searchableAttributes": ["title", "overview"], "filterableAttributes": ["genres"], "sortableAttributes": ["genres"], "stopWords": ["of", "the"] }, "error": null, "duration": "PT7.288826907S", "enqueuedAt": "2021-09-08T09:34:40.882977Z", "startedAt": "2021-09-08T09:34:40.883073093Z", "finishedAt": "2021-09-08T09:34:48.1719Z"}, { "uid": 0, "indexUid": "indexUID", "status": "succeeded", "type": "documentAdditionOrUpdate", "canceledBy": null, "details": { "receivedDocuments": 0, "indexedDocuments": 31968 }, "error": null, "duration": "PT9.090735774S", "enqueuedAt": "2021-09-08T09:34:16.036101Z", "startedAt": "2021-09-08T09:34:16.261191226Z", "finishedAt": "2021-09-08T09:34:25.351927Z" }], "total": 2, "limit": 20, "from": 1, "next": null })
     );
 
     // finally we're just going to check that we can still get a few documents by id
@@ -317,7 +317,7 @@ async fn import_dump_v2_movie_raw() {
     assert_eq!(code, 200);
     assert_eq!(
         tasks,
-        json!({ "results": [{"uid": 0, "indexUid": "indexUID", "status": "succeeded", "type": "documentAdditionOrUpdate", "canceledBy": null, "details": { "receivedDocuments": 0, "indexedDocuments": 31944 }, "error": null, "duration": "PT41.751156S", "enqueuedAt": "2021-09-08T08:30:30.550282Z", "startedAt": "2021-09-08T08:30:30.553012Z", "finishedAt": "2021-09-08T08:31:12.304168Z" }], "limit": 20, "from": 0, "next": null })
+        json!({ "results": [{"uid": 0, "indexUid": "indexUID", "status": "succeeded", "type": "documentAdditionOrUpdate", "canceledBy": null, "details": { "receivedDocuments": 0, "indexedDocuments": 31944 }, "error": null, "duration": "PT41.751156S", "enqueuedAt": "2021-09-08T08:30:30.550282Z", "startedAt": "2021-09-08T08:30:30.553012Z", "finishedAt": "2021-09-08T08:31:12.304168Z" }], "total": 1, "limit": 20, "from": 0, "next": null })
     );
 
     // finally we're just going to check that we can still get a few documents by id
@@ -409,7 +409,7 @@ async fn import_dump_v2_movie_with_settings() {
     assert_eq!(code, 200);
     assert_eq!(
         tasks,
-        json!({ "results": [{ "uid": 1, "indexUid": "indexUID", "status": "succeeded", "type": "settingsUpdate", "canceledBy": null, "details": { "displayedAttributes": ["title", "genres", "overview", "poster", "release_date"], "searchableAttributes": ["title", "overview"], "filterableAttributes": ["genres"], "stopWords": ["of", "the"] }, "error": null, "duration": "PT37.488777S", "enqueuedAt": "2021-09-08T08:24:02.323444Z", "startedAt": "2021-09-08T08:24:02.324145Z", "finishedAt": "2021-09-08T08:24:39.812922Z" }, { "uid": 0, "indexUid": "indexUID", "status": "succeeded", "type": "documentAdditionOrUpdate", "canceledBy": null, "details": { "receivedDocuments": 0, "indexedDocuments": 31944 }, "error": null, "duration": "PT39.941318S", "enqueuedAt": "2021-09-08T08:21:14.742672Z", "startedAt": "2021-09-08T08:21:14.750166Z", "finishedAt": "2021-09-08T08:21:54.691484Z" }], "limit": 20, "from": 1, "next": null })
+        json!({ "results": [{ "uid": 1, "indexUid": "indexUID", "status": "succeeded", "type": "settingsUpdate", "canceledBy": null, "details": { "displayedAttributes": ["title", "genres", "overview", "poster", "release_date"], "searchableAttributes": ["title", "overview"], "filterableAttributes": ["genres"], "stopWords": ["of", "the"] }, "error": null, "duration": "PT37.488777S", "enqueuedAt": "2021-09-08T08:24:02.323444Z", "startedAt": "2021-09-08T08:24:02.324145Z", "finishedAt": "2021-09-08T08:24:39.812922Z" }, { "uid": 0, "indexUid": "indexUID", "status": "succeeded", "type": "documentAdditionOrUpdate", "canceledBy": null, "details": { "receivedDocuments": 0, "indexedDocuments": 31944 }, "error": null, "duration": "PT39.941318S", "enqueuedAt": "2021-09-08T08:21:14.742672Z", "startedAt": "2021-09-08T08:21:14.750166Z", "finishedAt": "2021-09-08T08:21:54.691484Z" }], "total": 2, "limit": 20, "from": 1, "next": null })
     );
 
     // finally we're just going to check that we can still get a few documents by id
@@ -591,7 +591,7 @@ async fn import_dump_v3_movie_raw() {
     assert_eq!(code, 200);
     assert_eq!(
         tasks,
-        json!({ "results": [{"uid": 0, "indexUid": "indexUID", "status": "succeeded", "type": "documentAdditionOrUpdate", "canceledBy": null, "details": { "receivedDocuments": 0, "indexedDocuments": 31944 }, "error": null, "duration": "PT41.751156S", "enqueuedAt": "2021-09-08T08:30:30.550282Z", "startedAt": "2021-09-08T08:30:30.553012Z", "finishedAt": "2021-09-08T08:31:12.304168Z" }], "limit": 20, "from": 0, "next": null })
+        json!({ "results": [{"uid": 0, "indexUid": "indexUID", "status": "succeeded", "type": "documentAdditionOrUpdate", "canceledBy": null, "details": { "receivedDocuments": 0, "indexedDocuments": 31944 }, "error": null, "duration": "PT41.751156S", "enqueuedAt": "2021-09-08T08:30:30.550282Z", "startedAt": "2021-09-08T08:30:30.553012Z", "finishedAt": "2021-09-08T08:31:12.304168Z" }], "total": 1, "limit": 20, "from": 0, "next": null })
     );
 
     // finally we're just going to check that we can still get a few documents by id
@@ -683,7 +683,7 @@ async fn import_dump_v3_movie_with_settings() {
     assert_eq!(code, 200);
     assert_eq!(
         tasks,
-        json!({ "results": [{ "uid": 1, "indexUid": "indexUID", "status": "succeeded", "type": "settingsUpdate", "canceledBy": null, "details": { "displayedAttributes": ["title", "genres", "overview", "poster", "release_date"], "searchableAttributes": ["title", "overview"], "filterableAttributes": ["genres"], "stopWords": ["of", "the"] }, "error": null, "duration": "PT37.488777S", "enqueuedAt": "2021-09-08T08:24:02.323444Z", "startedAt": "2021-09-08T08:24:02.324145Z", "finishedAt": "2021-09-08T08:24:39.812922Z" }, { "uid": 0, "indexUid": "indexUID", "status": "succeeded", "type": "documentAdditionOrUpdate", "canceledBy": null, "details": { "receivedDocuments": 0, "indexedDocuments": 31944 }, "error": null, "duration": "PT39.941318S", "enqueuedAt": "2021-09-08T08:21:14.742672Z", "startedAt": "2021-09-08T08:21:14.750166Z", "finishedAt": "2021-09-08T08:21:54.691484Z" }], "limit": 20, "from": 1, "next": null })
+        json!({ "results": [{ "uid": 1, "indexUid": "indexUID", "status": "succeeded", "type": "settingsUpdate", "canceledBy": null, "details": { "displayedAttributes": ["title", "genres", "overview", "poster", "release_date"], "searchableAttributes": ["title", "overview"], "filterableAttributes": ["genres"], "stopWords": ["of", "the"] }, "error": null, "duration": "PT37.488777S", "enqueuedAt": "2021-09-08T08:24:02.323444Z", "startedAt": "2021-09-08T08:24:02.324145Z", "finishedAt": "2021-09-08T08:24:39.812922Z" }, { "uid": 0, "indexUid": "indexUID", "status": "succeeded", "type": "documentAdditionOrUpdate", "canceledBy": null, "details": { "receivedDocuments": 0, "indexedDocuments": 31944 }, "error": null, "duration": "PT39.941318S", "enqueuedAt": "2021-09-08T08:21:14.742672Z", "startedAt": "2021-09-08T08:21:14.750166Z", "finishedAt": "2021-09-08T08:21:54.691484Z" }], "total": 2, "limit": 20, "from": 1, "next": null })
     );
 
     // finally we're just going to check that we can["results"] still get a few documents by id
@@ -865,7 +865,7 @@ async fn import_dump_v4_movie_raw() {
     assert_eq!(code, 200);
     assert_eq!(
         tasks,
-        json!({ "results": [{"uid": 0, "indexUid": "indexUID", "status": "succeeded", "type": "documentAdditionOrUpdate", "canceledBy": null, "details": { "receivedDocuments": 0, "indexedDocuments": 31944 }, "error": null, "duration": "PT41.751156S", "enqueuedAt": "2021-09-08T08:30:30.550282Z", "startedAt": "2021-09-08T08:30:30.553012Z", "finishedAt": "2021-09-08T08:31:12.304168Z" }], "limit" : 20, "from": 0, "next": null })
+        json!({ "results": [{"uid": 0, "indexUid": "indexUID", "status": "succeeded", "type": "documentAdditionOrUpdate", "canceledBy": null, "details": { "receivedDocuments": 0, "indexedDocuments": 31944 }, "error": null, "duration": "PT41.751156S", "enqueuedAt": "2021-09-08T08:30:30.550282Z", "startedAt": "2021-09-08T08:30:30.553012Z", "finishedAt": "2021-09-08T08:31:12.304168Z" }], "total": 1, "limit" : 20, "from": 0, "next": null })
     );
 
     // finally we're just going to check that we can still get a few documents by id
@@ -957,7 +957,7 @@ async fn import_dump_v4_movie_with_settings() {
     assert_eq!(code, 200);
     assert_eq!(
         tasks,
-        json!({ "results": [{ "uid": 1, "indexUid": "indexUID", "status": "succeeded", "type": "settingsUpdate", "canceledBy": null, "details": { "displayedAttributes": ["title", "genres", "overview", "poster", "release_date"], "searchableAttributes": ["title", "overview"], "filterableAttributes": ["genres"], "stopWords": ["of", "the"] }, "error": null, "duration": "PT37.488777S", "enqueuedAt": "2021-09-08T08:24:02.323444Z", "startedAt": "2021-09-08T08:24:02.324145Z", "finishedAt": "2021-09-08T08:24:39.812922Z" }, { "uid": 0, "indexUid": "indexUID", "status": "succeeded", "type": "documentAdditionOrUpdate", "canceledBy": null, "details": { "receivedDocuments": 0, "indexedDocuments": 31944 }, "error": null, "duration": "PT39.941318S", "enqueuedAt": "2021-09-08T08:21:14.742672Z", "startedAt": "2021-09-08T08:21:14.750166Z", "finishedAt": "2021-09-08T08:21:54.691484Z" }], "limit": 20, "from": 1, "next": null })
+        json!({ "results": [{ "uid": 1, "indexUid": "indexUID", "status": "succeeded", "type": "settingsUpdate", "canceledBy": null, "details": { "displayedAttributes": ["title", "genres", "overview", "poster", "release_date"], "searchableAttributes": ["title", "overview"], "filterableAttributes": ["genres"], "stopWords": ["of", "the"] }, "error": null, "duration": "PT37.488777S", "enqueuedAt": "2021-09-08T08:24:02.323444Z", "startedAt": "2021-09-08T08:24:02.324145Z", "finishedAt": "2021-09-08T08:24:39.812922Z" }, { "uid": 0, "indexUid": "indexUID", "status": "succeeded", "type": "documentAdditionOrUpdate", "canceledBy": null, "details": { "receivedDocuments": 0, "indexedDocuments": 31944 }, "error": null, "duration": "PT39.941318S", "enqueuedAt": "2021-09-08T08:21:14.742672Z", "startedAt": "2021-09-08T08:21:14.750166Z", "finishedAt": "2021-09-08T08:21:54.691484Z" }], "total": 2, "limit": 20, "from": 1, "next": null })
     );
 
     // finally we're just going to check that we can still get a few documents by id

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v1_movie_raw/1.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v1_movie_raw/1.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T09:08:54.713227Z"
     }
   ],
+  "total": 1,
   "limit": 1,
   "from": 0,
   "next": null

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v1_movie_raw/2.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v1_movie_raw/2.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T09:08:54.713227Z"
     }
   ],
+  "total": 1,
   "limit": 1,
   "from": 0,
   "next": null

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v1_movie_raw/3.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v1_movie_raw/3.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T09:08:54.713227Z"
     }
   ],
+  "total": 1,
   "limit": 1,
   "from": 0,
   "next": null

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v1_movie_raw/4.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v1_movie_raw/4.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T09:08:54.713227Z"
     }
   ],
+  "total": 1,
   "limit": 1,
   "from": 0,
   "next": null

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v1_movie_raw/5.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v1_movie_raw/5.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T09:08:54.713227Z"
     }
   ],
+  "total": 1,
   "limit": 1,
   "from": 0,
   "next": null

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v1_movie_raw/6.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v1_movie_raw/6.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T09:08:54.713227Z"
     }
   ],
+  "total": 1,
   "limit": 1,
   "from": 0,
   "next": null

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v1_movie_raw/7.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v1_movie_raw/7.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T09:08:54.713227Z"
     }
   ],
+  "total": 1,
   "limit": 1,
   "from": 0,
   "next": null

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v1_movie_with_settings/1.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v1_movie_with_settings/1.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T09:34:25.351927Z"
     }
   ],
+  "total": 1,
   "limit": 1,
   "from": 0,
   "next": null

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v1_movie_with_settings/2.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v1_movie_with_settings/2.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T09:34:25.351927Z"
     }
   ],
+  "total": 1,
   "limit": 1,
   "from": 0,
   "next": null

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v1_movie_with_settings/3.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v1_movie_with_settings/3.snap
@@ -40,6 +40,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T09:34:48.1719Z"
     }
   ],
+  "total": 2,
   "limit": 1,
   "from": 1,
   "next": 0

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v1_movie_with_settings/4.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v1_movie_with_settings/4.snap
@@ -40,6 +40,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T09:34:48.1719Z"
     }
   ],
+  "total": 2,
   "limit": 1,
   "from": 1,
   "next": 0

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v1_movie_with_settings/5.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v1_movie_with_settings/5.snap
@@ -40,6 +40,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T09:34:48.1719Z"
     }
   ],
+  "total": 2,
   "limit": 1,
   "from": 1,
   "next": 0

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v1_movie_with_settings/6.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v1_movie_with_settings/6.snap
@@ -40,6 +40,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T09:34:48.1719Z"
     }
   ],
+  "total": 2,
   "limit": 1,
   "from": 1,
   "next": 0

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v1_movie_with_settings/7.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v1_movie_with_settings/7.snap
@@ -40,6 +40,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T09:34:48.1719Z"
     }
   ],
+  "total": 2,
   "limit": 1,
   "from": 1,
   "next": 0

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v1_rubygems_with_settings/1.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v1_rubygems_with_settings/1.snap
@@ -45,6 +45,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T09:26:57.319083Z"
     }
   ],
+  "total": 1,
   "limit": 1,
   "from": 0,
   "next": null

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v1_rubygems_with_settings/2.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v1_rubygems_with_settings/2.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T09:28:46.369971Z"
     }
   ],
+  "total": 92,
   "limit": 1,
   "from": 92,
   "next": 91

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v1_rubygems_with_settings/3.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v1_rubygems_with_settings/3.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T09:28:46.369971Z"
     }
   ],
+  "total": 93,
   "limit": 1,
   "from": 92,
   "next": 91

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v1_rubygems_with_settings/4.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v1_rubygems_with_settings/4.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T09:28:46.369971Z"
     }
   ],
+  "total": 93,
   "limit": 1,
   "from": 92,
   "next": 91

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v1_rubygems_with_settings/5.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v1_rubygems_with_settings/5.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T09:28:46.369971Z"
     }
   ],
+  "total": 93,
   "limit": 1,
   "from": 92,
   "next": 91

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v1_rubygems_with_settings/6.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v1_rubygems_with_settings/6.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T09:28:46.369971Z"
     }
   ],
+  "total": 93,
   "limit": 1,
   "from": 92,
   "next": 91

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v1_rubygems_with_settings/7.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v1_rubygems_with_settings/7.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T09:28:46.369971Z"
     }
   ],
+  "total": 93,
   "limit": 1,
   "from": 92,
   "next": 91

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v2_movie_raw/1.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v2_movie_raw/1.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:31:12.304168Z"
     }
   ],
+  "total": 1,
   "limit": 1,
   "from": 0,
   "next": null

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v2_movie_raw/2.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v2_movie_raw/2.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:31:12.304168Z"
     }
   ],
+  "total": 1,
   "limit": 1,
   "from": 0,
   "next": null

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v2_movie_raw/3.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v2_movie_raw/3.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:31:12.304168Z"
     }
   ],
+  "total": 1,
   "limit": 1,
   "from": 0,
   "next": null

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v2_movie_raw/4.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v2_movie_raw/4.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:31:12.304168Z"
     }
   ],
+  "total": 1,
   "limit": 1,
   "from": 0,
   "next": null

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v2_movie_raw/5.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v2_movie_raw/5.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:31:12.304168Z"
     }
   ],
+  "total": 1,
   "limit": 1,
   "from": 0,
   "next": null

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v2_movie_raw/6.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v2_movie_raw/6.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:31:12.304168Z"
     }
   ],
+  "total": 1,
   "limit": 1,
   "from": 0,
   "next": null

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v2_movie_raw/7.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v2_movie_raw/7.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:31:12.304168Z"
     }
   ],
+  "total": 1,
   "limit": 1,
   "from": 0,
   "next": null

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v2_movie_with_settings/1.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v2_movie_with_settings/1.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:21:54.691484Z"
     }
   ],
+  "total": 1,
   "limit": 1,
   "from": 0,
   "next": null

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v2_movie_with_settings/2.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v2_movie_with_settings/2.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:21:54.691484Z"
     }
   ],
+  "total": 1,
   "limit": 1,
   "from": 0,
   "next": null

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v2_movie_with_settings/3.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v2_movie_with_settings/3.snap
@@ -36,6 +36,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:24:39.812922Z"
     }
   ],
+  "total": 2,
   "limit": 1,
   "from": 1,
   "next": 0

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v2_movie_with_settings/4.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v2_movie_with_settings/4.snap
@@ -36,6 +36,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:24:39.812922Z"
     }
   ],
+  "total": 2,
   "limit": 1,
   "from": 1,
   "next": 0

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v2_movie_with_settings/5.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v2_movie_with_settings/5.snap
@@ -36,6 +36,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:24:39.812922Z"
     }
   ],
+  "total": 2,
   "limit": 1,
   "from": 1,
   "next": 0

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v2_movie_with_settings/6.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v2_movie_with_settings/6.snap
@@ -36,6 +36,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:24:39.812922Z"
     }
   ],
+  "total": 2,
   "limit": 1,
   "from": 1,
   "next": 0

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v2_movie_with_settings/7.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v2_movie_with_settings/7.snap
@@ -36,6 +36,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:24:39.812922Z"
     }
   ],
+  "total": 2,
   "limit": 1,
   "from": 1,
   "next": 0

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v2_rubygems_with_settings/1.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v2_rubygems_with_settings/1.snap
@@ -41,6 +41,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:40:28.669652Z"
     }
   ],
+  "total": 1,
   "limit": 1,
   "from": 0,
   "next": null

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v2_rubygems_with_settings/2.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v2_rubygems_with_settings/2.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:51:53.095314Z"
     }
   ],
+  "total": 92,
   "limit": 1,
   "from": 92,
   "next": 91

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v2_rubygems_with_settings/3.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v2_rubygems_with_settings/3.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:51:53.095314Z"
     }
   ],
+  "total": 93,
   "limit": 1,
   "from": 92,
   "next": 91

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v2_rubygems_with_settings/4.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v2_rubygems_with_settings/4.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:51:53.095314Z"
     }
   ],
+  "total": 93,
   "limit": 1,
   "from": 92,
   "next": 91

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v2_rubygems_with_settings/5.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v2_rubygems_with_settings/5.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:51:53.095314Z"
     }
   ],
+  "total": 93,
   "limit": 1,
   "from": 92,
   "next": 91

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v2_rubygems_with_settings/6.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v2_rubygems_with_settings/6.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:51:53.095314Z"
     }
   ],
+  "total": 93,
   "limit": 1,
   "from": 92,
   "next": 91

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v2_rubygems_with_settings/7.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v2_rubygems_with_settings/7.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:51:53.095314Z"
     }
   ],
+  "total": 93,
   "limit": 1,
   "from": 92,
   "next": 91

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v3_movie_raw/1.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v3_movie_raw/1.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:31:12.304168Z"
     }
   ],
+  "total": 1,
   "limit": 1,
   "from": 0,
   "next": null

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v3_movie_raw/2.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v3_movie_raw/2.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:31:12.304168Z"
     }
   ],
+  "total": 1,
   "limit": 1,
   "from": 0,
   "next": null

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v3_movie_raw/3.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v3_movie_raw/3.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:31:12.304168Z"
     }
   ],
+  "total": 1,
   "limit": 1,
   "from": 0,
   "next": null

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v3_movie_raw/4.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v3_movie_raw/4.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:31:12.304168Z"
     }
   ],
+  "total": 1,
   "limit": 1,
   "from": 0,
   "next": null

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v3_movie_raw/5.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v3_movie_raw/5.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:31:12.304168Z"
     }
   ],
+  "total": 1,
   "limit": 1,
   "from": 0,
   "next": null

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v3_movie_raw/6.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v3_movie_raw/6.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:31:12.304168Z"
     }
   ],
+  "total": 1,
   "limit": 1,
   "from": 0,
   "next": null

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v3_movie_raw/7.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v3_movie_raw/7.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:31:12.304168Z"
     }
   ],
+  "total": 1,
   "limit": 1,
   "from": 0,
   "next": null

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v3_movie_with_settings/1.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v3_movie_with_settings/1.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:21:54.691484Z"
     }
   ],
+  "total": 1,
   "limit": 1,
   "from": 0,
   "next": null

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v3_movie_with_settings/2.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v3_movie_with_settings/2.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:21:54.691484Z"
     }
   ],
+  "total": 1,
   "limit": 1,
   "from": 0,
   "next": null

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v3_movie_with_settings/3.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v3_movie_with_settings/3.snap
@@ -36,6 +36,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:24:39.812922Z"
     }
   ],
+  "total": 2,
   "limit": 1,
   "from": 1,
   "next": 0

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v3_movie_with_settings/4.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v3_movie_with_settings/4.snap
@@ -36,6 +36,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:24:39.812922Z"
     }
   ],
+  "total": 2,
   "limit": 1,
   "from": 1,
   "next": 0

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v3_movie_with_settings/5.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v3_movie_with_settings/5.snap
@@ -36,6 +36,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:24:39.812922Z"
     }
   ],
+  "total": 2,
   "limit": 1,
   "from": 1,
   "next": 0

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v3_movie_with_settings/6.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v3_movie_with_settings/6.snap
@@ -36,6 +36,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:24:39.812922Z"
     }
   ],
+  "total": 2,
   "limit": 1,
   "from": 1,
   "next": 0

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v3_movie_with_settings/7.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v3_movie_with_settings/7.snap
@@ -36,6 +36,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:24:39.812922Z"
     }
   ],
+  "total": 2,
   "limit": 1,
   "from": 1,
   "next": 0

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v3_rubygems_with_settings/1.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v3_rubygems_with_settings/1.snap
@@ -41,6 +41,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:40:28.669652Z"
     }
   ],
+  "total": 1,
   "limit": 1,
   "from": 0,
   "next": null

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v3_rubygems_with_settings/2.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v3_rubygems_with_settings/2.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:51:53.095314Z"
     }
   ],
+  "total": 92,
   "limit": 1,
   "from": 92,
   "next": 91

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v3_rubygems_with_settings/3.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v3_rubygems_with_settings/3.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:51:53.095314Z"
     }
   ],
+  "total": 93,
   "limit": 1,
   "from": 92,
   "next": 91

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v3_rubygems_with_settings/4.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v3_rubygems_with_settings/4.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:51:53.095314Z"
     }
   ],
+  "total": 93,
   "limit": 1,
   "from": 92,
   "next": 91

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v3_rubygems_with_settings/5.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v3_rubygems_with_settings/5.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:51:53.095314Z"
     }
   ],
+  "total": 93,
   "limit": 1,
   "from": 92,
   "next": 91

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v3_rubygems_with_settings/6.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v3_rubygems_with_settings/6.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:51:53.095314Z"
     }
   ],
+  "total": 93,
   "limit": 1,
   "from": 92,
   "next": 91

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v3_rubygems_with_settings/7.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v3_rubygems_with_settings/7.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:51:53.095314Z"
     }
   ],
+  "total": 93,
   "limit": 1,
   "from": 92,
   "next": 91

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v4_movie_raw/1.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v4_movie_raw/1.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:31:12.304168Z"
     }
   ],
+  "total": 1,
   "limit": 1,
   "from": 0,
   "next": null

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v4_movie_raw/2.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v4_movie_raw/2.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:31:12.304168Z"
     }
   ],
+  "total": 1,
   "limit": 1,
   "from": 0,
   "next": null

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v4_movie_raw/3.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v4_movie_raw/3.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:31:12.304168Z"
     }
   ],
+  "total": 1,
   "limit": 1,
   "from": 0,
   "next": null

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v4_movie_raw/4.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v4_movie_raw/4.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:31:12.304168Z"
     }
   ],
+  "total": 1,
   "limit": 1,
   "from": 0,
   "next": null

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v4_movie_raw/5.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v4_movie_raw/5.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:31:12.304168Z"
     }
   ],
+  "total": 1,
   "limit": 1,
   "from": 0,
   "next": null

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v4_movie_raw/6.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v4_movie_raw/6.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:31:12.304168Z"
     }
   ],
+  "total": 1,
   "limit": 1,
   "from": 0,
   "next": null

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v4_movie_raw/7.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v4_movie_raw/7.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:31:12.304168Z"
     }
   ],
+  "total": 1,
   "limit": 1,
   "from": 0,
   "next": null

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v4_movie_with_settings/1.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v4_movie_with_settings/1.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:21:54.691484Z"
     }
   ],
+  "total": 1,
   "limit": 1,
   "from": 0,
   "next": null

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v4_movie_with_settings/2.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v4_movie_with_settings/2.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:21:54.691484Z"
     }
   ],
+  "total": 1,
   "limit": 1,
   "from": 0,
   "next": null

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v4_movie_with_settings/3.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v4_movie_with_settings/3.snap
@@ -36,6 +36,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:24:39.812922Z"
     }
   ],
+  "total": 2,
   "limit": 1,
   "from": 1,
   "next": 0

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v4_movie_with_settings/4.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v4_movie_with_settings/4.snap
@@ -36,6 +36,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:24:39.812922Z"
     }
   ],
+  "total": 2,
   "limit": 1,
   "from": 1,
   "next": 0

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v4_movie_with_settings/5.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v4_movie_with_settings/5.snap
@@ -36,6 +36,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:24:39.812922Z"
     }
   ],
+  "total": 2,
   "limit": 1,
   "from": 1,
   "next": 0

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v4_movie_with_settings/6.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v4_movie_with_settings/6.snap
@@ -36,6 +36,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:24:39.812922Z"
     }
   ],
+  "total": 2,
   "limit": 1,
   "from": 1,
   "next": 0

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v4_movie_with_settings/7.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v4_movie_with_settings/7.snap
@@ -36,6 +36,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:24:39.812922Z"
     }
   ],
+  "total": 2,
   "limit": 1,
   "from": 1,
   "next": 0

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v4_rubygems_with_settings/1.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v4_rubygems_with_settings/1.snap
@@ -41,6 +41,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:40:28.669652Z"
     }
   ],
+  "total": 1,
   "limit": 1,
   "from": 0,
   "next": null

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v4_rubygems_with_settings/2.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v4_rubygems_with_settings/2.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:51:53.095314Z"
     }
   ],
+  "total": 92,
   "limit": 1,
   "from": 92,
   "next": 91

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v4_rubygems_with_settings/3.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v4_rubygems_with_settings/3.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:51:53.095314Z"
     }
   ],
+  "total": 93,
   "limit": 1,
   "from": 92,
   "next": 91

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v4_rubygems_with_settings/4.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v4_rubygems_with_settings/4.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:51:53.095314Z"
     }
   ],
+  "total": 93,
   "limit": 1,
   "from": 92,
   "next": 91

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v4_rubygems_with_settings/5.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v4_rubygems_with_settings/5.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:51:53.095314Z"
     }
   ],
+  "total": 93,
   "limit": 1,
   "from": 92,
   "next": 91

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v4_rubygems_with_settings/6.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v4_rubygems_with_settings/6.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:51:53.095314Z"
     }
   ],
+  "total": 93,
   "limit": 1,
   "from": 92,
   "next": 91

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v4_rubygems_with_settings/7.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v4_rubygems_with_settings/7.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2021-09-08T08:51:53.095314Z"
     }
   ],
+  "total": 93,
   "limit": 1,
   "from": 92,
   "next": 91

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v5/1.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v5/1.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2022-06-08T14:59:24.804443Z"
     }
   ],
+  "total": 1,
   "limit": 1,
   "from": 0,
   "next": null

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v5/2.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v5/2.snap
@@ -20,6 +20,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "2022-06-08T14:59:29.997781Z"
     }
   ],
+  "total": 2,
   "limit": 1,
   "from": 1,
   "next": 0

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v5/3.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v5/3.snap
@@ -19,6 +19,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "[date]"
     }
   ],
+  "total": 5,
   "limit": 1,
   "from": 4,
   "next": 3

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v5/4.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v5/4.snap
@@ -24,6 +24,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "[date]"
     }
   ],
+  "total": 2,
   "limit": 1,
   "from": 2,
   "next": 0

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v5/5.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v5/5.snap
@@ -19,6 +19,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "[date]"
     }
   ],
+  "total": 5,
   "limit": 1,
   "from": 4,
   "next": 3

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v5/6.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v5/6.snap
@@ -19,6 +19,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "[date]"
     }
   ],
+  "total": 5,
   "limit": 1,
   "from": 4,
   "next": 3

--- a/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v5/7.snap
+++ b/meilisearch/tests/dumps/snapshots/mod.rs/import_dump_v5/7.snap
@@ -19,6 +19,7 @@ source: meilisearch/tests/dumps/mod.rs
       "finishedAt": "[date]"
     }
   ],
+  "total": 5,
   "limit": 1,
   "from": 4,
   "next": 3

--- a/meilisearch/tests/swap_indexes/mod.rs
+++ b/meilisearch/tests/swap_indexes/mod.rs
@@ -55,6 +55,7 @@ async fn swap_indexes() {
           "finishedAt": "[date]"
         }
       ],
+      "total": 2,
       "limit": 20,
       "from": 1,
       "next": null
@@ -128,6 +129,7 @@ async fn swap_indexes() {
           "finishedAt": "[date]"
         }
       ],
+      "total": 3,
       "limit": 20,
       "from": 2,
       "next": null
@@ -193,6 +195,7 @@ async fn swap_indexes() {
           "finishedAt": "[date]"
         }
       ],
+      "total": 5,
       "limit": 2,
       "from": 4,
       "next": 2
@@ -336,6 +339,7 @@ async fn swap_indexes() {
           "finishedAt": "[date]"
         }
       ],
+      "total": 6,
       "limit": 20,
       "from": 5,
       "next": null


### PR DESCRIPTION
This PR returns a new field on the `/tasks` routes. The `total` field exposes the total number of tasks that matches the given filter/query. It is useful to display information on a user interface and can help understand when progress is made in processing tasks, i.e., the total number of tasks on `/tasks?statuses=succeeded` will increase over time.

Fixes #3888.

- [ ] Update the specs fo the `/tasks` route.

## How have I implemented it?

I found it much easier to run two times the task filtering system. Once with the original `from` and `limit` parameters and a second time without. The second call will return the total number of tasks that match the query, not only the number of tasks on the current page.

So far, in terms of performance, there doesn't seem to be any issue. I tried different filters with something like 250k tasks. Note that there is a limit of 1M tasks in the queue.