### PR TITLE
Prevent search hang on the processing index

### DIFF
--- a/index-scheduler/src/batch.rs
+++ b/index-scheduler/src/batch.rs
@@ -924,7 +924,8 @@ impl IndexScheduler {
                 };
 
                 // the index operation can take a long time, so save this handle to make it available tothe search for the duration of the tick
-                *self.currently_updating_index.write().unwrap() = Some((index_uid.clone(), index.clone()));
+                *self.currently_updating_index.write().unwrap() =
+                    Some((index_uid.clone(), index.clone()));
 
                 let mut index_wtxn = index.write_txn()?;
                 let tasks = self.apply_index_operation(&mut index_wtxn, &index, op)?;
@@ -963,8 +964,8 @@ impl IndexScheduler {
                 let rtxn = self.env.read_txn()?;
                 let index = self.index_mapper.index(&rtxn, &index_uid)?;
                 // the index update can take a long time, so save this handle to make it available tothe search for the duration of the tick
-                *self.currently_updating_index.write().unwrap() = Some((index_uid.clone(), index.clone()));
-
+                *self.currently_updating_index.write().unwrap() =
+                    Some((index_uid.clone(), index.clone()));
 
                 if let Some(primary_key) = primary_key.clone() {
                     let mut index_wtxn = index.write_txn()?;

--- a/index-scheduler/src/batch.rs
+++ b/index-scheduler/src/batch.rs
@@ -923,7 +923,7 @@ impl IndexScheduler {
                     self.index_mapper.index(&rtxn, &index_uid)?
                 };
 
-                // the index operation can take a long time, so save this handle to make it available tothe search for the duration of the tick
+                // the index operation can take a long time, so save this handle to make it available to the search for the duration of the tick
                 *self.currently_updating_index.write().unwrap() =
                     Some((index_uid.clone(), index.clone()));
 
@@ -963,9 +963,6 @@ impl IndexScheduler {
             Batch::IndexUpdate { index_uid, primary_key, mut task } => {
                 let rtxn = self.env.read_txn()?;
                 let index = self.index_mapper.index(&rtxn, &index_uid)?;
-                // the index update can take a long time, so save this handle to make it available tothe search for the duration of the tick
-                *self.currently_updating_index.write().unwrap() =
-                    Some((index_uid.clone(), index.clone()));
 
                 if let Some(primary_key) = primary_key.clone() {
                     let mut index_wtxn = index.write_txn()?;

--- a/index-scheduler/src/batch.rs
+++ b/index-scheduler/src/batch.rs
@@ -923,6 +923,9 @@ impl IndexScheduler {
                     self.index_mapper.index(&rtxn, &index_uid)?
                 };
 
+                // the index operation can take a long time, so save this handle to make it available tothe search for the duration of the tick
+                *self.currently_updating_index.write().unwrap() = Some((index_uid.clone(), index.clone()));
+
                 let mut index_wtxn = index.write_txn()?;
                 let tasks = self.apply_index_operation(&mut index_wtxn, &index, op)?;
                 index_wtxn.commit()?;
@@ -959,6 +962,9 @@ impl IndexScheduler {
             Batch::IndexUpdate { index_uid, primary_key, mut task } => {
                 let rtxn = self.env.read_txn()?;
                 let index = self.index_mapper.index(&rtxn, &index_uid)?;
+                // the index update can take a long time, so save this handle to make it available tothe search for the duration of the tick
+                *self.currently_updating_index.write().unwrap() = Some((index_uid.clone(), index.clone()));
+
 
                 if let Some(primary_key) = primary_key.clone() {
                     let mut index_wtxn = index.write_txn()?;

--- a/index-scheduler/src/insta_snapshot.rs
+++ b/index-scheduler/src/insta_snapshot.rs
@@ -39,6 +39,7 @@ pub fn snapshot_index_scheduler(scheduler: &IndexScheduler) -> String {
         test_breakpoint_sdr: _,
         planned_failures: _,
         run_loop_iteration: _,
+        currently_updating_index: _,
     } = scheduler;
 
     let rtxn = env.read_txn().unwrap();

--- a/index-scheduler/src/lib.rs
+++ b/index-scheduler/src/lib.rs
@@ -658,9 +658,11 @@ impl IndexScheduler {
     /// If you need to fetch information from or perform an action on all indexes,
     /// see the `try_for_each_index` function.
     pub fn index(&self, name: &str) -> Result<Index> {
-        if let Some((current_name, current_index)) = self.currently_updating_index.read().unwrap().as_ref() {
+        if let Some((current_name, current_index)) =
+            self.currently_updating_index.read().unwrap().as_ref()
+        {
             if current_name == name {
-                return Ok(current_index.clone())
+                return Ok(current_index.clone());
             }
         }
         let rtxn = self.env.read_txn()?;


### PR DESCRIPTION
Fixes #4206, an issue originally [reported on Discord](https://discord.com/channels/1006923006964154428/1148983671026618579/1148983671026618579) where having parallel search requests on more indexes than the index cache capacity would cause search requests on the currently updating index to hang until the index is done updating.

## Test setup

- Create 20 empty indexes by sending settings to them
- repeatedly send placeholder search requests to each of the indexes in a loop
- Create another index and send a significant batch of documents to index.
- Attempt to perform a search request on that last index.
  - Before this PR, the search request hangs while the index update task is processing
  - After this PR, the search request respond immediately even while the index update task is processing

## Changes

- When getting the handle to an index for some potentially long running batches of tasks, save it in the index scheduler.
- Drop the handle from the index-scheduler when the task is done so that we don't leak indexes.
- When getting an index from outside the task queue processor, check if there is such an handle matching the requested index. If so, skip the cache entirely and clone the handle.