### PR TITLE
Set rust toolchain to 1.71.1 in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Compile
-FROM    rust:alpine3.16 AS compiler
+FROM    rust:1.71.1-alpine3.18 AS compiler
 
 RUN     apk add -q --update-cache --no-cache build-base openssl-dev
 


### PR DESCRIPTION
Fixes docker [CI](https://github.com/meilisearch/meilisearch/actions/workflows/publish-docker-images.yml)