### PR TITLE
Change OpenAI default model

### DIFF
--- a/milli/src/vector/openai.rs
+++ b/milli/src/vector/openai.rs
@@ -66,11 +66,11 @@ pub enum EmbeddingModel {
     // # WARNING
     //
     // If ever adding a model, make sure to add it to the list of supported models below.
-    #[default]
     #[serde(rename = "text-embedding-ada-002")]
     #[deserr(rename = "text-embedding-ada-002")]
     TextEmbeddingAda002,
 
+    #[default]
     #[serde(rename = "text-embedding-3-small")]
     #[deserr(rename = "text-embedding-3-small")]
     TextEmbedding3Small,


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #4856

See also [public usage](https://meilisearch.notion.site/v1-11-AI-search-changes-0e37727193884a70999f254fa953ce6e#b4685a48c4784262a149ec307ec58671)

## What does this PR do?
- make the `text-embedding-3-small` the default model for OpenAI instead of `text-embedding-ada-002`. Existing embedders are not impacted
