### PR TITLE
Use the dtolnay's Rust Toolchain

### DIFF
--- a/.github/workflows/bench-manual.yml
+++ b/.github/workflows/bench-manual.yml
@@ -18,7 +18,7 @@ jobs:
         timeout-minutes: 180 # 3h
         steps:
             - uses: actions/checkout@v3
-            - uses: helix-editor/rust-toolchain@v1
+            - uses: dtolnay/rust-toolchain@v1.70
               with:
                 profile: minimal
 

--- a/.github/workflows/bench-manual.yml
+++ b/.github/workflows/bench-manual.yml
@@ -18,7 +18,7 @@ jobs:
         timeout-minutes: 180 # 3h
         steps:
             - uses: actions/checkout@v3
-            - uses: dtolnay/rust-toolchain@v1.70
+            - uses: dtolnay/rust-toolchain@1.79
               with:
                 profile: minimal
 

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -66,7 +66,7 @@ jobs:
             fetch-depth: 0 # fetch full history to be able to get main commit sha
             ref: ${{ steps.comment-branch.outputs.head_ref }}
 
-        - uses: helix-editor/rust-toolchain@v1
+        - uses: dtolnay/rust-toolchain@v1.70
           with:
             profile: minimal
 

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -66,7 +66,7 @@ jobs:
             fetch-depth: 0 # fetch full history to be able to get main commit sha
             ref: ${{ steps.comment-branch.outputs.head_ref }}
 
-        - uses: dtolnay/rust-toolchain@v1.70
+        - uses: dtolnay/rust-toolchain@1.79
           with:
             profile: minimal
 

--- a/.github/workflows/bench-push-indexing.yml
+++ b/.github/workflows/bench-push-indexing.yml
@@ -12,7 +12,7 @@ jobs:
         timeout-minutes: 180 # 3h
         steps:
           - uses: actions/checkout@v3
-          - uses: helix-editor/rust-toolchain@v1
+          - uses: dtolnay/rust-toolchain@v1.70
             with:
               profile: minimal
 

--- a/.github/workflows/bench-push-indexing.yml
+++ b/.github/workflows/bench-push-indexing.yml
@@ -12,7 +12,7 @@ jobs:
         timeout-minutes: 180 # 3h
         steps:
           - uses: actions/checkout@v3
-          - uses: dtolnay/rust-toolchain@v1.70
+          - uses: dtolnay/rust-toolchain@1.79
             with:
               profile: minimal
 

--- a/.github/workflows/benchmarks-manual.yml
+++ b/.github/workflows/benchmarks-manual.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 4320 # 72h
     steps:
       - uses: actions/checkout@v3
-      - uses: helix-editor/rust-toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1.70
         with:
           profile: minimal
 

--- a/.github/workflows/benchmarks-manual.yml
+++ b/.github/workflows/benchmarks-manual.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 4320 # 72h
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@v1.70
+      - uses: dtolnay/rust-toolchain@1.79
         with:
           profile: minimal
 

--- a/.github/workflows/benchmarks-pr.yml
+++ b/.github/workflows/benchmarks-pr.yml
@@ -44,7 +44,7 @@ jobs:
             exit 1
           fi
 
-      - uses: helix-editor/rust-toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1.70
         with:
           profile: minimal
 

--- a/.github/workflows/benchmarks-pr.yml
+++ b/.github/workflows/benchmarks-pr.yml
@@ -44,7 +44,7 @@ jobs:
             exit 1
           fi
 
-      - uses: dtolnay/rust-toolchain@v1.70
+      - uses: dtolnay/rust-toolchain@1.79
         with:
           profile: minimal
 

--- a/.github/workflows/benchmarks-push-indexing.yml
+++ b/.github/workflows/benchmarks-push-indexing.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 4320 # 72h
     steps:
       - uses: actions/checkout@v3
-      - uses: helix-editor/rust-toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1.70
         with:
           profile: minimal
 

--- a/.github/workflows/benchmarks-push-indexing.yml
+++ b/.github/workflows/benchmarks-push-indexing.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 4320 # 72h
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@v1.70
+      - uses: dtolnay/rust-toolchain@1.79
         with:
           profile: minimal
 

--- a/.github/workflows/benchmarks-push-search-geo.yml
+++ b/.github/workflows/benchmarks-push-search-geo.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: benchmarks
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@v1.70
+      - uses: dtolnay/rust-toolchain@1.79
         with:
           profile: minimal
 

--- a/.github/workflows/benchmarks-push-search-geo.yml
+++ b/.github/workflows/benchmarks-push-search-geo.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: benchmarks
     steps:
       - uses: actions/checkout@v3
-      - uses: helix-editor/rust-toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1.70
         with:
           profile: minimal
 

--- a/.github/workflows/benchmarks-push-search-songs.yml
+++ b/.github/workflows/benchmarks-push-search-songs.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: benchmarks
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@v1.70
+      - uses: dtolnay/rust-toolchain@1.79
         with:
           profile: minimal
 

--- a/.github/workflows/benchmarks-push-search-songs.yml
+++ b/.github/workflows/benchmarks-push-search-songs.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: benchmarks
     steps:
       - uses: actions/checkout@v3
-      - uses: helix-editor/rust-toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1.70
         with:
           profile: minimal
 

--- a/.github/workflows/benchmarks-push-search-wiki.yml
+++ b/.github/workflows/benchmarks-push-search-wiki.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: benchmarks
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@v1.70
+      - uses: dtolnay/rust-toolchain@1.79
         with:
           profile: minimal
 

--- a/.github/workflows/benchmarks-push-search-wiki.yml
+++ b/.github/workflows/benchmarks-push-search-wiki.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: benchmarks
     steps:
       - uses: actions/checkout@v3
-      - uses: helix-editor/rust-toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1.70
         with:
           profile: minimal
 

--- a/.github/workflows/flaky-tests.yml
+++ b/.github/workflows/flaky-tests.yml
@@ -17,7 +17,7 @@ jobs:
       run: |
         apt-get update && apt-get install -y curl
         apt-get install build-essential -y
-    - uses: helix-editor/rust-toolchain@v1
+    - uses: dtolnay/rust-toolchain@v1.70
     - name: Install cargo-flaky
       run: cargo install cargo-flaky
     - name: Run cargo flaky in the dumps

--- a/.github/workflows/flaky-tests.yml
+++ b/.github/workflows/flaky-tests.yml
@@ -17,7 +17,7 @@ jobs:
       run: |
         apt-get update && apt-get install -y curl
         apt-get install build-essential -y
-    - uses: dtolnay/rust-toolchain@v1.70
+    - uses: dtolnay/rust-toolchain@1.79
     - name: Install cargo-flaky
       run: cargo install cargo-flaky
     - name: Run cargo flaky in the dumps

--- a/.github/workflows/fuzzer-indexing.yml
+++ b/.github/workflows/fuzzer-indexing.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 4320 # 72h
     steps:
       - uses: actions/checkout@v3
-      - uses: helix-editor/rust-toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1.70
         with:
           profile: minimal
 

--- a/.github/workflows/fuzzer-indexing.yml
+++ b/.github/workflows/fuzzer-indexing.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 4320 # 72h
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@v1.70
+      - uses: dtolnay/rust-toolchain@1.79
         with:
           profile: minimal
 

--- a/.github/workflows/publish-apt-brew-pkg.yml
+++ b/.github/workflows/publish-apt-brew-pkg.yml
@@ -25,7 +25,7 @@ jobs:
       run: |
         apt-get update && apt-get install -y curl
         apt-get install build-essential -y
-    - uses: helix-editor/rust-toolchain@v1
+    - uses: dtolnay/rust-toolchain@v1.70
     - name: Install cargo-deb
       run: cargo install cargo-deb
     - uses: actions/checkout@v3

--- a/.github/workflows/publish-apt-brew-pkg.yml
+++ b/.github/workflows/publish-apt-brew-pkg.yml
@@ -25,7 +25,7 @@ jobs:
       run: |
         apt-get update && apt-get install -y curl
         apt-get install build-essential -y
-    - uses: dtolnay/rust-toolchain@v1.70
+    - uses: dtolnay/rust-toolchain@1.79
     - name: Install cargo-deb
       run: cargo install cargo-deb
     - uses: actions/checkout@v3

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -45,7 +45,7 @@ jobs:
       run: |
         apt-get update && apt-get install -y curl
         apt-get install build-essential -y
-    - uses: dtolnay/rust-toolchain@v1.70
+    - uses: dtolnay/rust-toolchain@1.79
     - name: Build
       run: cargo build --release --locked
     # No need to upload binaries for dry run (cron)
@@ -75,7 +75,7 @@ jobs:
             asset_name: meilisearch-windows-amd64.exe
     steps:
     - uses: actions/checkout@v3
-    - uses: dtolnay/rust-toolchain@v1.70
+    - uses: dtolnay/rust-toolchain@1.79
     - name: Build
       run: cargo build --release --locked
     # No need to upload binaries for dry run (cron)
@@ -101,7 +101,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Installing Rust toolchain
-        uses: dtolnay/rust-toolchain@v1.70
+        uses: dtolnay/rust-toolchain@1.79
         with:
           profile: minimal
           target: ${{ matrix.target }}
@@ -148,7 +148,7 @@ jobs:
           add-apt-repository "deb [arch=$(dpkg --print-architecture)] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
           apt-get update -y && apt-get install -y docker-ce
       - name: Installing Rust toolchain
-        uses: dtolnay/rust-toolchain@v1.70
+        uses: dtolnay/rust-toolchain@1.79
         with:
           profile: minimal
           target: ${{ matrix.target }}

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -45,7 +45,7 @@ jobs:
       run: |
         apt-get update && apt-get install -y curl
         apt-get install build-essential -y
-    - uses: helix-editor/rust-toolchain@v1
+    - uses: dtolnay/rust-toolchain@v1.70
     - name: Build
       run: cargo build --release --locked
     # No need to upload binaries for dry run (cron)
@@ -75,7 +75,7 @@ jobs:
             asset_name: meilisearch-windows-amd64.exe
     steps:
     - uses: actions/checkout@v3
-    - uses: helix-editor/rust-toolchain@v1
+    - uses: dtolnay/rust-toolchain@v1.70
     - name: Build
       run: cargo build --release --locked
     # No need to upload binaries for dry run (cron)
@@ -101,7 +101,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Installing Rust toolchain
-        uses: helix-editor/rust-toolchain@v1
+        uses: dtolnay/rust-toolchain@v1.70
         with:
           profile: minimal
           target: ${{ matrix.target }}
@@ -148,7 +148,7 @@ jobs:
           add-apt-repository "deb [arch=$(dpkg --print-architecture)] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
           apt-get update -y && apt-get install -y docker-ce
       - name: Installing Rust toolchain
-        uses: helix-editor/rust-toolchain@v1
+        uses: dtolnay/rust-toolchain@v1.70
         with:
           profile: minimal
           target: ${{ matrix.target }}

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -31,7 +31,7 @@ jobs:
           apt-get update && apt-get install -y curl
           apt-get install build-essential -y
       - name: Setup test with Rust stable
-        uses: helix-editor/rust-toolchain@v1
+        uses: dtolnay/rust-toolchain@v1.70
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2.7.1
       - name: Run cargo check without any default features
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2.7.1
-      - uses: helix-editor/rust-toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1.70
       - name: Run cargo check without any default features
         uses: actions-rs/cargo@v1
         with:
@@ -81,7 +81,7 @@ jobs:
         run: |
           apt-get update
           apt-get install --assume-yes build-essential curl
-      - uses: helix-editor/rust-toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1.70
       - name: Run cargo build with almost all features
         run: |
           cargo build --workspace --locked --release --features "$(cargo xtask list-features --exclude-feature cuda)"
@@ -101,7 +101,7 @@ jobs:
         run: |
           apt-get update
           apt-get install --assume-yes build-essential curl
-      - uses: helix-editor/rust-toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1.70
       - name: Run cargo tree without default features and check lindera is not present
         run: |
           if cargo tree -f '{p} {f}' -e normal --no-default-features | grep -qz lindera; then
@@ -125,7 +125,7 @@ jobs:
         run: |
           apt-get update && apt-get install -y curl
           apt-get install build-essential -y
-      - uses: helix-editor/rust-toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1.70
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2.7.1
       - name: Run tests in debug
@@ -139,7 +139,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: helix-editor/rust-toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1.70
         with:
           profile: minimal
           components: clippy
@@ -156,7 +156,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: helix-editor/rust-toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1.70
         with:
           profile: minimal
           toolchain: nightly-2024-07-09

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -31,7 +31,7 @@ jobs:
           apt-get update && apt-get install -y curl
           apt-get install build-essential -y
       - name: Setup test with Rust stable
-        uses: dtolnay/rust-toolchain@v1.70
+        uses: dtolnay/rust-toolchain@1.79
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2.7.1
       - name: Run cargo check without any default features
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2.7.1
-      - uses: dtolnay/rust-toolchain@v1.70
+      - uses: dtolnay/rust-toolchain@1.79
       - name: Run cargo check without any default features
         uses: actions-rs/cargo@v1
         with:
@@ -81,7 +81,7 @@ jobs:
         run: |
           apt-get update
           apt-get install --assume-yes build-essential curl
-      - uses: dtolnay/rust-toolchain@v1.70
+      - uses: dtolnay/rust-toolchain@1.79
       - name: Run cargo build with almost all features
         run: |
           cargo build --workspace --locked --release --features "$(cargo xtask list-features --exclude-feature cuda)"
@@ -101,7 +101,7 @@ jobs:
         run: |
           apt-get update
           apt-get install --assume-yes build-essential curl
-      - uses: dtolnay/rust-toolchain@v1.70
+      - uses: dtolnay/rust-toolchain@1.79
       - name: Run cargo tree without default features and check lindera is not present
         run: |
           if cargo tree -f '{p} {f}' -e normal --no-default-features | grep -qz lindera; then
@@ -125,7 +125,7 @@ jobs:
         run: |
           apt-get update && apt-get install -y curl
           apt-get install build-essential -y
-      - uses: dtolnay/rust-toolchain@v1.70
+      - uses: dtolnay/rust-toolchain@1.79
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2.7.1
       - name: Run tests in debug
@@ -139,7 +139,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@v1.70
+      - uses: dtolnay/rust-toolchain@1.79
         with:
           profile: minimal
           components: clippy
@@ -156,7 +156,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@v1.70
+      - uses: dtolnay/rust-toolchain@1.79
         with:
           profile: minimal
           toolchain: nightly-2024-07-09

--- a/.github/workflows/update-cargo-toml-version.yml
+++ b/.github/workflows/update-cargo-toml-version.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: helix-editor/rust-toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1.70
         with:
           profile: minimal
       - name: Install sd

--- a/.github/workflows/update-cargo-toml-version.yml
+++ b/.github/workflows/update-cargo-toml-version.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@v1.70
+      - uses: dtolnay/rust-toolchain@1.79
         with:
           profile: minimal
       - name: Install sd


### PR DESCRIPTION
Fixes the CI by using another rust-toolchain GitHub repo.

Note: the [helix-editor/rust-toolchain repository](https://github.com/helix-editor/rust-toolchain) has been deleted so we moved to the [dtolnay/rust-toolchain](https://github.com/dtolnay/rust-toolchain) one. However, the dtolnay's one doesn't support `rust-toolchain.toml` and the version is directly in the rust-toolchain@version. We keep the `rust-toolchain.toml` for local builds only.