### PR TITLE
Use rayon to sort entries in parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,12 +1663,12 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "grenad"
-version = "0.4.4"
-source = "git+https://github.com/meilisearch/grenad?branch=parallel-sorter#eafb6ae795af6078e087edf77e7cd31a26238707"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a007932af5475ebb5c63bef8812bb1c36f317983bb4ca663e9d6dd58d6a0f8c"
 dependencies = [
  "bytemuck",
  "byteorder",
- "crossbeam-channel",
  "rayon",
  "tempfile",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1664,11 +1664,12 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "grenad"
 version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5232b2d157b7bf63d7abe1b12177039e58db2f29e377517c0cdee1578cca4c93"
+source = "git+https://github.com/meilisearch/grenad?branch=parallel-sorter#eafb6ae795af6078e087edf77e7cd31a26238707"
 dependencies = [
  "bytemuck",
  "byteorder",
+ "crossbeam-channel",
+ "rayon",
  "tempfile",
 ]
 

--- a/index-scheduler/src/batch.rs
+++ b/index-scheduler/src/batch.rs
@@ -24,7 +24,7 @@ use std::fs::{self, File};
 use std::io::BufWriter;
 
 use dump::IndexMetadata;
-use log::{debug, error, info};
+use log::{debug, error, info, trace};
 use meilisearch_types::error::Code;
 use meilisearch_types::heed::{RoTxn, RwTxn};
 use meilisearch_types::milli::documents::{obkv_to_object, DocumentsBatchReader};
@@ -1190,7 +1190,7 @@ impl IndexScheduler {
                     index,
                     indexer_config,
                     config,
-                    |indexing_step| debug!("update: {:?}", indexing_step),
+                    |indexing_step| trace!("update: {:?}", indexing_step),
                     || must_stop_processing.get(),
                 )?;
 
@@ -1268,7 +1268,7 @@ impl IndexScheduler {
                         milli::update::Settings::new(index_wtxn, index, indexer_config);
                     builder.reset_primary_key();
                     builder.execute(
-                        |indexing_step| debug!("update: {:?}", indexing_step),
+                        |indexing_step| trace!("update: {:?}", indexing_step),
                         || must_stop_processing.clone().get(),
                     )?;
                 }
@@ -1288,7 +1288,7 @@ impl IndexScheduler {
                     index,
                     indexer_config,
                     config,
-                    |indexing_step| debug!("update: {:?}", indexing_step),
+                    |indexing_step| trace!("update: {:?}", indexing_step),
                     || must_stop_processing.get(),
                 )?;
 

--- a/meilisearch/src/lib.rs
+++ b/meilisearch/src/lib.rs
@@ -362,7 +362,7 @@ fn import_dump(
                 update_method: IndexDocumentsMethod::ReplaceDocuments,
                 ..Default::default()
             },
-            |indexing_step| log::debug!("update: {:?}", indexing_step),
+            |indexing_step| log::trace!("update: {:?}", indexing_step),
             || false,
         )?;
 

--- a/milli/Cargo.toml
+++ b/milli/Cargo.toml
@@ -26,9 +26,8 @@ flatten-serde-json = { path = "../flatten-serde-json" }
 fst = "0.4.7"
 fxhash = "0.2.1"
 geoutils = "0.5.1"
-grenad = { git = "https://github.com/meilisearch/grenad", branch = "parallel-sorter", default-features = false, features = [
-    "rayon",
-    "tempfile",
+grenad = { version = "0.4.5", default-features = false, features = [
+    "rayon", "tempfile"
 ] }
 heed = { git = "https://github.com/meilisearch/heed", tag = "v0.12.7", default-features = false, features = [
     "lmdb", "read-txn-no-tls"

--- a/milli/Cargo.toml
+++ b/milli/Cargo.toml
@@ -26,7 +26,8 @@ flatten-serde-json = { path = "../flatten-serde-json" }
 fst = "0.4.7"
 fxhash = "0.2.1"
 geoutils = "0.5.1"
-grenad = { version = "0.4.4", default-features = false, features = [
+grenad = { git = "https://github.com/meilisearch/grenad", branch = "parallel-sorter", default-features = false, features = [
+    "rayon",
     "tempfile",
 ] }
 heed = { git = "https://github.com/meilisearch/heed", tag = "v0.12.7", default-features = false, features = [

--- a/milli/src/update/index_documents/helpers/grenad_helpers.rs
+++ b/milli/src/update/index_documents/helpers/grenad_helpers.rs
@@ -47,6 +47,7 @@ pub fn create_sorter(
         builder.allow_realloc(false);
     }
     builder.sort_algorithm(sort_algorithm);
+    builder.sort_in_parallel(true);
     builder.build()
 }
 

--- a/milli/src/update/index_documents/transform.rs
+++ b/milli/src/update/index_documents/transform.rs
@@ -114,24 +114,43 @@ impl<'a, 'i> Transform<'a, 'i> {
         };
 
         // We initialize the sorter with the user indexing settings.
-        let original_sorter = create_sorter(
-            grenad::SortAlgorithm::Stable,
-            merge_function,
-            indexer_settings.chunk_compression_type,
-            indexer_settings.chunk_compression_level,
-            indexer_settings.max_nb_chunks,
-            indexer_settings.max_memory.map(|mem| mem / 2),
-        );
+        let original_sorter = {
+            let mut builder = grenad::Sorter::builder(merge_function);
+            builder.chunk_compression_type(indexer_settings.chunk_compression_type);
+            if let Some(level) = indexer_settings.chunk_compression_level {
+                builder.chunk_compression_level(level);
+            }
+            if let Some(nb_chunks) = indexer_settings.max_nb_chunks {
+                builder.max_nb_chunks(nb_chunks);
+            }
+            if let Some(memory) = indexer_settings.max_memory.map(|mem| mem / 2) {
+                builder.dump_threshold(memory);
+                builder.allow_realloc(false);
+            }
+            builder.sort_algorithm(grenad::SortAlgorithm::Stable);
+            builder.sort_in_parallel(true);
+            builder.build()
+        };
 
         // We initialize the sorter with the user indexing settings.
-        let flattened_sorter = create_sorter(
-            grenad::SortAlgorithm::Stable,
-            merge_function,
-            indexer_settings.chunk_compression_type,
-            indexer_settings.chunk_compression_level,
-            indexer_settings.max_nb_chunks,
-            indexer_settings.max_memory.map(|mem| mem / 2),
-        );
+        let flattened_sorter = {
+            let mut builder = grenad::Sorter::builder(merge_function);
+            builder.chunk_compression_type(indexer_settings.chunk_compression_type);
+            if let Some(level) = indexer_settings.chunk_compression_level {
+                builder.chunk_compression_level(level);
+            }
+            if let Some(nb_chunks) = indexer_settings.max_nb_chunks {
+                builder.max_nb_chunks(nb_chunks);
+            }
+            if let Some(memory) = indexer_settings.max_memory.map(|mem| mem / 2) {
+                builder.dump_threshold(memory);
+                builder.allow_realloc(false);
+            }
+            builder.sort_algorithm(grenad::SortAlgorithm::Stable);
+            builder.sort_in_parallel(true);
+            builder.build()
+        };
+
         let documents_ids = index.documents_ids(wtxn)?;
 
         Ok(Transform {

--- a/milli/src/update/index_documents/transform.rs
+++ b/milli/src/update/index_documents/transform.rs
@@ -114,43 +114,24 @@ impl<'a, 'i> Transform<'a, 'i> {
         };
 
         // We initialize the sorter with the user indexing settings.
-        let original_sorter = {
-            let mut builder = grenad::Sorter::builder(merge_function);
-            builder.chunk_compression_type(indexer_settings.chunk_compression_type);
-            if let Some(level) = indexer_settings.chunk_compression_level {
-                builder.chunk_compression_level(level);
-            }
-            if let Some(nb_chunks) = indexer_settings.max_nb_chunks {
-                builder.max_nb_chunks(nb_chunks);
-            }
-            if let Some(memory) = indexer_settings.max_memory.map(|mem| mem / 2) {
-                builder.dump_threshold(memory);
-                builder.allow_realloc(false);
-            }
-            builder.sort_algorithm(grenad::SortAlgorithm::Stable);
-            builder.sort_in_parallel(true);
-            builder.build()
-        };
+        let original_sorter = create_sorter(
+            grenad::SortAlgorithm::Stable,
+            merge_function,
+            indexer_settings.chunk_compression_type,
+            indexer_settings.chunk_compression_level,
+            indexer_settings.max_nb_chunks,
+            indexer_settings.max_memory.map(|mem| mem / 2),
+        );
 
         // We initialize the sorter with the user indexing settings.
-        let flattened_sorter = {
-            let mut builder = grenad::Sorter::builder(merge_function);
-            builder.chunk_compression_type(indexer_settings.chunk_compression_type);
-            if let Some(level) = indexer_settings.chunk_compression_level {
-                builder.chunk_compression_level(level);
-            }
-            if let Some(nb_chunks) = indexer_settings.max_nb_chunks {
-                builder.max_nb_chunks(nb_chunks);
-            }
-            if let Some(memory) = indexer_settings.max_memory.map(|mem| mem / 2) {
-                builder.dump_threshold(memory);
-                builder.allow_realloc(false);
-            }
-            builder.sort_algorithm(grenad::SortAlgorithm::Stable);
-            builder.sort_in_parallel(true);
-            builder.build()
-        };
-
+        let flattened_sorter = create_sorter(
+            grenad::SortAlgorithm::Stable,
+            merge_function,
+            indexer_settings.chunk_compression_type,
+            indexer_settings.chunk_compression_level,
+            indexer_settings.max_nb_chunks,
+            indexer_settings.max_memory.map(|mem| mem / 2),
+        );
         let documents_ids = index.documents_ids(wtxn)?;
 
         Ok(Transform {


### PR DESCRIPTION
Currently, it takes 732.5s to run the `Transform::read_documents` method on a 142M documents dataset on a 12 threads machine (with max threading to 12). When enabling this new rayon sorting feature, the method takes 351.8s, so a gain of 52%.