### PR TITLE
Improve error message when adding a wrong localhost URL #4811

### DIFF
--- a/meilisearch/src/middleware.rs
+++ b/meilisearch/src/middleware.rs
@@ -50,6 +50,22 @@ where
     fn call(&self, req: ServiceRequest) -> Self::Future {
         let mut histogram_timer: Option<HistogramTimer> = None;
 
+        let request_uri = req.uri().to_string();
+
+        if !request_uri.starts_with("http://") && !request_uri.starts_with("https://") {
+            
+            let error_response = actix_web::HttpResponse::BadRequest().body(
+                "Invalid URL: Missing scheme. Please provide a URL with 'http://' or 'https://'.
+                This issue might be related to incorrect configuration of --http-addr or MEILI_HTTP_ADDR."
+            );
+            
+            return Box::pin(async move {
+                Ok(req.into_response(error_response.into_body()))
+            });
+        }
+
+
+    
         // calling unwrap here is safe because index scheduler is added to app data while creating actix app.
         // also, the tests will fail if this is not present.
         let index_scheduler = req.app_data::<Data<IndexScheduler>>().unwrap();


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #4811 

## What does this PR do?
- Improves the error message returned when a URL lacks the required scheme (protocol). Ensures that users receive a clearer message explaining that the URL is missing a protocol and makes suggestions

## PR checklist
Please check if your PR fulfills the following requirements:
- [ /] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [/ ] Have you read the contributing guidelines?
- [/ ] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
