### PR TITLE
Remove default embedder

### DIFF
--- a/meilisearch/src/analytics/segment_analytics.rs
+++ b/meilisearch/src/analytics/segment_analytics.rs
@@ -646,8 +646,6 @@ pub struct SearchAggregator {
     max_vector_size: usize,
     // Whether the semantic ratio passed to a hybrid search equals the default ratio.
     semantic_ratio: bool,
-    // Whether a non-default embedder was specified
-    embedder: bool,
     hybrid: bool,
     retrieve_vectors: bool,
 
@@ -795,7 +793,6 @@ impl SearchAggregator {
 
         if let Some(hybrid) = hybrid {
             ret.semantic_ratio = hybrid.semantic_ratio != DEFAULT_SEMANTIC_RATIO();
-            ret.embedder = hybrid.embedder.is_some();
             ret.hybrid = true;
         }
 
@@ -863,7 +860,6 @@ impl SearchAggregator {
             show_ranking_score,
             show_ranking_score_details,
             semantic_ratio,
-            embedder,
             hybrid,
             total_degraded,
             total_used_negative_operator,
@@ -923,7 +919,6 @@ impl SearchAggregator {
         self.retrieve_vectors |= retrieve_vectors;
         self.semantic_ratio |= semantic_ratio;
         self.hybrid |= hybrid;
-        self.embedder |= embedder;
 
         // pagination
         self.max_limit = self.max_limit.max(max_limit);
@@ -999,7 +994,6 @@ impl SearchAggregator {
             show_ranking_score,
             show_ranking_score_details,
             semantic_ratio,
-            embedder,
             hybrid,
             total_degraded,
             total_used_negative_operator,
@@ -1051,7 +1045,6 @@ impl SearchAggregator {
                 "hybrid": {
                     "enabled": hybrid,
                     "semantic_ratio": semantic_ratio,
-                    "embedder": embedder,
                 },
                 "pagination": {
                    "max_limit": max_limit,
@@ -1782,7 +1775,6 @@ pub struct SimilarAggregator {
     used_syntax: HashMap<String, usize>,
 
     // Whether a non-default embedder was specified
-    embedder: bool,
     retrieve_vectors: bool,
 
     // pagination
@@ -1803,7 +1795,7 @@ impl SimilarAggregator {
     pub fn from_query(query: &SimilarQuery, request: &HttpRequest) -> Self {
         let SimilarQuery {
             id: _,
-            embedder,
+            embedder: _,
             offset,
             limit,
             attributes_to_retrieve: _,
@@ -1851,7 +1843,6 @@ impl SimilarAggregator {
         ret.show_ranking_score_details = *show_ranking_score_details;
         ret.ranking_score_threshold = ranking_score_threshold.is_some();
 
-        ret.embedder = embedder.is_some();
         ret.retrieve_vectors = *retrieve_vectors;
 
         ret
@@ -1883,7 +1874,6 @@ impl SimilarAggregator {
             max_attributes_to_retrieve,
             show_ranking_score,
             show_ranking_score_details,
-            embedder,
             ranking_score_threshold,
             retrieve_vectors,
         } = other;
@@ -1914,7 +1904,6 @@ impl SimilarAggregator {
             *used_syntax = used_syntax.saturating_add(value);
         }
 
-        self.embedder |= embedder;
         self.retrieve_vectors |= retrieve_vectors;
 
         // pagination
@@ -1948,7 +1937,6 @@ impl SimilarAggregator {
             max_attributes_to_retrieve,
             show_ranking_score,
             show_ranking_score_details,
-            embedder,
             ranking_score_threshold,
             retrieve_vectors,
         } = self;
@@ -1979,9 +1967,6 @@ impl SimilarAggregator {
                 },
                 "vector": {
                     "retrieve_vectors": retrieve_vectors,
-                },
-                "hybrid": {
-                    "embedder": embedder,
                 },
                 "pagination": {
                    "max_limit": max_limit,

--- a/meilisearch/src/error.rs
+++ b/meilisearch/src/error.rs
@@ -61,7 +61,7 @@ pub enum MeilisearchHttpError {
     DocumentFormat(#[from] DocumentFormatError),
     #[error(transparent)]
     Join(#[from] JoinError),
-    #[error("Invalid request: missing `hybrid` parameter when both `q` and `vector` are present.")]
+    #[error("Invalid request: missing `hybrid` parameter when `vector` is present.")]
     MissingSearchHybrid,
 }
 

--- a/meilisearch/src/routes/indexes/similar.rs
+++ b/meilisearch/src/routes/indexes/similar.rs
@@ -103,7 +103,7 @@ async fn similar(
     let index = index_scheduler.index(&index_uid)?;
 
     let (embedder_name, embedder) =
-        SearchKind::embedder(&index_scheduler, &index, query.embedder.as_deref(), None)?;
+        SearchKind::embedder(&index_scheduler, &index, &query.embedder, None)?;
 
     tokio::task::spawn_blocking(move || {
         perform_similar(
@@ -139,8 +139,8 @@ pub struct SimilarQueryGet {
     show_ranking_score_details: Param<bool>,
     #[deserr(default, error = DeserrQueryParamError<InvalidSimilarRankingScoreThreshold>, default)]
     pub ranking_score_threshold: Option<RankingScoreThresholdGet>,
-    #[deserr(default, error = DeserrQueryParamError<InvalidEmbedder>)]
-    pub embedder: Option<String>,
+    #[deserr(error = DeserrQueryParamError<InvalidEmbedder>)]
+    pub embedder: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, deserr::Deserr)]

--- a/meilisearch/src/search/mod.rs
+++ b/meilisearch/src/search/mod.rs
@@ -267,8 +267,8 @@ impl fmt::Debug for SearchQuery {
 pub struct HybridQuery {
     #[deserr(default, error = DeserrJsonError<InvalidSearchSemanticRatio>, default)]
     pub semantic_ratio: SemanticRatio,
-    #[deserr(default, error = DeserrJsonError<InvalidEmbedder>, default)]
-    pub embedder: Option<String>,
+    #[deserr(error = DeserrJsonError<InvalidEmbedder>)]
+    pub embedder: String,
 }
 
 #[derive(Clone)]
@@ -282,7 +282,7 @@ impl SearchKind {
     pub(crate) fn semantic(
         index_scheduler: &index_scheduler::IndexScheduler,
         index: &Index,
-        embedder_name: Option<&str>,
+        embedder_name: &str,
         vector_len: Option<usize>,
     ) -> Result<Self, ResponseError> {
         let (embedder_name, embedder) =
@@ -293,7 +293,7 @@ impl SearchKind {
     pub(crate) fn hybrid(
         index_scheduler: &index_scheduler::IndexScheduler,
         index: &Index,
-        embedder_name: Option<&str>,
+        embedder_name: &str,
         semantic_ratio: f32,
         vector_len: Option<usize>,
     ) -> Result<Self, ResponseError> {
@@ -305,13 +305,11 @@ impl SearchKind {
     pub(crate) fn embedder(
         index_scheduler: &index_scheduler::IndexScheduler,
         index: &Index,
-        embedder_name: Option<&str>,
+        embedder_name: &str,
         vector_len: Option<usize>,
     ) -> Result<(String, Arc<Embedder>), ResponseError> {
         let embedder_configs = index.embedding_configs(&index.read_txn()?)?;
         let embedders = index_scheduler.embedders(embedder_configs)?;
-
-        let embedder_name = embedder_name.unwrap_or_else(|| embedders.get_default_embedder_name());
 
         let embedder = embedders.get(embedder_name);
 
@@ -537,8 +535,8 @@ pub struct SimilarQuery {
     pub limit: usize,
     #[deserr(default, error = DeserrJsonError<InvalidSimilarFilter>)]
     pub filter: Option<Value>,
-    #[deserr(default, error = DeserrJsonError<InvalidEmbedder>, default)]
-    pub embedder: Option<String>,
+    #[deserr(error = DeserrJsonError<InvalidEmbedder>)]
+    pub embedder: String,
     #[deserr(default, error = DeserrJsonError<InvalidSimilarAttributesToRetrieve>)]
     pub attributes_to_retrieve: Option<BTreeSet<String>>,
     #[deserr(default, error = DeserrJsonError<InvalidSimilarRetrieveVectors>)]

--- a/meilisearch/tests/search/hybrid.rs
+++ b/meilisearch/tests/search/hybrid.rs
@@ -128,7 +128,7 @@ async fn simple_search() {
 
     let (response, code) = index
         .search_post(
-            json!({"q": "Captain", "vector": [1.0, 1.0], "hybrid": {"semanticRatio": 0.2}, "retrieveVectors": true}),
+            json!({"q": "Captain", "vector": [1.0, 1.0], "hybrid": {"semanticRatio": 0.2, "embedder": "default"}, "retrieveVectors": true}),
         )
         .await;
     snapshot!(code, @"200 OK");
@@ -137,7 +137,7 @@ async fn simple_search() {
 
     let (response, code) = index
         .search_post(
-            json!({"q": "Captain", "vector": [1.0, 1.0], "hybrid": {"semanticRatio": 0.5}, "showRankingScore": true, "retrieveVectors": true}),
+            json!({"q": "Captain", "vector": [1.0, 1.0], "hybrid": {"semanticRatio": 0.5, "embedder": "default"}, "showRankingScore": true, "retrieveVectors": true}),
         )
         .await;
     snapshot!(code, @"200 OK");
@@ -146,7 +146,7 @@ async fn simple_search() {
 
     let (response, code) = index
         .search_post(
-            json!({"q": "Captain", "vector": [1.0, 1.0], "hybrid": {"semanticRatio": 0.8}, "showRankingScore": true, "retrieveVectors": true}),
+            json!({"q": "Captain", "vector": [1.0, 1.0], "hybrid": {"semanticRatio": 0.8, "embedder": "default"}, "showRankingScore": true, "retrieveVectors": true}),
         )
         .await;
     snapshot!(code, @"200 OK");
@@ -161,7 +161,7 @@ async fn limit_offset() {
 
     let (response, code) = index
         .search_post(
-            json!({"q": "Captain", "vector": [1.0, 1.0], "hybrid": {"semanticRatio": 0.2}, "retrieveVectors": true, "offset": 1, "limit": 1}),
+            json!({"q": "Captain", "vector": [1.0, 1.0], "hybrid": {"semanticRatio": 0.2, "embedder": "default"}, "retrieveVectors": true, "offset": 1, "limit": 1}),
         )
         .await;
     snapshot!(code, @"200 OK");
@@ -174,7 +174,7 @@ async fn limit_offset() {
 
     let (response, code) = index
         .search_post(
-            json!({"q": "Captain", "vector": [1.0, 1.0], "hybrid": {"semanticRatio": 0.9}, "retrieveVectors": true, "offset": 1, "limit": 1}),
+            json!({"q": "Captain", "vector": [1.0, 1.0], "hybrid": {"semanticRatio": 0.9, "embedder": "default"}, "retrieveVectors": true, "offset": 1, "limit": 1}),
         )
         .await;
     snapshot!(code, @"200 OK");
@@ -188,8 +188,11 @@ async fn simple_search_hf() {
     let server = Server::new().await;
     let index = index_with_documents_hf(&server, &SIMPLE_SEARCH_DOCUMENTS).await;
 
-    let (response, code) =
-        index.search_post(json!({"q": "Captain", "hybrid": {"semanticRatio": 0.2}})).await;
+    let (response, code) = index
+        .search_post(
+            json!({"q": "Captain", "hybrid": {"semanticRatio": 0.2, "embedder": "default"}}),
+        )
+        .await;
     snapshot!(code, @"200 OK");
     snapshot!(response["hits"], @r###"[{"title":"Captain Planet","desc":"He's not part of the Marvel Cinematic Universe","id":"2"},{"title":"Captain Marvel","desc":"a Shazam ersatz","id":"3"},{"title":"Shazam!","desc":"a Captain Marvel ersatz","id":"1"}]"###);
     snapshot!(response["semanticHitCount"], @"0");
@@ -197,7 +200,7 @@ async fn simple_search_hf() {
     let (response, code) = index
         .search_post(
             // disable ranking score as the vectors between architectures are not equal
-            json!({"q": "Captain", "hybrid": {"semanticRatio": 0.55}, "showRankingScore": false}),
+            json!({"q": "Captain", "hybrid": {"embedder": "default", "semanticRatio": 0.55}, "showRankingScore": false}),
         )
         .await;
     snapshot!(code, @"200 OK");
@@ -206,7 +209,7 @@ async fn simple_search_hf() {
 
     let (response, code) = index
         .search_post(
-            json!({"q": "Captain", "hybrid": {"semanticRatio": 0.8}, "showRankingScore": false}),
+            json!({"q": "Captain", "hybrid": {"embedder": "default", "semanticRatio": 0.8}, "showRankingScore": false}),
         )
         .await;
     snapshot!(code, @"200 OK");
@@ -215,7 +218,7 @@ async fn simple_search_hf() {
 
     let (response, code) = index
         .search_post(
-            json!({"q": "Movie World", "hybrid": {"semanticRatio": 0.2}, "showRankingScore": false}),
+            json!({"q": "Movie World", "hybrid": {"embedder": "default", "semanticRatio": 0.2}, "showRankingScore": false}),
         )
         .await;
     snapshot!(code, @"200 OK");
@@ -224,7 +227,7 @@ async fn simple_search_hf() {
 
     let (response, code) = index
         .search_post(
-            json!({"q": "Wonder replacement", "hybrid": {"semanticRatio": 0.2}, "showRankingScore": false}),
+            json!({"q": "Wonder replacement", "hybrid": {"embedder": "default", "semanticRatio": 0.2}, "showRankingScore": false}),
         )
         .await;
     snapshot!(code, @"200 OK");
@@ -237,7 +240,7 @@ async fn distribution_shift() {
     let server = Server::new().await;
     let index = index_with_documents_user_provided(&server, &SIMPLE_SEARCH_DOCUMENTS_VEC).await;
 
-    let search = json!({"q": "Captain", "vector": [1.0, 1.0], "showRankingScore": true, "hybrid": {"semanticRatio": 1.0}, "retrieveVectors": true});
+    let search = json!({"q": "Captain", "vector": [1.0, 1.0], "showRankingScore": true, "hybrid": {"embedder": "default", "semanticRatio": 1.0}, "retrieveVectors": true});
     let (response, code) = index.search_post(search.clone()).await;
     snapshot!(code, @"200 OK");
     snapshot!(response["hits"], @r###"[{"title":"Captain Marvel","desc":"a Shazam ersatz","id":"3","_vectors":{"default":{"embeddings":[[2.0,3.0]],"regenerate":false}},"_rankingScore":0.990290343761444},{"title":"Captain Planet","desc":"He's not part of the Marvel Cinematic Universe","id":"2","_vectors":{"default":{"embeddings":[[1.0,2.0]],"regenerate":false}},"_rankingScore":0.974341630935669},{"title":"Shazam!","desc":"a Captain Marvel ersatz","id":"1","_vectors":{"default":{"embeddings":[[1.0,3.0]],"regenerate":false}},"_rankingScore":0.9472135901451112}]"###);
@@ -271,7 +274,7 @@ async fn highlighter() {
 
     let (response, code) = index
         .search_post(json!({"q": "Captain Marvel", "vector": [1.0, 1.0],
-            "hybrid": {"semanticRatio": 0.2},
+            "hybrid": {"embedder": "default", "semanticRatio": 0.2},
            "retrieveVectors": true,
            "attributesToHighlight": [
                      "desc",
@@ -287,7 +290,7 @@ async fn highlighter() {
 
     let (response, code) = index
         .search_post(json!({"q": "Captain Marvel", "vector": [1.0, 1.0],
-            "hybrid": {"semanticRatio": 0.8},
+            "hybrid": {"embedder": "default", "semanticRatio": 0.8},
             "retrieveVectors": true,
             "showRankingScore": true,
             "attributesToHighlight": [
@@ -304,7 +307,7 @@ async fn highlighter() {
     // no highlighting on full semantic
     let (response, code) = index
         .search_post(json!({"q": "Captain Marvel", "vector": [1.0, 1.0],
-            "hybrid": {"semanticRatio": 1.0},
+            "hybrid": {"embedder": "default", "semanticRatio": 1.0},
             "retrieveVectors": true,
             "showRankingScore": true,
             "attributesToHighlight": [
@@ -326,7 +329,7 @@ async fn invalid_semantic_ratio() {
 
     let (response, code) = index
         .search_post(
-            json!({"q": "Captain", "vector": [1.0, 1.0], "hybrid": {"semanticRatio": 1.2}}),
+            json!({"q": "Captain", "vector": [1.0, 1.0], "hybrid": {"embedder": "default", "semanticRatio": 1.2}}),
         )
         .await;
     snapshot!(code, @"400 Bad Request");
@@ -341,7 +344,7 @@ async fn invalid_semantic_ratio() {
 
     let (response, code) = index
         .search_post(
-            json!({"q": "Captain", "vector": [1.0, 1.0], "hybrid": {"semanticRatio": -0.8}}),
+            json!({"q": "Captain", "vector": [1.0, 1.0], "hybrid": {"embedder": "default", "semanticRatio": -0.8}}),
         )
         .await;
     snapshot!(code, @"400 Bad Request");
@@ -357,7 +360,7 @@ async fn invalid_semantic_ratio() {
     let (response, code) = index
         .search_get(
             &yaup::to_string(
-                &json!({"q": "Captain", "vector": [1.0, 1.0], "hybridSemanticRatio": 1.2}),
+                &json!({"q": "Captain", "vector": [1.0, 1.0], "hybridEmbedder": "default", "hybridSemanticRatio": 1.2}),
             )
             .unwrap(),
         )
@@ -375,7 +378,7 @@ async fn invalid_semantic_ratio() {
     let (response, code) = index
         .search_get(
             &yaup::to_string(
-                &json!({"q": "Captain", "vector": [1.0, 1.0], "hybridSemanticRatio": -0.2}),
+                &json!({"q": "Captain", "vector": [1.0, 1.0], "hybridEmbedder": "default", "hybridSemanticRatio": -0.2}),
             )
             .unwrap(),
         )
@@ -398,7 +401,7 @@ async fn single_document() {
 
     let (response, code) = index
     .search_post(
-        json!({"vector": [1.0, 3.0], "hybrid": {"semanticRatio": 1.0}, "showRankingScore": true, "retrieveVectors": true}),
+        json!({"vector": [1.0, 3.0], "hybrid": {"semanticRatio": 1.0, "embedder": "default"}, "showRankingScore": true, "retrieveVectors": true}),
     )
     .await;
 
@@ -414,7 +417,7 @@ async fn query_combination() {
 
     // search without query and vector, but with hybrid => still placeholder
     let (response, code) = index
-        .search_post(json!({"hybrid": {"semanticRatio": 1.0}, "showRankingScore": true, "retrieveVectors": true}))
+        .search_post(json!({"hybrid": {"embedder": "default", "semanticRatio": 1.0}, "showRankingScore": true, "retrieveVectors": true}))
         .await;
 
     snapshot!(code, @"200 OK");
@@ -423,7 +426,7 @@ async fn query_combination() {
 
     // same with a different semantic ratio
     let (response, code) = index
-        .search_post(json!({"hybrid": {"semanticRatio": 0.76}, "showRankingScore": true, "retrieveVectors": true}))
+        .search_post(json!({"hybrid": {"embedder": "default", "semanticRatio": 0.76}, "showRankingScore": true, "retrieveVectors": true}))
         .await;
 
     snapshot!(code, @"200 OK");
@@ -432,7 +435,7 @@ async fn query_combination() {
 
     // wrong vector dimensions
     let (response, code) = index
-    .search_post(json!({"vector": [1.0, 0.0, 1.0], "hybrid": {"semanticRatio": 1.0}, "showRankingScore": true, "retrieveVectors": true}))
+    .search_post(json!({"vector": [1.0, 0.0, 1.0], "hybrid": {"embedder": "default", "semanticRatio": 1.0}, "showRankingScore": true, "retrieveVectors": true}))
     .await;
 
     snapshot!(code, @"400 Bad Request");
@@ -447,7 +450,7 @@ async fn query_combination() {
 
     // full vector
     let (response, code) = index
-    .search_post(json!({"vector": [1.0, 0.0], "hybrid": {"semanticRatio": 1.0}, "showRankingScore": true, "retrieveVectors": true}))
+    .search_post(json!({"vector": [1.0, 0.0], "hybrid": {"embedder": "default", "semanticRatio": 1.0}, "showRankingScore": true, "retrieveVectors": true}))
     .await;
 
     snapshot!(code, @"200 OK");
@@ -456,7 +459,7 @@ async fn query_combination() {
 
     // full keyword, without a query
     let (response, code) = index
-    .search_post(json!({"vector": [1.0, 0.0], "hybrid": {"semanticRatio": 0.0}, "showRankingScore": true, "retrieveVectors": true}))
+    .search_post(json!({"vector": [1.0, 0.0], "hybrid": {"embedder": "default", "semanticRatio": 0.0}, "showRankingScore": true, "retrieveVectors": true}))
     .await;
 
     snapshot!(code, @"200 OK");
@@ -465,7 +468,7 @@ async fn query_combination() {
 
     // query + vector, full keyword => keyword
     let (response, code) = index
-    .search_post(json!({"q": "Captain", "vector": [1.0, 0.0], "hybrid": {"semanticRatio": 0.0}, "showRankingScore": true, "retrieveVectors": true}))
+    .search_post(json!({"q": "Captain", "vector": [1.0, 0.0], "hybrid": {"embedder": "default", "semanticRatio": 0.0}, "showRankingScore": true, "retrieveVectors": true}))
     .await;
 
     snapshot!(code, @"200 OK");
@@ -480,7 +483,7 @@ async fn query_combination() {
     snapshot!(code, @"400 Bad Request");
     snapshot!(response, @r###"
     {
-      "message": "Invalid request: missing `hybrid` parameter when both `q` and `vector` are present.",
+      "message": "Invalid request: missing `hybrid` parameter when `vector` is present.",
       "code": "missing_search_hybrid",
       "type": "invalid_request",
       "link": "https://docs.meilisearch.com/errors#missing_search_hybrid"
@@ -490,7 +493,7 @@ async fn query_combination() {
     // full vector, without a vector => error
     let (response, code) = index
         .search_post(
-            json!({"q": "Captain", "hybrid": {"semanticRatio": 1.0}, "showRankingScore": true, "retrieveVectors": true}),
+            json!({"q": "Captain", "hybrid": {"semanticRatio": 1.0, "embedder": "default"}, "showRankingScore": true, "retrieveVectors": true}),
         )
         .await;
 
@@ -507,7 +510,7 @@ async fn query_combination() {
     // hybrid without a vector => full keyword
     let (response, code) = index
         .search_post(
-            json!({"q": "Planet", "hybrid": {"semanticRatio": 0.99}, "showRankingScore": true, "retrieveVectors": true}),
+            json!({"q": "Planet", "hybrid": {"semanticRatio": 0.99, "embedder": "default"}, "showRankingScore": true, "retrieveVectors": true}),
         )
         .await;
 
@@ -523,7 +526,7 @@ async fn retrieve_vectors() {
 
     let (response, code) = index
         .search_post(
-            json!({"q": "Captain", "hybrid": {"semanticRatio": 0.2}, "retrieveVectors": true}),
+            json!({"q": "Captain", "hybrid": {"embedder": "default", "semanticRatio": 0.2}, "retrieveVectors": true}),
         )
         .await;
     snapshot!(code, @"200 OK");
@@ -573,7 +576,7 @@ async fn retrieve_vectors() {
 
     let (response, code) = index
         .search_post(
-            json!({"q": "Captain", "hybrid": {"semanticRatio": 0.2}, "retrieveVectors": true}),
+            json!({"q": "Captain", "hybrid": {"embedder": "default", "semanticRatio": 0.2}, "retrieveVectors": true}),
         )
         .await;
     snapshot!(code, @"200 OK");

--- a/meilisearch/tests/search/mod.rs
+++ b/meilisearch/tests/search/mod.rs
@@ -1099,22 +1099,28 @@ async fn experimental_feature_vector_store() {
     index.add_documents(json!(documents), None).await;
     index.wait_task(0).await;
 
-    index
-        .search(json!({
+    let (response, code) = index
+        .search_post(json!({
             "vector": [1.0, 2.0, 3.0],
+            "hybrid": {
+              "embedder": "manual",
+            },
             "showRankingScore": true
-        }), |response, code|{
-            meili_snap::snapshot!(code, @"400 Bad Request");
-            meili_snap::snapshot!(meili_snap::json_string!(response), @r###"
-            {
-              "message": "Passing `vector` as a parameter requires enabling the `vector store` experimental feature. See https://github.com/meilisearch/product/discussions/677",
-              "code": "feature_not_enabled",
-              "type": "invalid_request",
-              "link": "https://docs.meilisearch.com/errors#feature_not_enabled"
-            }
-            "###);
-        })
+        }))
         .await;
+
+    {
+        meili_snap::snapshot!(code, @"400 Bad Request");
+        meili_snap::snapshot!(meili_snap::json_string!(response), @r###"
+          {
+            "message": "Passing `vector` as a parameter requires enabling the `vector store` experimental feature. See https://github.com/meilisearch/product/discussions/677",
+            "code": "feature_not_enabled",
+            "type": "invalid_request",
+            "link": "https://docs.meilisearch.com/errors#feature_not_enabled"
+          }
+          "###);
+    }
+
     index
         .search(json!({
             "retrieveVectors": true,
@@ -1162,6 +1168,9 @@ async fn experimental_feature_vector_store() {
     let (response, code) = index
         .search_post(json!({
             "vector": [1.0, 2.0, 3.0],
+            "hybrid": {
+              "embedder": "manual",
+            },
             "showRankingScore": true,
             "retrieveVectors": true,
         }))

--- a/meilisearch/tests/similar/errors.rs
+++ b/meilisearch/tests/similar/errors.rs
@@ -18,7 +18,7 @@ async fn similar_unexisting_index() {
     });
 
     index
-        .similar(json!({"id": 287947}), |response, code| {
+        .similar(json!({"id": 287947, "embedder": "manual"}), |response, code| {
             assert_eq!(code, 404);
             assert_eq!(response, expected_response);
         })
@@ -44,7 +44,7 @@ async fn similar_feature_not_enabled() {
     let server = Server::new().await;
     let index = server.index("test");
 
-    let (response, code) = index.similar_post(json!({"id": 287947})).await;
+    let (response, code) = index.similar_post(json!({"id": 287947, "embedder": "manual"})).await;
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
@@ -199,7 +199,8 @@ async fn similar_not_found_id() {
     snapshot!(code, @"202 Accepted");
     server.wait_task(response.uid()).await;
 
-    let (response, code) = index.similar_post(json!({"id": "definitely-doesnt-exist"})).await;
+    let (response, code) =
+        index.similar_post(json!({"id": "definitely-doesnt-exist", "embedder": "manual"})).await;
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
@@ -230,7 +231,8 @@ async fn similar_bad_offset() {
     snapshot!(code, @"202 Accepted");
     server.wait_task(response.uid()).await;
 
-    let (response, code) = index.similar_post(json!({"id": 287947, "offset": "doggo"})).await;
+    let (response, code) =
+        index.similar_post(json!({"id": 287947, "offset": "doggo", "embedder": "manual"})).await;
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
@@ -241,7 +243,7 @@ async fn similar_bad_offset() {
     }
     "###);
 
-    let (response, code) = index.similar_get("?id=287947&offset=doggo").await;
+    let (response, code) = index.similar_get("?id=287947&offset=doggo&embedder=manual").await;
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
@@ -272,7 +274,8 @@ async fn similar_bad_limit() {
     snapshot!(code, @"202 Accepted");
     server.wait_task(response.uid()).await;
 
-    let (response, code) = index.similar_post(json!({"id": 287947, "limit": "doggo"})).await;
+    let (response, code) =
+        index.similar_post(json!({"id": 287947, "limit": "doggo", "embedder": "manual"})).await;
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
@@ -283,7 +286,7 @@ async fn similar_bad_limit() {
     }
     "###);
 
-    let (response, code) = index.similar_get("?id=287946&limit=doggo").await;
+    let (response, code) = index.similar_get("?id=287946&limit=doggo&embedder=manual").await;
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
@@ -323,7 +326,8 @@ async fn similar_bad_filter() {
     snapshot!(code, @"202 Accepted");
     index.wait_task(value.uid()).await;
 
-    let (response, code) = index.similar_post(json!({ "id": 287947, "filter": true })).await;
+    let (response, code) =
+        index.similar_post(json!({ "id": 287947, "filter": true, "embedder": "manual" })).await;
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
@@ -361,7 +365,7 @@ async fn filter_invalid_syntax_object() {
     index.wait_task(value.uid()).await;
 
     index
-        .similar(json!({"id": 287947, "filter": "title & Glass"}), |response, code| {
+        .similar(json!({"id": 287947, "filter": "title & Glass", "embedder": "manual"}), |response, code| {
             snapshot!(response, @r###"
             {
               "message": "Was expecting an operation `=`, `!=`, `>=`, `>`, `<=`, `<`, `IN`, `NOT IN`, `TO`, `EXISTS`, `NOT EXISTS`, `IS NULL`, `IS NOT NULL`, `IS EMPTY`, `IS NOT EMPTY`, `CONTAINS`, `NOT CONTAINS`, `_geoRadius`, or `_geoBoundingBox` at `title & Glass`.\n1:14 title & Glass",
@@ -400,7 +404,7 @@ async fn filter_invalid_syntax_array() {
     index.wait_task(value.uid()).await;
 
     index
-        .similar(json!({"id": 287947, "filter": ["title & Glass"]}), |response, code| {
+        .similar(json!({"id": 287947, "filter": ["title & Glass"], "embedder": "manual"}), |response, code| {
             snapshot!(response, @r###"
             {
               "message": "Was expecting an operation `=`, `!=`, `>=`, `>`, `<=`, `<`, `IN`, `NOT IN`, `TO`, `EXISTS`, `NOT EXISTS`, `IS NULL`, `IS NOT NULL`, `IS EMPTY`, `IS NOT EMPTY`, `CONTAINS`, `NOT CONTAINS`, `_geoRadius`, or `_geoBoundingBox` at `title & Glass`.\n1:14 title & Glass",
@@ -446,7 +450,7 @@ async fn filter_invalid_syntax_string() {
     });
     index
         .similar(
-            json!({"id": 287947, "filter": "title = Glass XOR title = Glass"}),
+            json!({"id": 287947, "filter": "title = Glass XOR title = Glass", "embedder": "manual"}),
             |response, code| {
                 assert_eq!(response, expected_response);
                 assert_eq!(code, 400);
@@ -486,10 +490,13 @@ async fn filter_invalid_attribute_array() {
         "link": "https://docs.meilisearch.com/errors#invalid_similar_filter"
     });
     index
-        .similar(json!({"id": 287947, "filter": ["many = Glass"]}), |response, code| {
-            assert_eq!(response, expected_response);
-            assert_eq!(code, 400);
-        })
+        .similar(
+            json!({"id": 287947, "filter": ["many = Glass"], "embedder": "manual"}),
+            |response, code| {
+                assert_eq!(response, expected_response);
+                assert_eq!(code, 400);
+            },
+        )
         .await;
 }
 
@@ -524,10 +531,13 @@ async fn filter_invalid_attribute_string() {
         "link": "https://docs.meilisearch.com/errors#invalid_similar_filter"
     });
     index
-        .similar(json!({"id": 287947, "filter": "many = Glass"}), |response, code| {
-            assert_eq!(response, expected_response);
-            assert_eq!(code, 400);
-        })
+        .similar(
+            json!({"id": 287947, "filter": "many = Glass", "embedder": "manual"}),
+            |response, code| {
+                assert_eq!(response, expected_response);
+                assert_eq!(code, 400);
+            },
+        )
         .await;
 }
 
@@ -562,10 +572,13 @@ async fn filter_reserved_geo_attribute_array() {
         "link": "https://docs.meilisearch.com/errors#invalid_similar_filter"
     });
     index
-        .similar(json!({"id": 287947, "filter": ["_geo = Glass"]}), |response, code| {
-            assert_eq!(response, expected_response);
-            assert_eq!(code, 400);
-        })
+        .similar(
+            json!({"id": 287947, "filter": ["_geo = Glass"], "embedder": "manual"}),
+            |response, code| {
+                assert_eq!(response, expected_response);
+                assert_eq!(code, 400);
+            },
+        )
         .await;
 }
 
@@ -600,10 +613,13 @@ async fn filter_reserved_geo_attribute_string() {
         "link": "https://docs.meilisearch.com/errors#invalid_similar_filter"
     });
     index
-        .similar(json!({"id": 287947, "filter": "_geo = Glass"}), |response, code| {
-            assert_eq!(response, expected_response);
-            assert_eq!(code, 400);
-        })
+        .similar(
+            json!({"id": 287947, "filter": "_geo = Glass", "embedder": "manual"}),
+            |response, code| {
+                assert_eq!(response, expected_response);
+                assert_eq!(code, 400);
+            },
+        )
         .await;
 }
 
@@ -638,10 +654,13 @@ async fn filter_reserved_attribute_array() {
         "link": "https://docs.meilisearch.com/errors#invalid_similar_filter"
     });
     index
-        .similar(json!({"id": 287947, "filter": ["_geoDistance = Glass"]}), |response, code| {
-            assert_eq!(response, expected_response);
-            assert_eq!(code, 400);
-        })
+        .similar(
+            json!({"id": 287947, "filter": ["_geoDistance = Glass"], "embedder": "manual"}),
+            |response, code| {
+                assert_eq!(response, expected_response);
+                assert_eq!(code, 400);
+            },
+        )
         .await;
 }
 
@@ -676,10 +695,13 @@ async fn filter_reserved_attribute_string() {
         "link": "https://docs.meilisearch.com/errors#invalid_similar_filter"
     });
     index
-        .similar(json!({"id": 287947, "filter": "_geoDistance = Glass"}), |response, code| {
-            assert_eq!(response, expected_response);
-            assert_eq!(code, 400);
-        })
+        .similar(
+            json!({"id": 287947, "filter": "_geoDistance = Glass", "embedder": "manual"}),
+            |response, code| {
+                assert_eq!(response, expected_response);
+                assert_eq!(code, 400);
+            },
+        )
         .await;
 }
 
@@ -714,10 +736,13 @@ async fn filter_reserved_geo_point_array() {
         "link": "https://docs.meilisearch.com/errors#invalid_similar_filter"
     });
     index
-        .similar(json!({"id": 287947, "filter": ["_geoPoint = Glass"]}), |response, code| {
-            assert_eq!(response, expected_response);
-            assert_eq!(code, 400);
-        })
+        .similar(
+            json!({"id": 287947, "filter": ["_geoPoint = Glass"], "embedder": "manual"}),
+            |response, code| {
+                assert_eq!(response, expected_response);
+                assert_eq!(code, 400);
+            },
+        )
         .await;
 }
 
@@ -752,10 +777,13 @@ async fn filter_reserved_geo_point_string() {
         "link": "https://docs.meilisearch.com/errors#invalid_similar_filter"
     });
     index
-        .similar(json!({"id": 287947, "filter": "_geoPoint = Glass"}), |response, code| {
-            assert_eq!(response, expected_response);
-            assert_eq!(code, 400);
-        })
+        .similar(
+            json!({"id": 287947, "filter": "_geoPoint = Glass", "embedder": "manual"}),
+            |response, code| {
+                assert_eq!(response, expected_response);
+                assert_eq!(code, 400);
+            },
+        )
         .await;
 }
 
@@ -765,7 +793,8 @@ async fn similar_bad_retrieve_vectors() {
     server.set_features(json!({"vectorStore": true})).await;
     let index = server.index("test");
 
-    let (response, code) = index.similar_post(json!({"retrieveVectors": "doggo"})).await;
+    let (response, code) =
+        index.similar_post(json!({"retrieveVectors": "doggo", "embedder": "manual"})).await;
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
@@ -776,7 +805,8 @@ async fn similar_bad_retrieve_vectors() {
     }
     "###);
 
-    let (response, code) = index.similar_post(json!({"retrieveVectors": [true]})).await;
+    let (response, code) =
+        index.similar_post(json!({"retrieveVectors": [true], "embedder": "manual"})).await;
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {

--- a/meilisearch/tests/similar/mod.rs
+++ b/meilisearch/tests/similar/mod.rs
@@ -80,9 +80,11 @@ async fn basic() {
     index.wait_task(value.uid()).await;
 
     index
-        .similar(json!({"id": 143, "retrieveVectors": true}), |response, code| {
-            snapshot!(code, @"200 OK");
-            snapshot!(json_string!(response["hits"]), @r###"
+        .similar(
+            json!({"id": 143, "retrieveVectors": true, "embedder": "manual"}),
+            |response, code| {
+                snapshot!(code, @"200 OK");
+                snapshot!(json_string!(response["hits"]), @r###"
             [
               {
                 "title": "Escape Room",
@@ -154,13 +156,16 @@ async fn basic() {
               }
             ]
             "###);
-        })
+            },
+        )
         .await;
 
     index
-        .similar(json!({"id": "299537", "retrieveVectors": true}), |response, code| {
-            snapshot!(code, @"200 OK");
-            snapshot!(json_string!(response["hits"]), @r###"
+        .similar(
+            json!({"id": "299537", "retrieveVectors": true, "embedder": "manual"}),
+            |response, code| {
+                snapshot!(code, @"200 OK");
+                snapshot!(json_string!(response["hits"]), @r###"
             [
               {
                 "title": "How to Train Your Dragon: The Hidden World",
@@ -232,7 +237,8 @@ async fn basic() {
               }
             ]
             "###);
-        })
+            },
+        )
         .await;
 }
 
@@ -272,7 +278,7 @@ async fn ranking_score_threshold() {
 
     index
         .similar(
-            json!({"id": 143, "showRankingScore": true, "rankingScoreThreshold": 0, "retrieveVectors": true}),
+            json!({"id": 143, "showRankingScore": true, "rankingScoreThreshold": 0, "retrieveVectors": true, "embedder": "manual"}),
             |response, code| {
                 snapshot!(code, @"200 OK");
                 meili_snap::snapshot!(meili_snap::json_string!(response["estimatedTotalHits"]), @"4");
@@ -358,7 +364,7 @@ async fn ranking_score_threshold() {
 
     index
         .similar(
-            json!({"id": 143, "showRankingScore": true, "rankingScoreThreshold": 0.2, "retrieveVectors": true}),
+            json!({"id": 143, "showRankingScore": true, "rankingScoreThreshold": 0.2, "retrieveVectors": true, "embedder": "manual"}),
             |response, code| {
                 snapshot!(code, @"200 OK");
                 meili_snap::snapshot!(meili_snap::json_string!(response["estimatedTotalHits"]), @"3");
@@ -426,7 +432,7 @@ async fn ranking_score_threshold() {
 
     index
         .similar(
-            json!({"id": 143, "showRankingScore": true, "rankingScoreThreshold": 0.3, "retrieveVectors": true}),
+            json!({"id": 143, "showRankingScore": true, "rankingScoreThreshold": 0.3, "retrieveVectors": true, "embedder": "manual"}),
             |response, code| {
                 snapshot!(code, @"200 OK");
                 meili_snap::snapshot!(meili_snap::json_string!(response["estimatedTotalHits"]), @"2");
@@ -476,7 +482,7 @@ async fn ranking_score_threshold() {
 
     index
         .similar(
-            json!({"id": 143, "showRankingScore": true, "rankingScoreThreshold": 0.6, "retrieveVectors": true}),
+            json!({"id": 143, "showRankingScore": true, "rankingScoreThreshold": 0.6, "retrieveVectors": true, "embedder": "manual"}),
             |response, code| {
                 snapshot!(code, @"200 OK");
                 meili_snap::snapshot!(meili_snap::json_string!(response["estimatedTotalHits"]), @"1");
@@ -508,7 +514,7 @@ async fn ranking_score_threshold() {
 
     index
         .similar(
-            json!({"id": 143, "showRankingScore": true, "rankingScoreThreshold": 0.9, "retrieveVectors": true}),
+            json!({"id": 143, "showRankingScore": true, "rankingScoreThreshold": 0.9, "retrieveVectors": true, "embedder": "manual"}),
             |response, code| {
                 snapshot!(code, @"200 OK");
                 snapshot!(json_string!(response["hits"]), @"[]");
@@ -553,7 +559,7 @@ async fn filter() {
 
     index
         .similar(
-            json!({"id": 522681, "filter": "release_year = 2019", "retrieveVectors": true}),
+            json!({"id": 522681, "filter": "release_year = 2019", "retrieveVectors": true, "embedder": "manual"}),
             |response, code| {
                 snapshot!(code, @"200 OK");
                 snapshot!(json_string!(response["hits"]), @r###"
@@ -617,7 +623,7 @@ async fn filter() {
 
     index
         .similar(
-            json!({"id": 522681, "filter": "release_year < 2000", "retrieveVectors": true}),
+            json!({"id": 522681, "filter": "release_year < 2000", "retrieveVectors": true, "embedder": "manual"}),
             |response, code| {
                 snapshot!(code, @"200 OK");
                 snapshot!(json_string!(response["hits"]), @r###"
@@ -681,9 +687,11 @@ async fn limit_and_offset() {
     index.wait_task(value.uid()).await;
 
     index
-        .similar(json!({"id": 143, "limit": 1, "retrieveVectors": true}), |response, code| {
-            snapshot!(code, @"200 OK");
-            snapshot!(json_string!(response["hits"]), @r###"
+        .similar(
+            json!({"id": 143, "limit": 1, "retrieveVectors": true, "embedder": "manual"}),
+            |response, code| {
+                snapshot!(code, @"200 OK");
+                snapshot!(json_string!(response["hits"]), @r###"
             [
               {
                 "title": "Escape Room",
@@ -704,12 +712,13 @@ async fn limit_and_offset() {
               }
             ]
             "###);
-        })
+            },
+        )
         .await;
 
     index
         .similar(
-            json!({"id": 143, "limit": 1, "offset": 1, "retrieveVectors": true}),
+            json!({"id": 143, "limit": 1, "offset": 1, "retrieveVectors": true, "embedder": "manual"}),
             |response, code| {
                 snapshot!(code, @"200 OK");
                 snapshot!(json_string!(response["hits"]), @r###"

--- a/meilisearch/tests/vector/mod.rs
+++ b/meilisearch/tests/vector/mod.rs
@@ -624,7 +624,8 @@ async fn clear_documents() {
     "###);
 
     // Make sure the arroy DB has been cleared
-    let (documents, _code) = index.search_post(json!({ "vector": [1, 1, 1] })).await;
+    let (documents, _code) =
+        index.search_post(json!({ "vector": [1, 1, 1], "hybrid": {"embedder": "manual"} })).await;
     snapshot!(documents, @r###"
     {
       "hits": [],
@@ -685,7 +686,11 @@ async fn add_remove_one_vector_4588() {
     let task = index.wait_task(value.uid()).await;
     snapshot!(task, name: "document-deleted");
 
-    let (documents, _code) = index.search_post(json!({"vector": [1, 1, 1] })).await;
+    let (documents, _code) = index
+        .search_post(
+            json!({"vector": [1, 1, 1], "hybrid": {"semanticRatio": 1.0, "embedder": "manual"} }),
+        )
+        .await;
     snapshot!(documents, @r###"
     {
       "hits": [

--- a/meilisearch/tests/vector/openai.rs
+++ b/meilisearch/tests/vector/openai.rs
@@ -449,7 +449,7 @@ async fn it_works() {
     let (response, code) = index
         .search_post(json!({
             "q": "chien de chasse",
-            "hybrid": {"semanticRatio": 1.0}
+            "hybrid": {"semanticRatio": 1.0, "embedder": "default"},
         }))
         .await;
     snapshot!(code, @"200 OK");
@@ -489,7 +489,7 @@ async fn it_works() {
     let (response, code) = index
         .search_post(json!({
             "q": "petit chien",
-            "hybrid": {"semanticRatio": 1.0}
+            "hybrid": {"semanticRatio": 1.0, "embedder": "default"}
         }))
         .await;
     snapshot!(code, @"200 OK");
@@ -529,7 +529,7 @@ async fn it_works() {
     let (response, code) = index
         .search_post(json!({
             "q": "grand chien de berger des montagnes",
-            "hybrid": {"semanticRatio": 1.0}
+            "hybrid": {"semanticRatio": 1.0, "embedder": "default"}
         }))
         .await;
     snapshot!(code, @"200 OK");
@@ -616,7 +616,7 @@ async fn tokenize_long_text() {
             "q": "grand chien de berger des montagnes",
             "showRankingScore": true,
             "attributesToRetrieve": ["id"],
-            "hybrid": {"semanticRatio": 1.0}
+            "hybrid": {"semanticRatio": 1.0, "embedder": "default"}
         }))
         .await;
     snapshot!(code, @"200 OK");
@@ -1064,7 +1064,7 @@ async fn smaller_dimensions() {
     let (response, code) = index
         .search_post(json!({
             "q": "chien de chasse",
-            "hybrid": {"semanticRatio": 1.0}
+            "hybrid": {"semanticRatio": 1.0, "embedder": "default"}
         }))
         .await;
     snapshot!(code, @"200 OK");
@@ -1104,7 +1104,7 @@ async fn smaller_dimensions() {
     let (response, code) = index
         .search_post(json!({
             "q": "petit chien",
-            "hybrid": {"semanticRatio": 1.0}
+            "hybrid": {"semanticRatio": 1.0, "embedder": "default"}
         }))
         .await;
     snapshot!(code, @"200 OK");
@@ -1144,7 +1144,7 @@ async fn smaller_dimensions() {
     let (response, code) = index
         .search_post(json!({
             "q": "grand chien de berger des montagnes",
-            "hybrid": {"semanticRatio": 1.0}
+            "hybrid": {"semanticRatio": 1.0, "embedder": "default"}
         }))
         .await;
     snapshot!(code, @"200 OK");
@@ -1295,7 +1295,7 @@ async fn small_embedding_model() {
     let (response, code) = index
         .search_post(json!({
             "q": "chien de chasse",
-            "hybrid": {"semanticRatio": 1.0}
+            "hybrid": {"semanticRatio": 1.0, "embedder": "default"}
         }))
         .await;
     snapshot!(code, @"200 OK");
@@ -1335,7 +1335,7 @@ async fn small_embedding_model() {
     let (response, code) = index
         .search_post(json!({
             "q": "petit chien",
-            "hybrid": {"semanticRatio": 1.0}
+            "hybrid": {"semanticRatio": 1.0, "embedder": "default"}
         }))
         .await;
     snapshot!(code, @"200 OK");
@@ -1375,7 +1375,7 @@ async fn small_embedding_model() {
     let (response, code) = index
         .search_post(json!({
             "q": "grand chien de berger des montagnes",
-            "hybrid": {"semanticRatio": 1.0}
+            "hybrid": {"semanticRatio": 1.0, "embedder": "default"}
         }))
         .await;
     snapshot!(code, @"200 OK");
@@ -1525,7 +1525,7 @@ async fn legacy_embedding_model() {
     let (response, code) = index
         .search_post(json!({
             "q": "chien de chasse",
-            "hybrid": {"semanticRatio": 1.0}
+            "hybrid": {"semanticRatio": 1.0, "embedder": "default"}
         }))
         .await;
     snapshot!(code, @"200 OK");
@@ -1565,7 +1565,7 @@ async fn legacy_embedding_model() {
     let (response, code) = index
         .search_post(json!({
             "q": "petit chien",
-            "hybrid": {"semanticRatio": 1.0}
+            "hybrid": {"semanticRatio": 1.0, "embedder": "default"}
         }))
         .await;
     snapshot!(code, @"200 OK");
@@ -1605,7 +1605,7 @@ async fn legacy_embedding_model() {
     let (response, code) = index
         .search_post(json!({
             "q": "grand chien de berger des montagnes",
-            "hybrid": {"semanticRatio": 1.0}
+            "hybrid": {"semanticRatio": 1.0, "embedder": "default"}
         }))
         .await;
     snapshot!(code, @"200 OK");
@@ -1756,7 +1756,7 @@ async fn it_still_works() {
     let (response, code) = index
         .search_post(json!({
             "q": "chien de chasse",
-            "hybrid": {"semanticRatio": 1.0}
+            "hybrid": {"semanticRatio": 1.0, "embedder": "default"}
         }))
         .await;
     snapshot!(code, @"200 OK");
@@ -1796,7 +1796,7 @@ async fn it_still_works() {
     let (response, code) = index
         .search_post(json!({
             "q": "petit chien",
-            "hybrid": {"semanticRatio": 1.0}
+            "hybrid": {"semanticRatio": 1.0, "embedder": "default"}
         }))
         .await;
     snapshot!(code, @"200 OK");
@@ -1836,7 +1836,7 @@ async fn it_still_works() {
     let (response, code) = index
         .search_post(json!({
             "q": "grand chien de berger des montagnes",
-            "hybrid": {"semanticRatio": 1.0}
+            "hybrid": {"semanticRatio": 1.0, "embedder": "default"}
         }))
         .await;
     snapshot!(code, @"200 OK");

--- a/meilisearch/tests/vector/settings.rs
+++ b/meilisearch/tests/vector/settings.rs
@@ -218,7 +218,8 @@ async fn reset_embedder_documents() {
     "###);
 
     // Make sure the arroy DB has been cleared
-    let (documents, _code) = index.search_post(json!({ "vector": [1, 1, 1] })).await;
+    let (documents, _code) =
+        index.search_post(json!({ "vector": [1, 1, 1], "hybrid": {"embedder": "default"} })).await;
     snapshot!(json_string!(documents), @r###"
     {
       "message": "Cannot find embedder with name `default`.",

--- a/milli/src/vector/mod.rs
+++ b/milli/src/vector/mod.rs
@@ -144,35 +144,12 @@ impl EmbeddingConfigs {
         self.0.get(name).cloned()
     }
 
-    /// Get the default embedder configuration, if any.
-    pub fn get_default(&self) -> Option<(Arc<Embedder>, Arc<Prompt>)> {
-        self.get(self.get_default_embedder_name())
-    }
-
     pub fn inner_as_ref(&self) -> &HashMap<String, (Arc<Embedder>, Arc<Prompt>)> {
         &self.0
     }
 
     pub fn into_inner(self) -> HashMap<String, (Arc<Embedder>, Arc<Prompt>)> {
         self.0
-    }
-
-    /// Get the name of the default embedder configuration.
-    ///
-    /// The default embedder is determined as follows:
-    ///
-    /// - If there is only one embedder, it is always the default.
-    /// - If there are multiple embedders and one of them is called `default`, then that one is the default embedder.
-    /// - In all other cases, there is no default embedder.
-    pub fn get_default_embedder_name(&self) -> &str {
-        let mut it = self.0.keys();
-        let first_name = it.next();
-        let second_name = it.next();
-        match (first_name, second_name) {
-            (None, _) => "default",
-            (Some(first), None) => first,
-            (Some(_), Some(_)) => "default",
-        }
     }
 }
 


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #4738 

## What does this PR do?

[See public usage](https://meilisearch.notion.site/v1-11-AI-search-changes-0e37727193884a70999f254fa953ce6e#1044b06b651f80edb9d4ef6dc367bad0)

- Remove `hybrid.embedder` boolean from analytics because embedder is now mandatory and so the boolean would always be `true`
- Rework search kind so that a search without query but with vector is a vector search regardless of (non-zero) semantic ratio
