### PR TITLE
Update grenad to fix rare DB corruption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2145,9 +2145,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "grenad"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a007932af5475ebb5c63bef8812bb1c36f317983bb4ca663e9d6dd58d6a0f8c"
+checksum = "c297f45167e6d543eb728e12ff284283e4ba2182a25c6cdcec883fda3316c7e7"
 dependencies = [
  "bytemuck",
  "byteorder",

--- a/milli/Cargo.toml
+++ b/milli/Cargo.toml
@@ -26,7 +26,7 @@ flatten-serde-json = { path = "../flatten-serde-json" }
 fst = "0.4.7"
 fxhash = "0.2.1"
 geoutils = "0.5.1"
-grenad = { version = "0.4.5", default-features = false, features = [
+grenad = { version = "0.4.6", default-features = false, features = [
     "rayon",
     "tempfile",
 ] }


### PR DESCRIPTION

Fixes https://github.com/meilisearch/meilisearch-support/issues/138 (internal link)

See https://github.com/meilisearch/grenad/pull/52