### PR TITLE
Bump charabia to 0.8.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -700,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "charabia"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57aa1b4a8dda126c03ebf2f7e31d16cfc8781c2fe80dedd1a33459efc3e07578"
+checksum = "098219a776307414866165a03a9cc68c1578764fe3616fe979e1c280790ddd73"
 dependencies = [
  "aho-corasick",
  "cow-utils",

--- a/milli/Cargo.toml
+++ b/milli/Cargo.toml
@@ -17,7 +17,7 @@ bincode = "1.3.3"
 bstr = "1.4.0"
 bytemuck = { version = "1.13.1", features = ["extern_crate_alloc"] }
 byteorder = "1.4.3"
-charabia = { version = "0.8.2", default-features = false }
+charabia = { version = "0.8.3", default-features = false }
 concat-arrays = "0.1.2"
 crossbeam-channel = "0.5.8"
 deserr = "0.5.0"


### PR DESCRIPTION
This PR fixes https://github.com/meilisearch/meilisearch-support/issues/1 by bumping Charabia. The latest version of Charabia contains [a patch to the normalizer](https://github.com/meilisearch/charabia/pull/234).