### PR TITLE
Add tests when the field limit is reached

### DIFF
--- a/meilisearch/tests/documents/add_documents.rs
+++ b/meilisearch/tests/documents/add_documents.rs
@@ -1237,8 +1237,8 @@ async fn error_add_documents_missing_document_id() {
 }
 
 #[actix_rt::test]
-#[ignore] // // TODO: Fix in an other PR: this does not provoke any error.
-async fn error_document_field_limit_reached() {
+#[should_panic]
+async fn error_document_field_limit_reached_in_one_document() {
     let server = Server::new().await;
     let index = server.index("test");
 
@@ -1246,22 +1246,241 @@ async fn error_document_field_limit_reached() {
 
     let mut big_object = std::collections::HashMap::new();
     big_object.insert("id".to_owned(), "wow");
-    for i in 0..65535 {
+    for i in 0..(u16::MAX as usize + 1) {
         let key = i.to_string();
         big_object.insert(key, "I am a text!");
     }
 
     let documents = json!([big_object]);
 
-    let (_response, code) = index.update_documents(documents, Some("id")).await;
-    snapshot!(code, @"202");
+    let (response, code) = index.update_documents(documents, Some("id")).await;
+    snapshot!(code, @"500 Internal Server Error");
 
-    index.wait_task(0).await;
-    let (response, code) = index.get_task(0).await;
-    snapshot!(code, @"200");
+    let response = index.wait_task(response.uid()).await;
+    snapshot!(code, @"202 Accepted");
     // Documents without a primary key are not accepted.
-    snapshot!(json_string!(response, { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
-        @"");
+    snapshot!(response,
+        @r###"
+    {
+      "uid": 1,
+      "indexUid": "test",
+      "status": "succeeded",
+      "type": "documentAdditionOrUpdate",
+      "canceledBy": null,
+      "details": {
+        "receivedDocuments": 1,
+        "indexedDocuments": 1
+      },
+      "error": null,
+      "duration": "[duration]",
+      "enqueuedAt": "[date]",
+      "startedAt": "[date]",
+      "finishedAt": "[date]"
+    }
+    "###);
+}
+
+#[actix_rt::test]
+async fn error_document_field_limit_reached_over_multiple_documents() {
+    let server = Server::new().await;
+    let index = server.index("test");
+
+    index.create(Some("id")).await;
+
+    let mut big_object = std::collections::HashMap::new();
+    big_object.insert("id".to_owned(), "wow");
+    for i in 0..(u16::MAX / 2) {
+        let key = i.to_string();
+        big_object.insert(key, "I am a text!");
+    }
+
+    let documents = json!([big_object]);
+
+    let (response, code) = index.update_documents(documents, Some("id")).await;
+    snapshot!(code, @"202 Accepted");
+
+    let response = index.wait_task(response.uid()).await;
+    snapshot!(code, @"202 Accepted");
+    snapshot!(response,
+        @r###"
+    {
+      "uid": 1,
+      "indexUid": "test",
+      "status": "succeeded",
+      "type": "documentAdditionOrUpdate",
+      "canceledBy": null,
+      "details": {
+        "receivedDocuments": 1,
+        "indexedDocuments": 1
+      },
+      "error": null,
+      "duration": "[duration]",
+      "enqueuedAt": "[date]",
+      "startedAt": "[date]",
+      "finishedAt": "[date]"
+    }
+    "###);
+
+    let mut big_object = std::collections::HashMap::new();
+    big_object.insert("id".to_owned(), "waw");
+    for i in (u16::MAX as usize / 2)..(u16::MAX as usize + 1) {
+        let key = i.to_string();
+        big_object.insert(key, "I am a text!");
+    }
+
+    let documents = json!([big_object]);
+
+    let (response, code) = index.update_documents(documents, Some("id")).await;
+    snapshot!(code, @"202 Accepted");
+
+    let response = index.wait_task(response.uid()).await;
+    snapshot!(code, @"202 Accepted");
+    snapshot!(response,
+        @r###"
+    {
+      "uid": 2,
+      "indexUid": "test",
+      "status": "failed",
+      "type": "documentAdditionOrUpdate",
+      "canceledBy": null,
+      "details": {
+        "receivedDocuments": 1,
+        "indexedDocuments": 0
+      },
+      "error": {
+        "message": "A document cannot contain more than 65,535 fields.",
+        "code": "max_fields_limit_exceeded",
+        "type": "invalid_request",
+        "link": "https://docs.meilisearch.com/errors#max_fields_limit_exceeded"
+      },
+      "duration": "[duration]",
+      "enqueuedAt": "[date]",
+      "startedAt": "[date]",
+      "finishedAt": "[date]"
+    }
+    "###);
+}
+
+#[actix_rt::test]
+async fn error_document_field_limit_reached_in_one_nested_document() {
+    let server = Server::new().await;
+    let index = server.index("test");
+
+    index.create(Some("id")).await;
+
+    let mut nested = std::collections::HashMap::new();
+    for i in 0..(u16::MAX as usize + 1) {
+        let key = i.to_string();
+        nested.insert(key, "I am a text!");
+    }
+    let mut big_object = std::collections::HashMap::new();
+    big_object.insert("id".to_owned(), "wow");
+
+    let documents = json!([big_object]);
+
+    let (response, code) = index.update_documents(documents, Some("id")).await;
+    snapshot!(code, @"202 Accepted");
+
+    let response = index.wait_task(response.uid()).await;
+    snapshot!(code, @"202 Accepted");
+    // Documents without a primary key are not accepted.
+    snapshot!(response,
+        @r###"
+    {
+      "uid": 1,
+      "indexUid": "test",
+      "status": "succeeded",
+      "type": "documentAdditionOrUpdate",
+      "canceledBy": null,
+      "details": {
+        "receivedDocuments": 1,
+        "indexedDocuments": 1
+      },
+      "error": null,
+      "duration": "[duration]",
+      "enqueuedAt": "[date]",
+      "startedAt": "[date]",
+      "finishedAt": "[date]"
+    }
+    "###);
+}
+
+#[actix_rt::test]
+async fn error_document_field_limit_reached_over_multiple_documents_with_nested_fields() {
+    let server = Server::new().await;
+    let index = server.index("test");
+
+    index.create(Some("id")).await;
+
+    let mut nested = std::collections::HashMap::new();
+    for i in 0..(u16::MAX / 2) {
+        let key = i.to_string();
+        nested.insert(key, "I am a text!");
+    }
+    let mut big_object = std::collections::HashMap::new();
+    big_object.insert("id".to_owned(), "wow");
+
+    let documents = json!([big_object]);
+
+    let (response, code) = index.update_documents(documents, Some("id")).await;
+    snapshot!(code, @"202 Accepted");
+
+    let response = index.wait_task(response.uid()).await;
+    snapshot!(code, @"202 Accepted");
+    snapshot!(response,
+        @r###"
+    {
+      "uid": 1,
+      "indexUid": "test",
+      "status": "succeeded",
+      "type": "documentAdditionOrUpdate",
+      "canceledBy": null,
+      "details": {
+        "receivedDocuments": 1,
+        "indexedDocuments": 1
+      },
+      "error": null,
+      "duration": "[duration]",
+      "enqueuedAt": "[date]",
+      "startedAt": "[date]",
+      "finishedAt": "[date]"
+    }
+    "###);
+
+    let mut nested = std::collections::HashMap::new();
+    for i in 0..(u16::MAX / 2) {
+        let key = i.to_string();
+        nested.insert(key, "I am a text!");
+    }
+    let mut big_object = std::collections::HashMap::new();
+    big_object.insert("id".to_owned(), "wow");
+
+    let documents = json!([big_object]);
+
+    let (response, code) = index.update_documents(documents, Some("id")).await;
+    snapshot!(code, @"202 Accepted");
+
+    let response = index.wait_task(response.uid()).await;
+    snapshot!(code, @"202 Accepted");
+    snapshot!(response,
+        @r###"
+    {
+      "uid": 2,
+      "indexUid": "test",
+      "status": "succeeded",
+      "type": "documentAdditionOrUpdate",
+      "canceledBy": null,
+      "details": {
+        "receivedDocuments": 1,
+        "indexedDocuments": 1
+      },
+      "error": null,
+      "duration": "[duration]",
+      "enqueuedAt": "[date]",
+      "startedAt": "[date]",
+      "finishedAt": "[date]"
+    }
+    "###);
 }
 
 #[actix_rt::test]


### PR DESCRIPTION
# Pull Request

## Related issue
Related to https://github.com/meilisearch/meilisearch/discussions/4429#discussioncomment-8689101

This user found out that the error message we’re supposed to return when the maximum number of attributes is reached is _not_ returned in some cases

## What does this PR do?
- This PR adds four tests around the maximum number of attributes:
  1. Add a document with u16::MAX + 1 fields - Meilisearch panics
  2. Add two documents which together adds up to u16::MAX + 1 fields - Meilisearch returns the expected error 
  3. Add a document with u16::MAX + 1 **nested fields** - No error message but the document isn’t indexed
  4. Add two documents which together add up to u16::MAX + 1 nested fields - Meilisearch doesn’t return any error but doesn’t index the document

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
