### PR TITLE
Split the field id map from the weight of each fields

### DIFF
--- a/index-scheduler/src/utils.rs
+++ b/index-scheduler/src/utils.rs
@@ -272,9 +272,9 @@ pub fn swap_index_uid_in_task(task: &mut Task, swap: (&str, &str)) {
     }
     for index_uid in index_uids {
         if index_uid == swap.0 {
-            *index_uid = swap.1.to_owned();
+            swap.1.clone_into(index_uid);
         } else if index_uid == swap.1 {
-            *index_uid = swap.0.to_owned();
+            swap.0.clone_into(index_uid);
         }
     }
 }

--- a/meilisearch/src/search.rs
+++ b/meilisearch/src/search.rs
@@ -730,7 +730,7 @@ pub fn perform_search(
         let mut ids = BTreeSet::new();
         for attr in attrs {
             if attr == "*" {
-                ids = displayed_ids.clone();
+                ids.clone_from(&displayed_ids);
                 break;
             }
 

--- a/meilisearch/src/search_queue.rs
+++ b/meilisearch/src/search_queue.rs
@@ -85,11 +85,13 @@ impl SearchQueue {
                 },
 
                 search_request = receive_new_searches.recv() => {
-                    if search_request.is_none() {
-                        continue;
-                    }
-                    // this unwrap is safe because we're sure the `SearchQueue` still lives somewhere in actix-web
-                    let search_request = search_request.unwrap();
+                    let search_request = match search_request {
+                        Some(search_request) => search_request,
+                        // This should never happen while actix-web is running, but it's not a reason to crash
+                        // and it can generate a lot of noise in the tests.
+                        None => continue,
+                    };
+
                     if searches_running < usize::from(parallelism) && queue.is_empty() {
                         searches_running += 1;
                         // if the search requests die it's not a hard error on our side

--- a/meilisearch/src/search_queue.rs
+++ b/meilisearch/src/search_queue.rs
@@ -85,6 +85,9 @@ impl SearchQueue {
                 },
 
                 search_request = receive_new_searches.recv() => {
+                    if search_request.is_none() {
+                        continue;
+                    }
                     // this unwrap is safe because we're sure the `SearchQueue` still lives somewhere in actix-web
                     let search_request = search_request.unwrap();
                     if searches_running < usize::from(parallelism) && queue.is_empty() {

--- a/meilisearch/tests/search/hybrid.rs
+++ b/meilisearch/tests/search/hybrid.rs
@@ -85,8 +85,8 @@ async fn simple_search() {
         )
         .await;
     snapshot!(code, @"200 OK");
-    snapshot!(response["hits"], @r###"[{"title":"Captain Planet","desc":"He's not part of the Marvel Cinematic Universe","id":"2","_vectors":{"default":[1.0,2.0]},"_rankingScore":0.996969696969697},{"title":"Captain Marvel","desc":"a Shazam ersatz","id":"3","_vectors":{"default":[2.0,3.0]},"_rankingScore":0.996969696969697},{"title":"Shazam!","desc":"a Captain Marvel ersatz","id":"1","_vectors":{"default":[1.0,3.0]},"_rankingScore":0.9472135901451112}]"###);
-    snapshot!(response["semanticHitCount"], @"1");
+    snapshot!(response["hits"], @r###"[{"title":"Captain Marvel","desc":"a Shazam ersatz","id":"3","_vectors":{"default":[2.0,3.0]},"_rankingScore":0.990290343761444},{"title":"Captain Planet","desc":"He's not part of the Marvel Cinematic Universe","id":"2","_vectors":{"default":[1.0,2.0]},"_rankingScore":0.9848484848484848},{"title":"Shazam!","desc":"a Captain Marvel ersatz","id":"1","_vectors":{"default":[1.0,3.0]},"_rankingScore":0.9472135901451112}]"###);
+    snapshot!(response["semanticHitCount"], @"2");
 
     let (response, code) = index
         .search_post(
@@ -331,7 +331,7 @@ async fn query_combination() {
     .await;
 
     snapshot!(code, @"200 OK");
-    snapshot!(response["hits"], @r###"[{"title":"Captain Planet","desc":"He's not part of the Marvel Cinematic Universe","id":"2","_vectors":{"default":[1.0,2.0]},"_rankingScore":0.996969696969697},{"title":"Captain Marvel","desc":"a Shazam ersatz","id":"3","_vectors":{"default":[2.0,3.0]},"_rankingScore":0.996969696969697},{"title":"Shazam!","desc":"a Captain Marvel ersatz","id":"1","_vectors":{"default":[1.0,3.0]},"_rankingScore":0.8848484848484849}]"###);
+    snapshot!(response["hits"], @r###"[{"title":"Captain Planet","desc":"He's not part of the Marvel Cinematic Universe","id":"2","_vectors":{"default":[1.0,2.0]},"_rankingScore":0.9848484848484848},{"title":"Captain Marvel","desc":"a Shazam ersatz","id":"3","_vectors":{"default":[2.0,3.0]},"_rankingScore":0.9848484848484848},{"title":"Shazam!","desc":"a Captain Marvel ersatz","id":"1","_vectors":{"default":[1.0,3.0]},"_rankingScore":0.9242424242424242}]"###);
     snapshot!(response["semanticHitCount"], @"null");
 
     // query + vector, no hybrid keyword =>
@@ -374,6 +374,6 @@ async fn query_combination() {
         .await;
 
     snapshot!(code, @"200 OK");
-    snapshot!(response["hits"], @r###"[{"title":"Captain Planet","desc":"He's not part of the Marvel Cinematic Universe","id":"2","_vectors":{"default":[1.0,2.0]},"_rankingScore":0.9848484848484848}]"###);
+    snapshot!(response["hits"], @r###"[{"title":"Captain Planet","desc":"He's not part of the Marvel Cinematic Universe","id":"2","_vectors":{"default":[1.0,2.0]},"_rankingScore":0.9242424242424242}]"###);
     snapshot!(response["semanticHitCount"], @"0");
 }

--- a/meilisearch/tests/search/mod.rs
+++ b/meilisearch/tests/search/mod.rs
@@ -921,7 +921,7 @@ async fn test_score_details() {
                         "order": 3,
                         "attributeRankingOrderScore": 1.0,
                         "queryWordDistanceScore": 0.8095238095238095,
-                        "score": 0.9727891156462584
+                        "score": 0.8095238095238095
                       },
                       "exactness": {
                         "order": 4,

--- a/meilisearch/tests/search/restrict_searchable.rs
+++ b/meilisearch/tests/search/restrict_searchable.rs
@@ -285,10 +285,10 @@ async fn attributes_ranking_rule_order() {
                 @r###"
             [
               {
-                "id": "2"
+                "id": "1"
               },
               {
-                "id": "1"
+                "id": "2"
               }
             ]
             "###

--- a/milli/examples/search.rs
+++ b/milli/examples/search.rs
@@ -48,7 +48,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
             let start = Instant::now();
 
-            let mut ctx = SearchContext::new(&index, &txn);
+            let mut ctx = SearchContext::new(&index, &txn)?;
             let universe = filtered_universe(&ctx, &None)?;
 
             let docs = execute_search(

--- a/milli/src/error.rs
+++ b/milli/src/error.rs
@@ -32,6 +32,8 @@ pub enum InternalError {
     DatabaseClosing,
     #[error("Missing {} in the {db_name} database.", key.unwrap_or("key"))]
     DatabaseMissingEntry { db_name: &'static str, key: Option<&'static str> },
+    #[error("Missing {key} in the fieldids weights mapping.")]
+    FieldidsWeightsMapMissingEntry { key: FieldId },
     #[error(transparent)]
     FieldIdMapMissingEntry(#[from] FieldIdMapMissingEntry),
     #[error("Missing {key} in the field id mapping.")]

--- a/milli/src/fieldids_weights_map.rs
+++ b/milli/src/fieldids_weights_map.rs
@@ -1,3 +1,5 @@
+//! The fieldids weights map is in charge of storing linking the searchable fields with their weights.
+
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
@@ -10,22 +12,29 @@ pub struct FieldidsWeightsMap {
 }
 
 impl FieldidsWeightsMap {
+    /// Insert a field id -> weigth into the map.
+    /// If the map did not have this key present, `None` is returned.
+    /// If the map did have this key present, the value is updated, and the old value is returned.
     pub fn insert(&mut self, fid: FieldId, weight: Weight) -> Option<Weight> {
         self.map.insert(fid, weight)
     }
 
+    /// Removes a field id from the map, returning the associated weight previously in the map.
     pub fn remove(&mut self, fid: FieldId) -> Option<Weight> {
         self.map.remove(&fid)
     }
 
+    /// Returns weight corresponding to the key.
     pub fn weight(&self, fid: FieldId) -> Option<Weight> {
         self.map.get(&fid).copied()
     }
 
+    /// Returns highest weight contained in the map if any.
     pub fn max_weight(&self) -> Option<Weight> {
         self.map.values().copied().max()
     }
 
+    /// Return an iterator visiting all field ids in arbitrary order.
     pub fn ids(&self) -> impl Iterator<Item = FieldId> + '_ {
         self.map.keys().copied()
     }

--- a/milli/src/fieldids_weights_map.rs
+++ b/milli/src/fieldids_weights_map.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{FieldId, Weight};
+use crate::{FieldId, FieldsIdsMap, Weight};
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct FieldidsWeightsMap {
@@ -17,6 +17,13 @@ impl FieldidsWeightsMap {
     /// If the map did have this key present, the value is updated, and the old value is returned.
     pub fn insert(&mut self, fid: FieldId, weight: Weight) -> Option<Weight> {
         self.map.insert(fid, weight)
+    }
+
+    /// Create the map from the fields ids maps.
+    /// Should only be called in the case there are NO searchable attributes.
+    /// The weights and the fields ids will have the same values.
+    pub fn from_field_id_map_without_searchable(fid_map: &FieldsIdsMap) -> Self {
+        FieldidsWeightsMap { map: fid_map.ids().map(|fid| (fid, fid)).collect() }
     }
 
     /// Removes a field id from the map, returning the associated weight previously in the map.

--- a/milli/src/fieldids_weights_map.rs
+++ b/milli/src/fieldids_weights_map.rs
@@ -26,7 +26,7 @@ impl FieldidsWeightsMap {
         self.map.values().copied().max()
     }
 
-    pub fn ids<'a>(&'a self) -> impl Iterator<Item = FieldId> + 'a {
+    pub fn ids(&self) -> impl Iterator<Item = FieldId> + '_ {
         self.map.keys().copied()
     }
 }

--- a/milli/src/fieldids_weights_map.rs
+++ b/milli/src/fieldids_weights_map.rs
@@ -21,9 +21,9 @@ impl FieldidsWeightsMap {
 
     /// Create the map from the fields ids maps.
     /// Should only be called in the case there are NO searchable attributes.
-    /// The weights and the fields ids will have the same values.
+    /// All the fields will be inserted in the order of the fields ids map with a weight of 0.
     pub fn from_field_id_map_without_searchable(fid_map: &FieldsIdsMap) -> Self {
-        FieldidsWeightsMap { map: fid_map.ids().map(|fid| (fid, fid)).collect() }
+        FieldidsWeightsMap { map: fid_map.ids().map(|fid| (fid, 0)).collect() }
     }
 
     /// Removes a field id from the map, returning the associated weight previously in the map.

--- a/milli/src/fieldids_weights_map.rs
+++ b/milli/src/fieldids_weights_map.rs
@@ -1,0 +1,28 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{FieldId, Weight};
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct FieldidsWeightsMap {
+    map: HashMap<FieldId, Weight>,
+}
+
+impl FieldidsWeightsMap {
+    pub fn insert(&mut self, fid: FieldId, weight: Weight) -> Option<Weight> {
+        self.map.insert(fid, weight)
+    }
+
+    pub fn remove(&mut self, fid: FieldId) -> Option<Weight> {
+        self.map.remove(&fid)
+    }
+
+    pub fn weight(&self, fid: FieldId) -> Option<Weight> {
+        self.map.get(&fid).copied()
+    }
+
+    pub fn max_weight(&self) -> Option<Weight> {
+        self.map.values().copied().max()
+    }
+}

--- a/milli/src/fieldids_weights_map.rs
+++ b/milli/src/fieldids_weights_map.rs
@@ -25,4 +25,8 @@ impl FieldidsWeightsMap {
     pub fn max_weight(&self) -> Option<Weight> {
         self.map.values().copied().max()
     }
+
+    pub fn ids<'a>(&'a self) -> impl Iterator<Item = FieldId> + 'a {
+        self.map.keys().copied()
+    }
 }

--- a/milli/src/index.rs
+++ b/milli/src/index.rs
@@ -2722,8 +2722,8 @@ pub(crate) mod tests {
         // We should find tamo first
         insta::assert_debug_snapshot!(results.documents_ids, @r###"
         [
-            0,
             1,
+            0,
         ]
         "###);
     }

--- a/milli/src/index.rs
+++ b/milli/src/index.rs
@@ -632,7 +632,7 @@ impl Index {
         // Special case if there is no user defined fields.
         // Then the whole field id map is marked as searchable.
         if user_fields.is_none() {
-            let mut weights = self.fieldids_weights_map(&wtxn)?;
+            let mut weights = self.fieldids_weights_map(wtxn)?;
             let mut searchable = Vec::new();
             for (weight, (fid, name)) in fields_ids_map.iter().enumerate() {
                 searchable.push(name);
@@ -648,7 +648,7 @@ impl Index {
         // We can write the user defined searchable fields as-is.
         self.put_user_defined_searchable_fields(wtxn, user_fields)?;
 
-        let mut weights = self.fieldids_weights_map(&wtxn)?;
+        let mut weights = self.fieldids_weights_map(wtxn)?;
 
         // Now we generate the real searchable fields:
         // 1. Take the user defined searchable fields as-is to keep the priority defined by the attributes criterion.
@@ -666,7 +666,7 @@ impl Index {
 
                     let weight: u16 =
                         weight.try_into().map_err(|_| UserError::AttributeLimitReached)?;
-                    weights.insert(id, weight as u16);
+                    weights.insert(id, weight);
                 }
             }
         }
@@ -701,7 +701,7 @@ impl Index {
         self.main
             .remap_types::<Str, SerdeBincode<Vec<&'t str>>>()
             .get(rtxn, main_key::SEARCHABLE_FIELDS_KEY)?
-            .map(|fields| Ok(fields.into_iter().map(|field| Cow::Borrowed(field)).collect()))
+            .map(|fields| Ok(fields.into_iter().map(Cow::Borrowed).collect()))
             .unwrap_or_else(|| {
                 Ok(self
                     .fields_ids_map(rtxn)?

--- a/milli/src/index.rs
+++ b/milli/src/index.rs
@@ -2662,17 +2662,18 @@ pub(crate) mod tests {
                 settings.set_filterable_fields(HashSet::from([S("age")]));
             })
             .unwrap();
+        // The order of the field id map shouldn't change
         db_snap!(index, fields_ids_map, @r###"
         0   name             |
-        1   realName         |
-        2   id               |
-        3   age              |
+        1   id               |
+        2   age              |
+        3   realName         |
         "###);
         db_snap!(index, searchable_fields, @r###"["name", "realName"]"###);
         db_snap!(index, fieldids_weights_map, @r###"
         fid weight
         0   0   |
-        1   1   |
+        3   1   |
         "###);
     }
 }

--- a/milli/src/index.rs
+++ b/milli/src/index.rs
@@ -2492,7 +2492,7 @@ pub(crate) mod tests {
         db_snap!(index, fieldids_weights_map, @r###"
         fid weight
         0   0   |
-        1   1   |
+        1   0   |
         "###);
 
         index.delete_documents(Default::default());
@@ -2512,7 +2512,7 @@ pub(crate) mod tests {
         db_snap!(index, fieldids_weights_map, @r###"
         fid weight
         0   0   |
-        1   1   |
+        1   0   |
         "###);
 
         index
@@ -2537,7 +2537,7 @@ pub(crate) mod tests {
         db_snap!(index, fieldids_weights_map, @r###"
         fid weight
         0   0   |
-        1   1   |
+        1   0   |
         "###);
 
         let rtxn = index.read_txn().unwrap();

--- a/milli/src/lib.rs
+++ b/milli/src/lib.rs
@@ -28,6 +28,7 @@ pub mod vector;
 #[cfg(test)]
 #[macro_use]
 pub mod snapshot_tests;
+mod fieldids_weights_map;
 
 use std::collections::{BTreeMap, HashMap};
 use std::convert::{TryFrom, TryInto};
@@ -52,6 +53,7 @@ pub use self::error::{
     Error, FieldIdMapMissingEntry, InternalError, SerializationError, UserError,
 };
 pub use self::external_documents_ids::ExternalDocumentsIds;
+pub use self::fieldids_weights_map::FieldidsWeightsMap;
 pub use self::fields_ids_map::FieldsIdsMap;
 pub use self::heed_codec::{
     BEU16StrCodec, BEU32StrCodec, BoRoaringBitmapCodec, BoRoaringBitmapLenCodec,
@@ -77,6 +79,7 @@ pub type FastMap4<K, V> = HashMap<K, V, BuildHasherDefault<FxHasher32>>;
 pub type FastMap8<K, V> = HashMap<K, V, BuildHasherDefault<FxHasher64>>;
 pub type FieldDistribution = BTreeMap<String, u64>;
 pub type FieldId = u16;
+pub type Weight = u16;
 pub type Object = serde_json::Map<String, serde_json::Value>;
 pub type Position = u32;
 pub type RelativePosition = u16;

--- a/milli/src/search/mod.rs
+++ b/milli/src/search/mod.rs
@@ -147,7 +147,7 @@ impl<'a> Search<'a> {
 
     pub fn execute_for_candidates(&self, has_vector_search: bool) -> Result<RoaringBitmap> {
         if has_vector_search {
-            let ctx = SearchContext::new(self.index, self.rtxn);
+            let ctx = SearchContext::new(self.index, self.rtxn)?;
             filtered_universe(&ctx, &self.filter)
         } else {
             Ok(self.execute()?.candidates)
@@ -155,7 +155,7 @@ impl<'a> Search<'a> {
     }
 
     pub fn execute(&self) -> Result<SearchResult> {
-        let mut ctx = SearchContext::new(self.index, self.rtxn);
+        let mut ctx = SearchContext::new(self.index, self.rtxn)?;
 
         if let Some(searchable_attributes) = self.searchable_attributes {
             ctx.searchable_attributes(searchable_attributes)?;

--- a/milli/src/search/mod.rs
+++ b/milli/src/search/mod.rs
@@ -158,7 +158,7 @@ impl<'a> Search<'a> {
         let mut ctx = SearchContext::new(self.index, self.rtxn)?;
 
         if let Some(searchable_attributes) = self.searchable_attributes {
-            ctx.searchable_attributes(searchable_attributes)?;
+            ctx.attributes_to_search_on(searchable_attributes)?;
         }
 
         let universe = filtered_universe(&ctx, &self.filter)?;

--- a/milli/src/search/new/bucket_sort.rs
+++ b/milli/src/search/new/bucket_sort.rs
@@ -101,7 +101,7 @@ pub fn bucket_sort<'ctx, Q: RankingRuleQueryTrait>(
 
     let mut ranking_rule_universes: Vec<RoaringBitmap> =
         vec![RoaringBitmap::default(); ranking_rules_len];
-    ranking_rule_universes[0] = universe.clone();
+    ranking_rule_universes[0].clone_from(universe);
     let mut cur_ranking_rule_index = 0;
 
     /// Finish iterating over the current ranking rule, yielding
@@ -232,7 +232,7 @@ pub fn bucket_sort<'ctx, Q: RankingRuleQueryTrait>(
         }
 
         cur_ranking_rule_index += 1;
-        ranking_rule_universes[cur_ranking_rule_index] = next_bucket.candidates.clone();
+        ranking_rule_universes[cur_ranking_rule_index].clone_from(&next_bucket.candidates);
         logger.start_iteration_ranking_rule(
             cur_ranking_rule_index,
             ranking_rules[cur_ranking_rule_index].as_ref(),

--- a/milli/src/search/new/db_cache.rs
+++ b/milli/src/search/new/db_cache.rs
@@ -159,36 +159,58 @@ impl<'ctx> SearchContext<'ctx> {
 
     /// Retrieve or insert the given value in the `word_docids` database.
     fn get_db_word_docids(&mut self, word: Interned<String>) -> Result<Option<RoaringBitmap>> {
-        let interned = self.word_interner.get(word).as_str();
-        let keys: Vec<_> =
-            self.searchable_fids.tolerant.iter().map(|(fid, _weight)| (interned, *fid)).collect();
+        match &self.restricted_fids {
+            Some(restricted_fids) => {
+                let interned = self.word_interner.get(word).as_str();
+                let keys: Vec<_> =
+                    restricted_fids.tolerant.iter().map(|(fid, _)| (interned, *fid)).collect();
 
-        DatabaseCache::get_value_from_keys::<_, _, CboRoaringBitmapCodec>(
-            self.txn,
-            word,
-            &keys[..],
-            &mut self.db_cache.word_docids,
-            self.index.word_fid_docids.remap_data_type::<Bytes>(),
-            merge_cbo_roaring_bitmaps,
-        )
+                DatabaseCache::get_value_from_keys::<_, _, CboRoaringBitmapCodec>(
+                    self.txn,
+                    word,
+                    &keys[..],
+                    &mut self.db_cache.word_docids,
+                    self.index.word_fid_docids.remap_data_type::<Bytes>(),
+                    merge_cbo_roaring_bitmaps,
+                )
+            }
+            None => DatabaseCache::get_value::<_, _, CboRoaringBitmapCodec>(
+                self.txn,
+                word,
+                self.word_interner.get(word).as_str(),
+                &mut self.db_cache.word_docids,
+                self.index.word_docids.remap_data_type::<Bytes>(),
+            ),
+        }
     }
 
     fn get_db_exact_word_docids(
         &mut self,
         word: Interned<String>,
     ) -> Result<Option<RoaringBitmap>> {
-        let interned = self.word_interner.get(word).as_str();
-        let keys: Vec<_> =
-            self.searchable_fids.exact.iter().map(|(fid, _weight)| (interned, *fid)).collect();
+        match &self.restricted_fids {
+            Some(restricted_fids) => {
+                let interned = self.word_interner.get(word).as_str();
+                let keys: Vec<_> =
+                    restricted_fids.exact.iter().map(|(fid, _)| (interned, *fid)).collect();
 
-        DatabaseCache::get_value_from_keys::<_, _, CboRoaringBitmapCodec>(
-            self.txn,
-            word,
-            &keys[..],
-            &mut self.db_cache.exact_word_docids,
-            self.index.word_fid_docids.remap_data_type::<Bytes>(),
-            merge_cbo_roaring_bitmaps,
-        )
+                DatabaseCache::get_value_from_keys::<_, _, CboRoaringBitmapCodec>(
+                    self.txn,
+                    word,
+                    &keys[..],
+                    &mut self.db_cache.exact_word_docids,
+                    self.index.word_fid_docids.remap_data_type::<Bytes>(),
+                    merge_cbo_roaring_bitmaps,
+                )
+            }
+            None => DatabaseCache::get_value::<_, _, CboRoaringBitmapCodec>(
+                self.txn,
+                word,
+                self.word_interner.get(word).as_str(),
+                &mut self.db_cache.exact_word_docids,
+                self.index.exact_word_docids.remap_data_type::<Bytes>(),
+            ),
+        }
     }
 
     pub fn word_prefix_docids(&mut self, prefix: Word) -> Result<Option<RoaringBitmap>> {
@@ -216,36 +238,58 @@ impl<'ctx> SearchContext<'ctx> {
         &mut self,
         prefix: Interned<String>,
     ) -> Result<Option<RoaringBitmap>> {
-        let interned = self.word_interner.get(prefix).as_str();
-        let keys: Vec<_> =
-            self.searchable_fids.tolerant.iter().map(|(fid, _weight)| (interned, *fid)).collect();
+        match &self.restricted_fids {
+            Some(restricted_fids) => {
+                let interned = self.word_interner.get(prefix).as_str();
+                let keys: Vec<_> =
+                    restricted_fids.tolerant.iter().map(|(fid, _)| (interned, *fid)).collect();
 
-        DatabaseCache::get_value_from_keys::<_, _, CboRoaringBitmapCodec>(
-            self.txn,
-            prefix,
-            &keys[..],
-            &mut self.db_cache.word_prefix_docids,
-            self.index.word_prefix_fid_docids.remap_data_type::<Bytes>(),
-            merge_cbo_roaring_bitmaps,
-        )
+                DatabaseCache::get_value_from_keys::<_, _, CboRoaringBitmapCodec>(
+                    self.txn,
+                    prefix,
+                    &keys[..],
+                    &mut self.db_cache.word_prefix_docids,
+                    self.index.word_prefix_fid_docids.remap_data_type::<Bytes>(),
+                    merge_cbo_roaring_bitmaps,
+                )
+            }
+            None => DatabaseCache::get_value::<_, _, CboRoaringBitmapCodec>(
+                self.txn,
+                prefix,
+                self.word_interner.get(prefix).as_str(),
+                &mut self.db_cache.word_prefix_docids,
+                self.index.word_prefix_docids.remap_data_type::<Bytes>(),
+            ),
+        }
     }
 
     fn get_db_exact_word_prefix_docids(
         &mut self,
         prefix: Interned<String>,
     ) -> Result<Option<RoaringBitmap>> {
-        let interned = self.word_interner.get(prefix).as_str();
-        let keys: Vec<_> =
-            self.searchable_fids.exact.iter().map(|(fid, _weight)| (interned, *fid)).collect();
+        match &self.restricted_fids {
+            Some(restricted_fids) => {
+                let interned = self.word_interner.get(prefix).as_str();
+                let keys: Vec<_> =
+                    restricted_fids.exact.iter().map(|(fid, _)| (interned, *fid)).collect();
 
-        DatabaseCache::get_value_from_keys::<_, _, CboRoaringBitmapCodec>(
-            self.txn,
-            prefix,
-            &keys[..],
-            &mut self.db_cache.exact_word_prefix_docids,
-            self.index.word_prefix_fid_docids.remap_data_type::<Bytes>(),
-            merge_cbo_roaring_bitmaps,
-        )
+                DatabaseCache::get_value_from_keys::<_, _, CboRoaringBitmapCodec>(
+                    self.txn,
+                    prefix,
+                    &keys[..],
+                    &mut self.db_cache.exact_word_prefix_docids,
+                    self.index.word_prefix_fid_docids.remap_data_type::<Bytes>(),
+                    merge_cbo_roaring_bitmaps,
+                )
+            }
+            None => DatabaseCache::get_value::<_, _, CboRoaringBitmapCodec>(
+                self.txn,
+                prefix,
+                self.word_interner.get(prefix).as_str(),
+                &mut self.db_cache.exact_word_prefix_docids,
+                self.index.exact_word_prefix_docids.remap_data_type::<Bytes>(),
+            ),
+        }
     }
 
     pub fn get_db_word_pair_proximity_docids(
@@ -421,8 +465,8 @@ impl<'ctx> SearchContext<'ctx> {
         word: Interned<String>,
         fid: u16,
     ) -> Result<Option<RoaringBitmap>> {
-        // if the requested fid isn't in the list of searchable, return None.
-        if !self.searchable_fids.contains(&fid) {
+        // if the requested fid isn't in the restricted list, return None.
+        if self.restricted_fids.as_ref().map_or(false, |fids| !fids.contains(&fid)) {
             return Ok(None);
         }
 
@@ -440,8 +484,8 @@ impl<'ctx> SearchContext<'ctx> {
         word_prefix: Interned<String>,
         fid: u16,
     ) -> Result<Option<RoaringBitmap>> {
-        // if the requested fid isn't in the searchable list, return None.
-        if !self.searchable_fids.contains(&fid) {
+        // if the requested fid isn't in the restricted list, return None.
+        if self.restricted_fids.as_ref().map_or(false, |fids| !fids.contains(&fid)) {
             return Ok(None);
         }
 

--- a/milli/src/search/new/db_cache.rs
+++ b/milli/src/search/new/db_cache.rs
@@ -315,11 +315,7 @@ impl<'ctx> SearchContext<'ctx> {
                         .map_err(heed::Error::Decoding)?
                 } else {
                     // Compute the distance at the attribute level and store it in the cache.
-                    let fids = if let Some(fids) = self.index.searchable_fields_ids(self.txn)? {
-                        fids
-                    } else {
-                        self.index.fields_ids_map(self.txn)?.ids().collect()
-                    };
+                    let fids = self.index.searchable_fields_ids(self.txn)?;
                     let mut docids = RoaringBitmap::new();
                     for fid in fids {
                         // for each field, intersect left word bitmap and right word bitmap,
@@ -408,11 +404,7 @@ impl<'ctx> SearchContext<'ctx> {
             let prefix_docids = match proximity_precision {
                 ProximityPrecision::ByAttribute => {
                     // Compute the distance at the attribute level and store it in the cache.
-                    let fids = if let Some(fids) = self.index.searchable_fields_ids(self.txn)? {
-                        fids
-                    } else {
-                        self.index.fields_ids_map(self.txn)?.ids().collect()
-                    };
+                    let fids = self.index.searchable_fields_ids(self.txn)?;
                     let mut prefix_docids = RoaringBitmap::new();
                     // for each field, intersect left word bitmap and right word bitmap,
                     // then merge the result in a global bitmap before storing it in the cache.

--- a/milli/src/search/new/db_cache.rs
+++ b/milli/src/search/new/db_cache.rs
@@ -159,58 +159,36 @@ impl<'ctx> SearchContext<'ctx> {
 
     /// Retrieve or insert the given value in the `word_docids` database.
     fn get_db_word_docids(&mut self, word: Interned<String>) -> Result<Option<RoaringBitmap>> {
-        match &self.restricted_fids {
-            Some(restricted_fids) => {
-                let interned = self.word_interner.get(word).as_str();
-                let keys: Vec<_> =
-                    restricted_fids.tolerant.iter().map(|fid| (interned, *fid)).collect();
+        let interned = self.word_interner.get(word).as_str();
+        let keys: Vec<_> =
+            self.searchable_fids.tolerant.iter().map(|(fid, _weight)| (interned, *fid)).collect();
 
-                DatabaseCache::get_value_from_keys::<_, _, CboRoaringBitmapCodec>(
-                    self.txn,
-                    word,
-                    &keys[..],
-                    &mut self.db_cache.word_docids,
-                    self.index.word_fid_docids.remap_data_type::<Bytes>(),
-                    merge_cbo_roaring_bitmaps,
-                )
-            }
-            None => DatabaseCache::get_value::<_, _, CboRoaringBitmapCodec>(
-                self.txn,
-                word,
-                self.word_interner.get(word).as_str(),
-                &mut self.db_cache.word_docids,
-                self.index.word_docids.remap_data_type::<Bytes>(),
-            ),
-        }
+        DatabaseCache::get_value_from_keys::<_, _, CboRoaringBitmapCodec>(
+            self.txn,
+            word,
+            &keys[..],
+            &mut self.db_cache.word_docids,
+            self.index.word_fid_docids.remap_data_type::<Bytes>(),
+            merge_cbo_roaring_bitmaps,
+        )
     }
 
     fn get_db_exact_word_docids(
         &mut self,
         word: Interned<String>,
     ) -> Result<Option<RoaringBitmap>> {
-        match &self.restricted_fids {
-            Some(restricted_fids) => {
-                let interned = self.word_interner.get(word).as_str();
-                let keys: Vec<_> =
-                    restricted_fids.exact.iter().map(|fid| (interned, *fid)).collect();
+        let interned = self.word_interner.get(word).as_str();
+        let keys: Vec<_> =
+            self.searchable_fids.exact.iter().map(|(fid, _weight)| (interned, *fid)).collect();
 
-                DatabaseCache::get_value_from_keys::<_, _, CboRoaringBitmapCodec>(
-                    self.txn,
-                    word,
-                    &keys[..],
-                    &mut self.db_cache.exact_word_docids,
-                    self.index.word_fid_docids.remap_data_type::<Bytes>(),
-                    merge_cbo_roaring_bitmaps,
-                )
-            }
-            None => DatabaseCache::get_value::<_, _, CboRoaringBitmapCodec>(
-                self.txn,
-                word,
-                self.word_interner.get(word).as_str(),
-                &mut self.db_cache.exact_word_docids,
-                self.index.exact_word_docids.remap_data_type::<Bytes>(),
-            ),
-        }
+        DatabaseCache::get_value_from_keys::<_, _, CboRoaringBitmapCodec>(
+            self.txn,
+            word,
+            &keys[..],
+            &mut self.db_cache.exact_word_docids,
+            self.index.word_fid_docids.remap_data_type::<Bytes>(),
+            merge_cbo_roaring_bitmaps,
+        )
     }
 
     pub fn word_prefix_docids(&mut self, prefix: Word) -> Result<Option<RoaringBitmap>> {
@@ -238,58 +216,36 @@ impl<'ctx> SearchContext<'ctx> {
         &mut self,
         prefix: Interned<String>,
     ) -> Result<Option<RoaringBitmap>> {
-        match &self.restricted_fids {
-            Some(restricted_fids) => {
-                let interned = self.word_interner.get(prefix).as_str();
-                let keys: Vec<_> =
-                    restricted_fids.tolerant.iter().map(|fid| (interned, *fid)).collect();
+        let interned = self.word_interner.get(prefix).as_str();
+        let keys: Vec<_> =
+            self.searchable_fids.tolerant.iter().map(|(fid, _weight)| (interned, *fid)).collect();
 
-                DatabaseCache::get_value_from_keys::<_, _, CboRoaringBitmapCodec>(
-                    self.txn,
-                    prefix,
-                    &keys[..],
-                    &mut self.db_cache.word_prefix_docids,
-                    self.index.word_prefix_fid_docids.remap_data_type::<Bytes>(),
-                    merge_cbo_roaring_bitmaps,
-                )
-            }
-            None => DatabaseCache::get_value::<_, _, CboRoaringBitmapCodec>(
-                self.txn,
-                prefix,
-                self.word_interner.get(prefix).as_str(),
-                &mut self.db_cache.word_prefix_docids,
-                self.index.word_prefix_docids.remap_data_type::<Bytes>(),
-            ),
-        }
+        DatabaseCache::get_value_from_keys::<_, _, CboRoaringBitmapCodec>(
+            self.txn,
+            prefix,
+            &keys[..],
+            &mut self.db_cache.word_prefix_docids,
+            self.index.word_prefix_fid_docids.remap_data_type::<Bytes>(),
+            merge_cbo_roaring_bitmaps,
+        )
     }
 
     fn get_db_exact_word_prefix_docids(
         &mut self,
         prefix: Interned<String>,
     ) -> Result<Option<RoaringBitmap>> {
-        match &self.restricted_fids {
-            Some(restricted_fids) => {
-                let interned = self.word_interner.get(prefix).as_str();
-                let keys: Vec<_> =
-                    restricted_fids.exact.iter().map(|fid| (interned, *fid)).collect();
+        let interned = self.word_interner.get(prefix).as_str();
+        let keys: Vec<_> =
+            self.searchable_fids.exact.iter().map(|(fid, _weight)| (interned, *fid)).collect();
 
-                DatabaseCache::get_value_from_keys::<_, _, CboRoaringBitmapCodec>(
-                    self.txn,
-                    prefix,
-                    &keys[..],
-                    &mut self.db_cache.exact_word_prefix_docids,
-                    self.index.word_prefix_fid_docids.remap_data_type::<Bytes>(),
-                    merge_cbo_roaring_bitmaps,
-                )
-            }
-            None => DatabaseCache::get_value::<_, _, CboRoaringBitmapCodec>(
-                self.txn,
-                prefix,
-                self.word_interner.get(prefix).as_str(),
-                &mut self.db_cache.exact_word_prefix_docids,
-                self.index.exact_word_prefix_docids.remap_data_type::<Bytes>(),
-            ),
-        }
+        DatabaseCache::get_value_from_keys::<_, _, CboRoaringBitmapCodec>(
+            self.txn,
+            prefix,
+            &keys[..],
+            &mut self.db_cache.exact_word_prefix_docids,
+            self.index.word_prefix_fid_docids.remap_data_type::<Bytes>(),
+            merge_cbo_roaring_bitmaps,
+        )
     }
 
     pub fn get_db_word_pair_proximity_docids(
@@ -465,8 +421,8 @@ impl<'ctx> SearchContext<'ctx> {
         word: Interned<String>,
         fid: u16,
     ) -> Result<Option<RoaringBitmap>> {
-        // if the requested fid isn't in the restricted list, return None.
-        if self.restricted_fids.as_ref().map_or(false, |fids| !fids.contains(&fid)) {
+        // if the requested fid isn't in the list of searchable, return None.
+        if !self.searchable_fids.contains(&fid) {
             return Ok(None);
         }
 
@@ -484,8 +440,8 @@ impl<'ctx> SearchContext<'ctx> {
         word_prefix: Interned<String>,
         fid: u16,
     ) -> Result<Option<RoaringBitmap>> {
-        // if the requested fid isn't in the restricted list, return None.
-        if self.restricted_fids.as_ref().map_or(false, |fids| !fids.contains(&fid)) {
+        // if the requested fid isn't in the searchable list, return None.
+        if !self.searchable_fids.contains(&fid) {
             return Ok(None);
         }
 

--- a/milli/src/search/new/exact_attribute.rs
+++ b/milli/src/search/new/exact_attribute.rs
@@ -184,13 +184,7 @@ impl State {
             return Ok(State::Empty(query_graph.clone()));
         }
 
-        let searchable_fields_ids = {
-            if let Some(fids) = ctx.index.searchable_fields_ids(ctx.txn)? {
-                fids
-            } else {
-                ctx.index.fields_ids_map(ctx.txn)?.ids().collect()
-            }
-        };
+        let searchable_fields_ids = ctx.index.searchable_fields_ids(ctx.txn)?;
 
         let mut candidates_per_attribute = Vec::with_capacity(searchable_fields_ids.len());
         // then check that there exists at least one attribute that has all of the terms

--- a/milli/src/search/new/matches/matching_words.rs
+++ b/milli/src/search/new/matches/matching_words.rs
@@ -258,7 +258,7 @@ pub(crate) mod tests {
     fn matching_words() {
         let temp_index = temp_index_with_documents();
         let rtxn = temp_index.read_txn().unwrap();
-        let mut ctx = SearchContext::new(&temp_index, &rtxn);
+        let mut ctx = SearchContext::new(&temp_index, &rtxn).unwrap();
         let mut builder = TokenizerBuilder::default();
         let tokenizer = builder.build();
         let tokens = tokenizer.tokenize("split this world");

--- a/milli/src/search/new/matches/mod.rs
+++ b/milli/src/search/new/matches/mod.rs
@@ -506,7 +506,7 @@ mod tests {
 
     impl<'a> MatcherBuilder<'a> {
         fn new_test(rtxn: &'a heed::RoTxn, index: &'a TempIndex, query: &str) -> Self {
-            let mut ctx = SearchContext::new(index, rtxn);
+            let mut ctx = SearchContext::new(index, rtxn).unwrap();
             let universe = filtered_universe(&ctx, &None).unwrap();
             let crate::search::PartialSearchResult { located_query_terms, .. } = execute_search(
                 &mut ctx,

--- a/milli/src/search/new/mod.rs
+++ b/milli/src/search/new/mod.rs
@@ -178,8 +178,7 @@ pub struct SearchableFids {
 
 impl SearchableFids {
     pub fn contains(&self, fid: &FieldId) -> bool {
-        self.tolerant.iter().find(|(id, _)| id == fid).is_some()
-            || self.exact.iter().find(|(id, _)| id == fid).is_some()
+        self.tolerant.iter().any(|(id, _)| id == fid) || self.exact.iter().any(|(id, _)| id == fid)
     }
 }
 

--- a/milli/src/search/new/query_term/parse_query.rs
+++ b/milli/src/search/new/query_term/parse_query.rs
@@ -366,7 +366,7 @@ mod tests {
         let tokens = tokenizer.tokenize(".");
         let index = temp_index_with_documents();
         let rtxn = index.read_txn()?;
-        let mut ctx = SearchContext::new(&index, &rtxn);
+        let mut ctx = SearchContext::new(&index, &rtxn)?;
         // panics with `attempt to add with overflow` before <https://github.com/meilisearch/meilisearch/issues/3785>
         let ExtractedTokens { query_terms, .. } =
             located_query_terms_from_tokens(&mut ctx, tokens, None)?;

--- a/milli/src/search/new/ranking_rule_graph/fid/mod.rs
+++ b/milli/src/search/new/ranking_rule_graph/fid/mod.rs
@@ -77,17 +77,7 @@ impl RankingRuleGraphTrait for FidGraph {
         }
 
         // always lookup the max_fid if we don't already and add an artificial condition for max scoring
-        let max_fid: Option<u16> = {
-            if let Some(max_fid) = ctx
-                .index
-                .searchable_fields_ids(ctx.txn)?
-                .map(|field_ids| field_ids.into_iter().max())
-            {
-                max_fid
-            } else {
-                ctx.index.fields_ids_map(ctx.txn)?.ids().max()
-            }
-        };
+        let max_fid: Option<u16> = ctx.index.searchable_fields_ids(ctx.txn)?.into_iter().max();
 
         if let Some(max_fid) = max_fid {
             if !all_fields.contains(&max_fid) {

--- a/milli/src/search/new/tests/attribute_fid.rs
+++ b/milli/src/search/new/tests/attribute_fid.rs
@@ -132,17 +132,17 @@ fn test_attribute_fid_simple() {
 fn test_attribute_fid_ngrams() {
     let index = create_index();
     db_snap!(index, fields_ids_map, @r###"
-    0   title            |
-    1   description      |
-    2   plot             |
-    3   id               |
+    0   id               |
+    1   title            |
+    2   description      |
+    3   plot             |
     "###);
     db_snap!(index, searchable_fields, @r###"["title", "description", "plot"]"###);
     db_snap!(index, fieldids_weights_map, @r###"
     fid weight
-    0   0   |
-    1   1   |
-    2   2   |
+    1   0   |
+    2   1   |
+    3   2   |
     "###);
 
     let txn = index.read_txn().unwrap();

--- a/milli/src/search/new/tests/attribute_fid.rs
+++ b/milli/src/search/new/tests/attribute_fid.rs
@@ -1,5 +1,5 @@
 use crate::index::tests::TempIndex;
-use crate::{Criterion, Search, SearchResult, TermsMatchingStrategy};
+use crate::{db_snap, Criterion, Search, SearchResult, TermsMatchingStrategy};
 
 fn create_index() -> TempIndex {
     let index = TempIndex::new();
@@ -131,6 +131,19 @@ fn test_attribute_fid_simple() {
 #[test]
 fn test_attribute_fid_ngrams() {
     let index = create_index();
+    db_snap!(index, fields_ids_map, @r###"
+    0   title            |
+    1   description      |
+    2   plot             |
+    3   id               |
+    "###);
+    db_snap!(index, searchable_fields, @r###"["title", "description", "plot"]"###);
+    db_snap!(index, fieldids_weights_map, @r###"
+    fid weight
+    0   0   |
+    1   1   |
+    2   2   |
+    "###);
 
     let txn = index.read_txn().unwrap();
 

--- a/milli/src/search/new/tests/snapshots/milli__search__new__tests__attribute_fid__attribute_fid_ngrams-4.snap
+++ b/milli/src/search/new/tests/snapshots/milli__search__new__tests__attribute_fid__attribute_fid_ngrams-4.snap
@@ -1,0 +1,244 @@
+---
+source: milli/src/search/new/tests/attribute_fid.rs
+expression: "format!(\"{document_ids_scores:#?}\")"
+---
+[
+    (
+        2,
+        [
+            Fid(
+                Rank {
+                    rank: 19,
+                    max_rank: 19,
+                },
+            ),
+            Position(
+                Rank {
+                    rank: 91,
+                    max_rank: 91,
+                },
+            ),
+        ],
+    ),
+    (
+        6,
+        [
+            Fid(
+                Rank {
+                    rank: 15,
+                    max_rank: 19,
+                },
+            ),
+            Position(
+                Rank {
+                    rank: 81,
+                    max_rank: 91,
+                },
+            ),
+        ],
+    ),
+    (
+        5,
+        [
+            Fid(
+                Rank {
+                    rank: 14,
+                    max_rank: 19,
+                },
+            ),
+            Position(
+                Rank {
+                    rank: 79,
+                    max_rank: 91,
+                },
+            ),
+        ],
+    ),
+    (
+        4,
+        [
+            Fid(
+                Rank {
+                    rank: 13,
+                    max_rank: 19,
+                },
+            ),
+            Position(
+                Rank {
+                    rank: 77,
+                    max_rank: 91,
+                },
+            ),
+        ],
+    ),
+    (
+        3,
+        [
+            Fid(
+                Rank {
+                    rank: 12,
+                    max_rank: 19,
+                },
+            ),
+            Position(
+                Rank {
+                    rank: 83,
+                    max_rank: 91,
+                },
+            ),
+        ],
+    ),
+    (
+        9,
+        [
+            Fid(
+                Rank {
+                    rank: 11,
+                    max_rank: 19,
+                },
+            ),
+            Position(
+                Rank {
+                    rank: 75,
+                    max_rank: 91,
+                },
+            ),
+        ],
+    ),
+    (
+        8,
+        [
+            Fid(
+                Rank {
+                    rank: 10,
+                    max_rank: 19,
+                },
+            ),
+            Position(
+                Rank {
+                    rank: 79,
+                    max_rank: 91,
+                },
+            ),
+        ],
+    ),
+    (
+        7,
+        [
+            Fid(
+                Rank {
+                    rank: 10,
+                    max_rank: 19,
+                },
+            ),
+            Position(
+                Rank {
+                    rank: 73,
+                    max_rank: 91,
+                },
+            ),
+        ],
+    ),
+    (
+        11,
+        [
+            Fid(
+                Rank {
+                    rank: 7,
+                    max_rank: 19,
+                },
+            ),
+            Position(
+                Rank {
+                    rank: 77,
+                    max_rank: 91,
+                },
+            ),
+        ],
+    ),
+    (
+        10,
+        [
+            Fid(
+                Rank {
+                    rank: 6,
+                    max_rank: 19,
+                },
+            ),
+            Position(
+                Rank {
+                    rank: 81,
+                    max_rank: 91,
+                },
+            ),
+        ],
+    ),
+    (
+        13,
+        [
+            Fid(
+                Rank {
+                    rank: 6,
+                    max_rank: 19,
+                },
+            ),
+            Position(
+                Rank {
+                    rank: 81,
+                    max_rank: 91,
+                },
+            ),
+        ],
+    ),
+    (
+        12,
+        [
+            Fid(
+                Rank {
+                    rank: 6,
+                    max_rank: 19,
+                },
+            ),
+            Position(
+                Rank {
+                    rank: 78,
+                    max_rank: 91,
+                },
+            ),
+        ],
+    ),
+    (
+        14,
+        [
+            Fid(
+                Rank {
+                    rank: 5,
+                    max_rank: 19,
+                },
+            ),
+            Position(
+                Rank {
+                    rank: 75,
+                    max_rank: 91,
+                },
+            ),
+        ],
+    ),
+    (
+        0,
+        [
+            Fid(
+                Rank {
+                    rank: 1,
+                    max_rank: 19,
+                },
+            ),
+            Position(
+                Rank {
+                    rank: 91,
+                    max_rank: 91,
+                },
+            ),
+        ],
+    ),
+]

--- a/milli/src/snapshot_tests.rs
+++ b/milli/src/snapshot_tests.rs
@@ -308,6 +308,25 @@ pub fn snap_fields_ids_map(index: &Index) -> String {
     }
     snap
 }
+pub fn snap_fieldids_weights_map(index: &Index) -> String {
+    let rtxn = index.read_txn().unwrap();
+    let weights_map = index.fieldids_weights_map(&rtxn).unwrap();
+
+    let mut snap = String::new();
+    writeln!(&mut snap, "fid weight").unwrap();
+    let mut field_ids: Vec<_> = weights_map.ids().collect();
+    field_ids.sort();
+    for field_id in field_ids {
+        let weight = weights_map.weight(field_id).unwrap();
+        writeln!(&mut snap, "{field_id:<3} {weight:<3} |").unwrap();
+    }
+    snap
+}
+pub fn snap_searchable_fields(index: &Index) -> String {
+    let rtxn = index.read_txn().unwrap();
+    let searchable_fields = index.searchable_fields(&rtxn).unwrap();
+    format!("{searchable_fields:?}")
+}
 pub fn snap_geo_faceted_documents_ids(index: &Index) -> String {
     let rtxn = index.read_txn().unwrap();
     let geo_faceted_documents_ids = index.geo_faceted_documents_ids(&rtxn).unwrap();
@@ -468,6 +487,12 @@ macro_rules! full_snap_of_db {
     }};
     ($index:ident, fields_ids_map) => {{
         $crate::snapshot_tests::snap_fields_ids_map(&$index)
+    }};
+    ($index:ident, fieldids_weights_map) => {{
+        $crate::snapshot_tests::snap_fieldids_weights_map(&$index)
+    }};
+    ($index:ident, searchable_fields) => {{
+        $crate::snapshot_tests::snap_searchable_fields(&$index)
     }};
     ($index:ident, geo_faceted_documents_ids) => {{
         $crate::snapshot_tests::snap_geo_faceted_documents_ids(&$index)

--- a/milli/src/update/index_documents/extract/extract_docid_word_positions.rs
+++ b/milli/src/update/index_documents/extract/extract_docid_word_positions.rs
@@ -186,7 +186,7 @@ fn searchable_fields_changed(
 ) -> bool {
     let searchable_fields = &settings_diff.new.searchable_fields_ids;
     for (field_id, field_bytes) in obkv.iter() {
-        if searchable_fields.as_ref().map_or(true, |sf| sf.contains(&field_id)) {
+        if searchable_fields.contains(&field_id) {
             let del_add = KvReaderDelAdd::new(field_bytes);
             match (del_add.get(DelAdd::Deletion), del_add.get(DelAdd::Addition)) {
                 // if both fields are None, check the next field.
@@ -298,7 +298,7 @@ fn lang_safe_tokens_from_document<'a>(
 /// Extract words mapped with their positions of a document.
 fn tokens_from_document<'a>(
     obkv: &KvReader<FieldId>,
-    searchable_fields: &Option<Vec<FieldId>>,
+    searchable_fields: &[FieldId],
     tokenizer: &Tokenizer,
     max_positions_per_attributes: u32,
     del_add: DelAdd,
@@ -309,7 +309,7 @@ fn tokens_from_document<'a>(
     let mut document_writer = KvWriterU16::new(&mut buffers.obkv_buffer);
     for (field_id, field_bytes) in obkv.iter() {
         // if field is searchable.
-        if searchable_fields.as_ref().map_or(true, |sf| sf.contains(&field_id)) {
+        if searchable_fields.as_ref().contains(&field_id) {
             // extract deletion or addition only.
             if let Some(field_bytes) = KvReaderDelAdd::new(field_bytes).get(del_add) {
                 // parse json.

--- a/milli/src/update/index_documents/mod.rs
+++ b/milli/src/update/index_documents/mod.rs
@@ -3260,6 +3260,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "all-tokenizations")]
     fn stored_detected_script_and_language_should_not_return_deleted_documents() {
         use charabia::{Language, Script};
         let index = TempIndex::new();

--- a/milli/src/update/settings.rs
+++ b/milli/src/update/settings.rs
@@ -1587,8 +1587,8 @@ mod tests {
         db_snap!(index, fieldids_weights_map, @r###"
         fid weight
         0   0   |
-        1   1   |
-        2   2   |
+        1   0   |
+        2   0   |
         "###);
 
         // Check that the searchable field have been reset and documents are found now.


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes https://github.com/meilisearch/meilisearch/issues/4484

## What does this PR do?
- Make the (internal) searchable fields database always contain the searchable fields (instead of None when the user-defined searchable fields were not defined)
- Introduce a new « fieldids_weights_map » that does the mapping between a fieldId and its Weight
- Ensure that when two searchable fields are swapped, the field ID map doesn't change anymore (and thus, doesn't re-index)
- Uses the weight instead of the order of the searchable fields in the attribute ranking rule at search time
- When no searchable attributes are defined, make all their weights equal to zero
- When a field is declared as searchable and contains nested fields, all its subfields share the same weight

## Impact on relevancy

### When no searchable attributes are declared

When no searchable attributes are declared, all the fields have the same importance instead of randomly giving more importance to the field we've encountered « the most early » in the life of the index.

This means that before this PR, send the following json:
```json
[
  { "id": 0, "name": "kefir", "color": "white" },
  { "id": 1, "name": "white", "last name": "spirit" }
]
```

Would make the field `name` more important than the field `color` or `last name`.
This means that searching for `white` would make the document `1` automatically higher ranked than the document `0`.

After this PR, all the fields have the same weight, and none are considered more important than others.

### When a nested field is made searchable

The second behavior change that happened with this PR is in the case you're sending this document, for example:

```json
{
  "id": 0,
  "name": "tamo",
  "doggo": {
    "name": "kefir",
    "surname": "le kef"
  },
  "catto": "gromez"
}
```

Previously, defining the searchable attributes as: `["tamo", "doggo", "catto"]` was actually defining the « real » searchable attributes in the engine as: `["tamo", "doggo", "catto", "doggo.name", "doggo.surname"]`, which means that `doggo.name` and `doggo.surname` were _NOT_ where the user expected them and had completely different weights than `doggo`.
In this PR all the weights have been unified, and the « real » searchable fields look like this:
```json
[ "tamo", "doggo", "doggo.name", "doggo.surname", "catto"]
   ^^^^    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    ^^^^^
Weight 0                 Weight 1                  Weight 2