### PR TITLE
Deactivate camel case segmentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -709,7 +709,6 @@ dependencies = [
  "csv",
  "deunicode",
  "either",
- "finl_unicode",
  "fst",
  "irg-kvariants",
  "jieba-rs",
@@ -1442,12 +1441,6 @@ dependencies = [
  "nom",
  "nom_locate",
 ]
-
-[[package]]
-name = "finl_unicode"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdc7a0362c9f4444381a9e697c79d435fe65b52a37466fc2c1184cee9edc6"
 
 [[package]]
 name = "flate2"

--- a/meilisearch/tests/search/mod.rs
+++ b/meilisearch/tests/search/mod.rs
@@ -888,7 +888,8 @@ async fn camelcased_words() {
         { "id": 0, "title": "DeLonghi" },
         { "id": 1, "title": "delonghi" },
         { "id": 2, "title": "TestAB" },
-        { "id": 3, "title": "testab" },
+        { "id": 3, "title": "TestAb" },
+        { "id": 4, "title": "testab" },
     ]);
     index.add_documents(documents, None).await;
     index.wait_task(0).await;
@@ -940,6 +941,10 @@ async fn camelcased_words() {
               },
               {
                 "id": 3,
+                "title": "TestAb"
+              },
+              {
+                "id": 4,
                 "title": "testab"
               }
             ]
@@ -958,6 +963,10 @@ async fn camelcased_words() {
               },
               {
                 "id": 3,
+                "title": "TestAb"
+              },
+              {
+                "id": 4,
                 "title": "testab"
               }
             ]
@@ -976,6 +985,10 @@ async fn camelcased_words() {
               },
               {
                 "id": 3,
+                "title": "TestAb"
+              },
+              {
+                "id": 4,
                 "title": "testab"
               }
             ]
@@ -994,6 +1007,10 @@ async fn camelcased_words() {
               },
               {
                 "id": 3,
+                "title": "TestAb"
+              },
+              {
+                "id": 4,
                 "title": "testab"
               }
             ]
@@ -1012,6 +1029,10 @@ async fn camelcased_words() {
               },
               {
                 "id": 3,
+                "title": "TestAb"
+              },
+              {
+                "id": 4,
                 "title": "testab"
               }
             ]
@@ -1019,8 +1040,27 @@ async fn camelcased_words() {
         })
         .await;
 
+    // with Typos
     index
-        .search(json!({"q": "tetsab"}), |response, code| {
+        .search(json!({"q": "dellonghi"}), |response, code| {
+            meili_snap::snapshot!(code, @"200 OK");
+            meili_snap::snapshot!(meili_snap::json_string!(response["hits"]), @r###"
+            [
+              {
+                "id": 0,
+                "title": "DeLonghi"
+              },
+              {
+                "id": 1,
+                "title": "delonghi"
+              }
+            ]
+            "###);
+        })
+        .await;
+
+    index
+        .search(json!({"q": "TetsAB"}), |response, code| {
             meili_snap::snapshot!(code, @"200 OK");
             meili_snap::snapshot!(meili_snap::json_string!(response["hits"]), @r###"
             [
@@ -1030,6 +1070,10 @@ async fn camelcased_words() {
               },
               {
                 "id": 3,
+                "title": "TestAb"
+              },
+              {
+                "id": 4,
                 "title": "testab"
               }
             ]
@@ -1048,6 +1092,10 @@ async fn camelcased_words() {
               },
               {
                 "id": 3,
+                "title": "TestAb"
+              },
+              {
+                "id": 4,
                 "title": "testab"
               }
             ]

--- a/meilisearch/tests/search/mod.rs
+++ b/meilisearch/tests/search/mod.rs
@@ -876,3 +876,182 @@ async fn experimental_feature_vector_store() {
     meili_snap::snapshot!(code, @"200 OK");
     meili_snap::snapshot!(meili_snap::json_string!(response["hits"]), @"[]");
 }
+
+#[cfg(feature = "default")]
+#[actix_rt::test]
+async fn camelcased_words() {
+    let server = Server::new().await;
+    let index = server.index("test");
+
+    // related to https://github.com/meilisearch/meilisearch/issues/3818
+    let documents = json!([
+        { "id": 0, "title": "DeLonghi" },
+        { "id": 1, "title": "delonghi" },
+        { "id": 2, "title": "TestAB" },
+        { "id": 3, "title": "testab" },
+    ]);
+    index.add_documents(documents, None).await;
+    index.wait_task(0).await;
+
+    index
+        .search(json!({"q": "deLonghi"}), |response, code| {
+            meili_snap::snapshot!(code, @"200 OK");
+            meili_snap::snapshot!(meili_snap::json_string!(response["hits"]), @r###"
+            [
+              {
+                "id": 0,
+                "title": "DeLonghi"
+              },
+              {
+                "id": 1,
+                "title": "delonghi"
+              }
+            ]
+            "###);
+        })
+        .await;
+
+    index
+        .search(json!({"q": "dellonghi"}), |response, code| {
+            meili_snap::snapshot!(code, @"200 OK");
+            meili_snap::snapshot!(meili_snap::json_string!(response["hits"]), @r###"
+            [
+              {
+                "id": 0,
+                "title": "DeLonghi"
+              },
+              {
+                "id": 1,
+                "title": "delonghi"
+              }
+            ]
+            "###);
+        })
+        .await;
+
+    index
+        .search(json!({"q": "testa"}), |response, code| {
+            meili_snap::snapshot!(code, @"200 OK");
+            meili_snap::snapshot!(meili_snap::json_string!(response["hits"]), @r###"
+            [
+              {
+                "id": 2,
+                "title": "TestAB"
+              },
+              {
+                "id": 3,
+                "title": "testab"
+              }
+            ]
+            "###);
+        })
+        .await;
+
+    index
+        .search(json!({"q": "testab"}), |response, code| {
+            meili_snap::snapshot!(code, @"200 OK");
+            meili_snap::snapshot!(meili_snap::json_string!(response["hits"]), @r###"
+            [
+              {
+                "id": 2,
+                "title": "TestAB"
+              },
+              {
+                "id": 3,
+                "title": "testab"
+              }
+            ]
+            "###);
+        })
+        .await;
+
+    index
+        .search(json!({"q": "TestaB"}), |response, code| {
+            meili_snap::snapshot!(code, @"200 OK");
+            meili_snap::snapshot!(meili_snap::json_string!(response["hits"]), @r###"
+            [
+              {
+                "id": 2,
+                "title": "TestAB"
+              },
+              {
+                "id": 3,
+                "title": "testab"
+              }
+            ]
+            "###);
+        })
+        .await;
+
+    index
+        .search(json!({"q": "Testab"}), |response, code| {
+            meili_snap::snapshot!(code, @"200 OK");
+            meili_snap::snapshot!(meili_snap::json_string!(response["hits"]), @r###"
+            [
+              {
+                "id": 2,
+                "title": "TestAB"
+              },
+              {
+                "id": 3,
+                "title": "testab"
+              }
+            ]
+            "###);
+        })
+        .await;
+
+    index
+        .search(json!({"q": "TestAb"}), |response, code| {
+            meili_snap::snapshot!(code, @"200 OK");
+            meili_snap::snapshot!(meili_snap::json_string!(response["hits"]), @r###"
+            [
+              {
+                "id": 2,
+                "title": "TestAB"
+              },
+              {
+                "id": 3,
+                "title": "testab"
+              }
+            ]
+            "###);
+        })
+        .await;
+
+    index
+        .search(json!({"q": "tetsab"}), |response, code| {
+            meili_snap::snapshot!(code, @"200 OK");
+            meili_snap::snapshot!(meili_snap::json_string!(response["hits"]), @r###"
+            [
+              {
+                "id": 2,
+                "title": "TestAB"
+              },
+              {
+                "id": 3,
+                "title": "testab"
+              }
+            ]
+            "###);
+        })
+        .await;
+
+    index
+        .search(json!({"q": "TetsAB"}), |response, code| {
+            meili_snap::snapshot!(code, @"200 OK");
+            meili_snap::snapshot!(meili_snap::json_string!(response["hits"]), @r###"
+            [
+              {
+                "id": 2,
+                "title": "TestAB"
+              },
+              {
+                "id": 3,
+                "title": "testab"
+              }
+            ]
+            "###);
+        })
+        .await;
+}

--- a/meilisearch/tests/search/restrict_searchable.rs
+++ b/meilisearch/tests/search/restrict_searchable.rs
@@ -240,7 +240,7 @@ async fn exactness_ranking_rule_order() {
         },
         {
             "title": "Captain Marvel",
-            "desc": "CaptainMarvel",
+            "desc": "Captain the Marvel",
             "id": "2",
         }]),
     )

--- a/milli/Cargo.toml
+++ b/milli/Cargo.toml
@@ -81,7 +81,7 @@ md5 = "0.7.0"
 rand = { version = "0.8.5", features = ["small_rng"] }
 
 [features]
-all-tokenizations = ["charabia/default"]
+all-tokenizations = ["charabia/chinese", "charabia/hebrew", "charabia/japanese", "charabia/thai", "charabia/korean", "charabia/greek"]
 
 # Use POSIX semaphores instead of SysV semaphores in LMDB
 # For more information on this feature, see heed's Cargo.toml


### PR DESCRIPTION
# Pull Request
This PR deactivates the camel case segmentation to retrieve the possibility to accept typos over camel-cased words

## Related issue
Fixes #3869
Fixes #3818

## What does this PR do?
- deactivates camelcase segmentation

related to #3919

