### PR TITLE
Update yaup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5063,18 +5063,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.58"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.58"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6090,12 +6090,13 @@ dependencies = [
 
 [[package]]
 name = "yaup"
-version = "0.2.1"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a59e7d27bed43f7c37c25df5192ea9d435a8092a902e02203359ac9ce3e429d9"
+checksum = "b0144f1a16a199846cb21024da74edd930b43443463292f536b7110b4855b5c6"
 dependencies = [
+ "form_urlencoded",
  "serde",
- "url",
+ "thiserror",
 ]
 
 [[package]]

--- a/meilisearch/Cargo.toml
+++ b/meilisearch/Cargo.toml
@@ -98,7 +98,6 @@ tokio-stream = "0.1.14"
 toml = "0.8.8"
 uuid = { version = "1.6.1", features = ["serde", "v4"] }
 walkdir = "2.4.0"
-yaup = "0.2.1"
 serde_urlencoded = "0.7.1"
 termcolor = "1.4.1"
 url = { version = "2.5.0", features = ["serde"] }
@@ -118,7 +117,7 @@ maplit = "1.0.2"
 meili-snap = { path = "../meili-snap" }
 temp-env = "0.3.6"
 urlencoding = "2.1.3"
-yaup = "0.2.1"
+yaup = "0.3.1"
 
 [build-dependencies]
 anyhow = { version = "1.0.79", optional = true }

--- a/meilisearch/tests/common/index.rs
+++ b/meilisearch/tests/common/index.rs
@@ -376,7 +376,7 @@ impl Index<'_> {
     }
 
     pub async fn search_get(&self, query: &str) -> (Value, StatusCode) {
-        let url = format!("/indexes/{}/search?{}", urlencode(self.uid.as_ref()), query);
+        let url = format!("/indexes/{}/search{}", urlencode(self.uid.as_ref()), query);
         self.service.get(url).await
     }
 
@@ -413,7 +413,7 @@ impl Index<'_> {
     }
 
     pub async fn similar_get(&self, query: &str) -> (Value, StatusCode) {
-        let url = format!("/indexes/{}/similar?{}", urlencode(self.uid.as_ref()), query);
+        let url = format!("/indexes/{}/similar{}", urlencode(self.uid.as_ref()), query);
         self.service.get(url).await
     }
 

--- a/meilisearch/tests/search/errors.rs
+++ b/meilisearch/tests/search/errors.rs
@@ -71,7 +71,7 @@ async fn search_bad_offset() {
     }
     "###);
 
-    let (response, code) = index.search_get("offset=doggo").await;
+    let (response, code) = index.search_get("?offset=doggo").await;
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
@@ -99,7 +99,7 @@ async fn search_bad_limit() {
     }
     "###);
 
-    let (response, code) = index.search_get("limit=doggo").await;
+    let (response, code) = index.search_get("?limit=doggo").await;
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
@@ -127,7 +127,7 @@ async fn search_bad_page() {
     }
     "###);
 
-    let (response, code) = index.search_get("page=doggo").await;
+    let (response, code) = index.search_get("?page=doggo").await;
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
@@ -155,7 +155,7 @@ async fn search_bad_hits_per_page() {
     }
     "###);
 
-    let (response, code) = index.search_get("hitsPerPage=doggo").await;
+    let (response, code) = index.search_get("?hitsPerPage=doggo").await;
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
@@ -201,7 +201,7 @@ async fn search_bad_crop_length() {
     }
     "###);
 
-    let (response, code) = index.search_get("cropLength=doggo").await;
+    let (response, code) = index.search_get("?cropLength=doggo").await;
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
@@ -291,7 +291,7 @@ async fn search_bad_show_matches_position() {
     }
     "###);
 
-    let (response, code) = index.search_get("showMatchesPosition=doggo").await;
+    let (response, code) = index.search_get("?showMatchesPosition=doggo").await;
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
@@ -340,7 +340,7 @@ async fn search_non_filterable_facets() {
     }
     "###);
 
-    let (response, code) = index.search_get("facets=doggo").await;
+    let (response, code) = index.search_get("?facets=doggo").await;
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
@@ -370,7 +370,7 @@ async fn search_non_filterable_facets_multiple_filterable() {
     }
     "###);
 
-    let (response, code) = index.search_get("facets=doggo").await;
+    let (response, code) = index.search_get("?facets=doggo").await;
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
@@ -400,7 +400,7 @@ async fn search_non_filterable_facets_no_filterable() {
     }
     "###);
 
-    let (response, code) = index.search_get("facets=doggo").await;
+    let (response, code) = index.search_get("?facets=doggo").await;
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
@@ -430,7 +430,7 @@ async fn search_non_filterable_facets_multiple_facets() {
     }
     "###);
 
-    let (response, code) = index.search_get("facets=doggo,neko").await;
+    let (response, code) = index.search_get("?facets=doggo,neko").await;
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
@@ -523,7 +523,7 @@ async fn search_bad_matching_strategy() {
     }
     "###);
 
-    let (response, code) = index.search_get("matchingStrategy=doggo").await;
+    let (response, code) = index.search_get("?matchingStrategy=doggo").await;
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {

--- a/meilisearch/tests/similar/errors.rs
+++ b/meilisearch/tests/similar/errors.rs
@@ -179,7 +179,7 @@ async fn similar_bad_offset() {
     }
     "###);
 
-    let (response, code) = index.similar_get("id=287947&offset=doggo").await;
+    let (response, code) = index.similar_get("?id=287947&offset=doggo").await;
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
@@ -221,7 +221,7 @@ async fn similar_bad_limit() {
     }
     "###);
 
-    let (response, code) = index.similar_get("id=287946&limit=doggo").await;
+    let (response, code) = index.similar_get("?id=287946&limit=doggo").await;
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {


### PR DESCRIPTION
There was a bug in `yaup` where serializing a structure with an array would give you a wrong query parameter.

Now, yaup is also in charge of sending the initial `?` before the query parameters.