### PR TITLE
v1.8 hybrid search changes

### DIFF
--- a/meilisearch/src/analytics/segment_analytics.rs
+++ b/meilisearch/src/analytics/segment_analytics.rs
@@ -758,7 +758,6 @@ impl SearchAggregator {
         let SearchResult {
             hits: _,
             query: _,
-            vector: _,
             processing_time_ms,
             hits_info: _,
             facet_distribution: _,

--- a/meilisearch/src/analytics/segment_analytics.rs
+++ b/meilisearch/src/analytics/segment_analytics.rs
@@ -760,6 +760,7 @@ impl SearchAggregator {
             query: _,
             processing_time_ms,
             hits_info: _,
+            semantic_hit_count: _,
             facet_distribution: _,
             facet_stats: _,
             degraded,

--- a/meilisearch/src/routes/indexes/facet_search.rs
+++ b/meilisearch/src/routes/indexes/facet_search.rs
@@ -12,6 +12,7 @@ use tracing::debug;
 use crate::analytics::{Analytics, FacetSearchAggregator};
 use crate::extractors::authentication::policies::*;
 use crate::extractors::authentication::GuardedData;
+use crate::routes::indexes::search::search_kind;
 use crate::search::{
     add_search_rules, perform_facet_search, HybridQuery, MatchingStrategy, SearchQuery,
     DEFAULT_CROP_LENGTH, DEFAULT_CROP_MARKER, DEFAULT_HIGHLIGHT_POST_TAG,
@@ -73,9 +74,10 @@ pub async fn search(
 
     let index = index_scheduler.index(&index_uid)?;
     let features = index_scheduler.features();
+    let search_kind = search_kind(&search_query, &index_scheduler, &index)?;
     let _permit = search_queue.try_get_search_permit().await?;
     let search_result = tokio::task::spawn_blocking(move || {
-        perform_facet_search(&index, search_query, facet_query, facet_name, features)
+        perform_facet_search(&index, search_query, facet_query, facet_name, features, search_kind)
     })
     .await?;
 

--- a/meilisearch/src/routes/indexes/facet_search.rs
+++ b/meilisearch/src/routes/indexes/facet_search.rs
@@ -74,10 +74,10 @@ pub async fn search(
 
     let index = index_scheduler.index(&index_uid)?;
     let features = index_scheduler.features();
-    let search_kind = search_kind(&search_query, &index_scheduler, &index)?;
+    let search_kind = search_kind(&search_query, &index_scheduler, &index, features)?;
     let _permit = search_queue.try_get_search_permit().await?;
     let search_result = tokio::task::spawn_blocking(move || {
-        perform_facet_search(&index, search_query, facet_query, facet_name, features, search_kind)
+        perform_facet_search(&index, search_query, facet_query, facet_name, search_kind)
     })
     .await?;
 

--- a/meilisearch/src/routes/indexes/search.rs
+++ b/meilisearch/src/routes/indexes/search.rs
@@ -277,7 +277,7 @@ pub fn search_kind(
         features.check_vector("Passing `hybrid` as a query parameter")?;
     }
 
-    // regardless of anything, always do a semantic search when we don't have a vector and the query is whitespace or missing
+    // regardless of anything, always do a keyword search when we don't have a vector and the query is whitespace or missing
     if query.vector.is_none() {
         match &query.q {
             Some(q) if q.trim().is_empty() => return Ok(SearchKind::KeywordOnly),

--- a/meilisearch/src/routes/indexes/search.rs
+++ b/meilisearch/src/routes/indexes/search.rs
@@ -8,19 +8,19 @@ use meilisearch_types::error::deserr_codes::*;
 use meilisearch_types::error::ResponseError;
 use meilisearch_types::index_uid::IndexUid;
 use meilisearch_types::milli;
-use meilisearch_types::milli::vector::DistributionShift;
 use meilisearch_types::serde_cs::vec::CS;
 use serde_json::Value;
-use tracing::{debug, warn};
+use tracing::debug;
 
 use crate::analytics::{Analytics, SearchAggregator};
+use crate::error::MeilisearchHttpError;
 use crate::extractors::authentication::policies::*;
 use crate::extractors::authentication::GuardedData;
 use crate::extractors::sequential_extractor::SeqHandler;
 use crate::metrics::MEILISEARCH_DEGRADED_SEARCH_REQUESTS;
 use crate::search::{
-    add_search_rules, perform_search, HybridQuery, MatchingStrategy, SearchQuery, SemanticRatio,
-    DEFAULT_CROP_LENGTH, DEFAULT_CROP_MARKER, DEFAULT_HIGHLIGHT_POST_TAG,
+    add_search_rules, perform_search, HybridQuery, MatchingStrategy, SearchKind, SearchQuery,
+    SemanticRatio, DEFAULT_CROP_LENGTH, DEFAULT_CROP_MARKER, DEFAULT_HIGHLIGHT_POST_TAG,
     DEFAULT_HIGHLIGHT_PRE_TAG, DEFAULT_SEARCH_LIMIT, DEFAULT_SEARCH_OFFSET, DEFAULT_SEMANTIC_RATIO,
 };
 use crate::search_queue::SearchQueue;
@@ -204,11 +204,11 @@ pub async fn search_with_url_query(
     let index = index_scheduler.index(&index_uid)?;
     let features = index_scheduler.features();
 
-    let distribution = embed(&mut query, index_scheduler.get_ref(), &index)?;
+    let search_kind = search_kind(&query, index_scheduler.get_ref(), &index)?;
 
     let _permit = search_queue.try_get_search_permit().await?;
     let search_result =
-        tokio::task::spawn_blocking(move || perform_search(&index, query, features, distribution))
+        tokio::task::spawn_blocking(move || perform_search(&index, query, features, search_kind))
             .await?;
     if let Ok(ref search_result) = search_result {
         aggregate.succeed(search_result);
@@ -245,11 +245,11 @@ pub async fn search_with_post(
 
     let features = index_scheduler.features();
 
-    let distribution = embed(&mut query, index_scheduler.get_ref(), &index)?;
+    let search_kind = search_kind(&query, index_scheduler.get_ref(), &index)?;
 
     let _permit = search_queue.try_get_search_permit().await?;
     let search_result =
-        tokio::task::spawn_blocking(move || perform_search(&index, query, features, distribution))
+        tokio::task::spawn_blocking(move || perform_search(&index, query, features, search_kind))
             .await?;
     if let Ok(ref search_result) = search_result {
         aggregate.succeed(search_result);
@@ -265,76 +265,49 @@ pub async fn search_with_post(
     Ok(HttpResponse::Ok().json(search_result))
 }
 
-pub fn embed(
-    query: &mut SearchQuery,
+pub fn search_kind(
+    query: &SearchQuery,
     index_scheduler: &IndexScheduler,
     index: &milli::Index,
-) -> Result<Option<DistributionShift>, ResponseError> {
-    match (&query.hybrid, &query.vector, &query.q) {
-        (Some(HybridQuery { semantic_ratio: _, embedder }), None, Some(q))
-            if !q.trim().is_empty() =>
-        {
-            let embedder_configs = index.embedding_configs(&index.read_txn()?)?;
-            let embedders = index_scheduler.embedders(embedder_configs)?;
-
-            let embedder = if let Some(embedder_name) = embedder {
-                embedders.get(embedder_name)
-            } else {
-                embedders.get_default()
-            };
-
-            let embedder = embedder
-                .ok_or(milli::UserError::InvalidEmbedder("default".to_owned()))
-                .map_err(milli::Error::from)?
-                .0;
-
-            let distribution = embedder.distribution();
-
-            let embeddings = embedder
-                .embed(vec![q.to_owned()])
-                .map_err(milli::vector::Error::from)
-                .map_err(milli::Error::from)?
-                .pop()
-                .expect("No vector returned from embedding");
-
-            if embeddings.iter().nth(1).is_some() {
-                warn!("Ignoring embeddings past the first one in long search query");
-                query.vector = Some(embeddings.iter().next().unwrap().to_vec());
-            } else {
-                query.vector = Some(embeddings.into_inner());
-            }
-            Ok(distribution)
+) -> Result<SearchKind, ResponseError> {
+    // regardless of anything, always do a semantic search when we don't have a vector and the query is whitespace or missing
+    if query.vector.is_none() {
+        match &query.q {
+            Some(q) if q.trim().is_empty() => return Ok(SearchKind::KeywordOnly),
+            None => return Ok(SearchKind::KeywordOnly),
+            _ => {}
         }
-        (Some(hybrid), vector, _) => {
-            let embedder_configs = index.embedding_configs(&index.read_txn()?)?;
-            let embedders = index_scheduler.embedders(embedder_configs)?;
+    }
 
-            let embedder = if let Some(embedder_name) = &hybrid.embedder {
-                embedders.get(embedder_name)
-            } else {
-                embedders.get_default()
-            };
-
-            let embedder = embedder
-                .ok_or(milli::UserError::InvalidEmbedder("default".to_owned()))
-                .map_err(milli::Error::from)?
-                .0;
-
-            if let Some(vector) = vector {
-                if vector.len() != embedder.dimensions() {
-                    return Err(meilisearch_types::milli::Error::UserError(
-                        meilisearch_types::milli::UserError::InvalidVectorDimensions {
-                            expected: embedder.dimensions(),
-                            found: vector.len(),
-                        },
-                    )
-                    .into());
-                }
-            }
-
-            Ok(embedder.distribution())
+    match &query.hybrid {
+        Some(HybridQuery { semantic_ratio, embedder }) if **semantic_ratio == 1.0 => {
+            Ok(SearchKind::semantic(
+                index_scheduler,
+                index,
+                embedder.as_deref(),
+                query.vector.as_ref().map(Vec::len),
+            )?)
         }
-        _ => Ok(None),
+        Some(HybridQuery { semantic_ratio, embedder: _ }) if **semantic_ratio == 0.0 => {
+            Ok(SearchKind::KeywordOnly)
+        }
+        Some(HybridQuery { semantic_ratio, embedder }) => Ok(SearchKind::hybrid(
+            index_scheduler,
+            index,
+            embedder.as_deref(),
+            **semantic_ratio,
+            query.vector.as_ref().map(Vec::len),
+        )?),
+        None => match (query.q.as_deref(), query.vector.as_deref()) {
+            (_query, None) => Ok(SearchKind::KeywordOnly),
+            (None, Some(_vector)) => Ok(SearchKind::semantic(
+                index_scheduler,
+                index,
+                None,
+                query.vector.as_ref().map(Vec::len),
+            )?),
+            (Some(_), Some(_)) => Err(MeilisearchHttpError::MissingSearchHybrid.into()),
+        },
     }
 }
 

--- a/meilisearch/src/routes/multi_search.rs
+++ b/meilisearch/src/routes/multi_search.rs
@@ -13,7 +13,7 @@ use crate::analytics::{Analytics, MultiSearchAggregator};
 use crate::extractors::authentication::policies::ActionPolicy;
 use crate::extractors::authentication::{AuthenticationError, GuardedData};
 use crate::extractors::sequential_extractor::SeqHandler;
-use crate::routes::indexes::search::embed;
+use crate::routes::indexes::search::search_kind;
 use crate::search::{
     add_search_rules, perform_search, SearchQueryWithIndex, SearchResultWithIndex,
 };
@@ -81,11 +81,11 @@ pub async fn multi_search_with_post(
                 })
                 .with_index(query_index)?;
 
-            let distribution =
-                embed(&mut query, index_scheduler.get_ref(), &index).with_index(query_index)?;
+            let search_kind =
+                search_kind(&query, index_scheduler.get_ref(), &index).with_index(query_index)?;
 
             let search_result = tokio::task::spawn_blocking(move || {
-                perform_search(&index, query, features, distribution)
+                perform_search(&index, query, features, search_kind)
             })
             .await
             .with_index(query_index)?;

--- a/meilisearch/src/routes/multi_search.rs
+++ b/meilisearch/src/routes/multi_search.rs
@@ -81,14 +81,13 @@ pub async fn multi_search_with_post(
                 })
                 .with_index(query_index)?;
 
-            let search_kind =
-                search_kind(&query, index_scheduler.get_ref(), &index).with_index(query_index)?;
+            let search_kind = search_kind(&query, index_scheduler.get_ref(), &index, features)
+                .with_index(query_index)?;
 
-            let search_result = tokio::task::spawn_blocking(move || {
-                perform_search(&index, query, features, search_kind)
-            })
-            .await
-            .with_index(query_index)?;
+            let search_result =
+                tokio::task::spawn_blocking(move || perform_search(&index, query, search_kind))
+                    .await
+                    .with_index(query_index)?;
 
             search_results.push(SearchResultWithIndex {
                 index_uid: index_uid.into_inner(),

--- a/meilisearch/src/search.rs
+++ b/meilisearch/src/search.rs
@@ -314,8 +314,6 @@ pub struct SearchHit {
 pub struct SearchResult {
     pub hits: Vec<SearchHit>,
     pub query: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub vector: Option<Vec<f32>>,
     pub processing_time_ms: u128,
     #[serde(flatten)]
     pub hits_info: HitsInfo,
@@ -713,7 +711,6 @@ pub fn perform_search(
         hits: documents,
         hits_info,
         query: query.q.unwrap_or_default(),
-        vector: query.vector,
         processing_time_ms: before_search.elapsed().as_millis(),
         facet_distribution,
         facet_stats,

--- a/meilisearch/src/search.rs
+++ b/meilisearch/src/search.rs
@@ -633,10 +633,8 @@ pub fn perform_search(
 
         let mut semantic_score = None;
         for details in &score {
-            if let ScoreDetails::Vector(score_details::Vector {
-                target_vector: _,
-                value_similarity: Some((_matching_vector, similarity)),
-            }) = details
+            if let ScoreDetails::Vector(score_details::Vector { similarity: Some(similarity) }) =
+                details
             {
                 semantic_score = Some(*similarity);
                 break;

--- a/meilisearch/tests/search/hybrid.rs
+++ b/meilisearch/tests/search/hybrid.rs
@@ -81,20 +81,20 @@ async fn simple_search() {
 
     let (response, code) = index
         .search_post(
-            json!({"q": "Captain", "vector": [1.0, 1.0], "hybrid": {"semanticRatio": 0.5}}),
+            json!({"q": "Captain", "vector": [1.0, 1.0], "hybrid": {"semanticRatio": 0.5}, "showRankingScore": true}),
         )
         .await;
     snapshot!(code, @"200 OK");
-    snapshot!(response["hits"], @r###"[{"title":"Captain Planet","desc":"He's not part of the Marvel Cinematic Universe","id":"2","_vectors":{"default":[1.0,2.0]}},{"title":"Captain Marvel","desc":"a Shazam ersatz","id":"3","_vectors":{"default":[2.0,3.0]}},{"title":"Shazam!","desc":"a Captain Marvel ersatz","id":"1","_vectors":{"default":[1.0,3.0]},"_semanticScore":0.9472136}]"###);
+    snapshot!(response["hits"], @r###"[{"title":"Captain Planet","desc":"He's not part of the Marvel Cinematic Universe","id":"2","_vectors":{"default":[1.0,2.0]},"_rankingScore":0.996969696969697},{"title":"Captain Marvel","desc":"a Shazam ersatz","id":"3","_vectors":{"default":[2.0,3.0]},"_rankingScore":0.996969696969697},{"title":"Shazam!","desc":"a Captain Marvel ersatz","id":"1","_vectors":{"default":[1.0,3.0]},"_rankingScore":0.9472135901451112}]"###);
     snapshot!(response["semanticHitCount"], @"1");
 
     let (response, code) = index
         .search_post(
-            json!({"q": "Captain", "vector": [1.0, 1.0], "hybrid": {"semanticRatio": 0.8}}),
+            json!({"q": "Captain", "vector": [1.0, 1.0], "hybrid": {"semanticRatio": 0.8}, "showRankingScore": true}),
         )
         .await;
     snapshot!(code, @"200 OK");
-    snapshot!(response["hits"], @r###"[{"title":"Captain Marvel","desc":"a Shazam ersatz","id":"3","_vectors":{"default":[2.0,3.0]},"_semanticScore":0.99029034},{"title":"Captain Planet","desc":"He's not part of the Marvel Cinematic Universe","id":"2","_vectors":{"default":[1.0,2.0]},"_semanticScore":0.97434163},{"title":"Shazam!","desc":"a Captain Marvel ersatz","id":"1","_vectors":{"default":[1.0,3.0]},"_semanticScore":0.9472136}]"###);
+    snapshot!(response["hits"], @r###"[{"title":"Captain Marvel","desc":"a Shazam ersatz","id":"3","_vectors":{"default":[2.0,3.0]},"_rankingScore":0.990290343761444},{"title":"Captain Planet","desc":"He's not part of the Marvel Cinematic Universe","id":"2","_vectors":{"default":[1.0,2.0]},"_rankingScore":0.974341630935669},{"title":"Shazam!","desc":"a Captain Marvel ersatz","id":"1","_vectors":{"default":[1.0,3.0]},"_rankingScore":0.9472135901451112}]"###);
     snapshot!(response["semanticHitCount"], @"3");
 }
 
@@ -152,6 +152,7 @@ async fn highlighter() {
     let (response, code) = index
         .search_post(json!({"q": "Captain Marvel", "vector": [1.0, 1.0],
             "hybrid": {"semanticRatio": 0.8},
+            "showRankingScore": true,
             "attributesToHighlight": [
                      "desc"
                    ],
@@ -160,13 +161,14 @@ async fn highlighter() {
         }))
         .await;
     snapshot!(code, @"200 OK");
-    snapshot!(response["hits"], @r###"[{"title":"Captain Marvel","desc":"a Shazam ersatz","id":"3","_vectors":{"default":[2.0,3.0]},"_formatted":{"title":"Captain Marvel","desc":"a Shazam ersatz","id":"3","_vectors":{"default":["2.0","3.0"]}},"_semanticScore":0.99029034},{"title":"Captain Planet","desc":"He's not part of the Marvel Cinematic Universe","id":"2","_vectors":{"default":[1.0,2.0]},"_formatted":{"title":"Captain Planet","desc":"He's not part of the **BEGIN**Marvel**END** Cinematic Universe","id":"2","_vectors":{"default":["1.0","2.0"]}},"_semanticScore":0.97434163},{"title":"Shazam!","desc":"a Captain Marvel ersatz","id":"1","_vectors":{"default":[1.0,3.0]},"_formatted":{"title":"Shazam!","desc":"a **BEGIN**Captain**END** **BEGIN**Marvel**END** ersatz","id":"1","_vectors":{"default":["1.0","3.0"]}},"_semanticScore":0.9472136}]"###);
+    snapshot!(response["hits"], @r###"[{"title":"Captain Marvel","desc":"a Shazam ersatz","id":"3","_vectors":{"default":[2.0,3.0]},"_formatted":{"title":"Captain Marvel","desc":"a Shazam ersatz","id":"3","_vectors":{"default":["2.0","3.0"]}},"_rankingScore":0.990290343761444},{"title":"Captain Planet","desc":"He's not part of the Marvel Cinematic Universe","id":"2","_vectors":{"default":[1.0,2.0]},"_formatted":{"title":"Captain Planet","desc":"He's not part of the **BEGIN**Marvel**END** Cinematic Universe","id":"2","_vectors":{"default":["1.0","2.0"]}},"_rankingScore":0.974341630935669},{"title":"Shazam!","desc":"a Captain Marvel ersatz","id":"1","_vectors":{"default":[1.0,3.0]},"_formatted":{"title":"Shazam!","desc":"a **BEGIN**Captain**END** **BEGIN**Marvel**END** ersatz","id":"1","_vectors":{"default":["1.0","3.0"]}},"_rankingScore":0.9472135901451112}]"###);
     snapshot!(response["semanticHitCount"], @"3");
 
     // no highlighting on full semantic
     let (response, code) = index
         .search_post(json!({"q": "Captain Marvel", "vector": [1.0, 1.0],
             "hybrid": {"semanticRatio": 1.0},
+            "showRankingScore": true,
             "attributesToHighlight": [
                      "desc"
                    ],
@@ -175,7 +177,7 @@ async fn highlighter() {
         }))
         .await;
     snapshot!(code, @"200 OK");
-    snapshot!(response["hits"], @r###"[{"title":"Captain Marvel","desc":"a Shazam ersatz","id":"3","_vectors":{"default":[2.0,3.0]},"_formatted":{"title":"Captain Marvel","desc":"a Shazam ersatz","id":"3","_vectors":{"default":["2.0","3.0"]}},"_semanticScore":0.99029034},{"title":"Captain Planet","desc":"He's not part of the Marvel Cinematic Universe","id":"2","_vectors":{"default":[1.0,2.0]},"_formatted":{"title":"Captain Planet","desc":"He's not part of the Marvel Cinematic Universe","id":"2","_vectors":{"default":["1.0","2.0"]}},"_semanticScore":0.97434163},{"title":"Shazam!","desc":"a Captain Marvel ersatz","id":"1","_vectors":{"default":[1.0,3.0]},"_formatted":{"title":"Shazam!","desc":"a Captain Marvel ersatz","id":"1","_vectors":{"default":["1.0","3.0"]}}}]"###);
+    snapshot!(response["hits"], @r###"[{"title":"Captain Marvel","desc":"a Shazam ersatz","id":"3","_vectors":{"default":[2.0,3.0]},"_formatted":{"title":"Captain Marvel","desc":"a Shazam ersatz","id":"3","_vectors":{"default":["2.0","3.0"]}},"_rankingScore":0.990290343761444},{"title":"Captain Planet","desc":"He's not part of the Marvel Cinematic Universe","id":"2","_vectors":{"default":[1.0,2.0]},"_formatted":{"title":"Captain Planet","desc":"He's not part of the Marvel Cinematic Universe","id":"2","_vectors":{"default":["1.0","2.0"]}},"_rankingScore":0.974341630935669},{"title":"Shazam!","desc":"a Captain Marvel ersatz","id":"1","_vectors":{"default":[1.0,3.0]},"_formatted":{"title":"Shazam!","desc":"a Captain Marvel ersatz","id":"1","_vectors":{"default":["1.0","3.0"]}},"_rankingScore":0.9472135901451112}]"###);
     snapshot!(response["semanticHitCount"], @"3");
 }
 
@@ -263,7 +265,7 @@ async fn single_document() {
     .await;
 
     snapshot!(code, @"200 OK");
-    snapshot!(response["hits"][0], @r###"{"title":"Shazam!","desc":"a Captain Marvel ersatz","id":"1","_vectors":{"default":[1.0,3.0]},"_rankingScore":1.0,"_semanticScore":1.0}"###);
+    snapshot!(response["hits"][0], @r###"{"title":"Shazam!","desc":"a Captain Marvel ersatz","id":"1","_vectors":{"default":[1.0,3.0]},"_rankingScore":1.0}"###);
     snapshot!(response["semanticHitCount"], @"1");
 }
 
@@ -311,7 +313,7 @@ async fn query_combination() {
     .await;
 
     snapshot!(code, @"200 OK");
-    snapshot!(response["hits"], @r###"[{"title":"Captain Marvel","desc":"a Shazam ersatz","id":"3","_vectors":{"default":[2.0,3.0]},"_rankingScore":0.7773500680923462,"_semanticScore":0.77735007},{"title":"Captain Planet","desc":"He's not part of the Marvel Cinematic Universe","id":"2","_vectors":{"default":[1.0,2.0]},"_rankingScore":0.7236068248748779,"_semanticScore":0.7236068},{"title":"Shazam!","desc":"a Captain Marvel ersatz","id":"1","_vectors":{"default":[1.0,3.0]},"_rankingScore":0.6581138968467712,"_semanticScore":0.6581139}]"###);
+    snapshot!(response["hits"], @r###"[{"title":"Captain Marvel","desc":"a Shazam ersatz","id":"3","_vectors":{"default":[2.0,3.0]},"_rankingScore":0.7773500680923462},{"title":"Captain Planet","desc":"He's not part of the Marvel Cinematic Universe","id":"2","_vectors":{"default":[1.0,2.0]},"_rankingScore":0.7236068248748779},{"title":"Shazam!","desc":"a Captain Marvel ersatz","id":"1","_vectors":{"default":[1.0,3.0]},"_rankingScore":0.6581138968467712}]"###);
     snapshot!(response["semanticHitCount"], @"3");
 
     // full keyword, without a query

--- a/meilisearch/tests/search/hybrid.rs
+++ b/meilisearch/tests/search/hybrid.rs
@@ -106,7 +106,7 @@ async fn distribution_shift() {
     let search = json!({"q": "Captain", "vector": [1.0, 1.0], "showRankingScore": true, "hybrid": {"semanticRatio": 1.0}});
     let (response, code) = index.search_post(search.clone()).await;
     snapshot!(code, @"200 OK");
-    snapshot!(response["hits"], @r###"[{"title":"Captain Marvel","desc":"a Shazam ersatz","id":"3","_vectors":{"default":[2.0,3.0]},"_rankingScore":0.990290343761444,"_semanticScore":0.99029034},{"title":"Captain Planet","desc":"He's not part of the Marvel Cinematic Universe","id":"2","_vectors":{"default":[1.0,2.0]},"_rankingScore":0.974341630935669,"_semanticScore":0.97434163},{"title":"Shazam!","desc":"a Captain Marvel ersatz","id":"1","_vectors":{"default":[1.0,3.0]},"_rankingScore":0.9472135901451112,"_semanticScore":0.9472136}]"###);
+    snapshot!(response["hits"], @r###"[{"title":"Captain Marvel","desc":"a Shazam ersatz","id":"3","_vectors":{"default":[2.0,3.0]},"_rankingScore":0.990290343761444},{"title":"Captain Planet","desc":"He's not part of the Marvel Cinematic Universe","id":"2","_vectors":{"default":[1.0,2.0]},"_rankingScore":0.974341630935669},{"title":"Shazam!","desc":"a Captain Marvel ersatz","id":"1","_vectors":{"default":[1.0,3.0]},"_rankingScore":0.9472135901451112}]"###);
 
     let (response, code) = index
         .update_settings(json!({
@@ -127,7 +127,7 @@ async fn distribution_shift() {
 
     let (response, code) = index.search_post(search).await;
     snapshot!(code, @"200 OK");
-    snapshot!(response["hits"], @r###"[{"title":"Captain Marvel","desc":"a Shazam ersatz","id":"3","_vectors":{"default":[2.0,3.0]},"_rankingScore":0.19161224365234375,"_semanticScore":0.19161224},{"title":"Captain Planet","desc":"He's not part of the Marvel Cinematic Universe","id":"2","_vectors":{"default":[1.0,2.0]},"_rankingScore":1.1920928955078125e-7,"_semanticScore":1.1920929e-7},{"title":"Shazam!","desc":"a Captain Marvel ersatz","id":"1","_vectors":{"default":[1.0,3.0]},"_rankingScore":1.1920928955078125e-7,"_semanticScore":1.1920929e-7}]"###);
+    snapshot!(response["hits"], @r###"[{"title":"Captain Marvel","desc":"a Shazam ersatz","id":"3","_vectors":{"default":[2.0,3.0]},"_rankingScore":0.19161224365234375},{"title":"Captain Planet","desc":"He's not part of the Marvel Cinematic Universe","id":"2","_vectors":{"default":[1.0,2.0]},"_rankingScore":1.1920928955078125e-7},{"title":"Shazam!","desc":"a Captain Marvel ersatz","id":"1","_vectors":{"default":[1.0,3.0]},"_rankingScore":1.1920928955078125e-7}]"###);
 }
 
 #[actix_rt::test]

--- a/meilisearch/tests/search/mod.rs
+++ b/meilisearch/tests/search/mod.rs
@@ -1040,6 +1040,7 @@ async fn experimental_feature_vector_store() {
     let (response, code) = index
         .search_post(json!({
             "vector": [1.0, 2.0, 3.0],
+            "showRankingScore": true
         }))
         .await;
     meili_snap::snapshot!(code, @"400 Bad Request");
@@ -1082,6 +1083,7 @@ async fn experimental_feature_vector_store() {
     let (response, code) = index
         .search_post(json!({
             "vector": [1.0, 2.0, 3.0],
+            "showRankingScore": true,
         }))
         .await;
 
@@ -1099,7 +1101,7 @@ async fn experimental_feature_vector_store() {
             3
           ]
         },
-        "_semanticScore": 1.0
+        "_rankingScore": 1.0
       },
       {
         "title": "Captain Marvel",
@@ -1111,7 +1113,7 @@ async fn experimental_feature_vector_store() {
             54
           ]
         },
-        "_semanticScore": 0.9129112
+        "_rankingScore": 0.9129111766815186
       },
       {
         "title": "Gläss",
@@ -1123,7 +1125,7 @@ async fn experimental_feature_vector_store() {
             90
           ]
         },
-        "_semanticScore": 0.8106413
+        "_rankingScore": 0.8106412887573242
       },
       {
         "title": "How to Train Your Dragon: The Hidden World",
@@ -1135,7 +1137,7 @@ async fn experimental_feature_vector_store() {
             32
           ]
         },
-        "_semanticScore": 0.74120104
+        "_rankingScore": 0.7412010431289673
       },
       {
         "title": "Escape Room",
@@ -1146,7 +1148,8 @@ async fn experimental_feature_vector_store() {
             -23,
             32
           ]
-        }
+        },
+        "_rankingScore": 0.6972063183784485
       }
     ]
     "###);

--- a/milli/src/error.rs
+++ b/milli/src/error.rs
@@ -196,7 +196,7 @@ only composed of alphanumeric characters (a-z A-Z 0-9), hyphens (-) and undersco
     InvalidPromptForEmbeddings(String, crate::prompt::error::NewPromptError),
     #[error("Too many embedders in the configuration. Found {0}, but limited to 256.")]
     TooManyEmbedders(usize),
-    #[error("Cannot find embedder with name {0}.")]
+    #[error("Cannot find embedder with name `{0}`.")]
     InvalidEmbedder(String),
     #[error("Too many vectors for document with id {0}: found {1}, but limited to 256.")]
     TooManyVectors(String, usize),

--- a/milli/src/index.rs
+++ b/milli/src/index.rs
@@ -1499,14 +1499,6 @@ impl Index {
             .unwrap_or_default())
     }
 
-    pub fn default_embedding_name(&self, rtxn: &RoTxn<'_>) -> Result<String> {
-        let configs = self.embedding_configs(rtxn)?;
-        Ok(match configs.as_slice() {
-            [(ref first_name, _)] => first_name.clone(),
-            _ => "default".to_owned(),
-        })
-    }
-
     pub(crate) fn put_search_cutoff(&self, wtxn: &mut RwTxn<'_>, cutoff: u64) -> heed::Result<()> {
         self.main.remap_types::<Str, BEU64>().put(wtxn, main_key::SEARCH_CUTOFF, &cutoff)
     }

--- a/milli/src/lib.rs
+++ b/milli/src/lib.rs
@@ -61,7 +61,7 @@ pub use self::index::Index;
 pub use self::search::facet::{FacetValueHit, SearchForFacetValues};
 pub use self::search::{
     FacetDistribution, Filter, FormatOptions, MatchBounds, MatcherBuilder, MatchingWords, OrderBy,
-    Search, SearchResult, TermsMatchingStrategy, DEFAULT_VALUES_PER_FACET,
+    Search, SearchResult, SemanticSearch, TermsMatchingStrategy, DEFAULT_VALUES_PER_FACET,
 };
 
 pub type Result<T> = std::result::Result<T, error::Error>;

--- a/milli/src/score_details.rs
+++ b/milli/src/score_details.rs
@@ -98,9 +98,9 @@ impl ScoreDetails {
             ScoreDetails::ExactWords(e) => RankOrValue::Rank(e.rank()),
             ScoreDetails::Sort(sort) => RankOrValue::Sort(sort),
             ScoreDetails::GeoSort(geosort) => RankOrValue::GeoSort(geosort),
-            ScoreDetails::Vector(vector) => RankOrValue::Score(
-                vector.value_similarity.as_ref().map(|(_, s)| *s as f64).unwrap_or(0.0f64),
-            ),
+            ScoreDetails::Vector(vector) => {
+                RankOrValue::Score(vector.similarity.as_ref().map(|s| *s as f64).unwrap_or(0.0f64))
+            }
             ScoreDetails::Skipped => RankOrValue::Rank(Rank { rank: 0, max_rank: 1 }),
         }
     }
@@ -249,16 +249,13 @@ impl ScoreDetails {
                     order += 1;
                 }
                 ScoreDetails::Vector(s) => {
-                    let vector = format!("vectorSort({:?})", s.target_vector);
-                    let value = s.value_similarity.as_ref().map(|(v, _)| v);
-                    let similarity = s.value_similarity.as_ref().map(|(_, s)| s);
+                    let similarity = s.similarity.as_ref();
 
                     let details = serde_json::json!({
                         "order": order,
-                        "value": value,
                         "similarity": similarity,
                     });
-                    details_map.insert(vector, details);
+                    details_map.insert("vectorSort".into(), details);
                     order += 1;
                 }
                 ScoreDetails::Skipped => {
@@ -494,8 +491,7 @@ impl PartialOrd for GeoSort {
 
 #[derive(Debug, Clone, PartialEq, PartialOrd)]
 pub struct Vector {
-    pub target_vector: Vec<f32>,
-    pub value_similarity: Option<(Vec<f32>, f32)>,
+    pub similarity: Option<f32>,
 }
 
 impl GeoSort {

--- a/milli/src/search/facet/search.rs
+++ b/milli/src/search/facet/search.rs
@@ -92,9 +92,15 @@ impl<'a> SearchForFacetValues<'a> {
             None => return Ok(Vec::new()),
         };
 
-        let search_candidates = self
-            .search_query
-            .execute_for_candidates(self.is_hybrid || self.search_query.vector.is_some())?;
+        let search_candidates = self.search_query.execute_for_candidates(
+            self.is_hybrid
+                || self
+                    .search_query
+                    .semantic
+                    .as_ref()
+                    .and_then(|semantic| semantic.vector.as_ref())
+                    .is_some(),
+        )?;
 
         let mut results = match index.sort_facet_values_by(rtxn)?.get(&self.facet) {
             OrderBy::Lexicographic => ValuesCollection::by_lexicographic(self.max_values),

--- a/milli/src/search/hybrid.rs
+++ b/milli/src/search/hybrid.rs
@@ -84,45 +84,73 @@ impl ScoreWithRatioResult {
         }
     }
 
-    fn merge(left: Self, right: Self, from: usize, length: usize) -> SearchResult {
-        let mut documents_ids =
-            Vec::with_capacity(left.document_scores.len() + right.document_scores.len());
-        let mut document_scores =
-            Vec::with_capacity(left.document_scores.len() + right.document_scores.len());
+    fn merge(
+        vector_results: Self,
+        keyword_results: Self,
+        from: usize,
+        length: usize,
+    ) -> (SearchResult, u32) {
+        #[derive(Clone, Copy)]
+        enum ResultSource {
+            Semantic,
+            Keyword,
+        }
+        let mut semantic_hit_count = 0;
+
+        let mut documents_ids = Vec::with_capacity(
+            vector_results.document_scores.len() + keyword_results.document_scores.len(),
+        );
+        let mut document_scores = Vec::with_capacity(
+            vector_results.document_scores.len() + keyword_results.document_scores.len(),
+        );
 
         let mut documents_seen = RoaringBitmap::new();
-        for (docid, (main_score, _sub_score)) in left
+        for ((docid, (main_score, _sub_score)), source) in vector_results
             .document_scores
             .into_iter()
-            .merge_by(right.document_scores.into_iter(), |(_, left), (_, right)| {
-                // the first value is the one with the greatest score
-                compare_scores(left, right).is_ge()
-            })
+            .zip(std::iter::repeat(ResultSource::Semantic))
+            .merge_by(
+                keyword_results
+                    .document_scores
+                    .into_iter()
+                    .zip(std::iter::repeat(ResultSource::Keyword)),
+                |((_, left), _), ((_, right), _)| {
+                    // the first value is the one with the greatest score
+                    compare_scores(left, right).is_ge()
+                },
+            )
             // remove documents we already saw
-            .filter(|(docid, _)| documents_seen.insert(*docid))
+            .filter(|((docid, _), _)| documents_seen.insert(*docid))
             // start skipping **after** the filter
             .skip(from)
             // take **after** skipping
             .take(length)
         {
+            if let ResultSource::Semantic = source {
+                semantic_hit_count += 1;
+            }
             documents_ids.push(docid);
             // TODO: pass both scores to documents_score in some way?
             document_scores.push(main_score);
         }
 
-        SearchResult {
-            matching_words: right.matching_words,
-            candidates: left.candidates | right.candidates,
-            documents_ids,
-            document_scores,
-            degraded: left.degraded | right.degraded,
-            used_negative_operator: left.used_negative_operator | right.used_negative_operator,
-        }
+        (
+            SearchResult {
+                matching_words: keyword_results.matching_words,
+                candidates: vector_results.candidates | keyword_results.candidates,
+                documents_ids,
+                document_scores,
+                degraded: vector_results.degraded | keyword_results.degraded,
+                used_negative_operator: vector_results.used_negative_operator
+                    | keyword_results.used_negative_operator,
+            },
+            semantic_hit_count,
+        )
     }
 }
 
 impl<'a> Search<'a> {
-    pub fn execute_hybrid(&self, semantic_ratio: f32) -> Result<SearchResult> {
+    pub fn execute_hybrid(&self, semantic_ratio: f32) -> Result<(SearchResult, Option<u32>)> {
         // TODO: find classier way to achieve that than to reset vector and query params
         // create separate keyword and semantic searches
         let mut search = Search {
@@ -148,14 +176,16 @@ impl<'a> Search<'a> {
 
         // completely skip semantic search if the results of the keyword search are good enough
         if self.results_good_enough(&keyword_results, semantic_ratio) {
-            return Ok(keyword_results);
+            return Ok((keyword_results, Some(0)));
         }
 
         // no vector search against placeholder search
-        let Some(query) = search.query.take() else { return Ok(keyword_results) };
+        let Some(query) = search.query.take() else {
+            return Ok((keyword_results, Some(0)));
+        };
         // no embedder, no semantic search
         let Some(SemanticSearch { vector, embedder_name, embedder }) = semantic else {
-            return Ok(keyword_results);
+            return Ok((keyword_results, Some(0)));
         };
 
         let vector_query = match vector {
@@ -166,7 +196,7 @@ impl<'a> Search<'a> {
                     Ok(embedding) => embedding,
                     Err(error) => {
                         tracing::error!(error=%error, "Embedding failed");
-                        return Ok(keyword_results);
+                        return Ok((keyword_results, Some(0)));
                     }
                 }
             }
@@ -181,10 +211,10 @@ impl<'a> Search<'a> {
         let keyword_results = ScoreWithRatioResult::new(keyword_results, 1.0 - semantic_ratio);
         let vector_results = ScoreWithRatioResult::new(vector_results, semantic_ratio);
 
-        let merge_results =
+        let (merge_results, semantic_hit_count) =
             ScoreWithRatioResult::merge(vector_results, keyword_results, self.offset, self.limit);
         assert!(merge_results.documents_ids.len() <= self.limit);
-        Ok(merge_results)
+        Ok((merge_results, Some(semantic_hit_count)))
     }
 
     fn results_good_enough(&self, keyword_results: &SearchResult, semantic_ratio: f32) -> bool {

--- a/milli/src/search/new/mod.rs
+++ b/milli/src/search/new/mod.rs
@@ -52,7 +52,7 @@ use self::vector_sort::VectorSort;
 use crate::error::FieldIdMapMissingEntry;
 use crate::score_details::{ScoreDetails, ScoringStrategy};
 use crate::search::new::distinct::apply_distinct_rule;
-use crate::vector::DistributionShift;
+use crate::vector::Embedder;
 use crate::{
     AscDesc, DocumentId, FieldId, Filter, Index, Member, Result, TermsMatchingStrategy, TimeBudget,
     UserError,
@@ -298,8 +298,8 @@ fn get_ranking_rules_for_vector<'ctx>(
     geo_strategy: geo_sort::Strategy,
     limit_plus_offset: usize,
     target: &[f32],
-    distribution_shift: Option<DistributionShift>,
     embedder_name: &str,
+    embedder: &Embedder,
 ) -> Result<Vec<BoxRankingRule<'ctx, PlaceholderQuery>>> {
     // query graph search
 
@@ -325,8 +325,8 @@ fn get_ranking_rules_for_vector<'ctx>(
                         target.to_vec(),
                         vector_candidates,
                         limit_plus_offset,
-                        distribution_shift,
                         embedder_name,
+                        embedder,
                     )?;
                     ranking_rules.push(Box::new(vector_sort));
                     vector = true;
@@ -548,8 +548,8 @@ pub fn execute_vector_search(
     geo_strategy: geo_sort::Strategy,
     from: usize,
     length: usize,
-    distribution_shift: Option<DistributionShift>,
     embedder_name: &str,
+    embedder: &Embedder,
     time_budget: TimeBudget,
 ) -> Result<PartialSearchResult> {
     check_sort_criteria(ctx, sort_criteria.as_ref())?;
@@ -562,8 +562,8 @@ pub fn execute_vector_search(
         geo_strategy,
         from + length,
         vector,
-        distribution_shift,
         embedder_name,
+        embedder,
     )?;
 
     let mut placeholder_search_logger = logger::DefaultSearchLogger;

--- a/milli/src/search/new/vector_sort.rs
+++ b/milli/src/search/new/vector_sort.rs
@@ -5,7 +5,7 @@ use roaring::RoaringBitmap;
 
 use super::ranking_rules::{RankingRule, RankingRuleOutput, RankingRuleQueryTrait};
 use crate::score_details::{self, ScoreDetails};
-use crate::vector::DistributionShift;
+use crate::vector::{DistributionShift, Embedder};
 use crate::{DocumentId, Result, SearchContext, SearchLogger};
 
 pub struct VectorSort<Q: RankingRuleQueryTrait> {
@@ -24,8 +24,8 @@ impl<Q: RankingRuleQueryTrait> VectorSort<Q> {
         target: Vec<f32>,
         vector_candidates: RoaringBitmap,
         limit: usize,
-        distribution_shift: Option<DistributionShift>,
         embedder_name: &str,
+        embedder: &Embedder,
     ) -> Result<Self> {
         let embedder_index = ctx
             .index
@@ -39,7 +39,7 @@ impl<Q: RankingRuleQueryTrait> VectorSort<Q> {
             vector_candidates,
             cached_sorted_docids: Default::default(),
             limit,
-            distribution_shift,
+            distribution_shift: embedder.distribution(),
             embedder_index,
         })
     }

--- a/milli/src/search/new/vector_sort.rs
+++ b/milli/src/search/new/vector_sort.rs
@@ -12,7 +12,7 @@ pub struct VectorSort<Q: RankingRuleQueryTrait> {
     query: Option<Q>,
     target: Vec<f32>,
     vector_candidates: RoaringBitmap,
-    cached_sorted_docids: std::vec::IntoIter<(DocumentId, f32, Vec<f32>)>,
+    cached_sorted_docids: std::vec::IntoIter<(DocumentId, f32)>,
     limit: usize,
     distribution_shift: Option<DistributionShift>,
     embedder_index: u8,
@@ -70,14 +70,9 @@ impl<Q: RankingRuleQueryTrait> VectorSort<Q> {
         for reader in readers.iter() {
             let nns_by_vector =
                 reader.nns_by_vector(ctx.txn, target, self.limit, None, Some(vector_candidates))?;
-            let vectors: std::result::Result<Vec<_>, _> = nns_by_vector
-                .iter()
-                .map(|(docid, _)| reader.item_vector(ctx.txn, *docid).transpose().unwrap())
-                .collect();
-            let vectors = vectors?;
-            results.extend(nns_by_vector.into_iter().zip(vectors).map(|((x, y), z)| (x, y, z)));
+            results.extend(nns_by_vector.into_iter());
         }
-        results.sort_unstable_by_key(|(_, distance, _)| OrderedFloat(*distance));
+        results.sort_unstable_by_key(|(_, distance)| OrderedFloat(*distance));
         self.cached_sorted_docids = results.into_iter();
 
         Ok(())
@@ -118,14 +113,11 @@ impl<'ctx, Q: RankingRuleQueryTrait> RankingRule<'ctx, Q> for VectorSort<Q> {
             return Ok(Some(RankingRuleOutput {
                 query,
                 candidates: universe.clone(),
-                score: ScoreDetails::Vector(score_details::Vector {
-                    target_vector: self.target.clone(),
-                    value_similarity: None,
-                }),
+                score: ScoreDetails::Vector(score_details::Vector { similarity: None }),
             }));
         }
 
-        for (docid, distance, vector) in self.cached_sorted_docids.by_ref() {
+        for (docid, distance) in self.cached_sorted_docids.by_ref() {
             if vector_candidates.contains(docid) {
                 let score = 1.0 - distance;
                 let score = self
@@ -135,10 +127,7 @@ impl<'ctx, Q: RankingRuleQueryTrait> RankingRule<'ctx, Q> for VectorSort<Q> {
                 return Ok(Some(RankingRuleOutput {
                     query,
                     candidates: RoaringBitmap::from_iter([docid]),
-                    score: ScoreDetails::Vector(score_details::Vector {
-                        target_vector: self.target.clone(),
-                        value_similarity: Some((vector, score)),
-                    }),
+                    score: ScoreDetails::Vector(score_details::Vector { similarity: Some(score) }),
                 }));
             }
         }
@@ -154,10 +143,7 @@ impl<'ctx, Q: RankingRuleQueryTrait> RankingRule<'ctx, Q> for VectorSort<Q> {
             return Ok(Some(RankingRuleOutput {
                 query,
                 candidates: universe.clone(),
-                score: ScoreDetails::Vector(score_details::Vector {
-                    target_vector: self.target.clone(),
-                    value_similarity: None,
-                }),
+                score: ScoreDetails::Vector(score_details::Vector { similarity: None }),
             }));
         }
 

--- a/milli/src/update/index_documents/mod.rs
+++ b/milli/src/update/index_documents/mod.rs
@@ -2672,7 +2672,16 @@ mod tests {
                .unwrap();
 
         let rtxn = index.read_txn().unwrap();
-        let res = index.search(&rtxn).vector([0.0, 1.0, 2.0].to_vec()).execute().unwrap();
+        let mut embedding_configs = index.embedding_configs(&rtxn).unwrap();
+        let (embedder_name, embedder) = embedding_configs.pop().unwrap();
+        let embedder =
+            std::sync::Arc::new(crate::vector::Embedder::new(embedder.embedder_options).unwrap());
+        assert_eq!("manual", embedder_name);
+        let res = index
+            .search(&rtxn)
+            .semantic(embedder_name, embedder, Some([0.0, 1.0, 2.0].to_vec()))
+            .execute()
+            .unwrap();
         assert_eq!(res.documents_ids.len(), 3);
     }
 

--- a/milli/src/vector/error.rs
+++ b/milli/src/vector/error.rs
@@ -58,7 +58,7 @@ pub enum EmbedErrorKind {
     RestResponseDeserialization(std::io::Error),
     #[error("component `{0}` not found in path `{1}` in response: `{2}`")]
     RestResponseMissingEmbeddings(String, String, String),
-    #[error("expected a response parseable as a vector or an array of vectors: {0}")]
+    #[error("unexpected format of the embedding response: {0}")]
     RestResponseFormat(serde_json::Error),
     #[error("expected a response containing {0} embeddings, got only {1}")]
     RestResponseEmbeddingCount(usize, usize),
@@ -78,6 +78,8 @@ pub enum EmbedErrorKind {
     RestNotAnObject(serde_json::Value, Vec<String>),
     #[error("while embedding tokenized, was expecting embeddings of dimension `{0}`, got embeddings of dimensions `{1}`")]
     OpenAiUnexpectedDimension(usize, usize),
+    #[error("no embedding was produced")]
+    MissingEmbedding,
 }
 
 impl EmbedError {
@@ -189,6 +191,9 @@ impl EmbedError {
             kind: EmbedErrorKind::OpenAiUnexpectedDimension(expected, got),
             fault: FaultSource::Runtime,
         }
+    }
+    pub(crate) fn missing_embedding() -> EmbedError {
+        Self { kind: EmbedErrorKind::MissingEmbedding, fault: FaultSource::Undecided }
     }
 }
 

--- a/milli/src/vector/mod.rs
+++ b/milli/src/vector/mod.rs
@@ -143,7 +143,7 @@ impl EmbeddingConfigs {
 
     /// Get the default embedder configuration, if any.
     pub fn get_default(&self) -> Option<(Arc<Embedder>, Arc<Prompt>)> {
-        self.get_default_embedder_name().and_then(|default| self.get(&default))
+        self.get(self.get_default_embedder_name())
     }
 
     /// Get the name of the default embedder configuration.
@@ -153,14 +153,14 @@ impl EmbeddingConfigs {
     /// - If there is only one embedder, it is always the default.
     /// - If there are multiple embedders and one of them is called `default`, then that one is the default embedder.
     /// - In all other cases, there is no default embedder.
-    pub fn get_default_embedder_name(&self) -> Option<String> {
+    pub fn get_default_embedder_name(&self) -> &str {
         let mut it = self.0.keys();
         let first_name = it.next();
         let second_name = it.next();
         match (first_name, second_name) {
-            (None, _) => None,
-            (Some(first), None) => Some(first.to_owned()),
-            (Some(_), Some(_)) => Some("default".to_owned()),
+            (None, _) => "default",
+            (Some(first), None) => first,
+            (Some(_), Some(_)) => "default",
         }
     }
 }

--- a/milli/src/vector/mod.rs
+++ b/milli/src/vector/mod.rs
@@ -237,6 +237,17 @@ impl Embedder {
         }
     }
 
+    pub fn embed_one(&self, text: String) -> std::result::Result<Embedding, EmbedError> {
+        let mut embeddings = self.embed(vec![text])?;
+        let embeddings = embeddings.pop().ok_or_else(EmbedError::missing_embedding)?;
+        Ok(if embeddings.iter().nth(1).is_some() {
+            tracing::warn!("Ignoring embeddings past the first one in long search query");
+            embeddings.iter().next().unwrap().to_vec()
+        } else {
+            embeddings.into_inner()
+        })
+    }
+
     /// Embed multiple chunks of texts.
     ///
     /// Each chunk is composed of one or multiple texts.


### PR DESCRIPTION
Implements the search changes from the [usage page](https://meilisearch.notion.site/v1-8-AI-search-API-usage-135552d6e85a4a52bc7109be82aeca42#40f24df3da694428a39cc8043c9cfc64)

### ⚠️ Breaking changes in an experimental feature:

- Removed the `_semanticScore`. Use the `_rankingScore` instead.
- Removed `vector` in the response of the search (output was too big).
- Removed all the vectors from the `vectorSort` ranking score details
  - target vector appearing in the name of the rule
  - matched vector appearing in the details of the rule

### Other user-facing changes

- Added `semanticHitCount`, indicating how many hits were returned from the semantic search. This is especially useful in the hybrid search.
- Embed lazily: Meilisearch no longer generates an embedding when the keyword results are "good enough".
- Graceful embedding failure in hybrid search: when doing hybrid search (`semanticRatio in ]0.0, 1.0[`), an embedding failure no longer causes the search request to fail. Instead, only the keyword search is performed. When doing a full vector search (`semanticRatio==1.0`), a failure to embed will still result in failing that search.