### PR TITLE
Fix highlighting bug when searching for a phrase with cropping

### DIFF
--- a/milli/src/search/new/matches/mod.rs
+++ b/milli/src/search/new/matches/mod.rs
@@ -798,20 +798,28 @@ mod tests {
     }
 
     #[test]
-    fn format_highlight_crop_phrase_only() {
+    fn format_highlight_crop_phrase_query() {
         //! testing: https://github.com/meilisearch/meilisearch/issues/3975
         let temp_index = temp_index_with_documents();
         let rtxn = temp_index.read_txn().unwrap();
-        let builder = MatcherBuilder::new_test(&rtxn, &temp_index, "\"the world\"");
 
         let format_options = FormatOptions { highlight: true, crop: Some(10) };
-
         let text = "The groundbreaking invention had the power to split the world between those who embraced progress and those who resisted change!";
+
+        let builder = MatcherBuilder::new_test(&rtxn, &temp_index, "\"the world\"");
         let mut matcher = builder.build(text);
         // should return 10 words with a marker at the start as well the end, and the highlighted matches.
         insta::assert_snapshot!(
             matcher.format(format_options),
             @"…had the power to split <em>the</em> <em>world</em> between those who…"
+        );
+
+        let builder = MatcherBuilder::new_test(&rtxn, &temp_index, "those \"and those\"");
+        let mut matcher = builder.build(text);
+        // should highlight both "and" and "those".
+        insta::assert_snapshot!(
+            matcher.format(format_options),
+            @"…between those who embraced progress <em>and</em> <em>those</em> who resisted change…"
         );
     }
 

--- a/milli/src/search/new/matches/mod.rs
+++ b/milli/src/search/new/matches/mod.rs
@@ -800,7 +800,12 @@ mod tests {
     #[test]
     fn format_highlight_crop_phrase_query() {
         //! testing: https://github.com/meilisearch/meilisearch/issues/3975
-        let temp_index = temp_index_with_documents();
+        let temp_index = TempIndex::new();
+        temp_index
+            .add_documents(documents!([
+                { "id": 1, "text": "The groundbreaking invention had the power to split the world between those who embraced progress and those who resisted change!" }
+            ]))
+            .unwrap();
         let rtxn = temp_index.read_txn().unwrap();
 
         let format_options = FormatOptions { highlight: true, crop: Some(10) };
@@ -816,10 +821,10 @@ mod tests {
 
         let builder = MatcherBuilder::new_test(&rtxn, &temp_index, "those \"and those\"");
         let mut matcher = builder.build(text);
-        // should highlight both "and" and "those".
+        // should highlight "those" and the phrase "and those".
         insta::assert_snapshot!(
             matcher.format(format_options),
-            @"…between those who embraced progress <em>and</em> <em>those</em> who resisted change…"
+            @"…world between <em>those</em> who embraced progress <em>and</em> <em>those</em> who resisted…"
         );
     }
 


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #3975

## What does this PR do?
This PR -
- Fixes the bug where searching **only** for a phrase (containing multiple words) along with cropping, highlighted only the first word of the phrase.
- Adds unit test case for the above mentioned scenario.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
