### PR TITLE
Add timeout on read and write operations.

### DIFF
--- a/milli/src/vector/rest.rs
+++ b/milli/src/vector/rest.rs
@@ -131,6 +131,7 @@ impl Embedder {
         let client = ureq::AgentBuilder::new()
             .max_idle_connections(REQUEST_PARALLELISM * 2)
             .max_idle_connections_per_host(REQUEST_PARALLELISM * 2)
+            .timeout(std::time::Duration::from_secs(30))
             .build();
 
         let request = Request::new(options.request)?;


### PR DESCRIPTION
# Pull Request

## Related issue
Addresses #5054 

## What does this PR do?
- Add a timeout for read and write operations in the REST embedder. This might address some issues about tasks that get "stuck" while embedding documents.
