### PR TITLE
Restore highlighting when possible for hybrid search

### DIFF
--- a/milli/src/search/hybrid.rs
+++ b/milli/src/search/hybrid.rs
@@ -102,7 +102,7 @@ impl ScoreWithRatioResult {
         }
 
         SearchResult {
-            matching_words: left.matching_words,
+            matching_words: right.matching_words,
             candidates: left.candidates | right.candidates,
             documents_ids,
             document_scores,


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #4351 

## What does this PR do?
- Use `MatchingWords` from keyword search instead of the one from vector search
- New: When `semanticRatio < 1.0`, all words from the query are now highlighted in all results, regardless of their source (keyword or semantic)
- No change: When `semanticRatio == 1.0`, no highlighting is applied, like before this PR

