### PR TITLE
Implements the search cutoff

### DIFF
--- a/assets/grafana-dashboard.json
+++ b/assets/grafana-dashboard.json
@@ -254,6 +254,70 @@
               {
                 "color": "green",
                 "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 8,
+        "y": 1
+      },
+      "id": 26,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "pluginVersion": "9.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus"
+          },
+          "editorMode": "builder",
+          "exemplar": true,
+          "expr": "round(increase(meilisearch_degraded_search_requests{job=\"$job\"}[1h]))",
+          "interval": "",
+          "legendFormat": "",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Total Degraded Searches (1h)",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
               }
             ]
           }

--- a/dump/src/lib.rs
+++ b/dump/src/lib.rs
@@ -277,6 +277,7 @@ pub(crate) mod test {
             }),
             pagination: Setting::NotSet,
             embedders: Setting::NotSet,
+            search_cutoff: Setting::NotSet,
             _kind: std::marker::PhantomData,
         };
         settings.check()

--- a/dump/src/lib.rs
+++ b/dump/src/lib.rs
@@ -277,7 +277,7 @@ pub(crate) mod test {
             }),
             pagination: Setting::NotSet,
             embedders: Setting::NotSet,
-            search_cutoff: Setting::NotSet,
+            search_cutoff_ms: Setting::NotSet,
             _kind: std::marker::PhantomData,
         };
         settings.check()

--- a/dump/src/reader/compat/v5_to_v6.rs
+++ b/dump/src/reader/compat/v5_to_v6.rs
@@ -379,6 +379,7 @@ impl<T> From<v5::Settings<T>> for v6::Settings<v6::Unchecked> {
                 v5::Setting::NotSet => v6::Setting::NotSet,
             },
             embedders: v6::Setting::NotSet,
+            search_cutoff: v6::Setting::NotSet,
             _kind: std::marker::PhantomData,
         }
     }

--- a/dump/src/reader/compat/v5_to_v6.rs
+++ b/dump/src/reader/compat/v5_to_v6.rs
@@ -379,7 +379,7 @@ impl<T> From<v5::Settings<T>> for v6::Settings<v6::Unchecked> {
                 v5::Setting::NotSet => v6::Setting::NotSet,
             },
             embedders: v6::Setting::NotSet,
-            search_cutoff: v6::Setting::NotSet,
+            search_cutoff_ms: v6::Setting::NotSet,
             _kind: std::marker::PhantomData,
         }
     }

--- a/meilisearch-types/src/error.rs
+++ b/meilisearch-types/src/error.rs
@@ -259,6 +259,7 @@ InvalidSettingsProximityPrecision     , InvalidRequest       , BAD_REQUEST ;
 InvalidSettingsFaceting               , InvalidRequest       , BAD_REQUEST ;
 InvalidSettingsFilterableAttributes   , InvalidRequest       , BAD_REQUEST ;
 InvalidSettingsPagination             , InvalidRequest       , BAD_REQUEST ;
+InvalidSettingsSearchCutoff           , InvalidRequest       , BAD_REQUEST ;
 InvalidSettingsEmbedders              , InvalidRequest       , BAD_REQUEST ;
 InvalidSettingsRankingRules           , InvalidRequest       , BAD_REQUEST ;
 InvalidSettingsSearchableAttributes   , InvalidRequest       , BAD_REQUEST ;

--- a/meilisearch-types/src/error.rs
+++ b/meilisearch-types/src/error.rs
@@ -259,7 +259,7 @@ InvalidSettingsProximityPrecision     , InvalidRequest       , BAD_REQUEST ;
 InvalidSettingsFaceting               , InvalidRequest       , BAD_REQUEST ;
 InvalidSettingsFilterableAttributes   , InvalidRequest       , BAD_REQUEST ;
 InvalidSettingsPagination             , InvalidRequest       , BAD_REQUEST ;
-InvalidSettingsSearchCutoff           , InvalidRequest       , BAD_REQUEST ;
+InvalidSettingsSearchCutoffMs           , InvalidRequest       , BAD_REQUEST ;
 InvalidSettingsEmbedders              , InvalidRequest       , BAD_REQUEST ;
 InvalidSettingsRankingRules           , InvalidRequest       , BAD_REQUEST ;
 InvalidSettingsSearchableAttributes   , InvalidRequest       , BAD_REQUEST ;

--- a/meilisearch-types/src/settings.rs
+++ b/meilisearch-types/src/settings.rs
@@ -203,7 +203,7 @@ pub struct Settings<T> {
     #[deserr(default, error = DeserrJsonError<InvalidSettingsEmbedders>)]
     pub embedders: Setting<BTreeMap<String, Setting<milli::vector::settings::EmbeddingSettings>>>,
     #[serde(default, skip_serializing_if = "Setting::is_not_set")]
-    #[deserr(default, error = DeserrJsonError<InvalidSettingsSearchCutoff>)]
+    #[deserr(default, error = DeserrJsonError<InvalidSettingsSearchCutoffMs>)]
     pub search_cutoff_ms: Setting<u64>,
 
     #[serde(skip)]

--- a/meilisearch-types/src/settings.rs
+++ b/meilisearch-types/src/settings.rs
@@ -204,7 +204,7 @@ pub struct Settings<T> {
     pub embedders: Setting<BTreeMap<String, Setting<milli::vector::settings::EmbeddingSettings>>>,
     #[serde(default, skip_serializing_if = "Setting::is_not_set")]
     #[deserr(default, error = DeserrJsonError<InvalidSettingsSearchCutoff>)]
-    pub search_cutoff: Setting<u64>,
+    pub search_cutoff_ms: Setting<u64>,
 
     #[serde(skip)]
     #[deserr(skip)]
@@ -230,7 +230,7 @@ impl Settings<Checked> {
             faceting: Setting::Reset,
             pagination: Setting::Reset,
             embedders: Setting::Reset,
-            search_cutoff: Setting::Reset,
+            search_cutoff_ms: Setting::Reset,
             _kind: PhantomData,
         }
     }
@@ -253,7 +253,7 @@ impl Settings<Checked> {
             faceting,
             pagination,
             embedders,
-            search_cutoff,
+            search_cutoff_ms,
             ..
         } = self;
 
@@ -274,7 +274,7 @@ impl Settings<Checked> {
             faceting,
             pagination,
             embedders,
-            search_cutoff,
+            search_cutoff_ms,
             _kind: PhantomData,
         }
     }
@@ -321,7 +321,7 @@ impl Settings<Unchecked> {
             faceting: self.faceting,
             pagination: self.pagination,
             embedders: self.embedders,
-            search_cutoff: self.search_cutoff,
+            search_cutoff_ms: self.search_cutoff_ms,
             _kind: PhantomData,
         }
     }
@@ -371,7 +371,7 @@ pub fn apply_settings_to_builder(
         faceting,
         pagination,
         embedders,
-        search_cutoff,
+        search_cutoff_ms,
         _kind,
     } = settings;
 
@@ -548,7 +548,7 @@ pub fn apply_settings_to_builder(
         Setting::NotSet => (),
     }
 
-    match search_cutoff {
+    match search_cutoff_ms {
         Setting::Set(cutoff) => builder.set_search_cutoff(*cutoff),
         Setting::Reset => builder.reset_search_cutoff(),
         Setting::NotSet => (),
@@ -641,7 +641,7 @@ pub fn settings(
         .collect();
     let embedders = if embedders.is_empty() { Setting::NotSet } else { Setting::Set(embedders) };
 
-    let search_cutoff = index.search_cutoff(rtxn)?;
+    let search_cutoff_ms = index.search_cutoff(rtxn)?;
 
     Ok(Settings {
         displayed_attributes: match displayed_attributes {
@@ -669,7 +669,7 @@ pub fn settings(
         faceting: Setting::Set(faceting),
         pagination: Setting::Set(pagination),
         embedders,
-        search_cutoff: match search_cutoff {
+        search_cutoff_ms: match search_cutoff_ms {
             Some(cutoff) => Setting::Set(cutoff),
             None => Setting::Reset,
         },
@@ -823,7 +823,7 @@ pub(crate) mod test {
             faceting: Setting::NotSet,
             pagination: Setting::NotSet,
             embedders: Setting::NotSet,
-            search_cutoff: Setting::NotSet,
+            search_cutoff_ms: Setting::NotSet,
             _kind: PhantomData::<Unchecked>,
         };
 
@@ -850,7 +850,7 @@ pub(crate) mod test {
             faceting: Setting::NotSet,
             pagination: Setting::NotSet,
             embedders: Setting::NotSet,
-            search_cutoff: Setting::NotSet,
+            search_cutoff_ms: Setting::NotSet,
             _kind: PhantomData::<Unchecked>,
         };
 

--- a/meilisearch/src/metrics.rs
+++ b/meilisearch/src/metrics.rs
@@ -22,6 +22,11 @@ lazy_static! {
         &["method", "path"]
     )
     .expect("Can't create a metric");
+    pub static ref MEILISEARCH_DEGRADED_SEARCH_REQUESTS: IntGauge = register_int_gauge!(opts!(
+        "meilisearch_degraded_search_requests",
+        "Meilisearch number of degraded search requests"
+    ))
+    .expect("Can't create a metric");
     pub static ref MEILISEARCH_DB_SIZE_BYTES: IntGauge =
         register_int_gauge!(opts!("meilisearch_db_size_bytes", "Meilisearch DB Size In Bytes"))
             .expect("Can't create a metric");

--- a/meilisearch/src/routes/indexes/search.rs
+++ b/meilisearch/src/routes/indexes/search.rs
@@ -17,6 +17,7 @@ use crate::analytics::{Analytics, SearchAggregator};
 use crate::extractors::authentication::policies::*;
 use crate::extractors::authentication::GuardedData;
 use crate::extractors::sequential_extractor::SeqHandler;
+use crate::metrics::MEILISEARCH_DEGRADED_SEARCH_REQUESTS;
 use crate::search::{
     add_search_rules, perform_search, HybridQuery, MatchingStrategy, SearchQuery, SemanticRatio,
     DEFAULT_CROP_LENGTH, DEFAULT_CROP_MARKER, DEFAULT_HIGHLIGHT_POST_TAG,
@@ -247,6 +248,9 @@ pub async fn search_with_post(
             .await?;
     if let Ok(ref search_result) = search_result {
         aggregate.succeed(search_result);
+        if search_result.degraded {
+            MEILISEARCH_DEGRADED_SEARCH_REQUESTS.inc();
+        }
     }
     analytics.post_search(aggregate);
 

--- a/meilisearch/src/routes/indexes/settings.rs
+++ b/meilisearch/src/routes/indexes/settings.rs
@@ -138,6 +138,7 @@ macro_rules! make_setting_route {
 
                 debug!(returns = ?settings, "Update settings");
                 let mut json = serde_json::json!(&settings);
+                dbg!(&json);
                 let val = json[$camelcase_attr].take();
 
                 Ok(HttpResponse::Ok().json(val))
@@ -625,14 +626,14 @@ fn embedder_analytics(
 }
 
 make_setting_route!(
-    "/search_cutoff",
-    patch,
+    "/search-cutoff",
+    put,
     u64,
     meilisearch_types::deserr::DeserrJsonError<
         meilisearch_types::error::deserr_codes::InvalidSettingsSearchCutoff,
     >,
     search_cutoff,
-    "search_cutoff",
+    "searchCutoff",
     analytics,
     |setting: &Option<u64>, req: &HttpRequest| {
         analytics.publish(
@@ -673,7 +674,8 @@ generate_configure!(
     typo_tolerance,
     pagination,
     faceting,
-    embedders
+    embedders,
+    search_cutoff
 );
 
 pub async fn update_all(

--- a/meilisearch/src/routes/indexes/settings.rs
+++ b/meilisearch/src/routes/indexes/settings.rs
@@ -624,6 +624,25 @@ fn embedder_analytics(
     )
 }
 
+make_setting_route!(
+    "/search_cutoff",
+    patch,
+    u64,
+    meilisearch_types::deserr::DeserrJsonError<
+        meilisearch_types::error::deserr_codes::InvalidSettingsSearchCutoff,
+    >,
+    search_cutoff,
+    "search_cutoff",
+    analytics,
+    |setting: &Option<u64>, req: &HttpRequest| {
+        analytics.publish(
+            "Search Cutoff Updated".to_string(),
+            serde_json::json!({"search_cutoff": setting }),
+            Some(req),
+        );
+    }
+);
+
 macro_rules! generate_configure {
     ($($mod:ident),*) => {
         pub fn configure(cfg: &mut web::ServiceConfig) {
@@ -765,7 +784,8 @@ pub async fn update_all(
             "synonyms": {
                 "total": new_settings.synonyms.as_ref().set().map(|synonyms| synonyms.len()),
             },
-            "embedders": crate::routes::indexes::settings::embedder_analytics(new_settings.embedders.as_ref().set())
+            "embedders": crate::routes::indexes::settings::embedder_analytics(new_settings.embedders.as_ref().set()),
+            "search_cutoff": new_settings.search_cutoff.as_ref().set(),
         }),
         Some(&req),
     );

--- a/meilisearch/src/routes/indexes/settings.rs
+++ b/meilisearch/src/routes/indexes/settings.rs
@@ -626,19 +626,19 @@ fn embedder_analytics(
 }
 
 make_setting_route!(
-    "/search-cutoff",
+    "/search-cutoff-ms",
     put,
     u64,
     meilisearch_types::deserr::DeserrJsonError<
         meilisearch_types::error::deserr_codes::InvalidSettingsSearchCutoff,
     >,
-    search_cutoff,
-    "searchCutoff",
+    search_cutoff_ms,
+    "searchCutoffMs",
     analytics,
     |setting: &Option<u64>, req: &HttpRequest| {
         analytics.publish(
             "Search Cutoff Updated".to_string(),
-            serde_json::json!({"search_cutoff": setting }),
+            serde_json::json!({"search_cutoff_ms": setting }),
             Some(req),
         );
     }
@@ -675,7 +675,7 @@ generate_configure!(
     pagination,
     faceting,
     embedders,
-    search_cutoff
+    search_cutoff_ms
 );
 
 pub async fn update_all(
@@ -787,7 +787,7 @@ pub async fn update_all(
                 "total": new_settings.synonyms.as_ref().set().map(|synonyms| synonyms.len()),
             },
             "embedders": crate::routes::indexes::settings::embedder_analytics(new_settings.embedders.as_ref().set()),
-            "search_cutoff": new_settings.search_cutoff.as_ref().set(),
+            "search_cutoff_ms": new_settings.search_cutoff_ms.as_ref().set(),
         }),
         Some(&req),
     );

--- a/meilisearch/src/routes/indexes/settings.rs
+++ b/meilisearch/src/routes/indexes/settings.rs
@@ -138,7 +138,6 @@ macro_rules! make_setting_route {
 
                 debug!(returns = ?settings, "Update settings");
                 let mut json = serde_json::json!(&settings);
-                dbg!(&json);
                 let val = json[$camelcase_attr].take();
 
                 Ok(HttpResponse::Ok().json(val))
@@ -630,7 +629,7 @@ make_setting_route!(
     put,
     u64,
     meilisearch_types::deserr::DeserrJsonError<
-        meilisearch_types::error::deserr_codes::InvalidSettingsSearchCutoff,
+        meilisearch_types::error::deserr_codes::InvalidSettingsSearchCutoffMs,
     >,
     search_cutoff_ms,
     "searchCutoffMs",

--- a/meilisearch/src/search.rs
+++ b/meilisearch/src/search.rs
@@ -324,7 +324,8 @@ pub struct SearchResult {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub facet_stats: Option<BTreeMap<String, FacetStats>>,
 
-    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    // This information is only used for analytics purposes
+    #[serde(skip)]
     pub degraded: bool,
 }
 

--- a/meilisearch/src/search.rs
+++ b/meilisearch/src/search.rs
@@ -729,8 +729,11 @@ pub fn perform_facet_search(
     features: RoFeatures,
 ) -> Result<FacetSearchResult, MeilisearchHttpError> {
     let before_search = Instant::now();
-    let time_budget = TimeBudget::new(Duration::from_millis(150));
     let rtxn = index.read_txn()?;
+    let time_budget = match index.search_cutoff(&rtxn)? {
+        Some(cutoff) => TimeBudget::new(Duration::from_millis(cutoff)),
+        None => TimeBudget::default(),
+    };
 
     let (search, _, _, _) =
         prepare_search(index, &rtxn, &search_query, features, None, time_budget)?;

--- a/meilisearch/tests/common/index.rs
+++ b/meilisearch/tests/common/index.rs
@@ -328,6 +328,11 @@ impl Index<'_> {
         self.service.patch_encoded(url, settings, self.encoder).await
     }
 
+    pub async fn update_settings_search_cutoff_ms(&self, settings: Value) -> (Value, StatusCode) {
+        let url = format!("/indexes/{}/settings/search-cutoff-ms", urlencode(self.uid.as_ref()));
+        self.service.put_encoded(url, settings, self.encoder).await
+    }
+
     pub async fn delete_settings(&self) -> (Value, StatusCode) {
         let url = format!("/indexes/{}/settings", urlencode(self.uid.as_ref()));
         self.service.delete(url).await

--- a/meilisearch/tests/common/mod.rs
+++ b/meilisearch/tests/common/mod.rs
@@ -16,6 +16,7 @@ pub use server::{default_settings, Server};
 pub struct Value(pub serde_json::Value);
 
 impl Value {
+    #[track_caller]
     pub fn uid(&self) -> u64 {
         if let Some(uid) = self["uid"].as_u64() {
             uid

--- a/meilisearch/tests/dumps/mod.rs
+++ b/meilisearch/tests/dumps/mod.rs
@@ -77,7 +77,8 @@ async fn import_dump_v1_movie_raw() {
       },
       "pagination": {
         "maxTotalHits": 1000
-      }
+      },
+      "searchCutoff": null
     }
     "###
     );
@@ -238,7 +239,8 @@ async fn import_dump_v1_movie_with_settings() {
       },
       "pagination": {
         "maxTotalHits": 1000
-      }
+      },
+      "searchCutoff": null
     }
     "###
     );
@@ -385,7 +387,8 @@ async fn import_dump_v1_rubygems_with_settings() {
       },
       "pagination": {
         "maxTotalHits": 1000
-      }
+      },
+      "searchCutoff": null
     }
     "###
     );
@@ -518,7 +521,8 @@ async fn import_dump_v2_movie_raw() {
       },
       "pagination": {
         "maxTotalHits": 1000
-      }
+      },
+      "searchCutoff": null
     }
     "###
     );
@@ -663,7 +667,8 @@ async fn import_dump_v2_movie_with_settings() {
       },
       "pagination": {
         "maxTotalHits": 1000
-      }
+      },
+      "searchCutoff": null
     }
     "###
     );
@@ -807,7 +812,8 @@ async fn import_dump_v2_rubygems_with_settings() {
       },
       "pagination": {
         "maxTotalHits": 1000
-      }
+      },
+      "searchCutoff": null
     }
     "###
     );
@@ -940,7 +946,8 @@ async fn import_dump_v3_movie_raw() {
       },
       "pagination": {
         "maxTotalHits": 1000
-      }
+      },
+      "searchCutoff": null
     }
     "###
     );
@@ -1085,7 +1092,8 @@ async fn import_dump_v3_movie_with_settings() {
       },
       "pagination": {
         "maxTotalHits": 1000
-      }
+      },
+      "searchCutoff": null
     }
     "###
     );
@@ -1229,7 +1237,8 @@ async fn import_dump_v3_rubygems_with_settings() {
       },
       "pagination": {
         "maxTotalHits": 1000
-      }
+      },
+      "searchCutoff": null
     }
     "###
     );
@@ -1362,7 +1371,8 @@ async fn import_dump_v4_movie_raw() {
       },
       "pagination": {
         "maxTotalHits": 1000
-      }
+      },
+      "searchCutoff": null
     }
     "###
     );
@@ -1507,7 +1517,8 @@ async fn import_dump_v4_movie_with_settings() {
       },
       "pagination": {
         "maxTotalHits": 1000
-      }
+      },
+      "searchCutoff": null
     }
     "###
     );
@@ -1651,7 +1662,8 @@ async fn import_dump_v4_rubygems_with_settings() {
       },
       "pagination": {
         "maxTotalHits": 1000
-      }
+      },
+      "searchCutoff": null
     }
     "###
     );
@@ -1895,7 +1907,8 @@ async fn import_dump_v6_containing_experimental_features() {
       },
       "pagination": {
         "maxTotalHits": 1000
-      }
+      },
+      "searchCutoff": null
     }
     "###);
 

--- a/meilisearch/tests/dumps/mod.rs
+++ b/meilisearch/tests/dumps/mod.rs
@@ -78,7 +78,7 @@ async fn import_dump_v1_movie_raw() {
       "pagination": {
         "maxTotalHits": 1000
       },
-      "searchCutoff": null
+      "searchCutoffMs": null
     }
     "###
     );
@@ -240,7 +240,7 @@ async fn import_dump_v1_movie_with_settings() {
       "pagination": {
         "maxTotalHits": 1000
       },
-      "searchCutoff": null
+      "searchCutoffMs": null
     }
     "###
     );
@@ -388,7 +388,7 @@ async fn import_dump_v1_rubygems_with_settings() {
       "pagination": {
         "maxTotalHits": 1000
       },
-      "searchCutoff": null
+      "searchCutoffMs": null
     }
     "###
     );
@@ -522,7 +522,7 @@ async fn import_dump_v2_movie_raw() {
       "pagination": {
         "maxTotalHits": 1000
       },
-      "searchCutoff": null
+      "searchCutoffMs": null
     }
     "###
     );
@@ -668,7 +668,7 @@ async fn import_dump_v2_movie_with_settings() {
       "pagination": {
         "maxTotalHits": 1000
       },
-      "searchCutoff": null
+      "searchCutoffMs": null
     }
     "###
     );
@@ -813,7 +813,7 @@ async fn import_dump_v2_rubygems_with_settings() {
       "pagination": {
         "maxTotalHits": 1000
       },
-      "searchCutoff": null
+      "searchCutoffMs": null
     }
     "###
     );
@@ -947,7 +947,7 @@ async fn import_dump_v3_movie_raw() {
       "pagination": {
         "maxTotalHits": 1000
       },
-      "searchCutoff": null
+      "searchCutoffMs": null
     }
     "###
     );
@@ -1093,7 +1093,7 @@ async fn import_dump_v3_movie_with_settings() {
       "pagination": {
         "maxTotalHits": 1000
       },
-      "searchCutoff": null
+      "searchCutoffMs": null
     }
     "###
     );
@@ -1238,7 +1238,7 @@ async fn import_dump_v3_rubygems_with_settings() {
       "pagination": {
         "maxTotalHits": 1000
       },
-      "searchCutoff": null
+      "searchCutoffMs": null
     }
     "###
     );
@@ -1372,7 +1372,7 @@ async fn import_dump_v4_movie_raw() {
       "pagination": {
         "maxTotalHits": 1000
       },
-      "searchCutoff": null
+      "searchCutoffMs": null
     }
     "###
     );
@@ -1518,7 +1518,7 @@ async fn import_dump_v4_movie_with_settings() {
       "pagination": {
         "maxTotalHits": 1000
       },
-      "searchCutoff": null
+      "searchCutoffMs": null
     }
     "###
     );
@@ -1663,7 +1663,7 @@ async fn import_dump_v4_rubygems_with_settings() {
       "pagination": {
         "maxTotalHits": 1000
       },
-      "searchCutoff": null
+      "searchCutoffMs": null
     }
     "###
     );
@@ -1908,7 +1908,7 @@ async fn import_dump_v6_containing_experimental_features() {
       "pagination": {
         "maxTotalHits": 1000
       },
-      "searchCutoff": null
+      "searchCutoffMs": null
     }
     "###);
 

--- a/meilisearch/tests/search/mod.rs
+++ b/meilisearch/tests/search/mod.rs
@@ -850,6 +850,7 @@ async fn test_degraded_score_details() {
         .search(
             json!({
                 "q": "b",
+                "attributesToRetrieve": ["doggos.name", "cattos"],
                 "showRankingScoreDetails": true,
             }),
             |response, code| {
@@ -857,81 +858,46 @@ async fn test_degraded_score_details() {
                 meili_snap::snapshot!(meili_snap::json_string!(response["hits"]), @r###"
                 [
                   {
-                    "id": 852,
-                    "father": "jean",
-                    "mother": "michelle",
                     "doggos": [
                       {
-                        "name": "bobby",
-                        "age": 2
+                        "name": "bobby"
                       },
                       {
-                        "name": "buddy",
-                        "age": 4
+                        "name": "buddy"
                       }
                     ],
                     "cattos": "pésti",
-                    "_vectors": {
-                      "manual": [
-                        1,
-                        2,
-                        3
-                      ]
-                    },
                     "_rankingScoreDetails": {
                       "skipped": 0.0
                     }
                   },
                   {
-                    "id": 654,
-                    "father": "pierre",
-                    "mother": "sabine",
                     "doggos": [
                       {
-                        "name": "gros bill",
-                        "age": 8
+                        "name": "gros bill"
                       }
                     ],
                     "cattos": [
                       "simba",
                       "pestiféré"
                     ],
-                    "_vectors": {
-                      "manual": [
-                        1,
-                        2,
-                        54
-                      ]
-                    },
                     "_rankingScoreDetails": {
                       "skipped": 0.0
                     }
                   },
                   {
-                    "id": 951,
-                    "father": "jean-baptiste",
-                    "mother": "sophie",
                     "doggos": [
                       {
-                        "name": "turbo",
-                        "age": 5
+                        "name": "turbo"
                       },
                       {
-                        "name": "fast",
-                        "age": 6
+                        "name": "fast"
                       }
                     ],
                     "cattos": [
                       "moumoute",
                       "gomez"
                     ],
-                    "_vectors": {
-                      "manual": [
-                        10,
-                        23,
-                        32
-                      ]
-                    },
                     "_rankingScoreDetails": {
                       "skipped": 0.0
                     }

--- a/meilisearch/tests/search/mod.rs
+++ b/meilisearch/tests/search/mod.rs
@@ -855,54 +855,61 @@ async fn test_degraded_score_details() {
             }),
             |response, code| {
                 meili_snap::snapshot!(code, @"200 OK");
-                meili_snap::snapshot!(meili_snap::json_string!(response["hits"]), @r###"
-                [
-                  {
-                    "doggos": [
-                      {
-                        "name": "bobby"
-                      },
-                      {
-                        "name": "buddy"
+                meili_snap::snapshot!(meili_snap::json_string!(response), @r###"
+                {
+                  "hits": [
+                    {
+                      "doggos": [
+                        {
+                          "name": "bobby"
+                        },
+                        {
+                          "name": "buddy"
+                        }
+                      ],
+                      "cattos": "pésti",
+                      "_rankingScoreDetails": {
+                        "skipped": 0.0
                       }
-                    ],
-                    "cattos": "pésti",
-                    "_rankingScoreDetails": {
-                      "skipped": 0.0
-                    }
-                  },
-                  {
-                    "doggos": [
-                      {
-                        "name": "gros bill"
+                    },
+                    {
+                      "doggos": [
+                        {
+                          "name": "gros bill"
+                        }
+                      ],
+                      "cattos": [
+                        "simba",
+                        "pestiféré"
+                      ],
+                      "_rankingScoreDetails": {
+                        "skipped": 0.0
                       }
-                    ],
-                    "cattos": [
-                      "simba",
-                      "pestiféré"
-                    ],
-                    "_rankingScoreDetails": {
-                      "skipped": 0.0
-                    }
-                  },
-                  {
-                    "doggos": [
-                      {
-                        "name": "turbo"
-                      },
-                      {
-                        "name": "fast"
+                    },
+                    {
+                      "doggos": [
+                        {
+                          "name": "turbo"
+                        },
+                        {
+                          "name": "fast"
+                        }
+                      ],
+                      "cattos": [
+                        "moumoute",
+                        "gomez"
+                      ],
+                      "_rankingScoreDetails": {
+                        "skipped": 0.0
                       }
-                    ],
-                    "cattos": [
-                      "moumoute",
-                      "gomez"
-                    ],
-                    "_rankingScoreDetails": {
-                      "skipped": 0.0
                     }
-                  }
-                ]
+                  ],
+                  "query": "b",
+                  "processingTimeMs": 0,
+                  "limit": 20,
+                  "offset": 0,
+                  "estimatedTotalHits": 3
+                }
                 "###);
             },
         )

--- a/meilisearch/tests/search/mod.rs
+++ b/meilisearch/tests/search/mod.rs
@@ -869,7 +869,9 @@ async fn test_degraded_score_details() {
                       ],
                       "cattos": "pésti",
                       "_rankingScoreDetails": {
-                        "skipped": 0.0
+                        "skipped": {
+                          "order": 0
+                        }
                       }
                     },
                     {
@@ -883,7 +885,9 @@ async fn test_degraded_score_details() {
                         "pestiféré"
                       ],
                       "_rankingScoreDetails": {
-                        "skipped": 0.0
+                        "skipped": {
+                          "order": 0
+                        }
                       }
                     },
                     {
@@ -900,7 +904,9 @@ async fn test_degraded_score_details() {
                         "gomez"
                       ],
                       "_rankingScoreDetails": {
-                        "skipped": 0.0
+                        "skipped": {
+                          "order": 0
+                        }
                       }
                     }
                   ],

--- a/meilisearch/tests/search/mod.rs
+++ b/meilisearch/tests/search/mod.rs
@@ -843,7 +843,7 @@ async fn test_degraded_score_details() {
 
     index.add_documents(json!(documents), None).await;
     // We can't really use anything else than 0ms here; otherwise, the test will get flaky.
-    let (res, _code) = index.update_settings(json!({ "searchCutoff": 0 })).await;
+    let (res, _code) = index.update_settings(json!({ "searchCutoffMs": 0 })).await;
     index.wait_task(res.uid()).await;
 
     index
@@ -855,7 +855,7 @@ async fn test_degraded_score_details() {
             }),
             |response, code| {
                 meili_snap::snapshot!(code, @"200 OK");
-                meili_snap::snapshot!(meili_snap::json_string!(response), @r###"
+                meili_snap::snapshot!(meili_snap::json_string!(response, { ".processingTimeMs" => "[duration]" }), @r###"
                 {
                   "hits": [
                     {
@@ -905,7 +905,7 @@ async fn test_degraded_score_details() {
                     }
                   ],
                   "query": "b",
-                  "processingTimeMs": 0,
+                  "processingTimeMs": "[duration]",
                   "limit": 20,
                   "offset": 0,
                   "estimatedTotalHits": 3

--- a/meilisearch/tests/settings/errors.rs
+++ b/meilisearch/tests/settings/errors.rs
@@ -337,3 +337,31 @@ async fn settings_bad_pagination() {
     }
     "###);
 }
+
+#[actix_rt::test]
+async fn settings_bad_search_cutoff_ms() {
+    let server = Server::new().await;
+    let index = server.index("test");
+
+    let (response, code) = index.update_settings(json!({ "searchCutoffMs": "doggo" })).await;
+    snapshot!(code, @"400 Bad Request");
+    snapshot!(json_string!(response), @r###"
+    {
+      "message": "Invalid value type at `.searchCutoffMs`: expected a positive integer, but found a string: `\"doggo\"`",
+      "code": "invalid_settings_search_cutoff_ms",
+      "type": "invalid_request",
+      "link": "https://docs.meilisearch.com/errors#invalid_settings_search_cutoff_ms"
+    }
+    "###);
+
+    let (response, code) = index.update_settings_search_cutoff_ms(json!("doggo")).await;
+    snapshot!(code, @"400 Bad Request");
+    snapshot!(json_string!(response), @r###"
+    {
+      "message": "Invalid value type: expected a positive integer, but found a string: `\"doggo\"`",
+      "code": "invalid_settings_search_cutoff_ms",
+      "type": "invalid_request",
+      "link": "https://docs.meilisearch.com/errors#invalid_settings_search_cutoff_ms"
+    }
+    "###);
+}

--- a/meilisearch/tests/settings/get_settings.rs
+++ b/meilisearch/tests/settings/get_settings.rs
@@ -49,12 +49,12 @@ async fn get_settings_unexisting_index() {
 async fn get_settings() {
     let server = Server::new().await;
     let index = server.index("test");
-    index.create(None).await;
-    index.wait_task(0).await;
+    let (response, _code) = index.create(None).await;
+    index.wait_task(response.uid()).await;
     let (response, code) = index.settings().await;
     assert_eq!(code, 200);
     let settings = response.as_object().unwrap();
-    assert_eq!(settings.keys().len(), 15);
+    assert_eq!(settings.keys().len(), 16);
     assert_eq!(settings["displayedAttributes"], json!(["*"]));
     assert_eq!(settings["searchableAttributes"], json!(["*"]));
     assert_eq!(settings["filterableAttributes"], json!([]));
@@ -84,6 +84,7 @@ async fn get_settings() {
         })
     );
     assert_eq!(settings["proximityPrecision"], json!("byWord"));
+    assert_eq!(settings["searchCutoff"], json!(null));
 }
 
 #[actix_rt::test]

--- a/meilisearch/tests/settings/get_settings.rs
+++ b/meilisearch/tests/settings/get_settings.rs
@@ -35,6 +35,7 @@ static DEFAULT_SETTINGS_VALUES: Lazy<HashMap<&'static str, Value>> = Lazy::new(|
             "maxTotalHits": json!(1000),
         }),
     );
+    map.insert("search_cutoff", json!(null));
     map
 });
 
@@ -286,7 +287,8 @@ test_setting_routes!(
     ranking_rules put,
     synonyms put,
     pagination patch,
-    faceting patch
+    faceting patch,
+    search_cutoff put
 );
 
 #[actix_rt::test]

--- a/meilisearch/tests/settings/get_settings.rs
+++ b/meilisearch/tests/settings/get_settings.rs
@@ -35,7 +35,7 @@ static DEFAULT_SETTINGS_VALUES: Lazy<HashMap<&'static str, Value>> = Lazy::new(|
             "maxTotalHits": json!(1000),
         }),
     );
-    map.insert("search_cutoff", json!(null));
+    map.insert("search_cutoff_ms", json!(null));
     map
 });
 
@@ -85,7 +85,7 @@ async fn get_settings() {
         })
     );
     assert_eq!(settings["proximityPrecision"], json!("byWord"));
-    assert_eq!(settings["searchCutoff"], json!(null));
+    assert_eq!(settings["searchCutoffMs"], json!(null));
 }
 
 #[actix_rt::test]
@@ -288,7 +288,7 @@ test_setting_routes!(
     synonyms put,
     pagination patch,
     faceting patch,
-    search_cutoff put
+    search_cutoff_ms put
 );
 
 #[actix_rt::test]

--- a/milli/examples/search.rs
+++ b/milli/examples/search.rs
@@ -6,7 +6,7 @@ use std::time::Instant;
 use heed::EnvOpenOptions;
 use milli::{
     execute_search, filtered_universe, DefaultSearchLogger, GeoSortStrategy, Index, SearchContext,
-    SearchLogger, TermsMatchingStrategy,
+    SearchLogger, TermsMatchingStrategy, TimeBudget,
 };
 
 #[global_allocator]
@@ -65,6 +65,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 None,
                 &mut DefaultSearchLogger,
                 logger,
+                TimeBudget::max(),
             )?;
             if let Some((logger, dir)) = detailed_logger {
                 logger.finish(&mut ctx, Path::new(dir))?;

--- a/milli/src/index.rs
+++ b/milli/src/index.rs
@@ -2421,6 +2421,7 @@ pub(crate) mod tests {
             candidates: _,
             document_scores: _,
             mut documents_ids,
+            degraded: _,
         } = search.execute().unwrap();
         let primary_key_id = index.fields_ids_map(&rtxn).unwrap().id("primary_key").unwrap();
         documents_ids.sort_unstable();

--- a/milli/src/index.rs
+++ b/milli/src/index.rs
@@ -67,6 +67,7 @@ pub mod main_key {
     pub const PAGINATION_MAX_TOTAL_HITS: &str = "pagination-max-total-hits";
     pub const PROXIMITY_PRECISION: &str = "proximity-precision";
     pub const EMBEDDING_CONFIGS: &str = "embedding_configs";
+    pub const SEARCH_CUTOFF: &str = "search_cutoff";
 }
 
 pub mod db_name {
@@ -1504,6 +1505,18 @@ impl Index {
             [(ref first_name, _)] => first_name.clone(),
             _ => "default".to_owned(),
         })
+    }
+
+    pub(crate) fn put_search_cutoff(&self, wtxn: &mut RwTxn<'_>, cutoff: u64) -> heed::Result<()> {
+        self.main.remap_types::<Str, BEU64>().put(wtxn, main_key::SEARCH_CUTOFF, &cutoff)
+    }
+
+    pub fn search_cutoff(&self, rtxn: &RoTxn<'_>) -> Result<Option<u64>> {
+        Ok(self.main.remap_types::<Str, BEU64>().get(rtxn, main_key::SEARCH_CUTOFF)?)
+    }
+
+    pub(crate) fn delete_search_cutoff(&self, wtxn: &mut RwTxn<'_>) -> heed::Result<bool> {
+        self.main.remap_key_type::<Str>().delete(wtxn, main_key::SEARCH_CUTOFF)
     }
 }
 

--- a/milli/src/lib.rs
+++ b/milli/src/lib.rs
@@ -121,6 +121,12 @@ impl fmt::Debug for TimeBudget {
     }
 }
 
+impl Default for TimeBudget {
+    fn default() -> Self {
+        Self::new(std::time::Duration::from_millis(150))
+    }
+}
+
 impl TimeBudget {
     pub fn new(budget: std::time::Duration) -> Self {
         Self { started_at: std::time::Instant::now(), budget }

--- a/milli/src/score_details.rs
+++ b/milli/src/score_details.rs
@@ -101,7 +101,7 @@ impl ScoreDetails {
             ScoreDetails::Vector(vector) => RankOrValue::Score(
                 vector.value_similarity.as_ref().map(|(_, s)| *s as f64).unwrap_or(0.0f64),
             ),
-            ScoreDetails::Skipped => RankOrValue::Score(0.),
+            ScoreDetails::Skipped => RankOrValue::Rank(Rank { rank: 0, max_rank: 1 }),
         }
     }
 
@@ -262,10 +262,8 @@ impl ScoreDetails {
                     order += 1;
                 }
                 ScoreDetails::Skipped => {
-                    details_map.insert(
-                        "skipped".to_string(),
-                        serde_json::Number::from_f64(0.).unwrap().into(),
-                    );
+                    details_map
+                        .insert("skipped".to_string(), serde_json::json!({ "order": order }));
                     order += 1;
                 }
             }

--- a/milli/src/search/hybrid.rs
+++ b/milli/src/search/hybrid.rs
@@ -132,7 +132,7 @@ impl<'a> Search<'a> {
             index: self.index,
             distribution_shift: self.distribution_shift,
             embedder_name: self.embedder_name.clone(),
-            time_budget: self.time_budget,
+            time_budget: self.time_budget.clone(),
         };
 
         let vector_query = search.vector.take();

--- a/milli/src/search/hybrid.rs
+++ b/milli/src/search/hybrid.rs
@@ -106,6 +106,7 @@ impl ScoreWithRatioResult {
             candidates: left.candidates | right.candidates,
             documents_ids,
             document_scores,
+            degraded: false,
         }
     }
 }
@@ -131,6 +132,7 @@ impl<'a> Search<'a> {
             index: self.index,
             distribution_shift: self.distribution_shift,
             embedder_name: self.embedder_name.clone(),
+            time_budget: self.time_budget,
         };
 
         let vector_query = search.vector.take();

--- a/milli/src/search/hybrid.rs
+++ b/milli/src/search/hybrid.rs
@@ -50,8 +50,12 @@ fn compare_scores(
                     order => return order,
                 }
             }
-            (Some(ScoreValue::Score(_)), Some(_)) => return Ordering::Greater,
-            (Some(_), Some(ScoreValue::Score(_))) => return Ordering::Less,
+            (Some(ScoreValue::Score(x)), Some(_)) => {
+                return if x == 0. { Ordering::Less } else { Ordering::Greater }
+            }
+            (Some(_), Some(ScoreValue::Score(x))) => {
+                return if x == 0. { Ordering::Greater } else { Ordering::Less }
+            }
             // if we have this, we're bad
             (Some(ScoreValue::GeoSort(_)), Some(ScoreValue::Sort(_)))
             | (Some(ScoreValue::Sort(_)), Some(ScoreValue::GeoSort(_))) => {

--- a/milli/src/search/hybrid.rs
+++ b/milli/src/search/hybrid.rs
@@ -10,6 +10,7 @@ struct ScoreWithRatioResult {
     matching_words: MatchingWords,
     candidates: RoaringBitmap,
     document_scores: Vec<(u32, ScoreWithRatio)>,
+    degraded: bool,
 }
 
 type ScoreWithRatio = (Vec<ScoreDetails>, f32);
@@ -72,6 +73,7 @@ impl ScoreWithRatioResult {
             matching_words: results.matching_words,
             candidates: results.candidates,
             document_scores,
+            degraded: results.degraded,
         }
     }
 
@@ -106,7 +108,7 @@ impl ScoreWithRatioResult {
             candidates: left.candidates | right.candidates,
             documents_ids,
             document_scores,
-            degraded: false,
+            degraded: left.degraded | right.degraded,
         }
     }
 }

--- a/milli/src/search/mod.rs
+++ b/milli/src/search/mod.rs
@@ -195,7 +195,7 @@ impl<'a> Search<'a> {
                 self.limit,
                 self.distribution_shift,
                 embedder_name,
-                self.time_budget,
+                self.time_budget.clone(),
             )?,
             None => execute_search(
                 &mut ctx,
@@ -211,7 +211,7 @@ impl<'a> Search<'a> {
                 Some(self.words_limit),
                 &mut DefaultSearchLogger,
                 &mut DefaultSearchLogger,
-                self.time_budget,
+                self.time_budget.clone(),
             )?,
         };
 

--- a/milli/src/search/mod.rs
+++ b/milli/src/search/mod.rs
@@ -260,7 +260,7 @@ impl fmt::Debug for Search<'_> {
             .field("words_limit", words_limit)
             .field("distribution_shift", distribution_shift)
             .field("embedder_name", embedder_name)
-            .field("time_bduget", time_budget)
+            .field("time_budget", time_budget)
             .finish()
     }
 }

--- a/milli/src/search/mod.rs
+++ b/milli/src/search/mod.rs
@@ -11,7 +11,7 @@ use crate::score_details::{ScoreDetails, ScoringStrategy};
 use crate::vector::DistributionShift;
 use crate::{
     execute_search, filtered_universe, AscDesc, DefaultSearchLogger, DocumentId, Index, Result,
-    SearchContext,
+    SearchContext, TimeBudget,
 };
 
 // Building these factories is not free.
@@ -43,6 +43,8 @@ pub struct Search<'a> {
     index: &'a Index,
     distribution_shift: Option<DistributionShift>,
     embedder_name: Option<String>,
+
+    time_budget: TimeBudget,
 }
 
 impl<'a> Search<'a> {
@@ -64,6 +66,7 @@ impl<'a> Search<'a> {
             index,
             distribution_shift: None,
             embedder_name: None,
+            time_budget: TimeBudget::max(),
         }
     }
 
@@ -143,6 +146,11 @@ impl<'a> Search<'a> {
         self
     }
 
+    pub fn time_budget(&mut self, time_budget: TimeBudget) -> &mut Search<'a> {
+        self.time_budget = time_budget;
+        self
+    }
+
     pub fn execute_for_candidates(&self, has_vector_search: bool) -> Result<RoaringBitmap> {
         if has_vector_search {
             let ctx = SearchContext::new(self.index, self.rtxn);
@@ -169,36 +177,43 @@ impl<'a> Search<'a> {
         }
 
         let universe = filtered_universe(&ctx, &self.filter)?;
-        let PartialSearchResult { located_query_terms, candidates, documents_ids, document_scores } =
-            match self.vector.as_ref() {
-                Some(vector) => execute_vector_search(
-                    &mut ctx,
-                    vector,
-                    self.scoring_strategy,
-                    universe,
-                    &self.sort_criteria,
-                    self.geo_strategy,
-                    self.offset,
-                    self.limit,
-                    self.distribution_shift,
-                    embedder_name,
-                )?,
-                None => execute_search(
-                    &mut ctx,
-                    self.query.as_deref(),
-                    self.terms_matching_strategy,
-                    self.scoring_strategy,
-                    self.exhaustive_number_hits,
-                    universe,
-                    &self.sort_criteria,
-                    self.geo_strategy,
-                    self.offset,
-                    self.limit,
-                    Some(self.words_limit),
-                    &mut DefaultSearchLogger,
-                    &mut DefaultSearchLogger,
-                )?,
-            };
+        let PartialSearchResult {
+            located_query_terms,
+            candidates,
+            documents_ids,
+            document_scores,
+            degraded,
+        } = match self.vector.as_ref() {
+            Some(vector) => execute_vector_search(
+                &mut ctx,
+                vector,
+                self.scoring_strategy,
+                universe,
+                &self.sort_criteria,
+                self.geo_strategy,
+                self.offset,
+                self.limit,
+                self.distribution_shift,
+                embedder_name,
+                self.time_budget,
+            )?,
+            None => execute_search(
+                &mut ctx,
+                self.query.as_deref(),
+                self.terms_matching_strategy,
+                self.scoring_strategy,
+                self.exhaustive_number_hits,
+                universe,
+                &self.sort_criteria,
+                self.geo_strategy,
+                self.offset,
+                self.limit,
+                Some(self.words_limit),
+                &mut DefaultSearchLogger,
+                &mut DefaultSearchLogger,
+                self.time_budget,
+            )?,
+        };
 
         // consume context and located_query_terms to build MatchingWords.
         let matching_words = match located_query_terms {
@@ -206,7 +221,7 @@ impl<'a> Search<'a> {
             None => MatchingWords::default(),
         };
 
-        Ok(SearchResult { matching_words, candidates, document_scores, documents_ids })
+        Ok(SearchResult { matching_words, candidates, document_scores, documents_ids, degraded })
     }
 }
 
@@ -229,6 +244,7 @@ impl fmt::Debug for Search<'_> {
             index: _,
             distribution_shift,
             embedder_name,
+            time_budget,
         } = self;
         f.debug_struct("Search")
             .field("query", query)
@@ -244,6 +260,7 @@ impl fmt::Debug for Search<'_> {
             .field("words_limit", words_limit)
             .field("distribution_shift", distribution_shift)
             .field("embedder_name", embedder_name)
+            .field("time_bduget", time_budget)
             .finish()
     }
 }
@@ -254,6 +271,7 @@ pub struct SearchResult {
     pub candidates: RoaringBitmap,
     pub documents_ids: Vec<DocumentId>,
     pub document_scores: Vec<Vec<ScoreDetails>>,
+    pub degraded: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/milli/src/search/new/matches/mod.rs
+++ b/milli/src/search/new/matches/mod.rs
@@ -502,7 +502,7 @@ mod tests {
 
     use super::*;
     use crate::index::tests::TempIndex;
-    use crate::{execute_search, filtered_universe, SearchContext};
+    use crate::{execute_search, filtered_universe, SearchContext, TimeBudget};
 
     impl<'a> MatcherBuilder<'a> {
         fn new_test(rtxn: &'a heed::RoTxn, index: &'a TempIndex, query: &str) -> Self {
@@ -522,6 +522,7 @@ mod tests {
                 Some(10),
                 &mut crate::DefaultSearchLogger,
                 &mut crate::DefaultSearchLogger,
+                TimeBudget::max(),
             )
             .unwrap();
 

--- a/milli/src/search/new/tests/cutoff.rs
+++ b/milli/src/search/new/tests/cutoff.rs
@@ -1,0 +1,419 @@
+//! This module test the search cutoff and ensure a few things:
+//! 1. A basic test works and mark the search as degraded
+//! 2. A test that ensure the filters are affectively applied even with a cutoff of 0
+//! 3. A test that ensure the cutoff works well with the ranking scores
+
+use std::time::Duration;
+
+use big_s::S;
+use maplit::hashset;
+use meili_snap::snapshot;
+
+use crate::index::tests::TempIndex;
+use crate::{Criterion, Filter, Search, TimeBudget};
+
+fn create_index() -> TempIndex {
+    let index = TempIndex::new();
+
+    index
+        .update_settings(|s| {
+            s.set_primary_key("id".to_owned());
+            s.set_searchable_fields(vec!["text".to_owned()]);
+            s.set_filterable_fields(hashset! { S("id") });
+            s.set_criteria(vec![Criterion::Words, Criterion::Typo]);
+        })
+        .unwrap();
+
+    // reverse the ID / insertion order so we see better what was sorted from what got the insertion order ordering
+    index
+        .add_documents(documents!([
+            {
+                "id": 4,
+                "text": "hella puppo kefir",
+            },
+            {
+                "id": 3,
+                "text": "hella puppy kefir",
+            },
+            {
+                "id": 2,
+                "text": "hello",
+            },
+            {
+                "id": 1,
+                "text": "hello puppy",
+            },
+            {
+                "id": 0,
+                "text": "hello puppy kefir",
+            },
+        ]))
+        .unwrap();
+    index
+}
+
+#[test]
+fn basic_degraded_search() {
+    let index = create_index();
+    let rtxn = index.read_txn().unwrap();
+
+    let mut search = Search::new(&rtxn, &index);
+    search.query("hello puppy kefir");
+    search.limit(3);
+    search.time_budget(TimeBudget::new(Duration::from_millis(0)));
+
+    let result = search.execute().unwrap();
+    assert!(result.degraded);
+}
+
+#[test]
+fn degraded_search_cannot_skip_filter() {
+    let index = create_index();
+    let rtxn = index.read_txn().unwrap();
+
+    let mut search = Search::new(&rtxn, &index);
+    search.query("hello puppy kefir");
+    search.limit(100);
+    search.time_budget(TimeBudget::new(Duration::from_millis(0)));
+    let filter_condition = Filter::from_str("id > 2").unwrap().unwrap();
+    search.filter(filter_condition);
+
+    let result = search.execute().unwrap();
+    assert!(result.degraded);
+    snapshot!(format!("{:?}\n{:?}", result.candidates, result.documents_ids), @r###"
+    RoaringBitmap<[0, 1]>
+    [0, 1]
+    "###);
+}
+
+#[test]
+fn degraded_search_and_score_details() {
+    let index = create_index();
+    let rtxn = index.read_txn().unwrap();
+
+    let mut search = Search::new(&rtxn, &index);
+    search.query("hello puppy kefir");
+    search.limit(4);
+    search.time_budget(TimeBudget::max());
+
+    let result = search.execute().unwrap();
+    snapshot!(format!("{:#?}\n{:#?}", result.documents_ids, result.document_scores), @r###"
+    [
+        4,
+        1,
+        0,
+        3,
+    ]
+    [
+        [
+            Words(
+                Words {
+                    matching_words: 3,
+                    max_matching_words: 3,
+                },
+            ),
+            Typo(
+                Typo {
+                    typo_count: 0,
+                    max_typo_count: 3,
+                },
+            ),
+        ],
+        [
+            Words(
+                Words {
+                    matching_words: 3,
+                    max_matching_words: 3,
+                },
+            ),
+            Typo(
+                Typo {
+                    typo_count: 1,
+                    max_typo_count: 3,
+                },
+            ),
+        ],
+        [
+            Words(
+                Words {
+                    matching_words: 3,
+                    max_matching_words: 3,
+                },
+            ),
+        ],
+        [
+            Words(
+                Words {
+                    matching_words: 2,
+                    max_matching_words: 3,
+                },
+            ),
+        ],
+    ]
+    "###);
+
+    // Do ONE loop iteration. Not much can be deduced, almost everyone matched the words first bucket.
+    search.time_budget(TimeBudget::max().with_stop_after(1));
+
+    let result = search.execute().unwrap();
+    snapshot!(format!("{:#?}\n{:#?}", result.documents_ids, result.document_scores), @r###"
+    [
+        0,
+        1,
+        4,
+        2,
+    ]
+    [
+        [
+            Words(
+                Words {
+                    matching_words: 3,
+                    max_matching_words: 3,
+                },
+            ),
+            Skipped,
+        ],
+        [
+            Words(
+                Words {
+                    matching_words: 3,
+                    max_matching_words: 3,
+                },
+            ),
+            Skipped,
+        ],
+        [
+            Words(
+                Words {
+                    matching_words: 3,
+                    max_matching_words: 3,
+                },
+            ),
+            Skipped,
+        ],
+        [
+            Skipped,
+        ],
+    ]
+    "###);
+
+    // Do TWO loop iterations. The first document should be entirely sorted
+    search.time_budget(TimeBudget::max().with_stop_after(2));
+
+    let result = search.execute().unwrap();
+    snapshot!(format!("{:#?}\n{:#?}", result.documents_ids, result.document_scores), @r###"
+    [
+        4,
+        0,
+        1,
+        2,
+    ]
+    [
+        [
+            Words(
+                Words {
+                    matching_words: 3,
+                    max_matching_words: 3,
+                },
+            ),
+            Typo(
+                Typo {
+                    typo_count: 0,
+                    max_typo_count: 3,
+                },
+            ),
+        ],
+        [
+            Words(
+                Words {
+                    matching_words: 3,
+                    max_matching_words: 3,
+                },
+            ),
+            Skipped,
+        ],
+        [
+            Words(
+                Words {
+                    matching_words: 3,
+                    max_matching_words: 3,
+                },
+            ),
+            Skipped,
+        ],
+        [
+            Skipped,
+        ],
+    ]
+    "###);
+
+    // Do THREE loop iterations. The second document should be entirely sorted as well
+    search.time_budget(TimeBudget::max().with_stop_after(3));
+
+    let result = search.execute().unwrap();
+    snapshot!(format!("{:#?}\n{:#?}", result.documents_ids, result.document_scores), @r###"
+    [
+        4,
+        1,
+        0,
+        2,
+    ]
+    [
+        [
+            Words(
+                Words {
+                    matching_words: 3,
+                    max_matching_words: 3,
+                },
+            ),
+            Typo(
+                Typo {
+                    typo_count: 0,
+                    max_typo_count: 3,
+                },
+            ),
+        ],
+        [
+            Words(
+                Words {
+                    matching_words: 3,
+                    max_matching_words: 3,
+                },
+            ),
+            Typo(
+                Typo {
+                    typo_count: 1,
+                    max_typo_count: 3,
+                },
+            ),
+        ],
+        [
+            Words(
+                Words {
+                    matching_words: 3,
+                    max_matching_words: 3,
+                },
+            ),
+            Skipped,
+        ],
+        [
+            Skipped,
+        ],
+    ]
+    "###);
+
+    // Do FOUR loop iterations. The third document should be entirely sorted as well
+    // The words bucket have still not progressed thus the last document doesn't have any info yet.
+    search.time_budget(TimeBudget::max().with_stop_after(4));
+
+    let result = search.execute().unwrap();
+    snapshot!(format!("{:#?}\n{:#?}", result.documents_ids, result.document_scores), @r###"
+    [
+        4,
+        1,
+        0,
+        2,
+    ]
+    [
+        [
+            Words(
+                Words {
+                    matching_words: 3,
+                    max_matching_words: 3,
+                },
+            ),
+            Typo(
+                Typo {
+                    typo_count: 0,
+                    max_typo_count: 3,
+                },
+            ),
+        ],
+        [
+            Words(
+                Words {
+                    matching_words: 3,
+                    max_matching_words: 3,
+                },
+            ),
+            Typo(
+                Typo {
+                    typo_count: 1,
+                    max_typo_count: 3,
+                },
+            ),
+        ],
+        [
+            Words(
+                Words {
+                    matching_words: 3,
+                    max_matching_words: 3,
+                },
+            ),
+        ],
+        [
+            Skipped,
+        ],
+    ]
+    "###);
+
+    // After FIVE loop iteration. The words ranking rule gave us a new bucket.
+    // Since we reached the limit we were able to early exit without checking the typo ranking rule.
+    search.time_budget(TimeBudget::max().with_stop_after(5));
+
+    let result = search.execute().unwrap();
+    snapshot!(format!("{:#?}\n{:#?}", result.documents_ids, result.document_scores), @r###"
+    [
+        4,
+        1,
+        0,
+        3,
+    ]
+    [
+        [
+            Words(
+                Words {
+                    matching_words: 3,
+                    max_matching_words: 3,
+                },
+            ),
+            Typo(
+                Typo {
+                    typo_count: 0,
+                    max_typo_count: 3,
+                },
+            ),
+        ],
+        [
+            Words(
+                Words {
+                    matching_words: 3,
+                    max_matching_words: 3,
+                },
+            ),
+            Typo(
+                Typo {
+                    typo_count: 1,
+                    max_typo_count: 3,
+                },
+            ),
+        ],
+        [
+            Words(
+                Words {
+                    matching_words: 3,
+                    max_matching_words: 3,
+                },
+            ),
+        ],
+        [
+            Words(
+                Words {
+                    matching_words: 2,
+                    max_matching_words: 3,
+                },
+            ),
+        ],
+    ]
+    "###);
+}

--- a/milli/src/search/new/tests/cutoff.rs
+++ b/milli/src/search/new/tests/cutoff.rs
@@ -10,7 +10,7 @@ use maplit::hashset;
 use meili_snap::snapshot;
 
 use crate::index::tests::TempIndex;
-use crate::score_details::ScoringStrategy;
+use crate::score_details::{ScoreDetails, ScoringStrategy};
 use crate::{Criterion, Filter, Search, TimeBudget};
 
 fn create_index() -> TempIndex {
@@ -88,6 +88,7 @@ fn degraded_search_cannot_skip_filter() {
 }
 
 #[test]
+#[allow(clippy::format_collect)] // the test is already quite big
 fn degraded_search_and_score_details() {
     let index = create_index();
     let rtxn = index.read_txn().unwrap();
@@ -99,13 +100,10 @@ fn degraded_search_and_score_details() {
     search.time_budget(TimeBudget::max());
 
     let result = search.execute().unwrap();
-    snapshot!(format!("{:#?}\n{:#?}", result.documents_ids, result.document_scores), @r###"
-    [
-        4,
-        1,
-        0,
-        3,
-    ]
+    snapshot!(format!("IDs: {:?}\nScores: {}\nScore Details:\n{:#?}", result.documents_ids, result.document_scores.iter().map(|scores| format!("{:.4} ", ScoreDetails::global_score(scores.iter()))).collect::<String>(), result.document_scores), @r###"
+    IDs: [4, 1, 0, 3]
+    Scores: 1.0000 0.9167 0.8333 0.6667 
+    Score Details:
     [
         [
             Words(
@@ -170,13 +168,10 @@ fn degraded_search_and_score_details() {
     search.time_budget(TimeBudget::max().with_stop_after(1));
 
     let result = search.execute().unwrap();
-    snapshot!(format!("{:#?}\n{:#?}", result.documents_ids, result.document_scores), @r###"
-    [
-        0,
-        1,
-        4,
-        2,
-    ]
+    snapshot!(format!("IDs: {:?}\nScores: {}\nScore Details:\n{:#?}", result.documents_ids, result.document_scores.iter().map(|scores| format!("{:.4} ", ScoreDetails::global_score(scores.iter()))).collect::<String>(), result.document_scores), @r###"
+    IDs: [0, 1, 4, 2]
+    Scores: 0.6667 0.6667 0.6667 0.0000 
+    Score Details:
     [
         [
             Words(
@@ -215,13 +210,10 @@ fn degraded_search_and_score_details() {
     search.time_budget(TimeBudget::max().with_stop_after(2));
 
     let result = search.execute().unwrap();
-    snapshot!(format!("{:#?}\n{:#?}", result.documents_ids, result.document_scores), @r###"
-    [
-        4,
-        0,
-        1,
-        2,
-    ]
+    snapshot!(format!("IDs: {:?}\nScores: {}\nScore Details:\n{:#?}", result.documents_ids, result.document_scores.iter().map(|scores| format!("{:.4} ", ScoreDetails::global_score(scores.iter()))).collect::<String>(), result.document_scores), @r###"
+    IDs: [4, 0, 1, 2]
+    Scores: 1.0000 0.6667 0.6667 0.0000 
+    Score Details:
     [
         [
             Words(
@@ -265,13 +257,10 @@ fn degraded_search_and_score_details() {
     search.time_budget(TimeBudget::max().with_stop_after(3));
 
     let result = search.execute().unwrap();
-    snapshot!(format!("{:#?}\n{:#?}", result.documents_ids, result.document_scores), @r###"
-    [
-        4,
-        1,
-        0,
-        2,
-    ]
+    snapshot!(format!("IDs: {:?}\nScores: {}\nScore Details:\n{:#?}", result.documents_ids, result.document_scores.iter().map(|scores| format!("{:.4} ", ScoreDetails::global_score(scores.iter()))).collect::<String>(), result.document_scores), @r###"
+    IDs: [4, 1, 0, 2]
+    Scores: 1.0000 0.9167 0.6667 0.0000 
+    Score Details:
     [
         [
             Words(
@@ -321,13 +310,10 @@ fn degraded_search_and_score_details() {
     search.time_budget(TimeBudget::max().with_stop_after(4));
 
     let result = search.execute().unwrap();
-    snapshot!(format!("{:#?}\n{:#?}", result.documents_ids, result.document_scores), @r###"
-    [
-        4,
-        1,
-        0,
-        2,
-    ]
+    snapshot!(format!("IDs: {:?}\nScores: {}\nScore Details:\n{:#?}", result.documents_ids, result.document_scores.iter().map(|scores| format!("{:.4} ", ScoreDetails::global_score(scores.iter()))).collect::<String>(), result.document_scores), @r###"
+    IDs: [4, 1, 0, 2]
+    Scores: 1.0000 0.9167 0.8333 0.0000 
+    Score Details:
     [
         [
             Words(
@@ -382,13 +368,10 @@ fn degraded_search_and_score_details() {
     search.time_budget(TimeBudget::max().with_stop_after(6));
 
     let result = search.execute().unwrap();
-    snapshot!(format!("{:#?}\n{:#?}", result.documents_ids, result.document_scores), @r###"
-    [
-        4,
-        1,
-        0,
-        3,
-    ]
+    snapshot!(format!("IDs: {:?}\nScores: {}\nScore Details:\n{:#?}", result.documents_ids, result.document_scores.iter().map(|scores| format!("{:.4} ", ScoreDetails::global_score(scores.iter()))).collect::<String>(), result.document_scores), @r###"
+    IDs: [4, 1, 0, 3]
+    Scores: 1.0000 0.9167 0.8333 0.3333 
+    Score Details:
     [
         [
             Words(

--- a/milli/src/search/new/tests/mod.rs
+++ b/milli/src/search/new/tests/mod.rs
@@ -1,5 +1,6 @@
 pub mod attribute_fid;
 pub mod attribute_position;
+pub mod cutoff;
 pub mod distinct;
 pub mod exactness;
 pub mod geo_sort;

--- a/milli/src/update/settings.rs
+++ b/milli/src/update/settings.rs
@@ -150,6 +150,7 @@ pub struct Settings<'a, 't, 'i> {
     pagination_max_total_hits: Setting<usize>,
     proximity_precision: Setting<ProximityPrecision>,
     embedder_settings: Setting<BTreeMap<String, Setting<EmbeddingSettings>>>,
+    search_cutoff: Setting<u64>,
 }
 
 impl<'a, 't, 'i> Settings<'a, 't, 'i> {
@@ -183,6 +184,7 @@ impl<'a, 't, 'i> Settings<'a, 't, 'i> {
             pagination_max_total_hits: Setting::NotSet,
             proximity_precision: Setting::NotSet,
             embedder_settings: Setting::NotSet,
+            search_cutoff: Setting::NotSet,
             indexer_config,
         }
     }
@@ -371,6 +373,14 @@ impl<'a, 't, 'i> Settings<'a, 't, 'i> {
 
     pub fn reset_embedder_settings(&mut self) {
         self.embedder_settings = Setting::Reset;
+    }
+
+    pub fn set_search_cutoff(&mut self, value: u64) {
+        self.search_cutoff = Setting::Set(value);
+    }
+
+    pub fn reset_search_cutoff(&mut self) {
+        self.search_cutoff = Setting::Reset;
     }
 
     #[tracing::instrument(
@@ -1026,6 +1036,24 @@ impl<'a, 't, 'i> Settings<'a, 't, 'i> {
         Ok(update)
     }
 
+    fn update_search_cutoff(&mut self) -> Result<bool> {
+        let changed = match self.search_cutoff {
+            Setting::Set(new) => {
+                let old = self.index.search_cutoff(self.wtxn)?;
+                if old == Some(new) {
+                    false
+                } else {
+                    self.index.put_search_cutoff(self.wtxn, new)?;
+                    true
+                }
+            }
+            Setting::Reset => self.index.delete_search_cutoff(self.wtxn)?,
+            Setting::NotSet => false,
+        };
+
+        Ok(changed)
+    }
+
     pub fn execute<FP, FA>(mut self, progress_callback: FP, should_abort: FA) -> Result<()>
     where
         FP: Fn(UpdateIndexingStep) + Sync,
@@ -1070,6 +1098,9 @@ impl<'a, 't, 'i> Settings<'a, 't, 'i> {
         // 2. Only change the name -> embedder mapping on a name change
         // 3. Keep the old vectors but reattempt indexing on a prompt change: only actually changed prompt will need embedding + storage
         let embedding_configs_updated = self.update_embedding_configs()?;
+
+        // never trigger re-indexing
+        self.update_search_cutoff()?;
 
         if stop_words_updated
             || non_separator_tokens_updated
@@ -2027,6 +2058,7 @@ mod tests {
                     pagination_max_total_hits,
                     proximity_precision,
                     embedder_settings,
+                    search_cutoff,
                 } = settings;
                 assert!(matches!(searchable_fields, Setting::NotSet));
                 assert!(matches!(displayed_fields, Setting::NotSet));
@@ -2050,6 +2082,7 @@ mod tests {
                 assert!(matches!(pagination_max_total_hits, Setting::NotSet));
                 assert!(matches!(proximity_precision, Setting::NotSet));
                 assert!(matches!(embedder_settings, Setting::NotSet));
+                assert!(matches!(search_cutoff, Setting::NotSet));
             })
             .unwrap();
     }

--- a/milli/tests/search/mod.rs
+++ b/milli/tests/search/mod.rs
@@ -1,19 +1,14 @@
 use std::cmp::Reverse;
 use std::collections::HashSet;
 use std::io::Cursor;
-use std::time::Duration;
 
 use big_s::S;
 use either::{Either, Left, Right};
 use heed::EnvOpenOptions;
 use maplit::{btreemap, hashset};
-use meili_snap::snapshot;
 use milli::documents::{DocumentsBatchBuilder, DocumentsBatchReader};
 use milli::update::{IndexDocuments, IndexDocumentsConfig, IndexerConfig, Settings};
-use milli::{
-    AscDesc, Criterion, DocumentId, Filter, Index, Member, Object, Search, TermsMatchingStrategy,
-    TimeBudget,
-};
+use milli::{AscDesc, Criterion, DocumentId, Index, Member, Object, TermsMatchingStrategy};
 use serde::{Deserialize, Deserializer};
 use slice_group_by::GroupBy;
 
@@ -353,42 +348,4 @@ where
 {
     let result = serde_json::Value::deserialize(deserializer)?;
     Ok(Some(result))
-}
-
-#[test]
-fn basic_degraded_search() {
-    use Criterion::*;
-    let criteria = vec![Words, Typo, Proximity, Attribute, Exactness];
-    let index = setup_search_index_with_criteria(&criteria);
-    let rtxn = index.read_txn().unwrap();
-
-    let mut search = Search::new(&rtxn, &index);
-    search.query(TEST_QUERY);
-    search.limit(EXTERNAL_DOCUMENTS_IDS.len());
-    search.time_budget(TimeBudget::new(Duration::from_millis(0)));
-
-    let result = search.execute().unwrap();
-    assert!(result.degraded);
-}
-
-#[test]
-fn degraded_search_cannot_skip_filter() {
-    use Criterion::*;
-    let criteria = vec![Words, Typo, Proximity, Attribute, Exactness];
-    let index = setup_search_index_with_criteria(&criteria);
-    let rtxn = index.read_txn().unwrap();
-
-    let mut search = Search::new(&rtxn, &index);
-    search.query(TEST_QUERY);
-    search.limit(EXTERNAL_DOCUMENTS_IDS.len());
-    search.time_budget(TimeBudget::new(Duration::from_millis(0)));
-    let filter_condition = Filter::from_str("tag = etiopia").unwrap().unwrap();
-    search.filter(filter_condition);
-
-    let result = search.execute().unwrap();
-    assert!(result.degraded);
-    snapshot!(format!("{:?}\n{:?}", result.candidates, result.documents_ids), @r###"
-    RoaringBitmap<[0, 2, 5, 8, 11, 14]>
-    [0, 2, 5, 8, 11, 14]
-    "###);
 }


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes https://github.com/meilisearch/meilisearch/issues/4488

## What does this PR do?
- Adds a cutoff to the bucket sort after 150ms has been spent
- Adds a new setting to customize the default value of 150ms
- When the time is exceeded, we exit early with what we had the time to sort
- If the cutoff has been reached, the search details are updated with a new `Skip` ranking details for the ranking rules that were skipped
- Adds analytics to measure the total number of degraded search requests
- Adds the number of degraded search requests to the Prometheus metrics and Grafana dashboard
- The cutoff **must not** skip the filters; otherwise, we would leak documents to people who don’t have the right to see them
