### PR TITLE
Always show facet numbers in alpha order in the facet distribution

### DIFF
--- a/milli/src/search/facet/facet_distribution.rs
+++ b/milli/src/search/facet/facet_distribution.rs
@@ -97,6 +97,7 @@ impl<'a> FacetDistribution<'a> {
     ) -> heed::Result<()> {
         match facet_type {
             FacetType::Number => {
+                let mut lexicographic_distribution = BTreeMap::new();
                 let mut key_buffer: Vec<_> = field_id.to_be_bytes().to_vec();
 
                 let distribution_prelength = distribution.len();
@@ -111,14 +112,17 @@ impl<'a> FacetDistribution<'a> {
 
                     for result in iter {
                         let ((_, _, value), ()) = result?;
-                        *distribution.entry(value.to_string()).or_insert(0) += 1;
+                        *lexicographic_distribution.entry(value.to_string()).or_insert(0) += 1;
 
-                        if distribution.len() - distribution_prelength == self.max_values_per_facet
+                        if lexicographic_distribution.len() - distribution_prelength
+                            == self.max_values_per_facet
                         {
                             break;
                         }
                     }
                 }
+
+                distribution.extend(lexicographic_distribution);
             }
             FacetType::String => {
                 let mut normalized_distribution = BTreeMap::new();


### PR DESCRIPTION
This PR fixes #4559 by making sure that the number facets (facets that come from numbers from the documents) are always displayed in alpha order, even when there is a small amount to display.

The issue was due to some algorithms executed when the number of facet values to display was small. We can see that now, facet values are always displayed correctly.

```json
"facetDistribution": {
    "release_year": {
        "2010": 1,
        "2011": 1,
        "2012": 1,
        "2013": 1,
        "2014": 1,
        "2015": 1,
        "2016": 1,
        "2017": 1,
        "2018": 1,
        "2019": 19,
        "2020": 1,
        "2021": 1,
        "2022": 1,
        "2023": 1,
        "2024": 1,
        "2025": 1
    }
}
```