### PR TITLE
Adapt prefix thresholds

### DIFF
--- a/milli/src/search/new/tests/proximity.rs
+++ b/milli/src/search/new/tests/proximity.rs
@@ -371,7 +371,7 @@ fn test_proximity_prefix_db() {
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
     s.query("best s");
     let SearchResult { documents_ids, document_scores, .. } = s.execute().unwrap();
-    insta::assert_snapshot!(format!("{documents_ids:?}"), @"[10, 9, 6, 7, 8, 11, 12, 13, 15]");
+    insta::assert_snapshot!(format!("{documents_ids:?}"), @"[10, 13, 9, 12, 6, 7, 8, 11, 15]");
     insta::assert_snapshot!(format!("{document_scores:#?}"));
     let texts = collect_field_values(&index, &txn, "text", &documents_ids);
 
@@ -379,13 +379,13 @@ fn test_proximity_prefix_db() {
     insta::assert_debug_snapshot!(texts, @r###"
     [
         "\"this is the best summer meal\"",
+        "\"summer best\"",
         "\"this is the best meal of summer\"",
+        "\"summer x best\"",
         "\"this is the best meal I have ever had in such a beautiful summer day\"",
         "\"this is the best cooked meal of the summer\"",
         "\"this is the best meal of the summer\"",
         "\"summer x y best\"",
-        "\"summer x best\"",
-        "\"summer best\"",
         "\"this is the best meal I have ever had in such a beautiful winter day\"",
     ]
     "###);
@@ -423,20 +423,20 @@ fn test_proximity_prefix_db() {
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
     s.query("best win");
     let SearchResult { documents_ids, document_scores, .. } = s.execute().unwrap();
-    insta::assert_snapshot!(format!("{documents_ids:?}"), @"[19, 18, 15, 16, 17, 20, 21, 22]");
+    insta::assert_snapshot!(format!("{documents_ids:?}"), @"[19, 22, 18, 21, 15, 16, 17, 20]");
     insta::assert_snapshot!(format!("{document_scores:#?}"));
     let texts = collect_field_values(&index, &txn, "text", &documents_ids);
 
     insta::assert_debug_snapshot!(texts, @r###"
     [
         "\"this is the best winter meal\"",
+        "\"winter best\"",
         "\"this is the best meal of winter\"",
+        "\"winter x best\"",
         "\"this is the best meal I have ever had in such a beautiful winter day\"",
         "\"this is the best cooked meal of the winter\"",
         "\"this is the best meal of the winter\"",
         "\"winter x y best\"",
-        "\"winter x best\"",
-        "\"winter best\"",
     ]
     "###);
 
@@ -471,20 +471,20 @@ fn test_proximity_prefix_db() {
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
     s.query("best wi");
     let SearchResult { documents_ids, document_scores, .. } = s.execute().unwrap();
-    insta::assert_snapshot!(format!("{documents_ids:?}"), @"[19, 18, 15, 16, 17, 20, 21, 22]");
+    insta::assert_snapshot!(format!("{documents_ids:?}"), @"[19, 22, 18, 21, 15, 16, 17, 20]");
     insta::assert_snapshot!(format!("{document_scores:#?}"));
     let texts = collect_field_values(&index, &txn, "text", &documents_ids);
 
     insta::assert_debug_snapshot!(texts, @r###"
     [
         "\"this is the best winter meal\"",
+        "\"winter best\"",
         "\"this is the best meal of winter\"",
+        "\"winter x best\"",
         "\"this is the best meal I have ever had in such a beautiful winter day\"",
         "\"this is the best cooked meal of the winter\"",
         "\"this is the best meal of the winter\"",
         "\"winter x y best\"",
-        "\"winter x best\"",
-        "\"winter best\"",
     ]
     "###);
 }

--- a/milli/src/search/new/tests/snapshots/milli__search__new__tests__proximity__proximity_prefix_db-14.snap
+++ b/milli/src/search/new/tests/snapshots/milli__search__new__tests__proximity__proximity_prefix_db-14.snap
@@ -14,6 +14,14 @@ expression: "format!(\"{document_scores:#?}\")"
     [
         Proximity(
             Rank {
+                rank: 3,
+                max_rank: 4,
+            },
+        ),
+    ],
+    [
+        Proximity(
+            Rank {
                 rank: 2,
                 max_rank: 4,
             },
@@ -22,15 +30,7 @@ expression: "format!(\"{document_scores:#?}\")"
     [
         Proximity(
             Rank {
-                rank: 1,
-                max_rank: 4,
-            },
-        ),
-    ],
-    [
-        Proximity(
-            Rank {
-                rank: 1,
+                rank: 2,
                 max_rank: 4,
             },
         ),

--- a/milli/src/search/new/tests/snapshots/milli__search__new__tests__proximity__proximity_prefix_db-2.snap
+++ b/milli/src/search/new/tests/snapshots/milli__search__new__tests__proximity__proximity_prefix_db-2.snap
@@ -14,6 +14,14 @@ expression: "format!(\"{document_scores:#?}\")"
     [
         Proximity(
             Rank {
+                rank: 3,
+                max_rank: 4,
+            },
+        ),
+    ],
+    [
+        Proximity(
+            Rank {
                 rank: 2,
                 max_rank: 4,
             },
@@ -22,15 +30,7 @@ expression: "format!(\"{document_scores:#?}\")"
     [
         Proximity(
             Rank {
-                rank: 1,
-                max_rank: 4,
-            },
-        ),
-    ],
-    [
-        Proximity(
-            Rank {
-                rank: 1,
+                rank: 2,
                 max_rank: 4,
             },
         ),

--- a/milli/src/search/new/tests/snapshots/milli__search__new__tests__proximity__proximity_prefix_db-8.snap
+++ b/milli/src/search/new/tests/snapshots/milli__search__new__tests__proximity__proximity_prefix_db-8.snap
@@ -14,6 +14,14 @@ expression: "format!(\"{document_scores:#?}\")"
     [
         Proximity(
             Rank {
+                rank: 3,
+                max_rank: 4,
+            },
+        ),
+    ],
+    [
+        Proximity(
+            Rank {
                 rank: 2,
                 max_rank: 4,
             },
@@ -22,15 +30,7 @@ expression: "format!(\"{document_scores:#?}\")"
     [
         Proximity(
             Rank {
-                rank: 1,
-                max_rank: 4,
-            },
-        ),
-    ],
-    [
-        Proximity(
-            Rank {
-                rank: 1,
+                rank: 2,
                 max_rank: 4,
             },
         ),

--- a/milli/src/update/words_prefixes_fst.rs
+++ b/milli/src/update/words_prefixes_fst.rs
@@ -15,7 +15,7 @@ pub struct WordsPrefixesFst<'t, 'i> {
 
 impl<'t, 'i> WordsPrefixesFst<'t, 'i> {
     pub fn new(wtxn: &'t mut RwTxn<'i>, index: &'i Index) -> WordsPrefixesFst<'t, 'i> {
-        WordsPrefixesFst { wtxn, index, threshold: 100, max_prefix_length: 4 }
+        WordsPrefixesFst { wtxn, index, threshold: 500, max_prefix_length: 3 }
     }
 
     /// Set the number of words required to make a prefix be part of the words prefixes


### PR DESCRIPTION
This PR changes the prefix database creation thresholds to reduce their impact on the indexing time.

## Explanations

There are two thresholds that we can change in the prefix database:
1) the minimum number of words prefixed by the prefix candidate, named `threshold`
2) the maximum number of characters in a prefix, named `max_prefix_length`

## Prior values and drawback

On Meilisearch v1.5, we have 100 as the `threshold` and 4 as the `max_prefix_length`, meaning that we compute and store every prefix that has at least 100 words prefixed by it and less than 5 characters.

By making some statistics using `movies`, `Wikipedia`, and `e-commerce` datasets, I found out that only 10% of the total count of stored prefixes have 1 character on a small dataset (10MB), and less than 1% on a bigger dataset (2GB).
This is a shame because the 1-character prefixes are the most important regarding search time gain.
On the opposite, the prefixes containing 3 or 4 characters represent more than 30% of the prefixes on a small dataset, which is acceptable, but represent more than 80% of the prefixes on big datasets.
In this configuration for the big datasets, we allocate between 80 and 100 times more for the least important prefixes than for the most important ones, which seems non-optimal to me. 

## New value
This PR changes the `threshold` from 100 to 500 and the `max_prefix_length` from 4 to 3 in order to rebalance the distribution.
This way:
1) on a small dataset:
  - the 1-character prefixes represent more than 40% of the prefixes (10% before)
  - the 3-character prefixes represent around 2% of the prefixes (30% before counting the 4-character prefixes)
2) on a bigger dataset:
  - the 1-character prefixes represent around 5% of the prefixes (less than 1% before)
  - the 3-character prefixes represent around 60% of the prefixes (more than 80% before counting the 4-character prefixes)

This suggested change is conservative, and we could think of raising the thresholds even more, but I'm afraid that it would have a significant impact on the search, and because we already are in the prerelease phase we will not be able to make that many benchmarks.

## Related

google sheet with some stats: https://docs.google.com/spreadsheets/d/1EOL4Bmg_2RW2WGt6DN5Ec7V2hsbIc42eC9iOjy5vzN8/edit#gid=558148218
