### PR TITLE
Fix document formatting performances

### DIFF
--- a/meilisearch/src/search.rs
+++ b/meilisearch/src/search.rs
@@ -897,9 +897,9 @@ fn format_fields<'a>(
     let mut matches_position = compute_matches.then(BTreeMap::new);
     let mut document = document.clone();
 
-    // reduce the formated option list to the attributes that should be formatted,
-    // instead of all the attribute to display.
-    let formating_fields_options: Vec<_> = formatted_options
+    // reduce the formatted option list to the attributes that should be formatted,
+    // instead of all the attributes to display.
+    let formatting_fields_options: Vec<_> = formatted_options
         .iter()
         .filter(|(_, option)| option.should_format())
         .map(|(fid, option)| (field_ids_map.name(*fid).unwrap(), option))
@@ -913,10 +913,10 @@ fn format_fields<'a>(
         // to the value and merge them together. eg. If a user said he wanted to highlight `doggo`
         // and crop `doggo.name`. `doggo.name` needs to be highlighted + cropped while `doggo.age` is only
         // highlighted.
-        // Warn: The time to compute the `format` list scales with the number of field to format;
-        // cummulated with `map_leaf_values` that iterates over all the nested fields, it gives a quadratic complexity:
-        // `d*f` where `d` is the total number of field to display and `f` the total number of field to format.
-        let format = formating_fields_options
+        // Warn: The time to compute the format list scales with the number of fields to format;
+        // cumulated with map_leaf_values that iterates over all the nested fields, it gives a quadratic complexity:
+        // d*f where d is the total number of fields to display and f is the total number of fields to format.
+        let format = formatting_fields_options
             .iter()
             .filter(|(name, _option)| {
                 milli::is_faceted_by(name, key) || milli::is_faceted_by(key, name)

--- a/meilisearch/src/search.rs
+++ b/meilisearch/src/search.rs
@@ -951,11 +951,6 @@ fn format_value<'a>(
     infos: &mut Vec<MatchBounds>,
     compute_matches: bool,
 ) -> Value {
-    // early skip recursive function if nothing needs to be changed.
-    if !format_options.as_ref().map_or(false, FormatOptions::should_format) && !compute_matches {
-        return value;
-    }
-
     match value {
         Value::String(old_string) => {
             let mut matcher = builder.build(&old_string);
@@ -1023,7 +1018,7 @@ fn format_value<'a>(
                     let value = matcher.format(format_options);
                     Value::String(value.into_owned())
                 }
-                None => Value::Number(number),
+                None => Value::String(s),
             }
         }
         value => value,

--- a/meilisearch/tests/settings/tokenizer_customization.rs
+++ b/meilisearch/tests/settings/tokenizer_customization.rs
@@ -94,7 +94,7 @@ async fn set_and_search() {
                 "id": 1,
                 "content": "Mac & cheese",
                 "_formatted": {
-                  "id": "1",
+                  "id": 1,
                   "content": "Mac <em>&</em> cheese"
                 }
               },
@@ -102,7 +102,7 @@ async fn set_and_search() {
                 "id": 3,
                 "content": "Mac&sep&&sepcheese",
                 "_formatted": {
-                  "id": "3",
+                  "id": 3,
                   "content": "Mac&sep<em>&</em>&sepcheese"
                 }
               }
@@ -254,7 +254,7 @@ async fn advanced_synergies() {
                 "id": 1,
                 "content": "J.R.R. Tolkien",
                 "_formatted": {
-                  "id": "1",
+                  "id": 1,
                   "content": "<em>J.R.R.</em> Tolkien"
                 }
               },
@@ -262,7 +262,7 @@ async fn advanced_synergies() {
                 "id": 2,
                 "content": "J. R. R. Tolkien",
                 "_formatted": {
-                  "id": "2",
+                  "id": 2,
                   "content": "<em>J. R. R.</em> Tolkien"
                 }
               },
@@ -270,7 +270,7 @@ async fn advanced_synergies() {
                 "id": 3,
                 "content": "jrr Tolkien",
                 "_formatted": {
-                  "id": "3",
+                  "id": 3,
                   "content": "<em>jrr</em> Tolkien"
                 }
               }

--- a/meilisearch/tests/settings/tokenizer_customization.rs
+++ b/meilisearch/tests/settings/tokenizer_customization.rs
@@ -94,7 +94,7 @@ async fn set_and_search() {
                 "id": 1,
                 "content": "Mac & cheese",
                 "_formatted": {
-                  "id": 1,
+                  "id": "1",
                   "content": "Mac <em>&</em> cheese"
                 }
               },
@@ -102,7 +102,7 @@ async fn set_and_search() {
                 "id": 3,
                 "content": "Mac&sep&&sepcheese",
                 "_formatted": {
-                  "id": 3,
+                  "id": "3",
                   "content": "Mac&sep<em>&</em>&sepcheese"
                 }
               }
@@ -254,7 +254,7 @@ async fn advanced_synergies() {
                 "id": 1,
                 "content": "J.R.R. Tolkien",
                 "_formatted": {
-                  "id": 1,
+                  "id": "1",
                   "content": "<em>J.R.R.</em> Tolkien"
                 }
               },
@@ -262,7 +262,7 @@ async fn advanced_synergies() {
                 "id": 2,
                 "content": "J. R. R. Tolkien",
                 "_formatted": {
-                  "id": 2,
+                  "id": "2",
                   "content": "<em>J. R. R.</em> Tolkien"
                 }
               },
@@ -270,7 +270,7 @@ async fn advanced_synergies() {
                 "id": 3,
                 "content": "jrr Tolkien",
                 "_formatted": {
-                  "id": 3,
+                  "id": "3",
                   "content": "<em>jrr</em> Tolkien"
                 }
               }

--- a/milli/src/search/new/bucket_sort.rs
+++ b/milli/src/search/new/bucket_sort.rs
@@ -15,6 +15,7 @@ pub struct BucketSortOutput {
 
 // TODO: would probably be good to regroup some of these inside of a struct?
 #[allow(clippy::too_many_arguments)]
+#[logging_timer::time]
 pub fn bucket_sort<'ctx, Q: RankingRuleQueryTrait>(
     ctx: &mut SearchContext<'ctx>,
     mut ranking_rules: Vec<BoxRankingRule<'ctx, Q>>,

--- a/milli/src/search/new/matches/mod.rs
+++ b/milli/src/search/new/matches/mod.rs
@@ -72,7 +72,7 @@ impl<'m> MatcherBuilder<'m> {
     }
 }
 
-#[derive(Copy, Clone, Default)]
+#[derive(Copy, Clone, Default, Debug)]
 pub struct FormatOptions {
     pub highlight: bool,
     pub crop: Option<usize>,
@@ -81,6 +81,10 @@ pub struct FormatOptions {
 impl FormatOptions {
     pub fn merge(self, other: Self) -> Self {
         Self { highlight: self.highlight || other.highlight, crop: self.crop.or(other.crop) }
+    }
+
+    pub fn should_format(&self) -> bool {
+        self.highlight || self.crop.is_some()
     }
 }
 

--- a/milli/src/search/new/mod.rs
+++ b/milli/src/search/new/mod.rs
@@ -191,6 +191,7 @@ fn resolve_maximally_reduced_query_graph(
     Ok(docids)
 }
 
+#[logging_timer::time]
 fn resolve_universe(
     ctx: &mut SearchContext,
     initial_universe: &RoaringBitmap,
@@ -556,6 +557,7 @@ pub fn execute_vector_search(
 }
 
 #[allow(clippy::too_many_arguments)]
+#[logging_timer::time]
 pub fn execute_search(
     ctx: &mut SearchContext,
     query: Option<&str>,

--- a/milli/src/search/new/query_term/parse_query.rs
+++ b/milli/src/search/new/query_term/parse_query.rs
@@ -5,6 +5,7 @@ use super::*;
 use crate::{Result, SearchContext, MAX_WORD_LENGTH};
 
 /// Convert the tokenised search query into a list of located query terms.
+#[logging_timer::time]
 pub fn located_query_terms_from_tokens(
     ctx: &mut SearchContext,
     query: NormalizedTokenIter,


### PR DESCRIPTION
reduce the formatted option list to the attributes that should be formatted,
instead of all the attributes to display.
The time to compute the `format` list scales with the number of fields to format;
cumulated with `map_leaf_values` that iterates over all the nested fields, it gives a quadratic complexity:
`d*f` where `d` is the total number of fields to display and `f` is the total number of fields to format.