### PR TITLE
allow to listen on unix domain sockets

### DIFF
--- a/meilisearch/src/main.rs
+++ b/meilisearch/src/main.rs
@@ -153,7 +153,11 @@ async fn run_http(
     if let Some(config) = opt_clone.get_ssl_config()? {
         http_server.bind_rustls_021(opt_clone.http_addr, config)?.run().await?;
     } else {
-        http_server.bind(&opt_clone.http_addr)?.run().await?;
+        if opt_clone.http_addr.starts_with("/") {
+            http_server.bind_uds(&opt_clone.http_addr)?.run().await?
+        } else {
+            http_server.bind(&opt_clone.http_addr)?.run().await?
+        }
     }
     Ok(())
 }
@@ -166,7 +170,13 @@ pub fn print_launch_resume(
     let build_info = build_info::BuildInfo::from_build();
 
     let protocol =
-        if opt.ssl_cert_path.is_some() && opt.ssl_key_path.is_some() { "https" } else { "http" };
+        if opt.ssl_cert_path.is_some() && opt.ssl_key_path.is_some() { 
+            "https"
+        } else if opt.http_addr.starts_with("/") {
+            "unix"
+        } else {
+            "http"
+        };
     let ascii_name = r#"
 888b     d888          d8b 888 d8b                                            888
 8888b   d8888          Y8P 888 Y8P                                            888


### PR DESCRIPTION
# Pull Request

## What does this PR do?
- adds the ability to set a Unix domein socket as host_addr
- show the protocol used on startup

## reason
It's easier to create multiple instances and create (nginx for example) vhosts for them

## PR checklist
Please check if your PR fulfills the following requirements:
- [ x ] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [ x ] Have you read the contributing guidelines?
- [ x ] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
