### PR TITLE
Log error from main using tracing

### DIFF
--- a/meilisearch/src/main.rs
+++ b/meilisearch/src/main.rs
@@ -72,6 +72,19 @@ fn on_panic(info: &std::panic::PanicInfo) {
 
 #[actix_web::main]
 async fn main() -> anyhow::Result<()> {
+    try_main().await.inspect_err(|error| {
+        tracing::error!(%error);
+        let mut current = error.source();
+        let mut depth = 0;
+        while let Some(source) = current {
+            tracing::info!(%source, depth, "Error caused by");
+            current = source.source();
+            depth += 1;
+        }
+    })
+}
+
+async fn try_main() -> anyhow::Result<()> {
     let (opt, config_read_from) = Opt::try_build()?;
 
     std::panic::set_hook(Box::new(on_panic));


### PR DESCRIPTION
Engine follow-up to https://github.com/meilisearch/meilisearch-support/issues/252#issuecomment-2251288276 (private link)

> @meilisearch/engine-team we need to open a PR to tracing::error! when an error occurs in the Meilisearch main. It would be nice to have it included in the second RC

<img width="1349" alt="Error logged when launching Meilisearch to import dump on path where the dump doesn't exist" src="https://github.com/user-attachments/assets/e5d2ae6e-f810-4029-9787-3b6ea9d47cfd">

---

<img width="1349" alt="Error logges when launching Meilisearch with a db path that is not writeable" src="https://github.com/user-attachments/assets/f672d78d-04b0-4d02-9402-259eaa6e2b62">

