### PR TITLE
Issue 4379: correct `download-latest.sh` to make it return error when system is using `MUSL` or `bionic` C library

### DIFF
--- a/download-latest.sh
+++ b/download-latest.sh
@@ -65,6 +65,21 @@ get_os() {
     return 0
 }
 
+# Gets the C lib the system is using by setting the $c_lib variable.
+# Returns 0 in case of success, 1 otherwise.
+get_C_library(){
+  if ldd --version | grep -i glibc;then
+    c_lib='glibc'
+  elif ldd --version | grep -i musl;then
+    c_library_failure_usage
+  elif ldd --version | grep -i bionic; then
+    c_library_failure_usage
+  else
+    return 1
+  fi
+  return 0
+}
+
 # Gets the architecture by setting the $archi variable.
 # Returns 0 in case of success, 1 otherwise.
 get_archi() {
@@ -106,6 +121,12 @@ not_available_failure_usage() {
     echo 'Follow the steps at the page ("Source" tab): https://www.meilisearch.com/docs/learn/getting_started/installation'
 }
 
+c_library_failure_usage() {
+    printf "$RED%s\n$DEFAULT" 'ERROR: Meilisearch binary is not compatible with the current C library your system is using.'
+    echo ''
+    echo 'Meilisearch is designed to work with certain C libraries, such as glibc. Ensure that your system uses a compatible C library environment.'
+}
+
 fetch_release_failure_usage() {
     echo ''
     printf "$RED%s\n$DEFAULT" 'ERROR: Impossible to get the latest stable version of Meilisearch.'
@@ -134,6 +155,11 @@ fill_release_variables() {
         not_available_failure_usage
         exit 1
      fi
+     # Fill $c_lib variable.
+     if ! get_C_library; then
+       c_library_failure_usage
+     fi
+
 }
 
 download_binary() {


### PR DESCRIPTION
Adapt the script to terminate on error in case the system is using bionic or MUSL


# Pull Request

## Related issue
Fixes #4379 

## What does this PR do?
- It adds a function that retrieve the C library host system is using.
- For now only check with `bionic`,  `glibc` and `musl` , with `glibc` being the only one working

## PR checklist
Please check if your PR fulfills the following requirements:
- [ x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x ] Have you read the contributing guidelines?
- [ x] Have you made sure that the title is accurate and descriptive of the changes?


If there is anything you want me to rework on, just let me know!
