### PR TITLE
Update BBQueue repo to point to the Meilisearch org

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -492,7 +492,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 [[package]]
 name = "bbqueue"
 version = "0.5.1"
-source = "git+https://github.com/kerollmops/bbqueue#cbb87cc707b5af415ef203bdaf2443e06ba0d6d4"
+source = "git+https://github.com/meilisearch/bbqueue#cbb87cc707b5af415ef203bdaf2443e06ba0d6d4"
 
 [[package]]
 name = "benchmarks"

--- a/crates/milli/Cargo.toml
+++ b/crates/milli/Cargo.toml
@@ -98,7 +98,7 @@ allocator-api2 = "0.2.18"
 rustc-hash = "2.0.0"
 uell = "0.1.0"
 enum-iterator = "2.1.0"
-bbqueue = { git = "https://github.com/kerollmops/bbqueue" }
+bbqueue = { git = "https://github.com/meilisearch/bbqueue" }
 flume = { version = "0.11.1", default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
This PR updates the milli dependencies to make BBQueue point to the Meilisearch org repo.