### PR TITLE
Add Ollama as an embeddings provider

### DIFF
--- a/meilisearch/src/routes/indexes/settings.rs
+++ b/meilisearch/src/routes/indexes/settings.rs
@@ -604,6 +604,7 @@ fn embedder_analytics(
                 EmbedderSource::OpenAi => sources.insert("openAi"),
                 EmbedderSource::HuggingFace => sources.insert("huggingFace"),
                 EmbedderSource::UserProvided => sources.insert("userProvided"),
+                EmbedderSource::Ollama => sources.insert("ollama"),
             };
         }
     };

--- a/milli/src/update/settings.rs
+++ b/milli/src/update/settings.rs
@@ -1179,8 +1179,8 @@ pub fn validate_embedding_settings(
             }
         }
         EmbedderSource::Ollama => {
-            // Existence & corrent dimensions of models cannot easily be checked here.
-            check_set(&dimensions, "dimensions", inferred_source, name)?;
+            // Dimensions get inferred, only model name is required
+            check_unset(&dimensions, "dimensions", inferred_source, name)?;
             check_set(&model, "model", inferred_source, name)?;
             check_unset(&api_key, "apiKey", inferred_source, name)?;
             check_unset(&revision, "revision", inferred_source, name)?;

--- a/milli/src/update/settings.rs
+++ b/milli/src/update/settings.rs
@@ -1178,6 +1178,13 @@ pub fn validate_embedding_settings(
                 }
             }
         }
+        EmbedderSource::Ollama => {
+            // Existence & corrent dimensions of models cannot easily be checked here.
+            check_set(&dimensions, "dimensions", inferred_source, name)?;
+            check_set(&model, "model", inferred_source, name)?;
+            check_unset(&api_key, "apiKey", inferred_source, name)?;
+            check_unset(&revision, "revision", inferred_source, name)?;
+        }
         EmbedderSource::HuggingFace => {
             check_unset(&api_key, "apiKey", inferred_source, name)?;
             check_unset(&dimensions, "dimensions", inferred_source, name)?;

--- a/milli/src/vector/error.rs
+++ b/milli/src/vector/error.rs
@@ -79,7 +79,7 @@ pub enum EmbedErrorKind {
     OllamaTooManyRequests(OllamaError),
     #[error("received internal error from Ollama: {0}")]
     OllamaInternalServerError(OllamaError),
-    #[error("model not found. MeiliSearch will not automatically download models from the Ollama library, please pull the model manually: {0}")]
+    #[error("model not found. Meilisearch will not automatically download models from the Ollama library, please pull the model manually: {0}")]
     OllamaModelNotFoundError(OllamaError),
     #[error("received unhandled HTTP status code {0} from Ollama")]
     OllamaUnhandledStatusCode(u16),

--- a/milli/src/vector/ollama.rs
+++ b/milli/src/vector/ollama.rs
@@ -1,0 +1,255 @@
+// Copied from "openai.rs" with the sections I actually understand changed for Ollama.
+// The common components of the Ollama and OpenAI interfaces might need to be extracted.
+
+use std::fmt::Display;
+
+use reqwest::StatusCode;
+
+use super::error::{EmbedError, NewEmbedderError};
+use super::openai::Retry;
+use super::{DistributionShift, Embedding, Embeddings};
+
+#[derive(Debug)]
+pub struct Embedder {
+    headers: reqwest::header::HeaderMap,
+    options: EmbedderOptions,
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+pub struct EmbedderOptions {
+    pub embedding_model: EmbeddingModel,
+    pub dimensions: usize,
+}
+
+#[derive(
+    Debug, Clone, Hash, PartialEq, Eq, serde::Serialize, serde::Deserialize, deserr::Deserr,
+)]
+#[deserr(deny_unknown_fields)]
+pub struct EmbeddingModel {
+    name: String,
+}
+
+#[derive(Debug, serde::Serialize)]
+struct OllamaRequest<'a> {
+    model: &'a str,
+    prompt: &'a str,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct OllamaResponse {
+    embedding: Embedding,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct OllamaErrorResponse {
+    error: OllamaError,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct OllamaError {
+    message: String,
+    // type: String,
+    code: Option<String>,
+}
+
+impl EmbeddingModel {
+    pub fn max_token(&self) -> usize {
+        // this might not be the same for all models
+        8192
+    }
+
+    pub fn default_dimensions(&self) -> usize {
+        // Dimensions for nomic-embed-text
+        768
+    }
+
+    pub fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    pub fn from_name(name: &str) -> Self {
+        Self { name: name.to_string() }
+    }
+
+    pub fn supports_overriding_dimensions(&self) -> bool {
+        false
+    }
+}
+
+impl Default for EmbeddingModel {
+    fn default() -> Self {
+        Self { name: "nomic-embed-text".to_string() }
+    }
+}
+
+impl EmbedderOptions {
+    pub fn with_default_model() -> Self {
+        Self { embedding_model: Default::default(), dimensions: 768 }
+    }
+
+    pub fn with_embedding_model(embedding_model: EmbeddingModel, dimensions: usize) -> Self {
+        Self { embedding_model, dimensions }
+    }
+}
+
+impl Embedder {
+    pub fn new_client(&self) -> Result<reqwest::Client, EmbedError> {
+        reqwest::ClientBuilder::new()
+            .default_headers(self.headers.clone())
+            .build()
+            .map_err(EmbedError::openai_initialize_web_client)
+    }
+
+    pub fn new(options: EmbedderOptions) -> Result<Self, NewEmbedderError> {
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(
+            reqwest::header::CONTENT_TYPE,
+            reqwest::header::HeaderValue::from_static("application/json"),
+        );
+
+        Ok(Self { options, headers })
+    }
+
+    async fn check_response(response: reqwest::Response) -> Result<reqwest::Response, Retry> {
+        if !response.status().is_success() {
+            // Not the same number of possible error cases covered as with OpenAI.
+            match response.status() {
+                StatusCode::TOO_MANY_REQUESTS => {
+                    let error_response: OllamaErrorResponse = response
+                        .json()
+                        .await
+                        .map_err(EmbedError::ollama_unexpected)
+                        .map_err(Retry::retry_later)?;
+
+                    return Err(Retry::rate_limited(EmbedError::ollama_too_many_requests(
+                        error_response.error,
+                    )));
+                }
+                StatusCode::SERVICE_UNAVAILABLE => {
+                    let error_response: OllamaErrorResponse = response
+                        .json()
+                        .await
+                        .map_err(EmbedError::ollama_unexpected)
+                        .map_err(Retry::retry_later)?;
+                    return Err(Retry::retry_later(EmbedError::ollama_internal_server_error(
+                        error_response.error,
+                    )));
+                }
+                code => {
+                    return Err(Retry::give_up(EmbedError::ollama_unhandled_status_code(
+                        code.as_u16(),
+                    )));
+                }
+            }
+        }
+        Ok(response)
+    }
+
+    pub async fn embed(
+        &self,
+        texts: Vec<String>,
+        client: &reqwest::Client,
+    ) -> Result<Vec<Embeddings<f32>>, EmbedError> {
+        // Ollama only embedds one document at a time.
+        let mut results = Vec::with_capacity(texts.len());
+
+        // The retry loop is inside the texts loop, might have to switch that around
+        for text in texts {
+            // Retries copied from openai.rs
+            for attempt in 0..7 {
+                let retry_duration = match self.try_embed(&text, client).await {
+                    Ok(result) => {
+                        results.push(result);
+                        break;
+                    }
+                    Err(retry) => {
+                        tracing::warn!("Failed: {}", retry.error);
+                        retry.into_duration(attempt)
+                    }
+                }?;
+                tracing::warn!(
+                    "Attempt #{}, retrying after {}ms.",
+                    attempt,
+                    retry_duration.as_millis()
+                );
+                tokio::time::sleep(retry_duration).await;
+            }
+        }
+
+        Ok(results)
+    }
+
+    async fn try_embed(
+        &self,
+        text: &str,
+        client: &reqwest::Client,
+    ) -> Result<Embeddings<f32>, Retry> {
+        let request = OllamaRequest { model: &self.options.embedding_model.name(), prompt: text };
+        let response = client
+            .post(get_ollama_path())
+            .json(&request)
+            .send()
+            .await
+            .map_err(EmbedError::openai_network)
+            .map_err(Retry::retry_later)?;
+
+        let response = Self::check_response(response).await?;
+
+        let response: OllamaResponse = response
+            .json()
+            .await
+            .map_err(EmbedError::openai_unexpected)
+            .map_err(Retry::retry_later)?;
+
+        tracing::trace!("response: {:?}", response.embedding);
+
+        let embedding = Embeddings::from_single_embedding(response.embedding);
+        Ok(embedding)
+    }
+
+    pub fn embed_chunks(
+        &self,
+        text_chunks: Vec<Vec<String>>,
+    ) -> Result<Vec<Vec<Embeddings<f32>>>, EmbedError> {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_io()
+            .enable_time()
+            .build()
+            .map_err(EmbedError::openai_runtime_init)?;
+        let client = self.new_client()?;
+        rt.block_on(futures::future::try_join_all(
+            text_chunks.into_iter().map(|prompts| self.embed(prompts, &client)),
+        ))
+    }
+
+    // Defaults copied from openai.rs
+    pub fn chunk_count_hint(&self) -> usize {
+        10
+    }
+
+    pub fn prompt_count_in_chunk_hint(&self) -> usize {
+        10
+    }
+
+    pub fn dimensions(&self) -> usize {
+        self.options.dimensions
+    }
+
+    pub fn distribution(&self) -> Option<DistributionShift> {
+        None
+    }
+}
+
+impl Display for OllamaError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.code {
+            Some(code) => write!(f, "{} ({})", self.message, code),
+            None => write!(f, "{}", self.message),
+        }
+    }
+}
+
+fn get_ollama_path() -> String {
+    // Important: Hostname not enough, has to be entire path to embeddings endpoint
+    std::env::var("MEILI_OLLAMA_URL").unwrap_or("http://localhost:11434/api/embeddings".to_string())
+}

--- a/milli/src/vector/openai.rs
+++ b/milli/src/vector/openai.rs
@@ -429,12 +429,12 @@ impl Embedder {
 
 // retrying in case of failure
 
-struct Retry {
-    error: EmbedError,
+pub struct Retry {
+    pub error: EmbedError,
     strategy: RetryStrategy,
 }
 
-enum RetryStrategy {
+pub enum RetryStrategy {
     GiveUp,
     Retry,
     RetryTokenized,
@@ -442,23 +442,23 @@ enum RetryStrategy {
 }
 
 impl Retry {
-    fn give_up(error: EmbedError) -> Self {
+    pub fn give_up(error: EmbedError) -> Self {
         Self { error, strategy: RetryStrategy::GiveUp }
     }
 
-    fn retry_later(error: EmbedError) -> Self {
+    pub fn retry_later(error: EmbedError) -> Self {
         Self { error, strategy: RetryStrategy::Retry }
     }
 
-    fn retry_tokenized(error: EmbedError) -> Self {
+    pub fn retry_tokenized(error: EmbedError) -> Self {
         Self { error, strategy: RetryStrategy::RetryTokenized }
     }
 
-    fn rate_limited(error: EmbedError) -> Self {
+    pub fn rate_limited(error: EmbedError) -> Self {
         Self { error, strategy: RetryStrategy::RetryAfterRateLimit }
     }
 
-    fn into_duration(self, attempt: u32) -> Result<tokio::time::Duration, EmbedError> {
+    pub fn into_duration(self, attempt: u32) -> Result<tokio::time::Duration, EmbedError> {
         match self.strategy {
             RetryStrategy::GiveUp => Err(self.error),
             RetryStrategy::Retry => Ok(tokio::time::Duration::from_millis((10u64).pow(attempt))),
@@ -469,11 +469,11 @@ impl Retry {
         }
     }
 
-    fn must_tokenize(&self) -> bool {
+    pub fn must_tokenize(&self) -> bool {
         matches!(self.strategy, RetryStrategy::RetryTokenized)
     }
 
-    fn into_error(self) -> EmbedError {
+    pub fn into_error(self) -> EmbedError {
         self.error
     }
 }

--- a/milli/src/vector/settings.rs
+++ b/milli/src/vector/settings.rs
@@ -85,9 +85,7 @@ impl EmbeddingSettings {
             }
             Self::REVISION => &[EmbedderSource::HuggingFace],
             Self::API_KEY => &[EmbedderSource::OpenAi],
-            Self::DIMENSIONS => {
-                &[EmbedderSource::OpenAi, EmbedderSource::UserProvided, EmbedderSource::Ollama]
-            }
+            Self::DIMENSIONS => &[EmbedderSource::OpenAi, EmbedderSource::UserProvided],
             Self::DOCUMENT_TEMPLATE => {
                 &[EmbedderSource::HuggingFace, EmbedderSource::OpenAi, EmbedderSource::Ollama]
             }
@@ -107,9 +105,7 @@ impl EmbeddingSettings {
             EmbedderSource::HuggingFace => {
                 &[Self::SOURCE, Self::MODEL, Self::REVISION, Self::DOCUMENT_TEMPLATE]
             }
-            EmbedderSource::Ollama => {
-                &[Self::SOURCE, Self::MODEL, Self::DIMENSIONS, Self::DOCUMENT_TEMPLATE]
-            }
+            EmbedderSource::Ollama => &[Self::SOURCE, Self::MODEL, Self::DOCUMENT_TEMPLATE],
             EmbedderSource::UserProvided => &[Self::SOURCE, Self::DIMENSIONS],
         }
     }
@@ -211,7 +207,7 @@ impl From<EmbeddingConfig> for EmbeddingSettings {
                 model: Setting::Set(options.embedding_model.name().to_owned()),
                 revision: Setting::NotSet,
                 api_key: Setting::NotSet,
-                dimensions: Setting::Set(options.dimensions),
+                dimensions: Setting::NotSet,
                 document_template: Setting::Set(prompt.template),
             },
             super::EmbedderOptions::UserProvided(options) => Self {
@@ -251,9 +247,8 @@ impl From<EmbeddingSettings> for EmbeddingConfig {
                 EmbedderSource::Ollama => {
                     let mut options: ollama::EmbedderOptions =
                         super::ollama::EmbedderOptions::with_default_model();
-                    if let (Some(model), Some(dim)) = (model.set(), dimensions.set()) {
+                    if let Some(model) = model.set() {
                         options.embedding_model = super::ollama::EmbeddingModel::from_name(&model);
-                        options.dimensions = dim;
                     }
                     this.embedder_options = super::EmbedderOptions::Ollama(options);
                 }


### PR DESCRIPTION
# Pull Request

## Related issue
[Related Discord Thread](https://discord.com/channels/1006923006964154428/1211977150316683305)

## What does this PR do?
- Adds Ollama as a provider of Embeddings besides HuggingFace and OpenAI under the name `ollama`
- Adds the environment variable `MEILI_OLLAMA_URL` to set the embeddings URL of an Ollama instance with a default value of `http://localhost:11434/api/embeddings` if no variable is set
- Changes some of the structs and functions in `openai.rs` to be public so that they can be shared.
- Added more error variants for Ollama specific errors
- It uses the model `nomic-embed-text` as default, but any string value is allowed, however it won't automatically check if the model actually exists or is an embedding model

Tested against Ollama version `v0.1.27` and the `nomic-embed-text` model.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?