### PR TITLE
Do not send empty edit document by function

### DIFF
--- a/meilisearch/src/analytics/segment_analytics.rs
+++ b/meilisearch/src/analytics/segment_analytics.rs
@@ -1572,6 +1572,10 @@ impl EditDocumentsByFunctionAggregator {
     pub fn into_event(self, user: &User, event_name: &str) -> Option<Track> {
         let Self { timestamp, user_agents, index_creation, filtered, with_context } = self;
 
+        // if we had no timestamp it means we never encountered any events and
+        // thus we don't need to send this event.
+        let timestamp = timestamp?;
+
         let properties = json!({
             "user-agent": user_agents,
             "filtered": filtered,
@@ -1580,7 +1584,7 @@ impl EditDocumentsByFunctionAggregator {
         });
 
         Some(Track {
-            timestamp,
+            timestamp: Some(timestamp),
             user: user.clone(),
             event: event_name.to_string(),
             properties,


### PR DESCRIPTION
# Pull Request

We realized that we had a huge usage of the feature from user who didn’t enable the feature at all. That shouldn’t be possible.
After a big investigation with @gmourier 
![image](https://github.com/user-attachments/assets/eae3e851-dc5b-4616-80ee-7237a4871522)
We found the issue, it was in the engine

## What does this PR do?
- Do not send the edit by function event to segment if no event was received during this batch