### PR TITLE
Add `indices` field to `_matchesPosition` to specify where in an array a match comes from

### DIFF
--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -1808,45 +1808,9 @@ fn format_value(
                 None => Value::String(old_string),
             }
         }
-        Value::Array(values) => Value::Array(
-            values
-                .into_iter()
-                .map(|v| {
-                    format_value(
-                        v,
-                        builder,
-                        format_options.map(|format_options| FormatOptions {
-                            highlight: format_options.highlight,
-                            crop: None,
-                        }),
-                        infos,
-                        compute_matches,
-                        locales,
-                    )
-                })
-                .collect(),
-        ),
-        Value::Object(object) => Value::Object(
-            object
-                .into_iter()
-                .map(|(k, v)| {
-                    (
-                        k,
-                        format_value(
-                            v,
-                            builder,
-                            format_options.map(|format_options| FormatOptions {
-                                highlight: format_options.highlight,
-                                crop: None,
-                            }),
-                            infos,
-                            compute_matches,
-                            locales,
-                        ),
-                    )
-                })
-                .collect(),
-        ),
+        // `map_leaf_values` makes sure this is only called for leaf fields
+        Value::Array(_) => unreachable!(),
+        Value::Object(_) => unreachable!(),
         Value::Number(number) => {
             let s = number.to_string();
 

--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -1733,46 +1733,51 @@ fn format_fields(
     // select the attributes to retrieve
     let displayable_names =
         displayable_ids.iter().map(|&fid| field_ids_map.name(fid).expect("Missing field name"));
-    permissive_json_pointer::map_leaf_values(&mut document, displayable_names, |key, value| {
-        // To get the formatting option of each key we need to see all the rules that applies
-        // to the value and merge them together. eg. If a user said he wanted to highlight `doggo`
-        // and crop `doggo.name`. `doggo.name` needs to be highlighted + cropped while `doggo.age` is only
-        // highlighted.
-        // Warn: The time to compute the format list scales with the number of fields to format;
-        // cumulated with map_leaf_values that iterates over all the nested fields, it gives a quadratic complexity:
-        // d*f where d is the total number of fields to display and f is the total number of fields to format.
-        let format = formatting_fields_options
-            .iter()
-            .filter(|(name, _option)| {
-                milli::is_faceted_by(name, key) || milli::is_faceted_by(key, name)
-            })
-            .map(|(_, option)| **option)
-            .reduce(|acc, option| acc.merge(option));
-        let mut infos = Vec::new();
-
-        // if no locales has been provided, we try to find the locales in the localized_attributes.
-        let locales = locales.or_else(|| {
-            localized_attributes
+    permissive_json_pointer::map_leaf_values(
+        &mut document,
+        displayable_names,
+        |key, array_indices, value| {
+            // To get the formatting option of each key we need to see all the rules that applies
+            // to the value and merge them together. eg. If a user said he wanted to highlight `doggo`
+            // and crop `doggo.name`. `doggo.name` needs to be highlighted + cropped while `doggo.age` is only
+            // highlighted.
+            // Warn: The time to compute the format list scales with the number of fields to format;
+            // cumulated with map_leaf_values that iterates over all the nested fields, it gives a quadratic complexity:
+            // d*f where d is the total number of fields to display and f is the total number of fields to format.
+            let format = formatting_fields_options
                 .iter()
-                .find(|rule| rule.match_str(key))
-                .map(LocalizedAttributesRule::locales)
-        });
+                .filter(|(name, _option)| {
+                    milli::is_faceted_by(name, key) || milli::is_faceted_by(key, name)
+                })
+                .map(|(_, option)| **option)
+                .reduce(|acc, option| acc.merge(option));
+            let mut infos = Vec::new();
 
-        *value = format_value(
-            std::mem::take(value),
-            builder,
-            format,
-            &mut infos,
-            compute_matches,
-            locales,
-        );
+            // if no locales has been provided, we try to find the locales in the localized_attributes.
+            let locales = locales.or_else(|| {
+                localized_attributes
+                    .iter()
+                    .find(|rule| rule.match_str(key))
+                    .map(LocalizedAttributesRule::locales)
+            });
 
-        if let Some(matches) = matches_position.as_mut() {
-            if !infos.is_empty() {
-                matches.insert(key.to_owned(), infos);
+            *value = format_value(
+                std::mem::take(value),
+                builder,
+                format,
+                &mut infos,
+                compute_matches,
+                array_indices,
+                locales,
+            );
+
+            if let Some(matches) = matches_position.as_mut() {
+                if !infos.is_empty() {
+                    matches.insert(key.to_owned(), infos);
+                }
             }
-        }
-    });
+        },
+    );
 
     let selectors = formatted_options
         .keys()
@@ -1790,13 +1795,14 @@ fn format_value(
     format_options: Option<FormatOptions>,
     infos: &mut Vec<MatchBounds>,
     compute_matches: bool,
+    array_indices: &[usize],
     locales: Option<&[Language]>,
 ) -> Value {
     match value {
         Value::String(old_string) => {
             let mut matcher = builder.build(&old_string, locales);
             if compute_matches {
-                let matches = matcher.matches();
+                let matches = matcher.matches(array_indices);
                 infos.extend_from_slice(&matches[..]);
             }
 
@@ -1816,7 +1822,7 @@ fn format_value(
 
             let mut matcher = builder.build(&s, locales);
             if compute_matches {
-                let matches = matcher.matches();
+                let matches = matcher.matches(array_indices);
                 infos.extend_from_slice(&matches[..]);
             }
 

--- a/crates/meilisearch/tests/search/formatted.rs
+++ b/crates/meilisearch/tests/search/formatted.rs
@@ -213,7 +213,10 @@ async fn format_nested() {
                         "doggos.name": [
                           {
                             "start": 0,
-                            "length": 5
+                            "length": 5,
+                            "indices": [
+                              0
+                            ]
                           }
                         ]
                       }

--- a/crates/milli/src/search/new/matches/mod.rs
+++ b/crates/milli/src/search/new/matches/mod.rs
@@ -105,6 +105,8 @@ impl FormatOptions {
 pub struct MatchBounds {
     pub start: usize,
     pub length: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub indices: Option<Vec<usize>>,
 }
 
 /// Structure used to analyze a string, compute words that match,
@@ -220,15 +222,20 @@ impl<'t, 'tokenizer> Matcher<'t, 'tokenizer, '_, '_> {
     }
 
     /// Returns boundaries of the words that match the query.
-    pub fn matches(&mut self) -> Vec<MatchBounds> {
+    pub fn matches(&mut self, array_indices: &[usize]) -> Vec<MatchBounds> {
         match &self.matches {
-            None => self.compute_matches().matches(),
+            None => self.compute_matches().matches(array_indices),
             Some((tokens, matches)) => matches
                 .iter()
                 .map(|m| MatchBounds {
                     start: tokens[m.get_first_token_pos()].byte_start,
                     // TODO: Why is this in chars, while start is in bytes?
                     length: m.char_count,
+                    indices: if array_indices.is_empty() {
+                        None
+                    } else {
+                        Some(array_indices.to_owned())
+                    },
                 })
                 .collect(),
         }


### PR DESCRIPTION
# Pull Request

## Related issue
https://github.com/orgs/meilisearch/discussions/550

## What does this PR do?
This adds an `indices` fields to the objects returned in `_matchesPosition`. The new field describes in what array element in the document the match was found. This was impossible before and users simply did not know where a match originated inside an array. 

Example document:

```json
{
  "id": "123",
  "names": ["foo", "bar", "catnip"],
  "noarray": "dog cat fox",
  "nested": [
    ["dog", "cat"],
    ["fox", "bear"]
  ]
}
```

Searching for `cat` now returns this:

```json
"_matchesPosition": {
  "names": [
    {
      "start": 0,
      "length": 3,
      "indices": [2]
    }
  ],
  "nested": [
    {
      "start": 0,
      "length": 3,
      "indices": [0, 1]
    }
  ],
  "noarray": [
    {
      "start": 4,
      "length": 3
    }
  ]
}
```

Having `indices` be an array is required due to nested arrays, so one sometimes needs multiple indices to know what data the match comes from.

## Alternative API designs

An alternative design would be to include the indices inside the key of `_matchesPosition`, e.g. `foo.bar[2].baz`. This is more intuitive to me and puts all "location inside document" information into one place, but has some disadvantages: the index needs to be parsed out of the key, which is annoying for end users. Also, JSON fields can have keys containing `[2]`, so escaping would be necessary. Or one could insert `.` dots before the `[2]` (e.g. `foo.bar.[2].baz`) which might make parsing easier. 

Another alternative could be to just include the full path inside the object, e.g.:

```json
{
  "start": 4,
  "length": 3,
  "path": ["foo", "bar", 2, "baz"]
}
```

String elements would mean fields in an object, numbers would mean indices into an array. This is nice as all path information is in one place. This this, unlike with the current design (of this PR), you would also not need to know the document structure to understand at what levels the `indices` actually apply.

Of course, the disadvantage is that there is duplication with the keys inside `_matchesPosition`. One could also convert `_matchesPosition` to an array, but that's quite the breaking change and it would make some use cases more annoying.

In summary: I personally am fine with all three designs. The implicit "you have to know where the indices go" of the current design is not too bad; the parsing of the `foo.bar[2].baz` approach also seems ok; adding the nicely typed full path also probably doesn't hurt too much thanks to compression. Let me know what you think! I can change this PR to switch to another approach.

