### PR TITLE
Add the content type in the webhook + improve the test

### DIFF
--- a/index-scheduler/src/lib.rs
+++ b/index-scheduler/src/lib.rs
@@ -1395,7 +1395,9 @@ impl IndexScheduler {
 
             // let reader = GzEncoder::new(BufReader::new(task_reader), Compression::default());
             let reader = GzEncoder::new(BufReader::new(task_reader), Compression::default());
-            let request = ureq::post(url).set("Content-Encoding", "gzip");
+            let request = ureq::post(url)
+                .set("Content-Encoding", "gzip")
+                .set("Content-Type", "application/x-ndjson");
             let request = match &self.webhook_authorization_header {
                 Some(header) => request.set("Authorization", header),
                 None => request,


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes https://github.com/meilisearch/meilisearch/issues/4436

## What does this PR do?
- Specify the content type of the webhook
- Ensure it’s the case in the test