### PR TITLE
Speed Up Filter ANDs operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4394,8 +4394,9 @@ dependencies = [
 
 [[package]]
 name = "roaring"
-version = "0.10.4"
-source = "git+https://github.com/RoaringBitmap/roaring-rs?branch=intersection-with-serialized#88b848b84cf7c8cc8d2ea02dfff77b5a54d822ec"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7699249cc2c7d71939f30868f47e9d7add0bdc030d90ee10bfd16887ff8bb1c8"
 dependencies = [
  "bytemuck",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4395,7 +4395,7 @@ dependencies = [
 [[package]]
 name = "roaring"
 version = "0.10.4"
-source = "git+https://github.com/RoaringBitmap/roaring-rs?branch=intersection-with-serialized#4466ae0104ed44a8cf41d187d9359483fe190701"
+source = "git+https://github.com/RoaringBitmap/roaring-rs?branch=intersection-with-serialized#88b848b84cf7c8cc8d2ea02dfff77b5a54d822ec"
 dependencies = [
  "bytemuck",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4378,12 +4378,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "retain_mut"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c31b5c4033f8fdde8700e4657be2c497e7288f01515be52168c631e2e4d4086"
-
-[[package]]
 name = "ring"
 version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4400,13 +4394,11 @@ dependencies = [
 
 [[package]]
 name = "roaring"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6106b5cf8587f5834158895e9715a3c6c9716c8aefab57f1f7680917191c7873"
+version = "0.10.4"
+source = "git+https://github.com/RoaringBitmap/roaring-rs?branch=intersection-with-serialized#4466ae0104ed44a8cf41d187d9359483fe190701"
 dependencies = [
  "bytemuck",
  "byteorder",
- "retain_mut",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,3 @@ opt-level = 3
 opt-level = 3
 [profile.bench.package.yada]
 opt-level = 3
-
-[patch.crates-io]
-roaring = { git = "https://github.com/RoaringBitmap/roaring-rs", branch = "intersection-with-serialized" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,3 +64,6 @@ opt-level = 3
 opt-level = 3
 [profile.bench.package.yada]
 opt-level = 3
+
+[patch.crates-io]
+roaring = { git = "https://github.com/RoaringBitmap/roaring-rs", branch = "intersection-with-serialized" }

--- a/milli/src/search/facet/facet_distribution_iter.rs
+++ b/milli/src/search/facet/facet_distribution_iter.rs
@@ -38,7 +38,7 @@ where
         field_id,
     )?;
 
-    if let Some(first_bound) = get_first_facet_value::<BytesRefCodec>(rtxn, db, field_id)? {
+    if let Some(first_bound) = get_first_facet_value::<BytesRefCodec, _>(rtxn, db, field_id)? {
         fd.iterate(candidates, highest_level, first_bound, usize::MAX)?;
         Ok(())
     } else {
@@ -81,7 +81,7 @@ where
         field_id,
     )?;
 
-    if let Some(first_bound) = get_first_facet_value::<BytesRefCodec>(rtxn, db, field_id)? {
+    if let Some(first_bound) = get_first_facet_value::<BytesRefCodec, _>(rtxn, db, field_id)? {
         // We first fill the heap with values from the highest level
         let starting_key =
             FacetGroupKey { field_id, level: highest_level, left_bound: first_bound };

--- a/milli/src/search/facet/facet_range_search.rs
+++ b/milli/src/search/facet/facet_range_search.rs
@@ -50,7 +50,7 @@ where
         Bound::Unbounded => Bound::Unbounded,
     };
     let db = db.remap_types::<FacetGroupKeyCodec<BytesRefCodec>, FacetGroupLazyValueCodec>();
-    let mut f = FacetRangeSearch { rtxn, db, field_id, left, right, universe, docids };
+    let mut f = FacetRangeSearch { rtxn, db, field_id, left, right, docids };
     let highest_level = get_highest_level(rtxn, db, field_id)?;
 
     if let Some(starting_left_bound) =
@@ -59,7 +59,7 @@ where
         let rightmost_bound =
             Bound::Included(get_last_facet_value::<BytesRefCodec, _>(rtxn, db, field_id)?.unwrap()); // will not fail because get_first_facet_value succeeded
         let group_size = usize::MAX;
-        f.run(highest_level, starting_left_bound, rightmost_bound, group_size)?;
+        f.run(highest_level, starting_left_bound, rightmost_bound, group_size, universe)?;
         Ok(())
     } else {
         Ok(())
@@ -73,14 +73,18 @@ struct FacetRangeSearch<'t, 'b, 'bitmap> {
     field_id: u16,
     left: Bound<&'b [u8]>,
     right: Bound<&'b [u8]>,
-    /// The subset of documents ids that are useful for this search.
-    /// Great performance optimizations can be achieved by only fetching values matching this subset.
-    universe: Option<&'bitmap RoaringBitmap>,
     docids: &'bitmap mut RoaringBitmap,
 }
 
 impl<'t, 'b, 'bitmap> FacetRangeSearch<'t, 'b, 'bitmap> {
-    fn run_level_0(&mut self, starting_left_bound: &'t [u8], group_size: usize) -> Result<()> {
+    fn run_level_0(
+        &mut self,
+        starting_left_bound: &'t [u8],
+        group_size: usize,
+        // The subset of documents ids that are useful for this search.
+        // Great performance optimizations can be achieved by only fetching values matching this subset.
+        universe: Option<&RoaringBitmap>,
+    ) -> Result<()> {
         let left_key =
             FacetGroupKey { field_id: self.field_id, level: 0, left_bound: starting_left_bound };
         let iter = self.db.range(self.rtxn, &(left_key..))?.take(group_size);
@@ -113,7 +117,7 @@ impl<'t, 'b, 'bitmap> FacetRangeSearch<'t, 'b, 'bitmap> {
             }
 
             if RangeBounds::<&[u8]>::contains(&(self.left, self.right), &key.left_bound) {
-                *self.docids |= match self.universe {
+                *self.docids |= match universe {
                     Some(universe) => CboRoaringBitmapCodec::intersection_with_serialized(
                         value.bitmap_bytes,
                         universe,
@@ -150,9 +154,10 @@ impl<'t, 'b, 'bitmap> FacetRangeSearch<'t, 'b, 'bitmap> {
         starting_left_bound: &'t [u8],
         rightmost_bound: Bound<&'t [u8]>,
         group_size: usize,
+        universe: Option<&RoaringBitmap>,
     ) -> Result<()> {
         if level == 0 {
-            return self.run_level_0(starting_left_bound, group_size);
+            return self.run_level_0(starting_left_bound, group_size, universe);
         }
 
         let left_key =
@@ -209,12 +214,16 @@ impl<'t, 'b, 'bitmap> FacetRangeSearch<'t, 'b, 'bitmap> {
                 };
                 left_condition && right_condition
             };
+            let subset = match universe {
+                Some(universe) => Some(CboRoaringBitmapCodec::intersection_with_serialized(
+                    previous_value.bitmap_bytes,
+                    universe,
+                )?),
+                None => None,
+            };
             if should_take_whole_group {
-                *self.docids |= match self.universe {
-                    Some(universe) => CboRoaringBitmapCodec::intersection_with_serialized(
-                        previous_value.bitmap_bytes,
-                        universe,
-                    )?,
+                *self.docids |= match subset {
+                    Some(subset) => subset,
                     None => CboRoaringBitmapCodec::deserialize_from(previous_value.bitmap_bytes)?,
                 };
                 previous_key = next_key;
@@ -229,7 +238,9 @@ impl<'t, 'b, 'bitmap> FacetRangeSearch<'t, 'b, 'bitmap> {
             let rightmost_bound = Bound::Excluded(next_key.left_bound);
             let group_size = previous_value.size as usize;
 
-            self.run(level, starting_left_bound, rightmost_bound, group_size)?;
+            if subset.as_ref().map_or(true, |u| !u.is_empty()) {
+                self.run(level, starting_left_bound, rightmost_bound, group_size, subset.as_ref())?;
+            }
 
             previous_key = next_key;
             previous_value = next_value;
@@ -311,12 +322,18 @@ impl<'t, 'b, 'bitmap> FacetRangeSearch<'t, 'b, 'bitmap> {
             };
             left_condition && right_condition
         };
+
+        let subset = match universe {
+            Some(universe) => Some(CboRoaringBitmapCodec::intersection_with_serialized(
+                previous_value.bitmap_bytes,
+                universe,
+            )?),
+            None => None,
+        };
+
         if should_take_whole_group {
-            *self.docids |= match self.universe {
-                Some(universe) => CboRoaringBitmapCodec::intersection_with_serialized(
-                    previous_value.bitmap_bytes,
-                    universe,
-                )?,
+            *self.docids |= match subset {
+                Some(subset) => subset,
                 None => CboRoaringBitmapCodec::deserialize_from(previous_value.bitmap_bytes)?,
             };
         } else {
@@ -324,7 +341,9 @@ impl<'t, 'b, 'bitmap> FacetRangeSearch<'t, 'b, 'bitmap> {
             let starting_left_bound = previous_key.left_bound;
             let group_size = previous_value.size as usize;
 
-            self.run(level, starting_left_bound, rightmost_bound, group_size)?;
+            if subset.as_ref().map_or(true, |u| !u.is_empty()) {
+                self.run(level, starting_left_bound, rightmost_bound, group_size, subset.as_ref())?;
+            }
         }
 
         Ok(())

--- a/milli/src/search/facet/facet_sort_ascending.rs
+++ b/milli/src/search/facet/facet_sort_ascending.rs
@@ -36,7 +36,7 @@ pub fn ascending_facet_sort<'t>(
     candidates: RoaringBitmap,
 ) -> Result<impl Iterator<Item = Result<(RoaringBitmap, &'t [u8])>> + 't> {
     let highest_level = get_highest_level(rtxn, db, field_id)?;
-    if let Some(first_bound) = get_first_facet_value::<BytesRefCodec>(rtxn, db, field_id)? {
+    if let Some(first_bound) = get_first_facet_value::<BytesRefCodec, _>(rtxn, db, field_id)? {
         let first_key = FacetGroupKey { field_id, level: highest_level, left_bound: first_bound };
         let iter = db.range(rtxn, &(first_key..)).unwrap().take(usize::MAX);
 

--- a/milli/src/search/facet/facet_sort_descending.rs
+++ b/milli/src/search/facet/facet_sort_descending.rs
@@ -19,9 +19,9 @@ pub fn descending_facet_sort<'t>(
     candidates: RoaringBitmap,
 ) -> Result<impl Iterator<Item = Result<(RoaringBitmap, &'t [u8])>> + 't> {
     let highest_level = get_highest_level(rtxn, db, field_id)?;
-    if let Some(first_bound) = get_first_facet_value::<BytesRefCodec>(rtxn, db, field_id)? {
+    if let Some(first_bound) = get_first_facet_value::<BytesRefCodec, _>(rtxn, db, field_id)? {
         let first_key = FacetGroupKey { field_id, level: highest_level, left_bound: first_bound };
-        let last_bound = get_last_facet_value::<BytesRefCodec>(rtxn, db, field_id)?.unwrap();
+        let last_bound = get_last_facet_value::<BytesRefCodec, _>(rtxn, db, field_id)?.unwrap();
         let last_key = FacetGroupKey { field_id, level: highest_level, left_bound: last_bound };
         let iter = db.rev_range(rtxn, &(first_key..=last_key))?.take(usize::MAX);
         Ok(itertools::Either::Left(DescendingFacetSort {

--- a/milli/src/search/facet/filter.rs
+++ b/milli/src/search/facet/filter.rs
@@ -343,6 +343,10 @@ impl<'a> Filter<'a> {
         filterable_fields: &HashSet<String>,
         universe: Option<&RoaringBitmap>,
     ) -> Result<RoaringBitmap> {
+        if universe.map_or(false, |u| u.is_empty()) {
+            return Ok(RoaringBitmap::new());
+        }
+
         match &self.condition {
             FilterCondition::Not(f) => {
                 // TODO improve the documents_ids to also support intersections at deserialize time.

--- a/milli/src/search/facet/mod.rs
+++ b/milli/src/search/facet/mod.rs
@@ -7,7 +7,7 @@ use roaring::RoaringBitmap;
 pub use self::facet_distribution::{FacetDistribution, OrderBy, DEFAULT_VALUES_PER_FACET};
 pub use self::filter::{BadGeoError, Filter};
 pub use self::search::{FacetValueHit, SearchForFacetValues};
-use crate::heed_codec::facet::{FacetGroupKeyCodec, FacetGroupValueCodec, OrderedF64Codec};
+use crate::heed_codec::facet::{FacetGroupKeyCodec, OrderedF64Codec};
 use crate::heed_codec::BytesRefCodec;
 use crate::{Index, Result};
 
@@ -54,9 +54,9 @@ pub fn facet_max_value<'t>(
 }
 
 /// Get the first facet value in the facet database
-pub(crate) fn get_first_facet_value<'t, BoundCodec>(
+pub(crate) fn get_first_facet_value<'t, BoundCodec, DC>(
     txn: &'t RoTxn,
-    db: heed::Database<FacetGroupKeyCodec<BytesRefCodec>, FacetGroupValueCodec>,
+    db: heed::Database<FacetGroupKeyCodec<BytesRefCodec>, DC>,
     field_id: u16,
 ) -> heed::Result<Option<BoundCodec::DItem>>
 where
@@ -78,9 +78,9 @@ where
 }
 
 /// Get the last facet value in the facet database
-pub(crate) fn get_last_facet_value<'t, BoundCodec>(
+pub(crate) fn get_last_facet_value<'t, BoundCodec, DC>(
     txn: &'t RoTxn,
-    db: heed::Database<FacetGroupKeyCodec<BytesRefCodec>, FacetGroupValueCodec>,
+    db: heed::Database<FacetGroupKeyCodec<BytesRefCodec>, DC>,
     field_id: u16,
 ) -> heed::Result<Option<BoundCodec::DItem>>
 where
@@ -102,9 +102,9 @@ where
 }
 
 /// Get the height of the highest level in the facet database
-pub(crate) fn get_highest_level<'t>(
+pub(crate) fn get_highest_level<'t, DC>(
     txn: &'t RoTxn<'t>,
-    db: heed::Database<FacetGroupKeyCodec<BytesRefCodec>, FacetGroupValueCodec>,
+    db: heed::Database<FacetGroupKeyCodec<BytesRefCodec>, DC>,
     field_id: u16,
 ) -> heed::Result<u8> {
     let field_id_prefix = &field_id.to_be_bytes();

--- a/milli/src/search/new/mod.rs
+++ b/milli/src/search/new/mod.rs
@@ -548,6 +548,7 @@ fn resolve_sort_criteria<'ctx, Query: RankingRuleQueryTrait>(
     Ok(())
 }
 
+#[tracing::instrument(level = "trace", skip_all, target = "search")]
 pub fn filtered_universe(
     index: &Index,
     txn: &RoTxn<'_>,


### PR DESCRIPTION
This PR fixes #4659 and improves the way we do AND operations by using the latest [RoaringBitmap feature to do intersections with serialized bitmaps](https://github.com/RoaringBitmap/roaring-rs/pull/281). Doing so drastically reduces the time spent reading, copying bytes in memory to use and keep a subset of the containers in the bitmap.

### Some Example Results

With a 45M documents dataset running on a good NVMe. This example filter was taking 77ms and with this PR only 13ms (6x speedup):

```sql
artist = 'The Beatles' AND (duration 150 TO 500 OR duration NOT EXISTS) AND genres IN [Rock, 'Rock and Roll'] AND rating > 4 AND released_year 1960 TO 1990
```

By reordering the filter AND clauses we can reach a constant 8ms execution time. However, note that it is a manual operation. On the other side the previous filter pipeline is still at a constant 45ms execution time with this filter. (6x speedup)

```sql
artist = 'The Beatles' AND genres IN [Rock, 'Rock and Roll'] AND released_year 1960 TO 1990 AND (duration 150 TO 500 OR duration NOT EXISTS)
```

### To Do
- [x] Rebase on `release-v1.9.0`.
- [ ] ~Skip branches of the facet/filter tree when nothing is in common with the universe~ slower this way.
- [x] When the universe is required use the universe given in parameter if possible.