### PR TITLE
Don't display dimensions as 0 when it is not set

### DIFF
--- a/milli/src/vector/settings.rs
+++ b/milli/src/vector/settings.rs
@@ -199,7 +199,7 @@ impl From<EmbeddingConfig> for EmbeddingSettings {
                 model: Setting::Set(options.embedding_model.name().to_owned()),
                 revision: Setting::NotSet,
                 api_key: options.api_key.map(Setting::Set).unwrap_or_default(),
-                dimensions: Setting::Set(options.dimensions.unwrap_or_default()),
+                dimensions: options.dimensions.map(Setting::Set).unwrap_or_default(),
                 document_template: Setting::Set(prompt.template),
             },
             super::EmbedderOptions::Ollama(options) => Self {


### PR DESCRIPTION
Fixes regression in embedders where `dimensions: 0` was displayed when it hadn't be set for the `openAi` source.

Was breaking a PHP SDK integration test: https://github.com/meilisearch/meilisearch-php/blob/cbaecb8c554fb7094b02f03ec55e077174869c93/tests/Settings/EmbeddersTest.php#L28