### PR TITLE
Create automation when creating Milestone to create update-version issue

### DIFF
--- a/.github/workflows/milestone-workflow.yml
+++ b/.github/workflows/milestone-workflow.yml
@@ -110,6 +110,25 @@ jobs:
             --milestone $MILESTONE_VERSION \
             --assignee curquiza
 
+  create-update-version-issue:
+    needs: get-release-version
+    # Create the changelog issue if the release is not only a patch release
+    if: github.event.action == 'created'
+    runs-on: ubuntu-latest
+    env:
+      ISSUE_TEMPLATE: issue-template.md
+    steps:
+      - uses: actions/checkout@v3
+      - name: Download the issue template
+        run: curl -s https://raw.githubusercontent.com/meilisearch/engine-team/main/issue-templates/update-version-issue.md > $ISSUE_TEMPLATE
+      - name: Create the issue
+        run: |
+          gh issue create \
+            --title "Update version in Cargo.toml for $MILESTONE_VERSION" \
+            --label 'maintenance' \
+            --body-file $ISSUE_TEMPLATE \
+            --milestone $MILESTONE_VERSION
+
 # ----------------
 # MILESTONE CLOSED
 # ----------------


### PR DESCRIPTION
Following our discussion @irevoire -> we miss reminder to update cargo version BEFORE rc0

Issue template [here](https://github.com/meilisearch/engine-team/blob/main/issue-templates/update-version-issue.md)