### PR TITLE
`attributesToSearchOn` supports wildcards

### DIFF
--- a/meilisearch/tests/search/restrict_searchable.rs
+++ b/meilisearch/tests/search/restrict_searchable.rs
@@ -77,15 +77,15 @@ async fn search_no_searchable_attribute_set() {
         )
         .await;
 
-    index.update_settings_searchable_attributes(json!(["description", "*", "title"])).await;
+    index.update_settings_searchable_attributes(json!(["*"])).await;
     index.wait_task(2).await;
 
     index
         .search(
-            json!({"q": "Captain Marvel", "attributesToSearchOn": ["unknown"]}),
+            json!({"q": "Captain Marvel", "attributesToSearchOn": ["unknown", "title"]}),
             |response, code| {
                 snapshot!(code, @"200 OK");
-                snapshot!(response["hits"].as_array().unwrap().len(), @"0");
+                snapshot!(response["hits"].as_array().unwrap().len(), @"2");
             },
         )
         .await;

--- a/meilisearch/tests/search/restrict_searchable.rs
+++ b/meilisearch/tests/search/restrict_searchable.rs
@@ -50,6 +50,76 @@ async fn simple_search_on_title() {
 }
 
 #[actix_rt::test]
+async fn search_no_searchable_attribute_set() {
+    let server = Server::new().await;
+    let index = index_with_documents(&server, &SIMPLE_SEARCH_DOCUMENTS).await;
+
+    index
+        .search(
+            json!({"q": "Captain Marvel", "attributesToSearchOn": ["unknown"]}),
+            |response, code| {
+                snapshot!(code, @"200 OK");
+                snapshot!(response["hits"].as_array().unwrap().len(), @"0");
+            },
+        )
+        .await;
+
+    index.update_settings_searchable_attributes(json!(["*"])).await;
+    index.wait_task(1).await;
+
+    index
+        .search(
+            json!({"q": "Captain Marvel", "attributesToSearchOn": ["unknown"]}),
+            |response, code| {
+                snapshot!(code, @"200 OK");
+                snapshot!(response["hits"].as_array().unwrap().len(), @"0");
+            },
+        )
+        .await;
+
+    index.update_settings_searchable_attributes(json!(["description", "*", "title"])).await;
+    index.wait_task(2).await;
+
+    index
+        .search(
+            json!({"q": "Captain Marvel", "attributesToSearchOn": ["unknown"]}),
+            |response, code| {
+                snapshot!(code, @"200 OK");
+                snapshot!(response["hits"].as_array().unwrap().len(), @"0");
+            },
+        )
+        .await;
+}
+
+#[actix_rt::test]
+async fn search_on_all_attributes() {
+    let server = Server::new().await;
+    let index = index_with_documents(&server, &SIMPLE_SEARCH_DOCUMENTS).await;
+
+    index
+        .search(json!({"q": "Captain Marvel", "attributesToSearchOn": ["*"]}), |response, code| {
+            snapshot!(code, @"200 OK");
+            snapshot!(response["hits"].as_array().unwrap().len(), @"3");
+        })
+        .await;
+}
+
+#[actix_rt::test]
+async fn search_on_all_attributes_restricted_set() {
+    let server = Server::new().await;
+    let index = index_with_documents(&server, &SIMPLE_SEARCH_DOCUMENTS).await;
+    index.update_settings_searchable_attributes(json!(["title"])).await;
+    index.wait_task(1).await;
+
+    index
+        .search(json!({"q": "Captain Marvel", "attributesToSearchOn": ["*"]}), |response, code| {
+            snapshot!(code, @"200 OK");
+            snapshot!(response["hits"].as_array().unwrap().len(), @"2");
+        })
+        .await;
+}
+
+#[actix_rt::test]
 async fn simple_prefix_search_on_title() {
     let server = Server::new().await;
     let index = index_with_documents(&server, &SIMPLE_SEARCH_DOCUMENTS).await;

--- a/milli/src/search/new/mod.rs
+++ b/milli/src/search/new/mod.rs
@@ -104,8 +104,10 @@ impl<'ctx> SearchContext<'ctx> {
                     }
                     .into())
                 }
+                // The field is not searchable, but the searchableAttributes are set to * => ignore field
+                (None, None) => continue,
                 // The field is not searchable => User error
-                _otherwise => {
+                (_fid, Some(false)) => {
                     let mut valid_fields: BTreeSet<_> =
                         fids_map.names().map(String::from).collect();
 

--- a/milli/src/search/new/mod.rs
+++ b/milli/src/search/new/mod.rs
@@ -85,7 +85,12 @@ impl<'ctx> SearchContext<'ctx> {
         let searchable_names = self.index.searchable_fields(self.txn)?;
 
         let mut restricted_fids = Vec::new();
+        let mut contains_wildcard = false;
         for field_name in searchable_attributes {
+            if field_name == "*" {
+                contains_wildcard = true;
+                continue;
+            }
             let searchable_contains_name =
                 searchable_names.as_ref().map(|sn| sn.iter().any(|name| name == field_name));
             let fid = match (fids_map.id(field_name), searchable_contains_name) {
@@ -132,7 +137,7 @@ impl<'ctx> SearchContext<'ctx> {
             restricted_fids.push(fid);
         }
 
-        self.restricted_fids = Some(restricted_fids);
+        self.restricted_fids = (!contains_wildcard).then_some(restricted_fids);
 
         Ok(())
     }


### PR DESCRIPTION
# Pull Request

## Related issue

Fixes #3912  and #3911 

## What does this PR do?
- Adding `*` in the list of `attributesToSearchOn` allows searching on all the `searchableAttributes`.
- If `searchableAttributes contains "*"`, then any attribute is accepted in the `attributesToSearchOn` list.
