### PR TITLE
Explicitely drop the search permits

### DIFF
--- a/meilisearch/src/routes/indexes/facet_search.rs
+++ b/meilisearch/src/routes/indexes/facet_search.rs
@@ -93,8 +93,9 @@ pub async fn search(
             locales,
         )
     })
-    .await?;
+    .await;
     permit.drop().await;
+    let search_result = search_result?;
 
     if let Ok(ref search_result) = search_result {
         aggregate.succeed(search_result);

--- a/meilisearch/src/routes/indexes/search.rs
+++ b/meilisearch/src/routes/indexes/search.rs
@@ -237,8 +237,9 @@ pub async fn search_with_url_query(
     let search_result = tokio::task::spawn_blocking(move || {
         perform_search(&index, query, search_kind, retrieve_vector, index_scheduler.features())
     })
-    .await?;
+    .await;
     permit.drop().await;
+    let search_result = search_result?;
     if let Ok(ref search_result) = search_result {
         aggregate.succeed(search_result);
     }
@@ -281,8 +282,9 @@ pub async fn search_with_post(
     let search_result = tokio::task::spawn_blocking(move || {
         perform_search(&index, query, search_kind, retrieve_vectors, index_scheduler.features())
     })
-    .await?;
+    .await;
     permit.drop().await;
+    let search_result = search_result?;
     if let Ok(ref search_result) = search_result {
         aggregate.succeed(search_result);
         if search_result.degraded {

--- a/meilisearch/src/routes/multi_search.rs
+++ b/meilisearch/src/routes/multi_search.rs
@@ -39,7 +39,7 @@ pub async fn multi_search_with_post(
 ) -> Result<HttpResponse, ResponseError> {
     // Since we don't want to process half of the search requests and then get a permit refused
     // we're going to get one permit for the whole duration of the multi-search request.
-    let _permit = search_queue.try_get_search_permit().await?;
+    let permit = search_queue.try_get_search_permit().await?;
 
     let federated_search = params.into_inner();
 
@@ -162,6 +162,7 @@ pub async fn multi_search_with_post(
             HttpResponse::Ok().json(SearchResults { results: search_results })
         }
     };
+    permit.drop().await;
 
     Ok(response)
 }

--- a/meilisearch/src/routes/multi_search.rs
+++ b/meilisearch/src/routes/multi_search.rs
@@ -81,6 +81,7 @@ pub async fn multi_search_with_post(
                 perform_federated_search(&index_scheduler, queries, federation, features)
             })
             .await;
+            permit.drop().await;
 
             if let Ok(Ok(_)) = search_result {
                 multi_aggregate.succeed();
@@ -143,6 +144,7 @@ pub async fn multi_search_with_post(
                 Ok(search_results)
             }
             .await;
+            permit.drop().await;
 
             if search_results.is_ok() {
                 multi_aggregate.succeed();
@@ -162,7 +164,6 @@ pub async fn multi_search_with_post(
             HttpResponse::Ok().json(SearchResults { results: search_results })
         }
     };
-    permit.drop().await;
 
     Ok(response)
 }

--- a/meilisearch/src/search_queue.rs
+++ b/meilisearch/src/search_queue.rs
@@ -33,9 +33,18 @@ pub struct SearchQueue {
 
 /// You should only run search requests while holding this permit.
 /// Once it's dropped, a new search request will be able to process.
+/// You should always try to drop the permit yourself calling the `drop` async method on it.
 #[derive(Debug)]
 pub struct Permit {
     sender: mpsc::Sender<()>,
+}
+
+impl Permit {
+    /// Drop the permit giving back on permit to the search queue.
+    pub async fn drop(self) {
+        // if the channel is closed then the whole instance is down
+        let _ = self.sender.send(()).await;
+    }
 }
 
 impl Drop for Permit {

--- a/meilisearch/src/search_queue.rs
+++ b/meilisearch/src/search_queue.rs
@@ -49,6 +49,7 @@ impl Permit {
 
 impl Drop for Permit {
     fn drop(&mut self) {
+        tracing::warn!("Internal error, a search permit was lazily dropped. If you see this message, please open an issue on the meilisearch repository at <https://github.com/meilisearch/meilisearch/issues/new?template=bug_report.md&title=[INTERNAL%20ERROR]%20Meilisearch%20lazily%20dropped%20a%20search%20permit>");
         let sender = self.sender.clone();
         // if the channel is closed then the whole instance is down
         std::mem::drop(tokio::spawn(async move { sender.send(()).await }));

--- a/meilisearch/src/search_queue.rs
+++ b/meilisearch/src/search_queue.rs
@@ -48,8 +48,10 @@ impl Permit {
 }
 
 impl Drop for Permit {
+    /// The implicit drop implementation can still be called in multiple cases:
+    /// - We forgot to call the explicit one somewhere => this should be fixed on our side asap
+    /// - The future is cancelled while running and the permit dropped with it
     fn drop(&mut self) {
-        tracing::warn!("Internal error, a search permit was lazily dropped. If you see this message, please open an issue on the meilisearch repository at <https://github.com/meilisearch/meilisearch/issues/new?template=bug_report.md&title=[INTERNAL%20ERROR]%20Meilisearch%20lazily%20dropped%20a%20search%20permit>");
         let sender = self.sender.clone();
         // if the channel is closed then the whole instance is down
         std::mem::drop(tokio::spawn(async move { sender.send(()).await }));

--- a/meilisearch/tests/search/search_queue.rs
+++ b/meilisearch/tests/search/search_queue.rs
@@ -38,6 +38,25 @@ async fn search_queue_register() {
 }
 
 #[actix_rt::test]
+async fn search_queue_register_with_explicit_drop() {
+    let queue = SearchQueue::new(4, NonZeroUsize::new(2).unwrap());
+
+    // First, use all the cores
+    let permit1 = queue.try_get_search_permit().await.unwrap();
+    let _permit2 = queue.try_get_search_permit().await.unwrap();
+
+    // If we free one spot we should be able to register one new search
+    permit1.drop().await;
+
+    let permit3 = queue.try_get_search_permit().await.unwrap();
+
+    // And again
+    permit3.drop().await;
+
+    let _permit4 = queue.try_get_search_permit().await.unwrap();
+}
+
+#[actix_rt::test]
 async fn wait_till_cores_are_available() {
     let queue = Arc::new(SearchQueue::new(4, NonZeroUsize::new(1).unwrap()));
 


### PR DESCRIPTION
# Pull Request

## Related issue
May be related to #4654 and https://github.com/meilisearch/meilisearch-support/issues/350

## What does this PR do?
- Stop spawning a tokio task that is not immediately scheduled and instead explicitly drop the search permit

This should make new search requests to be scheduled quicker than before and reduce the general load on tokio