### PR TITLE
Limit concurrent search requests

### DIFF
--- a/meilisearch-types/src/error.rs
+++ b/meilisearch-types/src/error.rs
@@ -305,6 +305,7 @@ MissingSwapIndexes                    , InvalidRequest       , BAD_REQUEST ;
 MissingTaskFilters                    , InvalidRequest       , BAD_REQUEST ;
 NoSpaceLeftOnDevice                   , System               , UNPROCESSABLE_ENTITY;
 PayloadTooLarge                       , InvalidRequest       , PAYLOAD_TOO_LARGE ;
+TooManySearchRequests                 , System               , SERVICE_UNAVAILABLE ;
 TaskNotFound                          , InvalidRequest       , NOT_FOUND ;
 TooManyOpenFiles                      , System               , UNPROCESSABLE_ENTITY ;
 TooManyVectors                        , InvalidRequest       , BAD_REQUEST ;

--- a/meilisearch/src/analytics/segment_analytics.rs
+++ b/meilisearch/src/analytics/segment_analytics.rs
@@ -252,6 +252,7 @@ impl super::Analytics for SegmentAnalytics {
 struct Infos {
     env: String,
     experimental_enable_metrics: bool,
+    experimental_search_queue_size: usize,
     experimental_logs_mode: LogMode,
     experimental_replication_parameters: bool,
     experimental_enable_logs_route: bool,
@@ -293,6 +294,7 @@ impl From<Opt> for Infos {
         let Opt {
             db_path,
             experimental_enable_metrics,
+            experimental_search_queue_size,
             experimental_logs_mode,
             experimental_replication_parameters,
             experimental_enable_logs_route,
@@ -342,6 +344,7 @@ impl From<Opt> for Infos {
         Self {
             env,
             experimental_enable_metrics,
+            experimental_search_queue_size,
             experimental_logs_mode,
             experimental_replication_parameters,
             experimental_enable_logs_route,

--- a/meilisearch/src/error.rs
+++ b/meilisearch/src/error.rs
@@ -31,7 +31,7 @@ pub enum MeilisearchHttpError {
     MissingPayload(PayloadType),
     #[error("Too many search requests running at the same time: {0}. Retry after 10s.")]
     TooManySearchRequests(usize),
-    #[error("Internal error: Search limiter is down")]
+    #[error("Internal error: Search limiter is down.")]
     SearchLimiterIsDown,
     #[error("The provided payload reached the size limit. The maximum accepted payload size is {}.",  Byte::from_bytes(*.0 as u64).get_appropriate_unit(true))]
     PayloadTooLarge(usize),

--- a/meilisearch/src/error.rs
+++ b/meilisearch/src/error.rs
@@ -29,8 +29,8 @@ pub enum MeilisearchHttpError {
     InvalidExpression(&'static [&'static str], Value),
     #[error("A {0} payload is missing.")]
     MissingPayload(PayloadType),
-    #[error("Too many search requests running at the same time: {0}. Retry after {1:?}.")]
-    TooManySearchRequests(usize, std::time::Duration),
+    #[error("Too many search requests running at the same time: {0}. Retry after 10s.")]
+    TooManySearchRequests(usize),
     #[error("Internal error: Search limiter is down")]
     SearchLimiterIsDown,
     #[error("The provided payload reached the size limit. The maximum accepted payload size is {}.",  Byte::from_bytes(*.0 as u64).get_appropriate_unit(true))]
@@ -73,7 +73,7 @@ impl ErrorCode for MeilisearchHttpError {
             MeilisearchHttpError::EmptyFilter => Code::InvalidDocumentFilter,
             MeilisearchHttpError::InvalidExpression(_, _) => Code::InvalidSearchFilter,
             MeilisearchHttpError::PayloadTooLarge(_) => Code::PayloadTooLarge,
-            MeilisearchHttpError::TooManySearchRequests(_, _) => Code::TooManySearchRequests,
+            MeilisearchHttpError::TooManySearchRequests(_) => Code::TooManySearchRequests,
             MeilisearchHttpError::SearchLimiterIsDown => Code::Internal,
             MeilisearchHttpError::SwapIndexPayloadWrongLength(_) => Code::InvalidSwapIndexes,
             MeilisearchHttpError::IndexUid(e) => e.error_code(),

--- a/meilisearch/src/error.rs
+++ b/meilisearch/src/error.rs
@@ -29,6 +29,10 @@ pub enum MeilisearchHttpError {
     InvalidExpression(&'static [&'static str], Value),
     #[error("A {0} payload is missing.")]
     MissingPayload(PayloadType),
+    #[error("Too many search requests running at the same time: {0}. Retry after {1:?}.")]
+    TooManySearchRequests(usize, std::time::Duration),
+    #[error("Internal error: Search limiter is down")]
+    SearchLimiterIsDown,
     #[error("The provided payload reached the size limit. The maximum accepted payload size is {}.",  Byte::from_bytes(*.0 as u64).get_appropriate_unit(true))]
     PayloadTooLarge(usize),
     #[error("Two indexes must be given for each swap. The list `[{}]` contains {} indexes.",
@@ -69,6 +73,8 @@ impl ErrorCode for MeilisearchHttpError {
             MeilisearchHttpError::EmptyFilter => Code::InvalidDocumentFilter,
             MeilisearchHttpError::InvalidExpression(_, _) => Code::InvalidSearchFilter,
             MeilisearchHttpError::PayloadTooLarge(_) => Code::PayloadTooLarge,
+            MeilisearchHttpError::TooManySearchRequests(_, _) => Code::TooManySearchRequests,
+            MeilisearchHttpError::SearchLimiterIsDown => Code::Internal,
             MeilisearchHttpError::SwapIndexPayloadWrongLength(_) => Code::InvalidSwapIndexes,
             MeilisearchHttpError::IndexUid(e) => e.error_code(),
             MeilisearchHttpError::SerdeJson(_) => Code::Internal,

--- a/meilisearch/src/lib.rs
+++ b/meilisearch/src/lib.rs
@@ -9,6 +9,7 @@ pub mod middleware;
 pub mod option;
 pub mod routes;
 pub mod search;
+pub mod search_queue;
 
 use std::fs::File;
 use std::io::{BufReader, BufWriter};

--- a/meilisearch/src/option.rs
+++ b/meilisearch/src/option.rs
@@ -345,8 +345,7 @@ pub struct Opt {
     #[serde(default)]
     pub experimental_enable_metrics: bool,
 
-    /// TODO: Update the discussion link
-    /// Experimental search queue size. For more information, see: <https://github.com/meilisearch/meilisearch/discussions/3518>
+    /// Experimental search queue size. For more information, see: <https://github.com/orgs/meilisearch/discussions/729>
     ///
     /// Lets you customize the size of the search queue. Meilisearch processes your search requests as fast as possible but once the
     /// queue is full it starts returning HTTP 503, Service Unavailable.

--- a/meilisearch/src/option.rs
+++ b/meilisearch/src/option.rs
@@ -54,6 +54,7 @@ const MEILI_EXPERIMENTAL_LOGS_MODE: &str = "MEILI_EXPERIMENTAL_LOGS_MODE";
 const MEILI_EXPERIMENTAL_REPLICATION_PARAMETERS: &str = "MEILI_EXPERIMENTAL_REPLICATION_PARAMETERS";
 const MEILI_EXPERIMENTAL_ENABLE_LOGS_ROUTE: &str = "MEILI_EXPERIMENTAL_ENABLE_LOGS_ROUTE";
 const MEILI_EXPERIMENTAL_ENABLE_METRICS: &str = "MEILI_EXPERIMENTAL_ENABLE_METRICS";
+const MEILI_EXPERIMENTAL_SEARCH_QUEUE_SIZE: &str = "MEILI_EXPERIMENTAL_SEARCH_QUEUE_SIZE";
 const MEILI_EXPERIMENTAL_REDUCE_INDEXING_MEMORY_USAGE: &str =
     "MEILI_EXPERIMENTAL_REDUCE_INDEXING_MEMORY_USAGE";
 const MEILI_EXPERIMENTAL_MAX_NUMBER_OF_BATCHED_TASKS: &str =
@@ -344,6 +345,16 @@ pub struct Opt {
     #[serde(default)]
     pub experimental_enable_metrics: bool,
 
+    /// TODO: Update the discussion link
+    /// Experimental search queue size. For more information, see: <https://github.com/meilisearch/meilisearch/discussions/3518>
+    ///
+    /// Lets you customize the size of the search queue. Meilisearch processes your search requests as fast as possible but once the
+    /// queue is full it starts returning HTTP 503, Service Unavailable.
+    /// The default value is 1000.
+    #[clap(long, env = MEILI_EXPERIMENTAL_SEARCH_QUEUE_SIZE, default_value_t = 1000)]
+    #[serde(default)]
+    pub experimental_search_queue_size: usize,
+
     /// Experimental logs mode feature. For more information, see: <https://github.com/orgs/meilisearch/discussions/723>
     ///
     /// Change the mode of the logs on the console.
@@ -473,6 +484,7 @@ impl Opt {
             #[cfg(feature = "analytics")]
             no_analytics,
             experimental_enable_metrics,
+            experimental_search_queue_size,
             experimental_logs_mode,
             experimental_enable_logs_route,
             experimental_replication_parameters,
@@ -531,6 +543,10 @@ impl Opt {
         export_to_env_if_not_present(
             MEILI_EXPERIMENTAL_ENABLE_METRICS,
             experimental_enable_metrics.to_string(),
+        );
+        export_to_env_if_not_present(
+            MEILI_EXPERIMENTAL_SEARCH_QUEUE_SIZE,
+            experimental_search_queue_size.to_string(),
         );
         export_to_env_if_not_present(
             MEILI_EXPERIMENTAL_LOGS_MODE,

--- a/meilisearch/src/routes/indexes/search.rs
+++ b/meilisearch/src/routes/indexes/search.rs
@@ -23,6 +23,7 @@ use crate::search::{
     DEFAULT_CROP_LENGTH, DEFAULT_CROP_MARKER, DEFAULT_HIGHLIGHT_POST_TAG,
     DEFAULT_HIGHLIGHT_PRE_TAG, DEFAULT_SEARCH_LIMIT, DEFAULT_SEARCH_OFFSET, DEFAULT_SEMANTIC_RATIO,
 };
+use crate::search_queue::SearchQueue;
 
 pub fn configure(cfg: &mut web::ServiceConfig) {
     cfg.service(
@@ -182,6 +183,7 @@ fn fix_sort_query_parameters(sort_query: &str) -> Vec<String> {
 
 pub async fn search_with_url_query(
     index_scheduler: GuardedData<ActionPolicy<{ actions::SEARCH }>, Data<IndexScheduler>>,
+    search_queue: web::Data<SearchQueue>,
     index_uid: web::Path<String>,
     params: AwebQueryParameter<SearchQueryGet, DeserrQueryParamError>,
     req: HttpRequest,
@@ -204,6 +206,7 @@ pub async fn search_with_url_query(
 
     let distribution = embed(&mut query, index_scheduler.get_ref(), &index).await?;
 
+    let _permit = search_queue.try_get_search_permit().await?;
     let search_result =
         tokio::task::spawn_blocking(move || perform_search(&index, query, features, distribution))
             .await?;
@@ -220,6 +223,7 @@ pub async fn search_with_url_query(
 
 pub async fn search_with_post(
     index_scheduler: GuardedData<ActionPolicy<{ actions::SEARCH }>, Data<IndexScheduler>>,
+    search_queue: web::Data<SearchQueue>,
     index_uid: web::Path<String>,
     params: AwebJson<SearchQuery, DeserrJsonError>,
     req: HttpRequest,
@@ -243,6 +247,7 @@ pub async fn search_with_post(
 
     let distribution = embed(&mut query, index_scheduler.get_ref(), &index).await?;
 
+    let _permit = search_queue.try_get_search_permit().await?;
     let search_result =
         tokio::task::spawn_blocking(move || perform_search(&index, query, features, distribution))
             .await?;

--- a/meilisearch/src/routes/mod.rs
+++ b/meilisearch/src/routes/mod.rs
@@ -15,6 +15,7 @@ use tracing::debug;
 use crate::analytics::Analytics;
 use crate::extractors::authentication::policies::*;
 use crate::extractors::authentication::GuardedData;
+use crate::search_queue::SearchQueue;
 use crate::Opt;
 
 const PAGINATION_DEFAULT_LIMIT: usize = 20;
@@ -385,10 +386,12 @@ pub async fn get_health(
     req: HttpRequest,
     index_scheduler: Data<IndexScheduler>,
     auth_controller: Data<AuthController>,
+    search_queue: Data<SearchQueue>,
     analytics: web::Data<dyn Analytics>,
 ) -> Result<HttpResponse, ResponseError> {
     analytics.health_seen(&req);
 
+    search_queue.health().unwrap();
     index_scheduler.health().unwrap();
     auth_controller.health().unwrap();
 

--- a/meilisearch/src/search_queue.rs
+++ b/meilisearch/src/search_queue.rs
@@ -72,6 +72,7 @@ impl SearchQueue {
                 _ = search_finished.recv() => {
                     searches_running = searches_running.saturating_sub(1);
                     if !queue.is_empty() {
+                        // Can't panic: the queue wasn't empty thus the range isn't empty.
                         let remove = rng.gen_range(0..queue.len());
                         let channel = queue.swap_remove(remove);
                         let _ = channel.send(Permit { sender: sender.clone() });

--- a/meilisearch/src/search_queue.rs
+++ b/meilisearch/src/search_queue.rs
@@ -1,4 +1,4 @@
-use std::{num::NonZeroUsize, time::Duration};
+use std::num::NonZeroUsize;
 
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use tokio::sync::{mpsc, oneshot};
@@ -25,10 +25,10 @@ impl Drop for Permit {
 
 impl SearchQueue {
     pub fn new(capacity: usize, paralellism: NonZeroUsize) -> Self {
-        // We can make the search requests wait until we're available.
-        // they're going to wait anyway right after, so let's not allocate any
-        // RAM by keeping a capacity of 1.
+        // Search requests are going to wait until we're available anyway,
+        // so let's not allocate any RAM and keep a capacity of 1.
         let (sender, receiver) = mpsc::channel(1);
+
         tokio::task::spawn(Self::run(capacity, paralellism, receiver));
         Self { sender, capacity }
     }
@@ -48,27 +48,22 @@ impl SearchQueue {
             tokio::select! {
                 search_request = receive_new_searches.recv() => {
                     let search_request = search_request.unwrap();
-                    println!("queue contains {} elements and already running {}", queue.len(), searches_running);
                     if searches_running < usize::from(parallelism) && queue.is_empty() {
-                        println!("We can process the search straight away");
                         searches_running += 1;
                         // if the search requests die it's not a hard error on our side
                         let _ = search_request.send(Permit { sender: sender.clone() });
                         continue;
                     }
                     if queue.len() >= capacity {
-                        println!("we're above capacity, dropping a random request");
                         let remove = rng.gen_range(0..queue.len());
                         let thing = queue.swap_remove(remove); // this will drop the channel and notify the search that it won't be processed
                         drop(thing);
                     }
-                    println!("pushed a new search request to the queue {}", queue.len());
                     queue.push(search_request);
                 },
                 _ = search_finished.recv() => {
                     searches_running = searches_running.saturating_sub(1);
                     if !queue.is_empty() {
-                        println!("processed an element in the queue");
                         let remove = rng.gen_range(0..queue.len());
                         let channel = queue.swap_remove(remove);
                         let _ = channel.send(Permit { sender: sender.clone() });
@@ -81,8 +76,6 @@ impl SearchQueue {
     pub async fn try_get_search_permit(&self) -> Result<Permit, MeilisearchHttpError> {
         let (sender, receiver) = oneshot::channel();
         self.sender.send(sender).await.map_err(|_| MeilisearchHttpError::SearchLimiterIsDown)?;
-        receiver.await.map_err(|_| {
-            MeilisearchHttpError::TooManySearchRequests(self.capacity, Duration::from_secs(10))
-        })
+        receiver.await.map_err(|_| MeilisearchHttpError::TooManySearchRequests(self.capacity))
     }
 }

--- a/meilisearch/src/search_queue.rs
+++ b/meilisearch/src/search_queue.rs
@@ -1,0 +1,88 @@
+use std::time::Duration;
+
+use rand::{rngs::StdRng, Rng, SeedableRng};
+use tokio::sync::{mpsc, oneshot};
+
+use crate::error::MeilisearchHttpError;
+
+#[derive(Debug)]
+pub struct SearchQueue {
+    sender: mpsc::Sender<oneshot::Sender<Permit>>,
+    capacity: usize,
+}
+
+#[derive(Debug)]
+pub struct Permit {
+    sender: mpsc::Sender<()>,
+}
+
+impl Drop for Permit {
+    fn drop(&mut self) {
+        // if the channel is closed then the whole instance is down
+        let _ = futures::executor::block_on(self.sender.send(()));
+    }
+}
+
+impl SearchQueue {
+    pub fn new(capacity: usize, paralellism: usize) -> Self {
+        // We can make the search requests wait until we're available.
+        // they're going to wait anyway right after, so let's not allocate any
+        // RAM by keeping a capacity of 1.
+        let (sender, receiver) = mpsc::channel(1);
+        tokio::task::spawn(Self::run(capacity, paralellism, receiver));
+        Self { sender, capacity }
+    }
+
+    async fn run(
+        capacity: usize,
+        parallelism: usize,
+        mut receive_new_searches: mpsc::Receiver<oneshot::Sender<Permit>>,
+    ) {
+        let mut queue: Vec<oneshot::Sender<Permit>> = Default::default();
+        let mut rng: StdRng = StdRng::from_entropy();
+        let mut searches_running = 0;
+        // by having a capacity of parallelism we ensures that every time a search finish it can release its RAM asap
+        let (sender, mut search_finished) = mpsc::channel(parallelism);
+
+        loop {
+            tokio::select! {
+                search_request = receive_new_searches.recv() => {
+                    let search_request = search_request.unwrap();
+                    println!("queue contains {} elements and already running {}", queue.len(), searches_running);
+                    if searches_running < parallelism && queue.is_empty() {
+                        println!("We can process the search straight away");
+                        searches_running += 1;
+                        // if the search requests die it's not a hard error on our side
+                        let _ = search_request.send(Permit { sender: sender.clone() });
+                        continue;
+                    }
+                    if queue.len() >= capacity {
+                        println!("we're above capacity, dropping a random request");
+                        let remove = rng.gen_range(0..queue.len());
+                        let thing = queue.swap_remove(remove); // this will drop the channel and notify the search that it won't be processed
+                        drop(thing);
+                    }
+                    println!("pushed a new search request to the queue {}", queue.len());
+                    queue.push(search_request);
+                },
+                _ = search_finished.recv() => {
+                    searches_running = searches_running.saturating_sub(1);
+                    if !queue.is_empty() {
+                        println!("processed an element in the queue");
+                        let remove = rng.gen_range(0..queue.len());
+                        let channel = queue.swap_remove(remove);
+                        let _ = channel.send(Permit { sender: sender.clone() });
+                    }
+                },
+            }
+        }
+    }
+
+    pub async fn register_search(&self) -> Result<Permit, MeilisearchHttpError> {
+        let (sender, receiver) = oneshot::channel();
+        self.sender.send(sender).await.map_err(|_| MeilisearchHttpError::SearchLimiterIsDown)?;
+        receiver.await.map_err(|_| {
+            MeilisearchHttpError::TooManySearchRequests(self.capacity, Duration::from_secs(10))
+        })
+    }
+}

--- a/meilisearch/src/search_queue.rs
+++ b/meilisearch/src/search_queue.rs
@@ -117,4 +117,14 @@ impl SearchQueue {
         self.sender.send(sender).await.map_err(|_| MeilisearchHttpError::SearchLimiterIsDown)?;
         receiver.await.map_err(|_| MeilisearchHttpError::TooManySearchRequests(self.capacity))
     }
+
+    /// Returns `Ok(())` if everything seems normal.
+    /// Returns `Err(MeilisearchHttpError::SearchLimiterIsDown)` if the search limiter seems down.
+    pub fn health(&self) -> Result<(), MeilisearchHttpError> {
+        if self.sender.is_closed() {
+            Err(MeilisearchHttpError::SearchLimiterIsDown)
+        } else {
+            Ok(())
+        }
+    }
 }

--- a/meilisearch/src/search_queue.rs
+++ b/meilisearch/src/search_queue.rs
@@ -1,6 +1,7 @@
 use std::num::NonZeroUsize;
 
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
 use tokio::sync::{mpsc, oneshot};
 
 use crate::error::MeilisearchHttpError;

--- a/meilisearch/tests/search/mod.rs
+++ b/meilisearch/tests/search/mod.rs
@@ -10,6 +10,7 @@ mod hybrid;
 mod multi;
 mod pagination;
 mod restrict_searchable;
+mod search_queue;
 
 use once_cell::sync::Lazy;
 

--- a/meilisearch/tests/search/search_queue.rs
+++ b/meilisearch/tests/search/search_queue.rs
@@ -1,0 +1,120 @@
+use std::{sync::Arc, time::Duration};
+
+use meili_snap::snapshot;
+use meilisearch::search_queue::SearchQueue;
+
+#[actix_rt::test]
+async fn search_queue_register() {
+    let queue = SearchQueue::new(4, 2);
+
+    // First, use all the cores
+    let permit1 = tokio::time::timeout(Duration::from_secs(1), queue.register_search())
+        .await
+        .expect("I should get a permit straight away")
+        .unwrap();
+    let _permit2 = tokio::time::timeout(Duration::from_secs(1), queue.register_search())
+        .await
+        .expect("I should get a permit straight away")
+        .unwrap();
+
+    // If we free one spot we should be able to register one new search
+    drop(permit1);
+
+    let permit3 = tokio::time::timeout(Duration::from_secs(1), queue.register_search())
+        .await
+        .expect("I should get a permit straight away")
+        .unwrap();
+
+    // And again
+    drop(permit3);
+
+    let _permit4 = tokio::time::timeout(Duration::from_secs(1), queue.register_search())
+        .await
+        .expect("I should get a permit straight away")
+        .unwrap();
+}
+
+#[actix_rt::test]
+async fn search_queue_wait_till_cores_available() {
+    let queue = Arc::new(SearchQueue::new(4, 1));
+
+    // First, use all the cores
+    let permit1 = tokio::time::timeout(Duration::from_secs(1), queue.register_search())
+        .await
+        .expect("I should get a permit straight away")
+        .unwrap();
+
+    let ret = tokio::time::timeout(Duration::from_secs(1), queue.register_search()).await;
+    assert!(ret.is_err(), "The capacity is full, we should not get a permit");
+
+    let q = queue.clone();
+    let task = tokio::task::spawn(async move { q.register_search().await });
+
+    // after dropping a permit the previous task should be able to finish
+    drop(permit1);
+    let _permit2 = tokio::time::timeout(Duration::from_secs(1), task)
+        .await
+        .expect("I should get a permit straight away")
+        .unwrap();
+}
+
+#[actix_rt::test]
+async fn search_queue_refuse_search_requests() {
+    let queue = Arc::new(SearchQueue::new(1, 1));
+
+    // First, use the whole capacity of the
+    let _permit1 = tokio::time::timeout(Duration::from_secs(1), queue.register_search())
+        .await
+        .expect("I should get a permit straight away")
+        .unwrap();
+
+    let q = queue.clone();
+    let permit2 = tokio::task::spawn(async move { q.register_search().await });
+
+    // Here the queue is full. By registering two new search requests the permit 2 and 3 should be thrown out
+    let q = queue.clone();
+    let _permit3 = tokio::task::spawn(async move { q.register_search().await });
+
+    let permit2 = tokio::time::timeout(Duration::from_secs(1), permit2)
+        .await
+        .expect("I should get a result straight away")
+        .unwrap(); // task should end successfully
+
+    snapshot!(permit2.unwrap_err(), @"Too many search requests running at the same time: 1. Retry after 10s.");
+}
+
+#[actix_rt::test]
+async fn search_request_crashes_while_holding_permits() {
+    let queue = Arc::new(SearchQueue::new(1, 1));
+
+    let (send, recv) = tokio::sync::oneshot::channel();
+
+    // This first request take a cpu
+    let q = queue.clone();
+    tokio::task::spawn(async move {
+        let _permit = q.register_search().await.unwrap();
+        recv.await.unwrap();
+        panic!("oops an unexpected crash happened")
+    });
+
+    // This second request waits in the queue till the first request finishes
+    let q = queue.clone();
+    let task = tokio::task::spawn(async move {
+        let _permit = q.register_search().await.unwrap();
+    });
+
+    // By sending something in the channel the request holding a CPU will panic and should lose its permit
+    send.send(()).unwrap();
+
+    // Then the second request should be able to process and finishes correctly without panic
+    tokio::time::timeout(Duration::from_secs(1), task)
+        .await
+        .expect("I should get a permit straight away")
+        .unwrap();
+
+    // I should even be able to take second permit here
+    let _permit1 = tokio::time::timeout(Duration::from_secs(1), queue.register_search())
+        .await
+        .expect("I should get a permit straight away")
+        .unwrap();
+}

--- a/meilisearch/tests/search/search_queue.rs
+++ b/meilisearch/tests/search/search_queue.rs
@@ -1,4 +1,6 @@
-use std::{num::NonZeroUsize, sync::Arc, time::Duration};
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+use std::time::Duration;
 
 use actix_web::ResponseError;
 use meili_snap::snapshot;

--- a/meilisearch/tests/search/search_queue.rs
+++ b/meilisearch/tests/search/search_queue.rs
@@ -1,18 +1,18 @@
-use std::{sync::Arc, time::Duration};
+use std::{num::NonZeroUsize, sync::Arc, time::Duration};
 
 use meili_snap::snapshot;
 use meilisearch::search_queue::SearchQueue;
 
 #[actix_rt::test]
 async fn search_queue_register() {
-    let queue = SearchQueue::new(4, 2);
+    let queue = SearchQueue::new(4, NonZeroUsize::new(2).unwrap());
 
     // First, use all the cores
-    let permit1 = tokio::time::timeout(Duration::from_secs(1), queue.register_search())
+    let permit1 = tokio::time::timeout(Duration::from_secs(1), queue.try_get_search_permit())
         .await
         .expect("I should get a permit straight away")
         .unwrap();
-    let _permit2 = tokio::time::timeout(Duration::from_secs(1), queue.register_search())
+    let _permit2 = tokio::time::timeout(Duration::from_secs(1), queue.try_get_search_permit())
         .await
         .expect("I should get a permit straight away")
         .unwrap();
@@ -20,7 +20,7 @@ async fn search_queue_register() {
     // If we free one spot we should be able to register one new search
     drop(permit1);
 
-    let permit3 = tokio::time::timeout(Duration::from_secs(1), queue.register_search())
+    let permit3 = tokio::time::timeout(Duration::from_secs(1), queue.try_get_search_permit())
         .await
         .expect("I should get a permit straight away")
         .unwrap();
@@ -28,7 +28,7 @@ async fn search_queue_register() {
     // And again
     drop(permit3);
 
-    let _permit4 = tokio::time::timeout(Duration::from_secs(1), queue.register_search())
+    let _permit4 = tokio::time::timeout(Duration::from_secs(1), queue.try_get_search_permit())
         .await
         .expect("I should get a permit straight away")
         .unwrap();
@@ -36,19 +36,19 @@ async fn search_queue_register() {
 
 #[actix_rt::test]
 async fn search_queue_wait_till_cores_available() {
-    let queue = Arc::new(SearchQueue::new(4, 1));
+    let queue = Arc::new(SearchQueue::new(4, NonZeroUsize::new(1).unwrap()));
 
     // First, use all the cores
-    let permit1 = tokio::time::timeout(Duration::from_secs(1), queue.register_search())
+    let permit1 = tokio::time::timeout(Duration::from_secs(1), queue.try_get_search_permit())
         .await
         .expect("I should get a permit straight away")
         .unwrap();
 
-    let ret = tokio::time::timeout(Duration::from_secs(1), queue.register_search()).await;
+    let ret = tokio::time::timeout(Duration::from_secs(1), queue.try_get_search_permit()).await;
     assert!(ret.is_err(), "The capacity is full, we should not get a permit");
 
     let q = queue.clone();
-    let task = tokio::task::spawn(async move { q.register_search().await });
+    let task = tokio::task::spawn(async move { q.try_get_search_permit().await });
 
     // after dropping a permit the previous task should be able to finish
     drop(permit1);
@@ -60,20 +60,20 @@ async fn search_queue_wait_till_cores_available() {
 
 #[actix_rt::test]
 async fn search_queue_refuse_search_requests() {
-    let queue = Arc::new(SearchQueue::new(1, 1));
+    let queue = Arc::new(SearchQueue::new(1, NonZeroUsize::new(1).unwrap()));
 
     // First, use the whole capacity of the
-    let _permit1 = tokio::time::timeout(Duration::from_secs(1), queue.register_search())
+    let _permit1 = tokio::time::timeout(Duration::from_secs(1), queue.try_get_search_permit())
         .await
         .expect("I should get a permit straight away")
         .unwrap();
 
     let q = queue.clone();
-    let permit2 = tokio::task::spawn(async move { q.register_search().await });
+    let permit2 = tokio::task::spawn(async move { q.try_get_search_permit().await });
 
     // Here the queue is full. By registering two new search requests the permit 2 and 3 should be thrown out
     let q = queue.clone();
-    let _permit3 = tokio::task::spawn(async move { q.register_search().await });
+    let _permit3 = tokio::task::spawn(async move { q.try_get_search_permit().await });
 
     let permit2 = tokio::time::timeout(Duration::from_secs(1), permit2)
         .await
@@ -85,14 +85,14 @@ async fn search_queue_refuse_search_requests() {
 
 #[actix_rt::test]
 async fn search_request_crashes_while_holding_permits() {
-    let queue = Arc::new(SearchQueue::new(1, 1));
+    let queue = Arc::new(SearchQueue::new(1, NonZeroUsize::new(1).unwrap()));
 
     let (send, recv) = tokio::sync::oneshot::channel();
 
     // This first request take a cpu
     let q = queue.clone();
     tokio::task::spawn(async move {
-        let _permit = q.register_search().await.unwrap();
+        let _permit = q.try_get_search_permit().await.unwrap();
         recv.await.unwrap();
         panic!("oops an unexpected crash happened")
     });
@@ -100,7 +100,7 @@ async fn search_request_crashes_while_holding_permits() {
     // This second request waits in the queue till the first request finishes
     let q = queue.clone();
     let task = tokio::task::spawn(async move {
-        let _permit = q.register_search().await.unwrap();
+        let _permit = q.try_get_search_permit().await.unwrap();
     });
 
     // By sending something in the channel the request holding a CPU will panic and should lose its permit
@@ -113,7 +113,7 @@ async fn search_request_crashes_while_holding_permits() {
         .unwrap();
 
     // I should even be able to take second permit here
-    let _permit1 = tokio::time::timeout(Duration::from_secs(1), queue.register_search())
+    let _permit1 = tokio::time::timeout(Duration::from_secs(1), queue.try_get_search_permit())
         .await
         .expect("I should get a permit straight away")
         .unwrap();

--- a/meilisearch/tests/search/search_queue.rs
+++ b/meilisearch/tests/search/search_queue.rs
@@ -85,7 +85,13 @@ async fn refuse_search_requests_when_queue_is_full() {
 
     let err = meilisearch_types::error::ResponseError::from(permit2.unwrap_err());
     let http_response = err.error_response();
-    snapshot!(format!("{:?}", http_response.headers()), @r###"HeaderMap { inner: {"retry-after": Value { inner: ["10"] }, "content-type": Value { inner: ["application/json"] }} }"###);
+    let mut headers: Vec<_> = http_response
+        .headers()
+        .iter()
+        .map(|(name, value)| (name.to_string(), value.to_str().unwrap().to_string()))
+        .collect();
+    headers.sort();
+    snapshot!(format!("{headers:?}"), @r###"[("content-type", "application/json"), ("retry-after", "10")]"###);
 
     let err = serde_json::to_string_pretty(&err).unwrap();
     snapshot!(err, @r###"
@@ -151,7 +157,13 @@ async fn works_with_capacity_of_zero() {
 
     let err = meilisearch_types::error::ResponseError::from(permit2.unwrap_err());
     let http_response = err.error_response();
-    snapshot!(format!("{:?}", http_response.headers()), @r###"HeaderMap { inner: {"content-type": Value { inner: ["application/json"] }, "retry-after": Value { inner: ["10"] }} }"###);
+    let mut headers: Vec<_> = http_response
+        .headers()
+        .iter()
+        .map(|(name, value)| (name.to_string(), value.to_str().unwrap().to_string()))
+        .collect();
+    headers.sort();
+    snapshot!(format!("{headers:?}"), @r###"[("content-type", "application/json"), ("retry-after", "10")]"###);
 
     let err = serde_json::to_string_pretty(&err).unwrap();
     snapshot!(err, @r###"


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes https://github.com/meilisearch/meilisearch/issues/4489

## What does this PR do?
- Adds a « search queue » that limits the number of search requests we can process at the same time and stores search requests to be processed
- Process only one search request per core/thread (we use available_parallelism)
- When the search queue is full, new search requests replace old ones **randomly**. The reason is that:
  - If we serve the oldest one first, like Typesense, we give the worst performances to everyone
  - If we serve the latest one, it gets too easy to DoS us (you just need to fill the queue with as many search requests as we can process simultaneously to ensure no other request will ever be processed)
  - By picking the search request randomly, we give a chance to recent search requests to be processed while ensuring that we can't be owned unless they fill our queue entirely and we start returning errors 5xx
- Adds an experimental parameter to control the size of the queue
- Adds a bunch of tests to ensure the search queue works correctly
- Ensure the loop consuming the search queue is running in the health route and crashes if it’s not the case