### PR TITLE
Rename the sortable into the filterable movies workload

### DIFF
--- a/workloads/search/filterable-movies.json
+++ b/workloads/search/filterable-movies.json
@@ -1,5 +1,5 @@
 {
-  "name": "search-sortable-movies.json",
+  "name": "search-filterable-movies.json",
   "run_count": 10,
   "target": "search::=trace",
   "extra_cli_args": [],


### PR DESCRIPTION
Fixes the workload name of one movie searchable.