### PR TITLE
Feat: add new OpenAI models and ability to override dimensions

### DIFF
--- a/meilisearch-types/src/error.rs
+++ b/meilisearch-types/src/error.rs
@@ -348,6 +348,8 @@ impl ErrorCode for milli::Error {
                     | UserError::MissingFieldForSource { .. }
                     | UserError::InvalidOpenAiModel { .. }
                     | UserError::InvalidOpenAiModelDimensions { .. }
+                    | UserError::InvalidOpenAiModelDimensionsMax { .. }
+                    | UserError::InvalidSettingsDimensions { .. }
                     | UserError::InvalidPrompt(_) => Code::InvalidSettingsEmbedders,
                     UserError::TooManyEmbedders(_) => Code::InvalidSettingsEmbedders,
                     UserError::InvalidPromptForEmbeddings(..) => Code::InvalidSettingsEmbedders,

--- a/meilisearch-types/src/error.rs
+++ b/meilisearch-types/src/error.rs
@@ -347,6 +347,7 @@ impl ErrorCode for milli::Error {
                     UserError::InvalidFieldForSource { .. }
                     | UserError::MissingFieldForSource { .. }
                     | UserError::InvalidOpenAiModel { .. }
+                    | UserError::InvalidOpenAiModelDimensions { .. }
                     | UserError::InvalidPrompt(_) => Code::InvalidSettingsEmbedders,
                     UserError::TooManyEmbedders(_) => Code::InvalidSettingsEmbedders,
                     UserError::InvalidPromptForEmbeddings(..) => Code::InvalidSettingsEmbedders,

--- a/milli/src/error.rs
+++ b/milli/src/error.rs
@@ -234,6 +234,15 @@ only composed of alphanumeric characters (a-z A-Z 0-9), hyphens (-) and undersco
         dimensions: usize,
         expected_dimensions: usize,
     },
+    #[error("`.embedders.{embedder_name}.dimensions`: Model `{model}` does not support overriding its dimensions to a value higher than {max_dimensions}. Found {dimensions}")]
+    InvalidOpenAiModelDimensionsMax {
+        embedder_name: String,
+        model: &'static str,
+        dimensions: usize,
+        max_dimensions: usize,
+    },
+    #[error("`.embedders.{embedder_name}.dimensions`: `dimensions` cannot be zero")]
+    InvalidSettingsDimensions { embedder_name: String },
 }
 
 impl From<crate::vector::Error> for Error {

--- a/milli/src/error.rs
+++ b/milli/src/error.rs
@@ -227,6 +227,13 @@ only composed of alphanumeric characters (a-z A-Z 0-9), hyphens (-) and undersco
         source_: crate::vector::settings::EmbedderSource,
         embedder_name: String,
     },
+    #[error("`.embedders.{embedder_name}.dimensions`: Model `{model}` does not support overriding its native dimensions of {expected_dimensions}. Found {dimensions}")]
+    InvalidOpenAiModelDimensions {
+        embedder_name: String,
+        model: &'static str,
+        dimensions: usize,
+        expected_dimensions: usize,
+    },
 }
 
 impl From<crate::vector::Error> for Error {

--- a/milli/src/update/settings.rs
+++ b/milli/src/update/settings.rs
@@ -1122,6 +1122,14 @@ pub fn validate_embedding_settings(
     let Setting::Set(settings) = settings else { return Ok(settings) };
     let EmbeddingSettings { source, model, revision, api_key, dimensions, document_template } =
         settings;
+
+    if let Some(0) = dimensions.set() {
+        return Err(crate::error::UserError::InvalidSettingsDimensions {
+            embedder_name: name.to_owned(),
+        }
+        .into());
+    }
+
     let Some(inferred_source) = source.set() else {
         return Ok(Setting::Set(EmbeddingSettings {
             source,
@@ -1150,6 +1158,15 @@ pub fn validate_embedding_settings(
                             model: model.name(),
                             dimensions,
                             expected_dimensions: model.default_dimensions(),
+                        }
+                        .into());
+                    }
+                    if dimensions > model.default_dimensions() {
+                        return Err(crate::error::UserError::InvalidOpenAiModelDimensionsMax {
+                            embedder_name: name.to_owned(),
+                            model: model.name(),
+                            dimensions,
+                            max_dimensions: model.default_dimensions(),
                         }
                         .into());
                     }

--- a/milli/src/vector/openai.rs
+++ b/milli/src/vector/openai.rs
@@ -68,8 +68,8 @@ impl EmbeddingModel {
     pub fn default_dimensions(&self) -> usize {
         match self {
             EmbeddingModel::TextEmbeddingAda002 => 1536,
-            EmbeddingModel::TextEmbedding3Large => 1536,
-            EmbeddingModel::TextEmbedding3Small => 3072,
+            EmbeddingModel::TextEmbedding3Large => 3072,
+            EmbeddingModel::TextEmbedding3Small => 1536,
         }
     }
 

--- a/milli/src/vector/openai.rs
+++ b/milli/src/vector/openai.rs
@@ -96,10 +96,10 @@ impl EmbeddingModel {
                 Some(DistributionShift { current_mean: 0.90, current_sigma: 0.08 })
             }
             EmbeddingModel::TextEmbedding3Large => {
-                Some(DistributionShift { current_mean: 0.90, current_sigma: 0.08 })
+                Some(DistributionShift { current_mean: 0.70, current_sigma: 0.1 })
             }
             EmbeddingModel::TextEmbedding3Small => {
-                Some(DistributionShift { current_mean: 0.90, current_sigma: 0.08 })
+                Some(DistributionShift { current_mean: 0.75, current_sigma: 0.1 })
             }
         }
     }

--- a/milli/src/vector/openai.rs
+++ b/milli/src/vector/openai.rs
@@ -17,6 +17,7 @@ pub struct Embedder {
 pub struct EmbedderOptions {
     pub api_key: Option<String>,
     pub embedding_model: EmbeddingModel,
+    pub dimensions: Option<usize>,
 }
 
 #[derive(
@@ -41,34 +42,54 @@ pub enum EmbeddingModel {
     #[serde(rename = "text-embedding-ada-002")]
     #[deserr(rename = "text-embedding-ada-002")]
     TextEmbeddingAda002,
+
+    #[serde(rename = "text-embedding-3-small")]
+    #[deserr(rename = "text-embedding-3-small")]
+    TextEmbedding3Small,
+
+    #[serde(rename = "text-embedding-3-large")]
+    #[deserr(rename = "text-embedding-3-large")]
+    TextEmbedding3Large,
 }
 
 impl EmbeddingModel {
     pub fn supported_models() -> &'static [&'static str] {
-        &["text-embedding-ada-002"]
+        &["text-embedding-ada-002", "text-embedding-3-small", "text-embedding-3-large"]
     }
 
     pub fn max_token(&self) -> usize {
         match self {
             EmbeddingModel::TextEmbeddingAda002 => 8191,
+            EmbeddingModel::TextEmbedding3Large => 8191,
+            EmbeddingModel::TextEmbedding3Small => 8191,
         }
     }
 
     pub fn dimensions(&self) -> usize {
         match self {
             EmbeddingModel::TextEmbeddingAda002 => 1536,
+
+            //Default value for the model
+            EmbeddingModel::TextEmbedding3Large => 1536,
+
+            //Default value for the model
+            EmbeddingModel::TextEmbedding3Small => 3072,
         }
     }
 
     pub fn name(&self) -> &'static str {
         match self {
             EmbeddingModel::TextEmbeddingAda002 => "text-embedding-ada-002",
+            EmbeddingModel::TextEmbedding3Large => "text-embedding-3-large",
+            EmbeddingModel::TextEmbedding3Small => "text-embedding-3-small",
         }
     }
 
     pub fn from_name(name: &str) -> Option<Self> {
         match name {
             "text-embedding-ada-002" => Some(EmbeddingModel::TextEmbeddingAda002),
+            "text-embedding-3-large" => Some(EmbeddingModel::TextEmbedding3Large),
+            "text-embedding-3-small" => Some(EmbeddingModel::TextEmbedding3Small),
             _ => None,
         }
     }
@@ -78,6 +99,20 @@ impl EmbeddingModel {
             EmbeddingModel::TextEmbeddingAda002 => {
                 Some(DistributionShift { current_mean: 0.90, current_sigma: 0.08 })
             }
+            EmbeddingModel::TextEmbedding3Large => {
+                Some(DistributionShift { current_mean: 0.90, current_sigma: 0.08 })
+            }
+            EmbeddingModel::TextEmbedding3Small => {
+                Some(DistributionShift { current_mean: 0.90, current_sigma: 0.08 })
+            }
+        }
+    }
+
+    pub fn is_optional_dimensions_supported(&self) -> bool {
+        match self {
+            EmbeddingModel::TextEmbeddingAda002 => false,
+            EmbeddingModel::TextEmbedding3Large => true,
+            EmbeddingModel::TextEmbedding3Small => true,
         }
     }
 }
@@ -86,11 +121,11 @@ pub const OPENAI_EMBEDDINGS_URL: &str = "https://api.openai.com/v1/embeddings";
 
 impl EmbedderOptions {
     pub fn with_default_model(api_key: Option<String>) -> Self {
-        Self { api_key, embedding_model: Default::default() }
+        Self { api_key, embedding_model: Default::default(), dimensions: None }
     }
 
     pub fn with_embedding_model(api_key: Option<String>, embedding_model: EmbeddingModel) -> Self {
-        Self { api_key, embedding_model }
+        Self { api_key, embedding_model, dimensions: None }
     }
 }
 
@@ -237,7 +272,15 @@ impl Embedder {
         for text in texts {
             log::trace!("Received prompt: {}", text.as_ref())
         }
-        let request = OpenAiRequest { model: self.options.embedding_model.name(), input: texts };
+        let request = OpenAiRequest {
+            model: self.options.embedding_model.name(),
+            input: texts,
+            dimension: if self.options.embedding_model.is_optional_dimensions_supported() {
+                self.options.dimensions.as_ref()
+            } else {
+                None
+            },
+        };
         let response = client
             .post(OPENAI_EMBEDDINGS_URL)
             .json(&request)
@@ -366,7 +409,7 @@ impl Embedder {
     }
 
     pub fn dimensions(&self) -> usize {
-        self.options.embedding_model.dimensions()
+        self.options.dimensions.unwrap_or_else(|| self.options.embedding_model.dimensions())
     }
 
     pub fn distribution(&self) -> Option<DistributionShift> {
@@ -431,6 +474,7 @@ impl Retry {
 struct OpenAiRequest<'a, S: AsRef<str> + serde::Serialize> {
     model: &'a str,
     input: &'a [S],
+    dimension: Option<&'a usize>,
 }
 
 #[derive(Debug, Serialize)]

--- a/milli/src/vector/settings.rs
+++ b/milli/src/vector/settings.rs
@@ -208,6 +208,9 @@ impl From<EmbeddingSettings> for EmbeddingConfig {
                     if let Some(api_key) = api_key.set() {
                         options.api_key = Some(api_key);
                     }
+                    if let Some(dimensions) = dimensions.set() {
+                        options.dimensions = Some(dimensions);
+                    }
                     this.embedder_options = super::EmbedderOptions::OpenAi(options);
                 }
                 EmbedderSource::HuggingFace => {

--- a/milli/src/vector/settings.rs
+++ b/milli/src/vector/settings.rs
@@ -176,7 +176,7 @@ impl From<EmbeddingConfig> for EmbeddingSettings {
                 model: Setting::Set(options.embedding_model.name().to_owned()),
                 revision: Setting::NotSet,
                 api_key: options.api_key.map(Setting::Set).unwrap_or_default(),
-                dimensions: Setting::NotSet,
+                dimensions: options.dimensions.map(Setting::Set).unwrap_or_default(),
                 document_template: Setting::Set(prompt.template),
             },
             super::EmbedderOptions::UserProvided(options) => Self {


### PR DESCRIPTION
# Pull Request

Fixes #4394 

## Related discussion
https://github.com/orgs/meilisearch/discussions/677#discussioncomment-8306384

## What does this PR do?
- Add text-embedding-3-small
- Add text-embedding-3-large
- Add optional dimensions parameter for both new models


## Note
As the dimensions option is not available for text-embedding-ada-002 I've added a manual check to prevent, but I feel it could be implemented in a more idiomatic rust 

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
