### PR TITLE
Remove split_words and ngrams penalty on typo tolerance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -709,7 +709,6 @@ dependencies = [
  "csv",
  "deunicode",
  "either",
- "finl_unicode",
  "fst",
  "irg-kvariants",
  "jieba-rs",
@@ -1442,12 +1441,6 @@ dependencies = [
  "nom",
  "nom_locate",
 ]
-
-[[package]]
-name = "finl_unicode"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdc7a0362c9f4444381a9e697c79d435fe65b52a37466fc2c1184cee9edc6"
 
 [[package]]
 name = "flate2"

--- a/meilisearch/tests/search/mod.rs
+++ b/meilisearch/tests/search/mod.rs
@@ -922,31 +922,34 @@ async fn camelcased_words() {
                 "title": "TestAB"
               },
               {
-                "id": 4,
-                "title": "testab"
-              },
-              {
                 "id": 3,
                 "title": "TestAb"
+              },
+              {
+                "id": 4,
+                "title": "testab"
               }
             ]
             "###);
         })
         .await;
 
-    // TODO: documents 2 should match
     index
         .search(json!({"q": "testab"}), |response, code| {
             meili_snap::snapshot!(code, @"200 OK");
             meili_snap::snapshot!(meili_snap::json_string!(response["hits"]), @r###"
             [
               {
-                "id": 4,
-                "title": "testab"
+                "id": 2,
+                "title": "TestAB"
               },
               {
                 "id": 3,
                 "title": "TestAb"
+              },
+              {
+                "id": 4,
+                "title": "testab"
               }
             ]
             "###);
@@ -975,19 +978,22 @@ async fn camelcased_words() {
         })
         .await;
 
-    // TODO: documents 2 should match
     index
         .search(json!({"q": "Testab"}), |response, code| {
             meili_snap::snapshot!(code, @"200 OK");
             meili_snap::snapshot!(meili_snap::json_string!(response["hits"]), @r###"
             [
               {
-                "id": 4,
-                "title": "testab"
+                "id": 2,
+                "title": "TestAB"
               },
               {
                 "id": 3,
                 "title": "TestAb"
+              },
+              {
+                "id": 4,
+                "title": "testab"
               }
             ]
             "###);
@@ -1000,12 +1006,12 @@ async fn camelcased_words() {
             meili_snap::snapshot!(meili_snap::json_string!(response["hits"]), @r###"
             [
               {
-                "id": 3,
-                "title": "TestAb"
-              },
-              {
                 "id": 2,
                 "title": "TestAB"
+              },
+              {
+                "id": 3,
+                "title": "TestAb"
               },
               {
                 "id": 4,
@@ -1017,12 +1023,15 @@ async fn camelcased_words() {
         .await;
 
     // with Typos
-    // TODO: documents 0 should match
     index
         .search(json!({"q": "dellonghi"}), |response, code| {
             meili_snap::snapshot!(code, @"200 OK");
             meili_snap::snapshot!(meili_snap::json_string!(response["hits"]), @r###"
             [
+              {
+                "id": 0,
+                "title": "DeLonghi"
+              },
               {
                 "id": 1,
                 "title": "delonghi"
@@ -1032,12 +1041,19 @@ async fn camelcased_words() {
         })
         .await;
 
-    // TODO: documents 2 and 3 should match
     index
         .search(json!({"q": "tetsab"}), |response, code| {
             meili_snap::snapshot!(code, @"200 OK");
             meili_snap::snapshot!(meili_snap::json_string!(response["hits"]), @r###"
             [
+              {
+                "id": 2,
+                "title": "TestAB"
+              },
+              {
+                "id": 3,
+                "title": "TestAb"
+              },
               {
                 "id": 4,
                 "title": "testab"
@@ -1047,11 +1063,25 @@ async fn camelcased_words() {
         })
         .await;
 
-    // TODO: documents 2, 3 and 4 should match
     index
         .search(json!({"q": "TetsAB"}), |response, code| {
             meili_snap::snapshot!(code, @"200 OK");
-            meili_snap::snapshot!(meili_snap::json_string!(response["hits"]), @"[]");
+            meili_snap::snapshot!(meili_snap::json_string!(response["hits"]), @r###"
+            [
+              {
+                "id": 2,
+                "title": "TestAB"
+              },
+              {
+                "id": 3,
+                "title": "TestAb"
+              },
+              {
+                "id": 4,
+                "title": "testab"
+              }
+            ]
+            "###);
         })
         .await;
 }

--- a/meilisearch/tests/search/mod.rs
+++ b/meilisearch/tests/search/mod.rs
@@ -876,3 +876,182 @@ async fn experimental_feature_vector_store() {
     meili_snap::snapshot!(code, @"200 OK");
     meili_snap::snapshot!(meili_snap::json_string!(response["hits"]), @"[]");
 }
+
+#[cfg(feature = "default")]
+#[actix_rt::test]
+async fn camelcased_words() {
+    let server = Server::new().await;
+    let index = server.index("test");
+
+    // related to https://github.com/meilisearch/meilisearch/issues/3818
+    let documents = json!([
+        { "id": 0, "title": "DeLonghi" },
+        { "id": 1, "title": "delonghi" },
+        { "id": 2, "title": "TestAB" },
+        { "id": 3, "title": "testab" },
+    ]);
+    index.add_documents(documents, None).await;
+    index.wait_task(0).await;
+
+    index
+        .search(json!({"q": "deLonghi"}), |response, code| {
+            meili_snap::snapshot!(code, @"200 OK");
+            meili_snap::snapshot!(meili_snap::json_string!(response["hits"]), @r###"
+            [
+              {
+                "id": 0,
+                "title": "DeLonghi"
+              },
+              {
+                "id": 1,
+                "title": "delonghi"
+              }
+            ]
+            "###);
+        })
+        .await;
+
+    index
+        .search(json!({"q": "dellonghi"}), |response, code| {
+            meili_snap::snapshot!(code, @"200 OK");
+            meili_snap::snapshot!(meili_snap::json_string!(response["hits"]), @r###"
+            [
+              {
+                "id": 0,
+                "title": "DeLonghi"
+              },
+              {
+                "id": 1,
+                "title": "delonghi"
+              }
+            ]
+            "###);
+        })
+        .await;
+
+    index
+        .search(json!({"q": "testa"}), |response, code| {
+            meili_snap::snapshot!(code, @"200 OK");
+            meili_snap::snapshot!(meili_snap::json_string!(response["hits"]), @r###"
+            [
+              {
+                "id": 2,
+                "title": "TestAB"
+              },
+              {
+                "id": 3,
+                "title": "testab"
+              }
+            ]
+            "###);
+        })
+        .await;
+
+    index
+        .search(json!({"q": "testab"}), |response, code| {
+            meili_snap::snapshot!(code, @"200 OK");
+            meili_snap::snapshot!(meili_snap::json_string!(response["hits"]), @r###"
+            [
+              {
+                "id": 2,
+                "title": "TestAB"
+              },
+              {
+                "id": 3,
+                "title": "testab"
+              }
+            ]
+            "###);
+        })
+        .await;
+
+    index
+        .search(json!({"q": "TestaB"}), |response, code| {
+            meili_snap::snapshot!(code, @"200 OK");
+            meili_snap::snapshot!(meili_snap::json_string!(response["hits"]), @r###"
+            [
+              {
+                "id": 2,
+                "title": "TestAB"
+              },
+              {
+                "id": 3,
+                "title": "testab"
+              }
+            ]
+            "###);
+        })
+        .await;
+
+    index
+        .search(json!({"q": "Testab"}), |response, code| {
+            meili_snap::snapshot!(code, @"200 OK");
+            meili_snap::snapshot!(meili_snap::json_string!(response["hits"]), @r###"
+            [
+              {
+                "id": 2,
+                "title": "TestAB"
+              },
+              {
+                "id": 3,
+                "title": "testab"
+              }
+            ]
+            "###);
+        })
+        .await;
+
+    index
+        .search(json!({"q": "TestAb"}), |response, code| {
+            meili_snap::snapshot!(code, @"200 OK");
+            meili_snap::snapshot!(meili_snap::json_string!(response["hits"]), @r###"
+            [
+              {
+                "id": 2,
+                "title": "TestAB"
+              },
+              {
+                "id": 3,
+                "title": "testab"
+              }
+            ]
+            "###);
+        })
+        .await;
+
+    index
+        .search(json!({"q": "tetsab"}), |response, code| {
+            meili_snap::snapshot!(code, @"200 OK");
+            meili_snap::snapshot!(meili_snap::json_string!(response["hits"]), @r###"
+            [
+              {
+                "id": 2,
+                "title": "TestAB"
+              },
+              {
+                "id": 3,
+                "title": "testab"
+              }
+            ]
+            "###);
+        })
+        .await;
+
+    index
+        .search(json!({"q": "TetsAB"}), |response, code| {
+            meili_snap::snapshot!(code, @"200 OK");
+            meili_snap::snapshot!(meili_snap::json_string!(response["hits"]), @r###"
+            [
+              {
+                "id": 2,
+                "title": "TestAB"
+              },
+              {
+                "id": 3,
+                "title": "testab"
+              }
+            ]
+            "###);
+        })
+        .await;
+}

--- a/meilisearch/tests/search/mod.rs
+++ b/meilisearch/tests/search/mod.rs
@@ -888,31 +888,14 @@ async fn camelcased_words() {
         { "id": 0, "title": "DeLonghi" },
         { "id": 1, "title": "delonghi" },
         { "id": 2, "title": "TestAB" },
-        { "id": 3, "title": "testab" },
+        { "id": 3, "title": "TestAb" },
+        { "id": 4, "title": "testab" },
     ]);
     index.add_documents(documents, None).await;
     index.wait_task(0).await;
 
     index
         .search(json!({"q": "deLonghi"}), |response, code| {
-            meili_snap::snapshot!(code, @"200 OK");
-            meili_snap::snapshot!(meili_snap::json_string!(response["hits"]), @r###"
-            [
-              {
-                "id": 0,
-                "title": "DeLonghi"
-              },
-              {
-                "id": 1,
-                "title": "delonghi"
-              }
-            ]
-            "###);
-        })
-        .await;
-
-    index
-        .search(json!({"q": "dellonghi"}), |response, code| {
             meili_snap::snapshot!(code, @"200 OK");
             meili_snap::snapshot!(meili_snap::json_string!(response["hits"]), @r###"
             [
@@ -939,26 +922,31 @@ async fn camelcased_words() {
                 "title": "TestAB"
               },
               {
-                "id": 3,
+                "id": 4,
                 "title": "testab"
+              },
+              {
+                "id": 3,
+                "title": "TestAb"
               }
             ]
             "###);
         })
         .await;
 
+    // TODO: documents 2 should match
     index
         .search(json!({"q": "testab"}), |response, code| {
             meili_snap::snapshot!(code, @"200 OK");
             meili_snap::snapshot!(meili_snap::json_string!(response["hits"]), @r###"
             [
               {
-                "id": 2,
-                "title": "TestAB"
+                "id": 4,
+                "title": "testab"
               },
               {
                 "id": 3,
-                "title": "testab"
+                "title": "TestAb"
               }
             ]
             "###);
@@ -976,6 +964,10 @@ async fn camelcased_words() {
               },
               {
                 "id": 3,
+                "title": "TestAb"
+              },
+              {
+                "id": 4,
                 "title": "testab"
               }
             ]
@@ -983,18 +975,19 @@ async fn camelcased_words() {
         })
         .await;
 
+    // TODO: documents 2 should match
     index
         .search(json!({"q": "Testab"}), |response, code| {
             meili_snap::snapshot!(code, @"200 OK");
             meili_snap::snapshot!(meili_snap::json_string!(response["hits"]), @r###"
             [
               {
-                "id": 2,
-                "title": "TestAB"
+                "id": 4,
+                "title": "testab"
               },
               {
                 "id": 3,
-                "title": "testab"
+                "title": "TestAb"
               }
             ]
             "###);
@@ -1007,11 +1000,15 @@ async fn camelcased_words() {
             meili_snap::snapshot!(meili_snap::json_string!(response["hits"]), @r###"
             [
               {
+                "id": 3,
+                "title": "TestAb"
+              },
+              {
                 "id": 2,
                 "title": "TestAB"
               },
               {
-                "id": 3,
+                "id": 4,
                 "title": "testab"
               }
             ]
@@ -1019,17 +1016,30 @@ async fn camelcased_words() {
         })
         .await;
 
+    // with Typos
+    // TODO: documents 0 should match
+    index
+        .search(json!({"q": "dellonghi"}), |response, code| {
+            meili_snap::snapshot!(code, @"200 OK");
+            meili_snap::snapshot!(meili_snap::json_string!(response["hits"]), @r###"
+            [
+              {
+                "id": 1,
+                "title": "delonghi"
+              }
+            ]
+            "###);
+        })
+        .await;
+
+    // TODO: documents 2 and 3 should match
     index
         .search(json!({"q": "tetsab"}), |response, code| {
             meili_snap::snapshot!(code, @"200 OK");
             meili_snap::snapshot!(meili_snap::json_string!(response["hits"]), @r###"
             [
               {
-                "id": 2,
-                "title": "TestAB"
-              },
-              {
-                "id": 3,
+                "id": 4,
                 "title": "testab"
               }
             ]
@@ -1037,21 +1047,11 @@ async fn camelcased_words() {
         })
         .await;
 
+    // TODO: documents 2, 3 and 4 should match
     index
         .search(json!({"q": "TetsAB"}), |response, code| {
             meili_snap::snapshot!(code, @"200 OK");
-            meili_snap::snapshot!(meili_snap::json_string!(response["hits"]), @r###"
-            [
-              {
-                "id": 2,
-                "title": "TestAB"
-              },
-              {
-                "id": 3,
-                "title": "testab"
-              }
-            ]
-            "###);
+            meili_snap::snapshot!(meili_snap::json_string!(response["hits"]), @"[]");
         })
         .await;
 }

--- a/milli/Cargo.toml
+++ b/milli/Cargo.toml
@@ -81,7 +81,7 @@ md5 = "0.7.0"
 rand = { version = "0.8.5", features = ["small_rng"] }
 
 [features]
-all-tokenizations = ["charabia/default"]
+all-tokenizations = ["charabia/chinese", "charabia/hebrew", "charabia/japanese", "charabia/thai", "charabia/korean", "charabia/greek"]
 
 # Use POSIX semaphores instead of SysV semaphores in LMDB
 # For more information on this feature, see heed's Cargo.toml

--- a/milli/src/search/new/query_term/mod.rs
+++ b/milli/src/search/new/query_term/mod.rs
@@ -261,17 +261,11 @@ impl QueryTermSubset {
 
         match &self.one_typo_subset {
             NTypoTermSubset::All => {
-                let Lazy::Init(OneTypoTerm { one_typo }) = &original.one_typo
-                else {
-                    panic!()
-                };
+                let Lazy::Init(OneTypoTerm { one_typo }) = &original.one_typo else { panic!() };
                 result.extend(one_typo.iter().copied().map(Word::Derived))
             }
             NTypoTermSubset::Subset { words, phrases: _ } => {
-                let Lazy::Init(OneTypoTerm { one_typo }) = &original.one_typo
-                else {
-                    panic!()
-                };
+                let Lazy::Init(OneTypoTerm { one_typo }) = &original.one_typo else { panic!() };
                 result.extend(one_typo.intersection(words).copied().map(Word::Derived));
             }
             NTypoTermSubset::Nothing => {}

--- a/milli/src/search/new/query_term/parse_query.rs
+++ b/milli/src/search/new/query_term/parse_query.rs
@@ -269,6 +269,7 @@ impl PhraseBuilder {
                     zero_typo: ZeroTypoTerm {
                         phrase: Some(phrase),
                         exact: None,
+                        split_words: None,
                         prefix_of: BTreeSet::default(),
                         synonyms: BTreeSet::default(),
                         use_prefix_db: None,

--- a/milli/src/search/new/ranking_rule_graph/typo/mod.rs
+++ b/milli/src/search/new/ranking_rule_graph/typo/mod.rs
@@ -46,10 +46,6 @@ impl RankingRuleGraphTrait for TypoGraph {
         let term = to_term;
 
         let mut edges = vec![];
-        // Ngrams have a base typo cost
-        // 2-gram -> equivalent to 1 typo
-        // 3-gram -> equivalent to 2 typos
-        let base_cost = if term.term_ids.len() == 1 { 0 } else { term.term_ids.len() as u32 };
 
         for nbr_typos in 0..=term.term_subset.max_typo_cost(ctx) {
             let mut term = term.clone();
@@ -70,7 +66,7 @@ impl RankingRuleGraphTrait for TypoGraph {
             };
 
             edges.push((
-                nbr_typos as u32 + base_cost,
+                nbr_typos as u32,
                 conditions_interner.insert(TypoCondition { term, nbr_typos }),
             ));
         }

--- a/milli/src/search/new/tests/distinct.rs
+++ b/milli/src/search/new/tests/distinct.rs
@@ -547,7 +547,7 @@ fn test_distinct_typo() {
     s.terms_matching_strategy(TermsMatchingStrategy::Last);
 
     let SearchResult { documents_ids, .. } = s.execute().unwrap();
-    insta::assert_snapshot!(format!("{documents_ids:?}"), @"[3, 26, 0, 7, 8, 9, 15, 22, 18, 20, 25, 24]");
+    insta::assert_snapshot!(format!("{documents_ids:?}"), @"[2, 26, 0, 5, 8, 9, 15, 19, 22, 20, 25, 24]");
 
     let distinct_values = verify_distinct(&index, &txn, &documents_ids);
     insta::assert_debug_snapshot!(distinct_values, @r###"
@@ -559,8 +559,8 @@ fn test_distinct_typo() {
         "\"D\"",
         "\"E\"",
         "\"F\"",
-        "\"I\"",
         "\"G\"",
+        "\"I\"",
         "\"H\"",
         "__does_not_exist__",
         "__does_not_exist__",
@@ -570,15 +570,15 @@ fn test_distinct_typo() {
     let text_values = collect_field_values(&index, &txn, "text", &documents_ids);
     insta::assert_debug_snapshot!(text_values, @r###"
     [
-        "\"the quick brown fox jumps over the lazy dog\"",
+        "\"the quick brown foxjumps over the lazy dog\"",
         "\"the quick brown fox jumps over the lazy dog\"",
         "\"the quick brown fox jamps over the lazy dog\"",
-        "\"the quick brown fox jumps over the lazy\"",
+        "\"the quickbrownfox jumps over the lazy\"",
         "\"the quick brown fox jumps over the lazy\"",
         "\"the quick brown fox jumps over the lazy\"",
         "\"the quick brownf fox jumps over\"",
+        "\"the quick brownfoxjumps\"",
         "\"the quick brown fox jumps\"",
-        "\"the qick brown fox jumps\"",
         "\"the quick brow fox jumps\"",
         "\"the quick brown\"",
         "\"the quick\"",

--- a/milli/src/search/new/tests/snapshots/milli__search__new__tests__attribute_fid__attribute_fid_ngrams.snap
+++ b/milli/src/search/new/tests/snapshots/milli__search__new__tests__attribute_fid__attribute_fid_ngrams.snap
@@ -25,13 +25,13 @@ expression: "format!(\"{document_ids_scores:#?}\")"
         [
             Fid(
                 Rank {
-                    rank: 15,
+                    rank: 16,
                     max_rank: 19,
                 },
             ),
             Position(
                 Rank {
-                    rank: 81,
+                    rank: 80,
                     max_rank: 91,
                 },
             ),
@@ -42,7 +42,7 @@ expression: "format!(\"{document_ids_scores:#?}\")"
         [
             Fid(
                 Rank {
-                    rank: 14,
+                    rank: 15,
                     max_rank: 19,
                 },
             ),
@@ -59,7 +59,7 @@ expression: "format!(\"{document_ids_scores:#?}\")"
         [
             Fid(
                 Rank {
-                    rank: 13,
+                    rank: 14,
                     max_rank: 19,
                 },
             ),
@@ -76,13 +76,13 @@ expression: "format!(\"{document_ids_scores:#?}\")"
         [
             Fid(
                 Rank {
-                    rank: 12,
+                    rank: 13,
                     max_rank: 19,
                 },
             ),
             Position(
                 Rank {
-                    rank: 83,
+                    rank: 82,
                     max_rank: 91,
                 },
             ),
@@ -93,7 +93,7 @@ expression: "format!(\"{document_ids_scores:#?}\")"
         [
             Fid(
                 Rank {
-                    rank: 11,
+                    rank: 13,
                     max_rank: 19,
                 },
             ),
@@ -110,13 +110,13 @@ expression: "format!(\"{document_ids_scores:#?}\")"
         [
             Fid(
                 Rank {
-                    rank: 10,
+                    rank: 12,
                     max_rank: 19,
                 },
             ),
             Position(
                 Rank {
-                    rank: 79,
+                    rank: 78,
                     max_rank: 91,
                 },
             ),
@@ -127,7 +127,7 @@ expression: "format!(\"{document_ids_scores:#?}\")"
         [
             Fid(
                 Rank {
-                    rank: 10,
+                    rank: 12,
                     max_rank: 19,
                 },
             ),
@@ -144,7 +144,7 @@ expression: "format!(\"{document_ids_scores:#?}\")"
         [
             Fid(
                 Rank {
-                    rank: 7,
+                    rank: 9,
                     max_rank: 19,
                 },
             ),
@@ -161,13 +161,13 @@ expression: "format!(\"{document_ids_scores:#?}\")"
         [
             Fid(
                 Rank {
-                    rank: 6,
+                    rank: 7,
                     max_rank: 19,
                 },
             ),
             Position(
                 Rank {
-                    rank: 81,
+                    rank: 80,
                     max_rank: 91,
                 },
             ),
@@ -178,13 +178,13 @@ expression: "format!(\"{document_ids_scores:#?}\")"
         [
             Fid(
                 Rank {
-                    rank: 6,
+                    rank: 7,
                     max_rank: 19,
                 },
             ),
             Position(
                 Rank {
-                    rank: 81,
+                    rank: 80,
                     max_rank: 91,
                 },
             ),
@@ -195,13 +195,13 @@ expression: "format!(\"{document_ids_scores:#?}\")"
         [
             Fid(
                 Rank {
-                    rank: 6,
+                    rank: 7,
                     max_rank: 19,
                 },
             ),
             Position(
                 Rank {
-                    rank: 78,
+                    rank: 77,
                     max_rank: 91,
                 },
             ),

--- a/milli/src/search/new/tests/snapshots/milli__search__new__tests__attribute_fid__attribute_fid_simple.snap
+++ b/milli/src/search/new/tests/snapshots/milli__search__new__tests__attribute_fid__attribute_fid_simple.snap
@@ -25,13 +25,13 @@ expression: "format!(\"{document_ids_scores:#?}\")"
         [
             Fid(
                 Rank {
-                    rank: 15,
+                    rank: 16,
                     max_rank: 19,
                 },
             ),
             Position(
                 Rank {
-                    rank: 81,
+                    rank: 80,
                     max_rank: 91,
                 },
             ),
@@ -42,7 +42,7 @@ expression: "format!(\"{document_ids_scores:#?}\")"
         [
             Fid(
                 Rank {
-                    rank: 14,
+                    rank: 15,
                     max_rank: 19,
                 },
             ),
@@ -59,7 +59,7 @@ expression: "format!(\"{document_ids_scores:#?}\")"
         [
             Fid(
                 Rank {
-                    rank: 13,
+                    rank: 14,
                     max_rank: 19,
                 },
             ),
@@ -76,13 +76,13 @@ expression: "format!(\"{document_ids_scores:#?}\")"
         [
             Fid(
                 Rank {
-                    rank: 12,
+                    rank: 13,
                     max_rank: 19,
                 },
             ),
             Position(
                 Rank {
-                    rank: 83,
+                    rank: 82,
                     max_rank: 91,
                 },
             ),
@@ -93,7 +93,7 @@ expression: "format!(\"{document_ids_scores:#?}\")"
         [
             Fid(
                 Rank {
-                    rank: 11,
+                    rank: 13,
                     max_rank: 19,
                 },
             ),
@@ -110,13 +110,13 @@ expression: "format!(\"{document_ids_scores:#?}\")"
         [
             Fid(
                 Rank {
-                    rank: 10,
+                    rank: 12,
                     max_rank: 19,
                 },
             ),
             Position(
                 Rank {
-                    rank: 79,
+                    rank: 78,
                     max_rank: 91,
                 },
             ),
@@ -127,7 +127,7 @@ expression: "format!(\"{document_ids_scores:#?}\")"
         [
             Fid(
                 Rank {
-                    rank: 10,
+                    rank: 12,
                     max_rank: 19,
                 },
             ),
@@ -144,7 +144,7 @@ expression: "format!(\"{document_ids_scores:#?}\")"
         [
             Fid(
                 Rank {
-                    rank: 7,
+                    rank: 9,
                     max_rank: 19,
                 },
             ),
@@ -161,13 +161,13 @@ expression: "format!(\"{document_ids_scores:#?}\")"
         [
             Fid(
                 Rank {
-                    rank: 6,
+                    rank: 7,
                     max_rank: 19,
                 },
             ),
             Position(
                 Rank {
-                    rank: 81,
+                    rank: 80,
                     max_rank: 91,
                 },
             ),
@@ -178,13 +178,13 @@ expression: "format!(\"{document_ids_scores:#?}\")"
         [
             Fid(
                 Rank {
-                    rank: 6,
+                    rank: 7,
                     max_rank: 19,
                 },
             ),
             Position(
                 Rank {
-                    rank: 81,
+                    rank: 80,
                     max_rank: 91,
                 },
             ),
@@ -195,13 +195,13 @@ expression: "format!(\"{document_ids_scores:#?}\")"
         [
             Fid(
                 Rank {
-                    rank: 6,
+                    rank: 7,
                     max_rank: 19,
                 },
             ),
             Position(
                 Rank {
-                    rank: 78,
+                    rank: 77,
                     max_rank: 91,
                 },
             ),

--- a/milli/src/search/new/tests/snapshots/milli__search__new__tests__typo__typo_bucketing-5.snap
+++ b/milli/src/search/new/tests/snapshots/milli__search__new__tests__typo__typo_bucketing-5.snap
@@ -22,7 +22,7 @@ expression: "format!(\"{document_scores:#?}\")"
     [
         Typo(
             Typo {
-                typo_count: 1,
+                typo_count: 0,
                 max_typo_count: 5,
             },
         ),

--- a/milli/src/search/new/tests/snapshots/milli__search__new__tests__typo__typo_bucketing-8.snap
+++ b/milli/src/search/new/tests/snapshots/milli__search__new__tests__typo__typo_bucketing-8.snap
@@ -7,7 +7,7 @@ expression: "format!(\"{document_scores:#?}\")"
         Typo(
             Typo {
                 typo_count: 0,
-                max_typo_count: 6,
+                max_typo_count: 5,
             },
         ),
     ],
@@ -15,7 +15,31 @@ expression: "format!(\"{document_scores:#?}\")"
         Typo(
             Typo {
                 typo_count: 0,
-                max_typo_count: 6,
+                max_typo_count: 5,
+            },
+        ),
+    ],
+    [
+        Typo(
+            Typo {
+                typo_count: 0,
+                max_typo_count: 5,
+            },
+        ),
+    ],
+    [
+        Typo(
+            Typo {
+                typo_count: 0,
+                max_typo_count: 5,
+            },
+        ),
+    ],
+    [
+        Typo(
+            Typo {
+                typo_count: 1,
+                max_typo_count: 5,
             },
         ),
     ],
@@ -23,31 +47,7 @@ expression: "format!(\"{document_scores:#?}\")"
         Typo(
             Typo {
                 typo_count: 2,
-                max_typo_count: 6,
-            },
-        ),
-    ],
-    [
-        Typo(
-            Typo {
-                typo_count: 2,
-                max_typo_count: 6,
-            },
-        ),
-    ],
-    [
-        Typo(
-            Typo {
-                typo_count: 3,
-                max_typo_count: 6,
-            },
-        ),
-    ],
-    [
-        Typo(
-            Typo {
-                typo_count: 4,
-                max_typo_count: 6,
+                max_typo_count: 5,
             },
         ),
     ],

--- a/milli/src/search/new/tests/snapshots/milli__search__new__tests__typo__typo_synonyms-2.snap
+++ b/milli/src/search/new/tests/snapshots/milli__search__new__tests__typo__typo_synonyms-2.snap
@@ -7,7 +7,7 @@ expression: "format!(\"{document_scores:#?}\")"
         Typo(
             Typo {
                 typo_count: 0,
-                max_typo_count: 13,
+                max_typo_count: 10,
             },
         ),
     ],
@@ -15,7 +15,7 @@ expression: "format!(\"{document_scores:#?}\")"
         Typo(
             Typo {
                 typo_count: 0,
-                max_typo_count: 13,
+                max_typo_count: 10,
             },
         ),
     ],
@@ -23,7 +23,7 @@ expression: "format!(\"{document_scores:#?}\")"
         Typo(
             Typo {
                 typo_count: 1,
-                max_typo_count: 13,
+                max_typo_count: 10,
             },
         ),
     ],

--- a/milli/src/search/new/tests/snapshots/milli__search__new__tests__typo__typo_synonyms-5.snap
+++ b/milli/src/search/new/tests/snapshots/milli__search__new__tests__typo__typo_synonyms-5.snap
@@ -7,23 +7,23 @@ expression: "format!(\"{document_scores:#?}\")"
         Typo(
             Typo {
                 typo_count: 0,
-                max_typo_count: 13,
+                max_typo_count: 10,
             },
         ),
     ],
     [
         Typo(
             Typo {
-                typo_count: 2,
-                max_typo_count: 13,
+                typo_count: 0,
+                max_typo_count: 10,
             },
         ),
     ],
     [
         Typo(
             Typo {
-                typo_count: 2,
-                max_typo_count: 13,
+                typo_count: 0,
+                max_typo_count: 10,
             },
         ),
     ],

--- a/milli/src/search/new/tests/snapshots/milli__search__new__tests__typo_proximity__trap_complex2-2.snap
+++ b/milli/src/search/new/tests/snapshots/milli__search__new__tests__typo_proximity__trap_complex2-2.snap
@@ -7,7 +7,7 @@ expression: "format!(\"{document_scores:#?}\")"
         Typo(
             Typo {
                 typo_count: 1,
-                max_typo_count: 5,
+                max_typo_count: 4,
             },
         ),
         Proximity(
@@ -21,7 +21,7 @@ expression: "format!(\"{document_scores:#?}\")"
         Typo(
             Typo {
                 typo_count: 1,
-                max_typo_count: 5,
+                max_typo_count: 4,
             },
         ),
         Proximity(

--- a/milli/src/search/new/tests/typo.rs
+++ b/milli/src/search/new/tests/typo.rs
@@ -550,14 +550,14 @@ fn test_typo_bucketing() {
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
     s.query("network interconnection sunflower");
     let SearchResult { documents_ids, document_scores, .. } = s.execute().unwrap();
-    insta::assert_snapshot!(format!("{documents_ids:?}"), @"[16, 18, 17, 20, 15, 14]");
+    insta::assert_snapshot!(format!("{documents_ids:?}"), @"[16, 17, 18, 20, 15, 14]");
     insta::assert_snapshot!(format!("{document_scores:#?}"));
     let texts = collect_field_values(&index, &txn, "text", &documents_ids);
     insta::assert_debug_snapshot!(texts, @r###"
     [
         "\"network interconnection sunflower\"",
-        "\"network interconnection sunflowering\"",
         "\"network interconnection sun flower\"",
+        "\"network interconnection sunflowering\"",
         "\"network interconnection sunflowar\"",
         "\"network interconnections sunflawer\"",
         "\"netwolk interconections sunflawar\"",
@@ -569,15 +569,15 @@ fn test_typo_bucketing() {
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
     s.query("network interconnection sun flower");
     let SearchResult { documents_ids, document_scores, .. } = s.execute().unwrap();
-    insta::assert_snapshot!(format!("{documents_ids:?}"), @"[17, 19, 16, 18, 20, 15]");
+    insta::assert_snapshot!(format!("{documents_ids:?}"), @"[16, 17, 18, 19, 20, 15]");
     insta::assert_snapshot!(format!("{document_scores:#?}"));
     let texts = collect_field_values(&index, &txn, "text", &documents_ids);
     insta::assert_debug_snapshot!(texts, @r###"
     [
-        "\"network interconnection sun flower\"",
-        "\"network interconnection sun flowering\"",
         "\"network interconnection sunflower\"",
+        "\"network interconnection sun flower\"",
         "\"network interconnection sunflowering\"",
+        "\"network interconnection sun flowering\"",
         "\"network interconnection sunflowar\"",
         "\"network interconnections sunflawer\"",
     ]
@@ -624,7 +624,7 @@ fn test_typo_synonyms() {
     // The interaction of ngrams + synonyms means that the multi-word synonyms end up having a typo cost.
     // This is probably not what we want.
     let SearchResult { documents_ids, document_scores, .. } = s.execute().unwrap();
-    insta::assert_snapshot!(format!("{documents_ids:?}"), @"[21, 0, 22]");
+    insta::assert_snapshot!(format!("{documents_ids:?}"), @"[0, 21, 22]");
     insta::assert_snapshot!(format!("{document_scores:#?}"));
     let texts = collect_field_values(&index, &txn, "text", &documents_ids);
     insta::assert_debug_snapshot!(texts, @r###"

--- a/milli/src/search/new/tests/typo.rs
+++ b/milli/src/search/new/tests/typo.rs
@@ -629,8 +629,8 @@ fn test_typo_synonyms() {
     let texts = collect_field_values(&index, &txn, "text", &documents_ids);
     insta::assert_debug_snapshot!(texts, @r###"
     [
-        "\"the fast brownish fox jumps over the lackadaisical dog\"",
         "\"the quick brown fox jumps over the lazy dog\"",
+        "\"the fast brownish fox jumps over the lackadaisical dog\"",
         "\"the quick brown fox jumps over the lackadaisical dog\"",
     ]
     "###);


### PR DESCRIPTION
Having a typo tolerance penalty on `ngrams` and `split words` is not relevant for any word that has been split in another way than relying on a separator like dictionary-based language segmentation.

- partially fix https://github.com/meilisearch/meilisearch/issues/3869