### PR TITLE
Display default value when proximityPrecision is not set

### DIFF
--- a/meilisearch/tests/dumps/mod.rs
+++ b/meilisearch/tests/dumps/mod.rs
@@ -59,7 +59,7 @@ async fn import_dump_v1_movie_raw() {
       "dictionary": [],
       "synonyms": {},
       "distinctAttribute": null,
-      "proximityPrecision": null,
+      "proximityPrecision": "byWord",
       "typoTolerance": {
         "enabled": true,
         "minWordSizeForTypos": {
@@ -221,7 +221,7 @@ async fn import_dump_v1_movie_with_settings() {
       "dictionary": [],
       "synonyms": {},
       "distinctAttribute": null,
-      "proximityPrecision": null,
+      "proximityPrecision": "byWord",
       "typoTolerance": {
         "enabled": true,
         "minWordSizeForTypos": {
@@ -369,7 +369,7 @@ async fn import_dump_v1_rubygems_with_settings() {
       "dictionary": [],
       "synonyms": {},
       "distinctAttribute": null,
-      "proximityPrecision": null,
+      "proximityPrecision": "byWord",
       "typoTolerance": {
         "enabled": true,
         "minWordSizeForTypos": {
@@ -503,7 +503,7 @@ async fn import_dump_v2_movie_raw() {
       "dictionary": [],
       "synonyms": {},
       "distinctAttribute": null,
-      "proximityPrecision": null,
+      "proximityPrecision": "byWord",
       "typoTolerance": {
         "enabled": true,
         "minWordSizeForTypos": {
@@ -649,7 +649,7 @@ async fn import_dump_v2_movie_with_settings() {
       "dictionary": [],
       "synonyms": {},
       "distinctAttribute": null,
-      "proximityPrecision": null,
+      "proximityPrecision": "byWord",
       "typoTolerance": {
         "enabled": true,
         "minWordSizeForTypos": {
@@ -794,7 +794,7 @@ async fn import_dump_v2_rubygems_with_settings() {
       "dictionary": [],
       "synonyms": {},
       "distinctAttribute": null,
-      "proximityPrecision": null,
+      "proximityPrecision": "byWord",
       "typoTolerance": {
         "enabled": true,
         "minWordSizeForTypos": {
@@ -928,7 +928,7 @@ async fn import_dump_v3_movie_raw() {
       "dictionary": [],
       "synonyms": {},
       "distinctAttribute": null,
-      "proximityPrecision": null,
+      "proximityPrecision": "byWord",
       "typoTolerance": {
         "enabled": true,
         "minWordSizeForTypos": {
@@ -1074,7 +1074,7 @@ async fn import_dump_v3_movie_with_settings() {
       "dictionary": [],
       "synonyms": {},
       "distinctAttribute": null,
-      "proximityPrecision": null,
+      "proximityPrecision": "byWord",
       "typoTolerance": {
         "enabled": true,
         "minWordSizeForTypos": {
@@ -1219,7 +1219,7 @@ async fn import_dump_v3_rubygems_with_settings() {
       "dictionary": [],
       "synonyms": {},
       "distinctAttribute": null,
-      "proximityPrecision": null,
+      "proximityPrecision": "byWord",
       "typoTolerance": {
         "enabled": true,
         "minWordSizeForTypos": {
@@ -1353,7 +1353,7 @@ async fn import_dump_v4_movie_raw() {
       "dictionary": [],
       "synonyms": {},
       "distinctAttribute": null,
-      "proximityPrecision": null,
+      "proximityPrecision": "byWord",
       "typoTolerance": {
         "enabled": true,
         "minWordSizeForTypos": {
@@ -1499,7 +1499,7 @@ async fn import_dump_v4_movie_with_settings() {
       "dictionary": [],
       "synonyms": {},
       "distinctAttribute": null,
-      "proximityPrecision": null,
+      "proximityPrecision": "byWord",
       "typoTolerance": {
         "enabled": true,
         "minWordSizeForTypos": {
@@ -1644,7 +1644,7 @@ async fn import_dump_v4_rubygems_with_settings() {
       "dictionary": [],
       "synonyms": {},
       "distinctAttribute": null,
-      "proximityPrecision": null,
+      "proximityPrecision": "byWord",
       "typoTolerance": {
         "enabled": true,
         "minWordSizeForTypos": {

--- a/meilisearch/tests/settings/get_settings.rs
+++ b/meilisearch/tests/settings/get_settings.rs
@@ -84,6 +84,7 @@ async fn get_settings() {
         })
     );
     assert_eq!(settings["embedders"], json!({}));
+    assert_eq!(settings["proximityPrecision"], json!("byWord"));
 }
 
 #[actix_rt::test]


### PR DESCRIPTION
# Pull Request

## Related
Issue: #4187
Spec change requests: https://github.com/meilisearch/specifications/pull/261#discussion_r1441725272

## What does this PR do?
- Display default value when proximityPrecision is not set instead of Null
