### PR TITLE
Attach declared localized-attributes subroutes

### DIFF
--- a/meilisearch/src/routes/indexes/settings.rs
+++ b/meilisearch/src/routes/indexes/settings.rs
@@ -682,6 +682,7 @@ generate_configure!(
     filterable_attributes,
     sortable_attributes,
     displayed_attributes,
+    localized_attributes,
     searchable_attributes,
     distinct_attribute,
     proximity_precision,

--- a/meilisearch/tests/settings/get_settings.rs
+++ b/meilisearch/tests/settings/get_settings.rs
@@ -9,6 +9,7 @@ static DEFAULT_SETTINGS_VALUES: Lazy<HashMap<&'static str, Value>> = Lazy::new(|
     let mut map = HashMap::new();
     map.insert("displayed_attributes", json!(["*"]));
     map.insert("searchable_attributes", json!(["*"]));
+    map.insert("localized_attributes", json!(null));
     map.insert("filterable_attributes", json!([]));
     map.insert("distinct_attribute", json!(null));
     map.insert(
@@ -409,6 +410,7 @@ macro_rules! test_setting_routes {
 test_setting_routes!(
     filterable_attributes put,
     displayed_attributes put,
+    localized_attributes put,
     searchable_attributes put,
     distinct_attribute put,
     stop_words put,


### PR DESCRIPTION
RC.0 unexpectedly doesn't contain the `GET /indexes/{indexUid}/localized-attributes` and `PUT /indexes/{indexUid}/localized-attributes` subroute.

This PR makes them available.