### PR TITLE
Add index exists function in index_scheduler which stops opening indexes to only check if they exist.

### DIFF
--- a/meilisearch/src/analytics/mod.rs
+++ b/meilisearch/src/analytics/mod.rs
@@ -102,7 +102,7 @@ pub trait Analytics: Sync + Send {
     /// This method should be called to aggregate post facet values searches
     fn post_facet_search(&self, aggregate: FacetSearchAggregator);
 
-    // this method should be called to aggregate a add documents request
+    // this method should be called to aggregate an add documents request
     fn add_documents(
         &self,
         documents_query: &UpdateDocumentsQuery,

--- a/meilisearch/src/routes/indexes/documents.rs
+++ b/meilisearch/src/routes/indexes/documents.rs
@@ -304,7 +304,7 @@ pub async fn replace_documents(
     debug!(parameters = ?params, "Replace documents");
     let params = params.into_inner();
 
-    analytics.add_documents(&params, index_scheduler.index_exists(&index_uid) == Ok(true), &req);
+    analytics.add_documents(&params, index_scheduler.index_exists(&index_uid) != Ok(true), &req);
 
     let allow_index_creation = index_scheduler.filters().allow_index_creation(&index_uid);
     let uid = get_task_id(&req, &opt)?;
@@ -341,7 +341,7 @@ pub async fn update_documents(
     let params = params.into_inner();
     debug!(parameters = ?params, "Update documents");
 
-    analytics.update_documents(&params, index_scheduler.index_exists(&index_uid) == Ok(true), &req);
+    analytics.update_documents(&params, index_scheduler.index_exists(&index_uid) != Ok(true), &req);
 
     let allow_index_creation = index_scheduler.filters().allow_index_creation(&index_uid);
     let uid = get_task_id(&req, &opt)?;

--- a/meilisearch/src/routes/indexes/documents.rs
+++ b/meilisearch/src/routes/indexes/documents.rs
@@ -304,7 +304,11 @@ pub async fn replace_documents(
     debug!(parameters = ?params, "Replace documents");
     let params = params.into_inner();
 
-    analytics.add_documents(&params, index_scheduler.index(&index_uid).is_err(), &req);
+    analytics.add_documents(
+        &params,
+        !matches!(index_scheduler.index_exists(&index_uid), Ok(true)),
+        &req,
+    );
 
     let allow_index_creation = index_scheduler.filters().allow_index_creation(&index_uid);
     let uid = get_task_id(&req, &opt)?;
@@ -341,7 +345,11 @@ pub async fn update_documents(
     let params = params.into_inner();
     debug!(parameters = ?params, "Update documents");
 
-    analytics.update_documents(&params, index_scheduler.index(&index_uid).is_err(), &req);
+    analytics.update_documents(
+        &params,
+        !matches!(index_scheduler.index_exists(&index_uid), Ok(true)),
+        &req,
+    );
 
     let allow_index_creation = index_scheduler.filters().allow_index_creation(&index_uid);
     let uid = get_task_id(&req, &opt)?;

--- a/meilisearch/src/routes/indexes/documents.rs
+++ b/meilisearch/src/routes/indexes/documents.rs
@@ -304,11 +304,7 @@ pub async fn replace_documents(
     debug!(parameters = ?params, "Replace documents");
     let params = params.into_inner();
 
-    analytics.add_documents(
-        &params,
-        !matches!(index_scheduler.index_exists(&index_uid), Ok(true)),
-        &req,
-    );
+    analytics.add_documents(&params, index_scheduler.index_exists(&index_uid) == Ok(true), &req);
 
     let allow_index_creation = index_scheduler.filters().allow_index_creation(&index_uid);
     let uid = get_task_id(&req, &opt)?;
@@ -345,11 +341,7 @@ pub async fn update_documents(
     let params = params.into_inner();
     debug!(parameters = ?params, "Update documents");
 
-    analytics.update_documents(
-        &params,
-        !matches!(index_scheduler.index_exists(&index_uid), Ok(true)),
-        &req,
-    );
+    analytics.update_documents(&params, index_scheduler.index_exists(&index_uid) == Ok(true), &req);
 
     let allow_index_creation = index_scheduler.filters().allow_index_creation(&index_uid);
     let uid = get_task_id(&req, &opt)?;

--- a/meilisearch/src/routes/indexes/documents.rs
+++ b/meilisearch/src/routes/indexes/documents.rs
@@ -304,7 +304,11 @@ pub async fn replace_documents(
     debug!(parameters = ?params, "Replace documents");
     let params = params.into_inner();
 
-    analytics.add_documents(&params, index_scheduler.index_exists(&index_uid) != Ok(true), &req);
+    analytics.add_documents(
+        &params,
+        index_scheduler.index_exists(&index_uid).map_or(true, |x| !x),
+        &req,
+    );
 
     let allow_index_creation = index_scheduler.filters().allow_index_creation(&index_uid);
     let uid = get_task_id(&req, &opt)?;
@@ -341,7 +345,11 @@ pub async fn update_documents(
     let params = params.into_inner();
     debug!(parameters = ?params, "Update documents");
 
-    analytics.update_documents(&params, index_scheduler.index_exists(&index_uid) != Ok(true), &req);
+    analytics.add_documents(
+        &params,
+        index_scheduler.index_exists(&index_uid).map_or(true, |x| !x),
+        &req,
+    );
 
     let allow_index_creation = index_scheduler.filters().allow_index_creation(&index_uid);
     let uid = get_task_id(&req, &opt)?;


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #4784

## What does this PR do?
- Added index_exists function in the index_scheduler.
- Resolved opening indexes to only check if they exist.
- Made changes to existing tests to test this function.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
