### PR TITLE
Swedish docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN     set -eux; \
         if [ "$apkArch" = "aarch64" ]; then \
             export JEMALLOC_SYS_WITH_LG_PAGE=16; \
         fi && \
-        cargo build --release -p meilisearch -p meilitool
+        cargo build --release -p meilisearch -p meilitool --features "swedish-recomposition"
 
 # Run
 FROM    alpine:3.16


### PR DESCRIPTION
> ⚠️ this PR is not meant to be merged.

This PR enables the Swedish character's recomposition, avoiding the diacritic removal from the letters and preserving expected Swedish character ordering.
It's a hotfix provided to Swedish users, allowing them to use Meilisearch without having normalization issues before a final fix is released.

## How to use this prototype?

### Docker images

**[Meilisearch v1.9.0](https://github.com/meilisearch/meilisearch/releases/tag/v1.9.0)** (latest stable):
```
$ docker pull getmeili/meilisearch:prototype-swedish-3
```

**[Meilisearch v1.8.4](https://github.com/meilisearch/meilisearch/releases/tag/v1.8.4)**:
```
$ docker pull getmeili/meilisearch:prototype-swedish-184
```

**[Meilisearch v1.8.2](https://github.com/meilisearch/meilisearch/releases/tag/v1.8.2)**:
```
$ docker pull getmeili/meilisearch:prototype-swedish-2
```

**[Meilisearch v1.8.1](https://github.com/meilisearch/meilisearch/releases/tag/v1.8.1)**:
```
$ docker pull getmeili/meilisearch:prototype-swedish-1
```

**[Meilisearch v1.8.0-rc.2](https://github.com/meilisearch/meilisearch/releases/tag/v1.8.0-rc.2)**:
```
$ docker pull getmeili/meilisearch:prototype-swedish-0
```
