### PR TITLE
Settings opt out error msg

### DIFF
--- a/crates/meilisearch-types/src/error.rs
+++ b/crates/meilisearch-types/src/error.rs
@@ -279,7 +279,7 @@ InvalidSearchPage                     , InvalidRequest       , BAD_REQUEST ;
 InvalidSearchQ                        , InvalidRequest       , BAD_REQUEST ;
 InvalidFacetSearchQuery               , InvalidRequest       , BAD_REQUEST ;
 InvalidFacetSearchName                , InvalidRequest       , BAD_REQUEST ;
-InvalidFacetSearchDisabled            , InvalidRequest       , BAD_REQUEST ;
+FacetSearchDisabled                   , InvalidRequest       , BAD_REQUEST ;
 InvalidSearchVector                   , InvalidRequest       , BAD_REQUEST ;
 InvalidSearchShowMatchesPosition      , InvalidRequest       , BAD_REQUEST ;
 InvalidSearchShowRankingScore         , InvalidRequest       , BAD_REQUEST ;

--- a/crates/meilisearch-types/src/error.rs
+++ b/crates/meilisearch-types/src/error.rs
@@ -279,6 +279,7 @@ InvalidSearchPage                     , InvalidRequest       , BAD_REQUEST ;
 InvalidSearchQ                        , InvalidRequest       , BAD_REQUEST ;
 InvalidFacetSearchQuery               , InvalidRequest       , BAD_REQUEST ;
 InvalidFacetSearchName                , InvalidRequest       , BAD_REQUEST ;
+InvalidFacetSearchDisabled            , InvalidRequest       , BAD_REQUEST ;
 InvalidSearchVector                   , InvalidRequest       , BAD_REQUEST ;
 InvalidSearchShowMatchesPosition      , InvalidRequest       , BAD_REQUEST ;
 InvalidSearchShowRankingScore         , InvalidRequest       , BAD_REQUEST ;

--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -1410,7 +1410,7 @@ pub fn perform_facet_search(
     if !index.facet_search(&rtxn)? {
         return Err(ResponseError::from_msg(
             "The facet search is disabled for this index".to_string(),
-            Code::InvalidFacetSearchDisabled,
+            Code::FacetSearchDisabled,
         ));
     }
 

--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -1407,6 +1407,13 @@ pub fn perform_facet_search(
         None => TimeBudget::default(),
     };
 
+    if !index.facet_search(&rtxn)? {
+        return Err(ResponseError::from_msg(
+            "The facet search is disabled for this index".to_string(),
+            Code::InvalidFacetSearchDisabled,
+        ));
+    }
+
     // In the faceted search context, we want to use the intersection between the locales provided by the user
     // and the locales of the facet string.
     // If the facet string is not localized, we **ignore** the locales provided by the user because the facet data has no locale.

--- a/crates/meilisearch/tests/search/facet_search.rs
+++ b/crates/meilisearch/tests/search/facet_search.rs
@@ -224,10 +224,10 @@ async fn add_documents_and_deactivate_facet_search() {
     assert_eq!(code, 400, "{}", response);
     snapshot!(response, @r###"
     {
-      "message": "Facet search is disabled for this index",
-      "code": "invalid_search_disabled_facet_search",
+      "message": "The facet search is disabled for this index",
+      "code": "invalid_facet_search_disabled",
       "type": "invalid_request",
-      "link": "https://docs.meilisearch.com/errors#invalid_search_disabled_facet_search"
+      "link": "https://docs.meilisearch.com/errors#invalid_facet_search_disabled"
     }
     "###);
 }
@@ -255,10 +255,10 @@ async fn deactivate_facet_search_and_add_documents() {
     assert_eq!(code, 400, "{}", response);
     snapshot!(response, @r###"
     {
-      "message": "Facet search is disabled for this index",
-      "code": "invalid_search_disabled_facet_search",
+      "message": "The facet search is disabled for this index",
+      "code": "invalid_facet_search_disabled",
       "type": "invalid_request",
-      "link": "https://docs.meilisearch.com/errors#invalid_search_disabled_facet_search"
+      "link": "https://docs.meilisearch.com/errors#invalid_facet_search_disabled"
     }
     "###);
 }

--- a/crates/meilisearch/tests/search/facet_search.rs
+++ b/crates/meilisearch/tests/search/facet_search.rs
@@ -225,9 +225,9 @@ async fn add_documents_and_deactivate_facet_search() {
     snapshot!(response, @r###"
     {
       "message": "The facet search is disabled for this index",
-      "code": "invalid_facet_search_disabled",
+      "code": "facet_search_disabled",
       "type": "invalid_request",
-      "link": "https://docs.meilisearch.com/errors#invalid_facet_search_disabled"
+      "link": "https://docs.meilisearch.com/errors#facet_search_disabled"
     }
     "###);
 }
@@ -256,9 +256,9 @@ async fn deactivate_facet_search_and_add_documents() {
     snapshot!(response, @r###"
     {
       "message": "The facet search is disabled for this index",
-      "code": "invalid_facet_search_disabled",
+      "code": "facet_search_disabled",
       "type": "invalid_request",
-      "link": "https://docs.meilisearch.com/errors#invalid_facet_search_disabled"
+      "link": "https://docs.meilisearch.com/errors#facet_search_disabled"
     }
     "###);
 }

--- a/crates/meilisearch/tests/search/facet_search.rs
+++ b/crates/meilisearch/tests/search/facet_search.rs
@@ -221,8 +221,15 @@ async fn add_documents_and_deactivate_facet_search() {
     let (response, code) =
         index.facet_search(json!({"facetName": "genres", "facetQuery": "a"})).await;
 
-    assert_eq!(code, 200, "{}", response);
-    assert_eq!(dbg!(response)["facetHits"].as_array().unwrap().len(), 0);
+    assert_eq!(code, 400, "{}", response);
+    snapshot!(response, @r###"
+    {
+      "message": "Facet search is disabled for this index",
+      "code": "invalid_search_disabled_facet_search",
+      "type": "invalid_request",
+      "link": "https://docs.meilisearch.com/errors#invalid_search_disabled_facet_search"
+    }
+    "###);
 }
 
 #[actix_rt::test]
@@ -245,8 +252,15 @@ async fn deactivate_facet_search_and_add_documents() {
     let (response, code) =
         index.facet_search(json!({"facetName": "genres", "facetQuery": "a"})).await;
 
-    assert_eq!(code, 200, "{}", response);
-    assert_eq!(dbg!(response)["facetHits"].as_array().unwrap().len(), 0);
+    assert_eq!(code, 400, "{}", response);
+    snapshot!(response, @r###"
+    {
+      "message": "Facet search is disabled for this index",
+      "code": "invalid_search_disabled_facet_search",
+      "type": "invalid_request",
+      "link": "https://docs.meilisearch.com/errors#invalid_search_disabled_facet_search"
+    }
+    "###);
 }
 
 #[actix_rt::test]


### PR DESCRIPTION
# Pull Request

## Related issue
PRD: https://meilisearch.notion.site/API-usage-Settings-to-opt-out-indexing-features-fff4b06b651f8108ade3f858aeb16b14?pvs=4
## What does this PR do?

Add a new error code and message when the user tries a facet search on an index where the facet search is disabled:
```json
{
  "message": "The facet search is disabled for this index",
  "code": "facet_search_disabled",
  "type": "invalid_request",
  "link": "https://docs.meilisearch.com/errors#invalid_facet_search_disabled"
}
 ```
