### PR TITLE
Add a timeout to the webhook

### DIFF
--- a/index-scheduler/src/lib.rs
+++ b/index-scheduler/src/lib.rs
@@ -1396,6 +1396,7 @@ impl IndexScheduler {
             // let reader = GzEncoder::new(BufReader::new(task_reader), Compression::default());
             let reader = GzEncoder::new(BufReader::new(task_reader), Compression::default());
             let request = ureq::post(url)
+                .timeout(Duration::from_secs(30))
                 .set("Content-Encoding", "gzip")
                 .set("Content-Type", "application/x-ndjson");
             let request = match &self.webhook_authorization_header {


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes https://github.com/meilisearch/meilisearch/issues/4506

## What does this PR do?
- Adds a timeout of 30s (the value we were already using while trying to establish the connection)
- When the timeout is reached, a log is emitted, and the engine continues its work:
```
2024-03-19T13:52:57.676316Z ERROR index_scheduler: While sending data to the webhook: http://localhost:3001/: Network Error: Network Error: Error encountered in the status line: timed out reading response
```

