### PR TITLE
DO NOT MERGE: Adjust default budget to relieve stress on virtual memory space

### DIFF
--- a/index-scheduler/src/lib.rs
+++ b/index-scheduler/src/lib.rs
@@ -1834,7 +1834,7 @@ mod tests {
                 task_db_size: 1000 * 1000, // 1 MB, we don't use MiB on purpose.
                 index_base_map_size: 1000 * 1000, // 1 MB, we don't use MiB on purpose.
                 enable_mdb_writemap: false,
-                index_growth_amount: 1000 * 1000, // 1 MB
+                index_growth_amount: 1000 * 1000 * 1000 * 1000, // 1 TB
                 index_count: 5,
                 indexer_config,
                 autobatching_enabled: true,

--- a/index-scheduler/src/lib.rs
+++ b/index-scheduler/src/lib.rs
@@ -540,7 +540,7 @@ impl IndexScheduler {
         #[cfg(windows)]
         const DEFAULT_BUDGET: usize = 6 * 1024 * 1024 * 1024 * 1024; // 6 TiB, 1 index
         #[cfg(not(windows))]
-        const DEFAULT_BUDGET: usize = 80 * 1024 * 1024 * 1024 * 1024; // 80 TiB, 18 indexes
+        const DEFAULT_BUDGET: usize = 60 * 1024 * 1024 * 1024 * 1024; // 60 TiB, 13 indexes
 
         let budget = if Self::is_good_heed(tasks_path, DEFAULT_BUDGET) {
             DEFAULT_BUDGET

--- a/index-scheduler/src/lib.rs
+++ b/index-scheduler/src/lib.rs
@@ -567,16 +567,16 @@ impl IndexScheduler {
 
         tracing::debug!("index budget: {budget}B");
         let mut index_count = budget / base_map_size;
-        if index_count < 2 {
+        if index_count < 3 {
             // take a bit less than half than the budget to make sure we can always afford to open an index
             let map_size = (budget * 2) / 5;
             // single index of max budget
             tracing::debug!("1 index of {map_size}B can be opened simultaneously.");
             return IndexBudget { map_size, index_count: 1, task_db_size };
         }
-        // give us some space for an additional index when the cache is already full
-        // decrement is OK because index_count >= 2.
-        index_count -= 1;
+        // give us some space for additional indexes when the cache is already full
+        // decrement is OK because index_count >= 3.
+        index_count -= 2;
         if index_count > max_index_count {
             index_count = max_index_count;
         }

--- a/index-scheduler/src/lib.rs
+++ b/index-scheduler/src/lib.rs
@@ -540,7 +540,7 @@ impl IndexScheduler {
         #[cfg(windows)]
         const DEFAULT_BUDGET: usize = 6 * 1024 * 1024 * 1024 * 1024; // 6 TiB, 1 index
         #[cfg(not(windows))]
-        const DEFAULT_BUDGET: usize = 60 * 1024 * 1024 * 1024 * 1024; // 60 TiB, 13 indexes
+        const DEFAULT_BUDGET: usize = 80 * 1024 * 1024 * 1024 * 1024; // 80 TiB, 18 indexes
 
         let budget = if Self::is_good_heed(tasks_path, DEFAULT_BUDGET) {
             DEFAULT_BUDGET


### PR DESCRIPTION
PR opened for testing purposes

1. Clone Meilisearch
```
git clone https://github.com/meilisearch/meilisearch
```
2. switch to this branch
```
git checkout tmp-v1.8.1-fewer-indexes
```
3. build meilisearch
```
cargo build --release
```
4. the built binary is located in `target/release/meilisearch`
