### PR TITLE
Fix the milli crate

### DIFF
--- a/milli/Cargo.toml
+++ b/milli/Cargo.toml
@@ -21,7 +21,7 @@ charabia = { version = "0.8.1", default-features = false }
 concat-arrays = "0.1.2"
 crossbeam-channel = "0.5.8"
 deserr = "0.5.0"
-either = "1.8.1"
+either = { version = "1.8.1", features = ["serde"] }
 flatten-serde-json = { path = "../flatten-serde-json" }
 fst = "0.4.7"
 fxhash = "0.2.1"


### PR DESCRIPTION
Milli was using the serde feature of either without enabling it first; thus, it wasn't working.

It was working in meilisearch, though, because `meilisearch-types` was using the feature which enables it globally for all the other crates.

## Related issue
Fixes https://github.com/meilisearch/meilisearch/issues/3962