### PR TITLE
Trace the Memory Usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3669,6 +3669,7 @@ dependencies = [
  "siphasher 1.0.0",
  "slice-group-by",
  "static-files",
+ "stats_alloc",
  "sysinfo",
  "tar",
  "temp-env",
@@ -5230,6 +5231,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "stats_alloc"
+version = "0.1.10"
+source = "git+https://github.com/Kerollmops/stats_alloc?branch=stable-const-fn-trait#6f83c52160c7d0550fdf770e1f73d239b0ff9a97"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5706,8 +5712,10 @@ version = "0.1.0"
 dependencies = [
  "color-spantrace",
  "fxprof-processed-profile",
+ "once_cell",
  "serde",
  "serde_json",
+ "stats_alloc",
  "tracing",
  "tracing-error",
  "tracing-subscriber",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5710,9 +5710,9 @@ dependencies = [
 name = "tracing-trace"
 version = "0.1.0"
 dependencies = [
+ "byte-unit",
  "color-spantrace",
  "fxprof-processed-profile",
- "once_cell",
  "serde",
  "serde_json",
  "stats_alloc",

--- a/meilisearch/Cargo.toml
+++ b/meilisearch/Cargo.toml
@@ -137,7 +137,7 @@ vergen = { version = "7.5.1", default-features = false, features = ["git"] }
 zip = { version = "0.6.6", optional = true }
 
 [features]
-default = ["stats_alloc", "analytics", "meilisearch-types/all-tokenizations", "mini-dashboard"]
+default = ["analytics", "meilisearch-types/all-tokenizations", "mini-dashboard"]
 analytics = ["segment"]
 mini-dashboard = [
     "actix-web-static-files",

--- a/meilisearch/Cargo.toml
+++ b/meilisearch/Cargo.toml
@@ -108,6 +108,7 @@ url = { version = "2.5.0", features = ["serde"] }
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 tracing-trace = { version = "0.1.0", path = "../tracing-trace" }
+stats_alloc = { git = "https://github.com/Kerollmops/stats_alloc", branch = "stable-const-fn-trait", optional = true }
 
 [dev-dependencies]
 actix-rt = "2.9.0"
@@ -136,7 +137,7 @@ vergen = { version = "7.5.1", default-features = false, features = ["git"] }
 zip = { version = "0.6.6", optional = true }
 
 [features]
-default = ["analytics", "meilisearch-types/all-tokenizations", "mini-dashboard"]
+default = ["stats_alloc", "analytics", "meilisearch-types/all-tokenizations", "mini-dashboard"]
 analytics = ["segment"]
 mini-dashboard = [
     "actix-web-static-files",

--- a/meilisearch/src/main.rs
+++ b/meilisearch/src/main.rs
@@ -35,8 +35,10 @@ fn setup(opt: &Opt) -> anyhow::Result<()> {
 
     let file = std::fs::File::create(&trace_file)
         .with_context(|| format!("could not create trace file at '{}'", trace_file))?;
-    // TODO kero: Pass the allocator stats to Trace here
+    #[cfg(not(feature = "stats_alloc"))]
     let (mut trace, layer) = tracing_trace::Trace::new(file);
+    #[cfg(feature = "stats_alloc")]
+    let (mut trace, layer) = tracing_trace::Trace::with_stats_alloc(file, &ALLOC);
 
     let subscriber = tracing_subscriber::registry()
         .with(

--- a/meilisearch/src/main.rs
+++ b/meilisearch/src/main.rs
@@ -14,12 +14,18 @@ use is_terminal::IsTerminal;
 use meilisearch::analytics::Analytics;
 use meilisearch::{analytics, create_app, prototype_name, setup_meilisearch, Opt};
 use meilisearch_auth::{generate_master_key, AuthController, MASTER_KEY_MIN_SIZE};
+use mimalloc::MiMalloc;
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 use tracing_subscriber::layer::SubscriberExt as _;
 use tracing_subscriber::Layer;
 
+#[cfg(not(feature = "stats_alloc"))]
 #[global_allocator]
-static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
+static ALLOC: MiMalloc = MiMalloc;
+
+#[cfg(feature = "stats_alloc")]
+#[global_allocator]
+static ALLOC: stats_alloc::StatsAlloc<MiMalloc> = stats_alloc::StatsAlloc::new(MiMalloc);
 
 /// does all the setup before meilisearch is launched
 fn setup(opt: &Opt) -> anyhow::Result<()> {

--- a/tracing-trace/Cargo.toml
+++ b/tracing-trace/Cargo.toml
@@ -13,3 +13,5 @@ serde_json = "1.0.111"
 tracing = "0.1.40"
 tracing-error = "0.2.0"
 tracing-subscriber = "0.3.18"
+stats_alloc = { git = "https://github.com/Kerollmops/stats_alloc", branch = "stable-const-fn-trait" }
+once_cell = "1.19.0"

--- a/tracing-trace/Cargo.toml
+++ b/tracing-trace/Cargo.toml
@@ -14,4 +14,8 @@ tracing = "0.1.40"
 tracing-error = "0.2.0"
 tracing-subscriber = "0.3.18"
 stats_alloc = { git = "https://github.com/Kerollmops/stats_alloc", branch = "stable-const-fn-trait" }
-once_cell = "1.19.0"
+byte-unit = { version = "4.0.19", default-features = false, features = [
+    "std",
+    "serde",
+] }
+

--- a/tracing-trace/src/entry.rs
+++ b/tracing-trace/src/entry.rs
@@ -1,5 +1,4 @@
 use std::borrow::Cow;
-use std::ops::Sub;
 
 use serde::{Deserialize, Serialize};
 use tracing::span::Id as TracingId;
@@ -123,18 +122,16 @@ impl From<stats_alloc::Stats> for MemoryStats {
     }
 }
 
-impl Sub for MemoryStats {
-    type Output = Self;
-
-    fn sub(self, other: Self) -> Self::Output {
-        Self {
-            allocations: self.allocations - other.allocations,
-            deallocations: self.deallocations - other.deallocations,
-            reallocations: self.reallocations - other.reallocations,
-            bytes_allocated: self.bytes_allocated - other.bytes_allocated,
-            bytes_deallocated: self.bytes_deallocated - other.bytes_deallocated,
-            bytes_reallocated: self.bytes_reallocated - other.bytes_reallocated,
-        }
+impl MemoryStats {
+    pub fn checked_sub(self, other: Self) -> Option<Self> {
+        Some(Self {
+            allocations: self.allocations.checked_sub(other.allocations)?,
+            deallocations: self.deallocations.checked_sub(other.deallocations)?,
+            reallocations: self.reallocations.checked_sub(other.reallocations)?,
+            bytes_allocated: self.bytes_allocated.checked_sub(other.bytes_allocated)?,
+            bytes_deallocated: self.bytes_deallocated.checked_sub(other.bytes_deallocated)?,
+            bytes_reallocated: self.bytes_reallocated.checked_sub(other.bytes_reallocated)?,
+        })
     }
 }
 

--- a/tracing-trace/src/entry.rs
+++ b/tracing-trace/src/entry.rs
@@ -133,6 +133,14 @@ impl MemoryStats {
             bytes_reallocated: self.bytes_reallocated.checked_sub(other.bytes_reallocated)?,
         })
     }
+
+    pub fn usage(&self) -> isize {
+        (self.bytes_allocated - self.bytes_deallocated) as isize + self.bytes_reallocated
+    }
+
+    pub fn operations(&self) -> usize {
+        self.allocations + self.deallocations + self.reallocations
+    }
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]

--- a/tracing-trace/src/layer.rs
+++ b/tracing-trace/src/layer.rs
@@ -83,7 +83,7 @@ enum OpaqueIdentifier {
     Call(tracing::callsite::Identifier),
 }
 
-impl TraceLayer {
+impl<A: GlobalAlloc> TraceLayer<A> {
     fn resource_id(&self, opaque: OpaqueIdentifier) -> Option<ResourceId> {
         self.callsites.read().unwrap().get(&opaque).copied()
     }
@@ -132,9 +132,10 @@ impl TraceLayer {
     }
 }
 
-impl<S> Layer<S> for TraceLayer
+impl<S, A> Layer<S> for TraceLayer<A>
 where
     S: Subscriber,
+    A: GlobalAlloc,
 {
     fn on_new_span(&self, attrs: &Attributes<'_>, id: &TracingId, _ctx: Context<'_, S>) {
         let call_id = self

--- a/tracing-trace/src/processor/fmt.rs
+++ b/tracing-trace/src/processor/fmt.rs
@@ -147,6 +147,24 @@ fn print_duration(duration: std::time::Duration) -> String {
     }
 }
 
+/// Format only the allocated bytes, deallocated bytes and reallocated bytes in GiB, MiB, KiB, Bytes.
 fn print_memory(memory: MemoryStats) -> String {
-    // Format only the total allocations in GiB, MiB, KiB, Bytes
+    use byte_unit::Byte;
+
+    let allocated_bytes = Byte::from_bytes(memory.bytes_allocated.try_into().unwrap());
+    let deallocated_bytes = Byte::from_bytes(memory.bytes_deallocated.try_into().unwrap());
+
+    let reallocated_sign = if memory.bytes_reallocated < 0 { "-" } else { "" };
+    let reallocated_bytes =
+        Byte::from_bytes(memory.bytes_reallocated.abs_diff(0).try_into().unwrap());
+
+    let adjusted_allocated_bytes = allocated_bytes.get_appropriate_unit(true);
+    let adjusted_deallocated_bytes = deallocated_bytes.get_appropriate_unit(true);
+    let adjusted_reallocated_bytes = reallocated_bytes.get_appropriate_unit(true);
+
+    format!(
+        "Allocated {adjusted_allocated_bytes:.2}, \
+        Deallocated {adjusted_deallocated_bytes:.2}, \
+        Reallocated {reallocated_sign}{adjusted_reallocated_bytes:.2}"
+    )
 }


### PR DESCRIPTION
By using the `stats_alloc` feature in meilisearch, we can log:
 - the number of allocations, deallocations, and reallocations.
 - the size of the allocations, deallocations, and reallocations.

We internally use a fork [of the `stats_alloc` crate](https://github.com/Kerollmops/stats_alloc/tree/stable-const-fn-trait). [I asked the maintainer](https://fosstodon.org/@kero/111776474944810212) if he could merge our changes into the main crate... no answer so far.