### PR TITLE
Improve the `critcmp` results in a PR message

### DIFF
--- a/.github/workflows/trigger-benchmarks-on-message.yml
+++ b/.github/workflows/trigger-benchmarks-on-message.yml
@@ -73,9 +73,9 @@ jobs:
       # Compute the diff of the benchmarks and send a message on the GitHub PR
       - name: Compute and send a message in the PR
         run: |
-          export base=git rev-parse $(git cherry main | head -n 1 | cut -c 3-)~ | cut -c -8
+          export base=$(git rev-parse $(git cherry main | head -n 1 | cut -c 3-)~ | cut -c -8)
           echo 'Here are your benchmarks diff 👊' >> body.txt
           echo '```' >> body.txt
-          ./benchmaks/scipts/compare.sh $base ${{ steps.file.outputs.basename }}.json >> body.txt
+          ./benchmaks/scripts/compare.sh $base ${{ steps.file.outputs.basename }}.json >> body.txt
           echo '```' >> body.txt
           gh pr comment ${GITHUB_REF#refs/heads/} --body-file body.txt


### PR DESCRIPTION
This pull request is here to check and improve the `critcmp` results in a PR message CI feature. This PR also modifies the shape of the message for something like the following. It allows us to specify the benchmark we want to run.

```
/benchmark search_geo
/benchmark indexing
```