### PR TITLE
Catch the MDB_TXN_FULL error and reduce the batch size to eventually succeed

### DIFF
--- a/milli/src/error.rs
+++ b/milli/src/error.rs
@@ -69,6 +69,8 @@ pub enum InternalError {
     ArroyError(#[from] arroy::Error),
     #[error(transparent)]
     VectorEmbeddingError(#[from] crate::vector::Error),
+    #[error(transparent)]
+    MdbTxnFullError,
 }
 
 #[derive(Error, Debug)]
@@ -444,6 +446,7 @@ impl From<HeedError> for Error {
             HeedError::Io(error) => Error::from(error),
             HeedError::Mdb(MdbError::MapFull) => UserError(MaxDatabaseSizeReached),
             HeedError::Mdb(MdbError::Invalid) => UserError(InvalidStoreFile),
+            HeedError::Mdb(MdbError::TxnFull) => InternalError(MdbTxnFullError),
             HeedError::Mdb(error) => InternalError(Store(error)),
             // TODO use the encoding
             HeedError::Encoding(_) => InternalError(Serialization(Encoding { db_name: None })),

--- a/milli/src/error.rs
+++ b/milli/src/error.rs
@@ -69,8 +69,6 @@ pub enum InternalError {
     ArroyError(#[from] arroy::Error),
     #[error(transparent)]
     VectorEmbeddingError(#[from] crate::vector::Error),
-    #[error(transparent)]
-    MdbTxnFullError,
 }
 
 #[derive(Error, Debug)]
@@ -446,7 +444,6 @@ impl From<HeedError> for Error {
             HeedError::Io(error) => Error::from(error),
             HeedError::Mdb(MdbError::MapFull) => UserError(MaxDatabaseSizeReached),
             HeedError::Mdb(MdbError::Invalid) => UserError(InvalidStoreFile),
-            HeedError::Mdb(MdbError::TxnFull) => InternalError(MdbTxnFullError),
             HeedError::Mdb(error) => InternalError(Store(error)),
             // TODO use the encoding
             HeedError::Encoding(_) => InternalError(Serialization(Encoding { db_name: None })),


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #4791

## What does this PR do?
- Catches the MDB_TXN_FULL when batches are executed and reduces the max_number_of_batched_tasks and tries again.

## PR checklist
Please check if your PR fulfills the following requirements:
- [ x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x ] Have you read the contributing guidelines?
- [x ] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
