### PR TITLE
increase the default search time budget from 150ms to 1.5s

### DIFF
--- a/milli/src/lib.rs
+++ b/milli/src/lib.rs
@@ -128,7 +128,7 @@ impl fmt::Debug for TimeBudget {
 
 impl Default for TimeBudget {
     fn default() -> Self {
-        Self::new(std::time::Duration::from_millis(150))
+        Self::new(std::time::Duration::from_millis(1500))
     }
 }
 


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #4575

## What does this PR do?
- increase the default search time budget from 150ms to 1.5s
