### PR TITLE
Add cross tasks

### DIFF
--- a/workloads/hackernews-add-new-documents.json
+++ b/workloads/hackernews-add-new-documents.json
@@ -1,106 +1,105 @@
 {
-    "name": "hackernews.add_new_documents",
-    "run_count": 3,
-    "extra_cli_args": [],
-    "assets": {
-        "hackernews-01.ndjson": {
-          "local_location": null,
-          "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/01.ndjson",
-          "sha256": "cd3627b86c064d865b6754848ed0e73ef1d8142752a25e5f0765c3a1296dd3ae"
-        },
-        "hackernews-02.ndjson": {
-          "local_location": null,
-          "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/02.ndjson",
-          "sha256": "5d533b83bcf992201dace88b4d0c0be8b4df5225c6c4b763582d986844bcc23b"
-        },
-        "hackernews-03.ndjson": {
-          "local_location": null,
-          "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/03.ndjson",
-          "sha256": "f5f351a0d04a8a83643ace12cafa2b7ec8ca8cb7d46fd268e5126492a6c66f2a"
-        },
-        "hackernews-04.ndjson": {
-          "local_location": null,
-          "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/04.ndjson",
-          "sha256": "ac1915ee7ce53a6718548c255a6cc59969784b2570745dc5b739f714beda291a"
-        },
-        "hackernews-05.ndjson": {
-          "local_location": null,
-          "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/05.ndjson",
-          "sha256": "be31d5632602f798e62d1c10c83bdfda2b4deaa068477eacde05fdd247572b82"
+  "name": "hackernews.add_new_documents",
+  "run_count": 3,
+  "extra_cli_args": [],
+  "assets": {
+      "hackernews-01.ndjson": {
+        "local_location": null,
+        "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/01.ndjson",
+        "sha256": "cd3627b86c064d865b6754848ed0e73ef1d8142752a25e5f0765c3a1296dd3ae"
+      },
+      "hackernews-02.ndjson": {
+        "local_location": null,
+        "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/02.ndjson",
+        "sha256": "5d533b83bcf992201dace88b4d0c0be8b4df5225c6c4b763582d986844bcc23b"
+      },
+      "hackernews-03.ndjson": {
+        "local_location": null,
+        "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/03.ndjson",
+        "sha256": "f5f351a0d04a8a83643ace12cafa2b7ec8ca8cb7d46fd268e5126492a6c66f2a"
+      },
+      "hackernews-04.ndjson": {
+        "local_location": null,
+        "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/04.ndjson",
+        "sha256": "ac1915ee7ce53a6718548c255a6cc59969784b2570745dc5b739f714beda291a"
+      },
+      "hackernews-05.ndjson": {
+        "local_location": null,
+        "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/05.ndjson",
+        "sha256": "be31d5632602f798e62d1c10c83bdfda2b4deaa068477eacde05fdd247572b82"
+      }
+  },
+  "precommands": [
+    {
+      "route": "indexes/movies/settings",
+      "method": "PATCH",
+      "body": {
+        "inline": {
+          "displayedAttributes": [
+            "title",
+            "by",
+            "score",
+            "time",
+            "text"
+          ],
+          "searchableAttributes": [
+            "title",
+            "text"
+          ],
+          "filterableAttributes": [
+            "by",
+            "kids",
+            "parent"
+          ],
+          "sortableAttributes": [
+            "score",
+            "time"
+          ]
         }
+      },
+      "synchronous": "WaitForTask"
     },
-    "precommands": [
-      {
-        "route": "indexes/movies/settings",
-        "method": "PATCH",
-        "body": {
-          "inline": {
-            "displayedAttributes": [
-              "title",
-              "by",
-              "score",
-              "time",
-              "text"
-            ],
-            "searchableAttributes": [
-              "title",
-              "text"
-            ],
-            "filterableAttributes": [
-              "by",
-              "kids",
-              "parent"
-            ],
-            "sortableAttributes": [
-              "score",
-              "time"
-            ]
-          }
-        },
-        "synchronous": "WaitForTask"
+    {
+      "route": "indexes/movies/documents",
+      "method": "POST",
+      "body": {
+        "asset": "hackernews-01.ndjson"
       },
+      "synchronous": "WaitForResponse"
+    },
+    {
+      "route": "indexes/movies/documents",
+      "method": "POST",
+      "body": {
+        "asset": "hackernews-02.ndjson"
+      },
+      "synchronous": "WaitForResponse"
+    },
+    {
+      "route": "indexes/movies/documents",
+      "method": "POST",
+      "body": {
+        "asset": "hackernews-03.ndjson"
+      },
+      "synchronous": "WaitForResponse"
+    },
+    {
+      "route": "indexes/movies/documents",
+      "method": "POST",
+      "body": {
+        "asset": "hackernews-04.ndjson"
+      },
+      "synchronous": "WaitForTask"
+    }
+  ],
+  "commands": [
       {
         "route": "indexes/movies/documents",
         "method": "POST",
         "body": {
-          "asset": "hackernews-01.ndjson"
-        },
-        "synchronous": "WaitForResponse"
-      },
-      {
-        "route": "indexes/movies/documents",
-        "method": "POST",
-        "body": {
-          "asset": "hackernews-02.ndjson"
-        },
-        "synchronous": "WaitForResponse"
-      },
-      {
-        "route": "indexes/movies/documents",
-        "method": "POST",
-        "body": {
-          "asset": "hackernews-03.ndjson"
-        },
-        "synchronous": "WaitForResponse"
-      },
-      {
-        "route": "indexes/movies/documents",
-        "method": "POST",
-        "body": {
-          "asset": "hackernews-04.ndjson"
+          "asset": "hackernews-05.ndjson"
         },
         "synchronous": "WaitForTask"
       }
-    ],
-    "commands": [
-        {
-          "route": "indexes/movies/documents",
-          "method": "POST",
-          "body": {
-            "asset": "hackernews-05.ndjson"
-          },
-          "synchronous": "WaitForTask"
-        }
-    ]
-  }
-  
+  ]
+}

--- a/workloads/hackernews-add-new-documents.json
+++ b/workloads/hackernews-add-new-documents.json
@@ -1,0 +1,106 @@
+{
+    "name": "hackernews.add_new_documents",
+    "run_count": 3,
+    "extra_cli_args": [],
+    "assets": {
+        "hackernews-01.ndjson": {
+          "local_location": null,
+          "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/01.ndjson",
+          "sha256": "cd3627b86c064d865b6754848ed0e73ef1d8142752a25e5f0765c3a1296dd3ae"
+        },
+        "hackernews-02.ndjson": {
+          "local_location": null,
+          "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/02.ndjson",
+          "sha256": "5d533b83bcf992201dace88b4d0c0be8b4df5225c6c4b763582d986844bcc23b"
+        },
+        "hackernews-03.ndjson": {
+          "local_location": null,
+          "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/03.ndjson",
+          "sha256": "f5f351a0d04a8a83643ace12cafa2b7ec8ca8cb7d46fd268e5126492a6c66f2a"
+        },
+        "hackernews-04.ndjson": {
+          "local_location": null,
+          "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/04.ndjson",
+          "sha256": "ac1915ee7ce53a6718548c255a6cc59969784b2570745dc5b739f714beda291a"
+        },
+        "hackernews-05.ndjson": {
+          "local_location": null,
+          "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/05.ndjson",
+          "sha256": "be31d5632602f798e62d1c10c83bdfda2b4deaa068477eacde05fdd247572b82"
+        }
+    },
+    "precommands": [
+      {
+        "route": "indexes/movies/settings",
+        "method": "PATCH",
+        "body": {
+          "inline": {
+            "displayedAttributes": [
+              "title",
+              "by",
+              "score",
+              "time",
+              "text"
+            ],
+            "searchableAttributes": [
+              "title",
+              "text"
+            ],
+            "filterableAttributes": [
+              "by",
+              "kids",
+              "parent"
+            ],
+            "sortableAttributes": [
+              "score",
+              "time"
+            ]
+          }
+        },
+        "synchronous": "WaitForTask"
+      },
+      {
+        "route": "indexes/movies/documents",
+        "method": "POST",
+        "body": {
+          "asset": "hackernews-01.ndjson"
+        },
+        "synchronous": "WaitForResponse"
+      },
+      {
+        "route": "indexes/movies/documents",
+        "method": "POST",
+        "body": {
+          "asset": "hackernews-02.ndjson"
+        },
+        "synchronous": "WaitForResponse"
+      },
+      {
+        "route": "indexes/movies/documents",
+        "method": "POST",
+        "body": {
+          "asset": "hackernews-03.ndjson"
+        },
+        "synchronous": "WaitForResponse"
+      },
+      {
+        "route": "indexes/movies/documents",
+        "method": "POST",
+        "body": {
+          "asset": "hackernews-04.ndjson"
+        },
+        "synchronous": "WaitForTask"
+      }
+    ],
+    "commands": [
+        {
+          "route": "indexes/movies/documents",
+          "method": "POST",
+          "body": {
+            "asset": "hackernews-05.ndjson"
+          },
+          "synchronous": "WaitForTask"
+        }
+    ]
+  }
+  

--- a/workloads/hackernews-modify-facet-numbers.json
+++ b/workloads/hackernews-modify-facet-numbers.json
@@ -31,7 +31,7 @@
     "hackernews-02-modified-filters.ndjson": {
       "local_location": null,
       "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/02-modified-filters.ndjson",
-      "sha256": "1fcb6f89ddeff51c3fe7b86b3574f894ff9859a76cf056ab7e7dacc72970dabb"
+      "sha256": "7272cbfd41110d32d7fe168424a0000f07589bfe40f664652b34f4f20aaf3802"
     }
   },
   "precommands": [

--- a/workloads/hackernews-modify-facet-numbers.json
+++ b/workloads/hackernews-modify-facet-numbers.json
@@ -1,0 +1,111 @@
+{
+    "name": "hackernews.modify_facet_numbers",
+    "run_count": 3,
+    "extra_cli_args": [],
+    "assets": {
+      "hackernews-01.ndjson": {
+        "local_location": null,
+        "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/01.ndjson",
+        "sha256": "cd3627b86c064d865b6754848ed0e73ef1d8142752a25e5f0765c3a1296dd3ae"
+      },
+      "hackernews-02.ndjson": {
+        "local_location": null,
+        "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/02.ndjson",
+        "sha256": "5d533b83bcf992201dace88b4d0c0be8b4df5225c6c4b763582d986844bcc23b"
+      },
+      "hackernews-03.ndjson": {
+        "local_location": null,
+        "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/03.ndjson",
+        "sha256": "f5f351a0d04a8a83643ace12cafa2b7ec8ca8cb7d46fd268e5126492a6c66f2a"
+      },
+      "hackernews-04.ndjson": {
+        "local_location": null,
+        "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/04.ndjson",
+        "sha256": "ac1915ee7ce53a6718548c255a6cc59969784b2570745dc5b739f714beda291a"
+      },
+      "hackernews-05.ndjson": {
+        "local_location": null,
+        "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/05.ndjson",
+        "sha256": "be31d5632602f798e62d1c10c83bdfda2b4deaa068477eacde05fdd247572b82"
+      },
+      "hackernews-02-modified-filters.ndjson": {
+        "local_location": null,
+        "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/02-modified-filters.ndjson",
+        "sha256": "1fcb6f89ddeff51c3fe7b86b3574f894ff9859a76cf056ab7e7dacc72970dabb"
+      }
+    },
+    "precommands": [
+      {
+        "route": "indexes/movies/settings",
+        "method": "PATCH",
+        "body": {
+          "inline": {
+            "displayedAttributes": [
+              "title",
+              "by",
+              "score",
+              "time",
+              "text"
+            ],
+            "searchableAttributes": [
+              "title",
+              "text"
+            ],
+            "filterableAttributes": [
+              "by",
+              "kids",
+              "parent"
+            ],
+            "sortableAttributes": [
+              "score",
+              "time"
+            ]
+          }
+        },
+        "synchronous": "WaitForTask"
+      },
+      {
+        "route": "indexes/movies/documents",
+        "method": "POST",
+        "body": {
+          "asset": "hackernews-01.ndjson"
+        },
+        "synchronous": "WaitForResponse"
+      },
+      {
+        "route": "indexes/movies/documents",
+        "method": "POST",
+        "body": {
+          "asset": "hackernews-02.ndjson"
+        },
+        "synchronous": "WaitForResponse"
+      },
+      {
+        "route": "indexes/movies/documents",
+        "method": "POST",
+        "body": {
+          "asset": "hackernews-03.ndjson"
+        },
+        "synchronous": "WaitForResponse"
+      },
+      {
+        "route": "indexes/movies/documents",
+        "method": "POST",
+        "body": {
+          "asset": "hackernews-04.ndjson"
+        },
+        "synchronous": "WaitForTask"
+      }
+    ],
+    "commands": [
+        {
+          "route": "indexes/movies/documents",
+          "method": "POST",
+          "body": {
+            "asset": "hackernews-01-modified-filters.ndjson"
+          },
+          "synchronous": "WaitForTask"
+        }
+    ]
+  }
+  

--- a/workloads/hackernews-modify-facet-numbers.json
+++ b/workloads/hackernews-modify-facet-numbers.json
@@ -102,7 +102,7 @@
         "route": "indexes/movies/documents",
         "method": "POST",
         "body": {
-          "asset": "hackernews-01-modified-filters.ndjson"
+          "asset": "hackernews-02-modified-filters.ndjson"
         },
         "synchronous": "WaitForTask"
       }

--- a/workloads/hackernews-modify-facet-numbers.json
+++ b/workloads/hackernews-modify-facet-numbers.json
@@ -1,111 +1,111 @@
 {
-    "name": "hackernews.modify_facet_numbers",
-    "run_count": 3,
-    "extra_cli_args": [],
-    "assets": {
-      "hackernews-01.ndjson": {
-        "local_location": null,
-        "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/01.ndjson",
-        "sha256": "cd3627b86c064d865b6754848ed0e73ef1d8142752a25e5f0765c3a1296dd3ae"
-      },
-      "hackernews-02.ndjson": {
-        "local_location": null,
-        "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/02.ndjson",
-        "sha256": "5d533b83bcf992201dace88b4d0c0be8b4df5225c6c4b763582d986844bcc23b"
-      },
-      "hackernews-03.ndjson": {
-        "local_location": null,
-        "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/03.ndjson",
-        "sha256": "f5f351a0d04a8a83643ace12cafa2b7ec8ca8cb7d46fd268e5126492a6c66f2a"
-      },
-      "hackernews-04.ndjson": {
-        "local_location": null,
-        "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/04.ndjson",
-        "sha256": "ac1915ee7ce53a6718548c255a6cc59969784b2570745dc5b739f714beda291a"
-      },
-      "hackernews-05.ndjson": {
-        "local_location": null,
-        "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/05.ndjson",
-        "sha256": "be31d5632602f798e62d1c10c83bdfda2b4deaa068477eacde05fdd247572b82"
-      },
-      "hackernews-02-modified-filters.ndjson": {
-        "local_location": null,
-        "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/02-modified-filters.ndjson",
-        "sha256": "1fcb6f89ddeff51c3fe7b86b3574f894ff9859a76cf056ab7e7dacc72970dabb"
-      }
+  "name": "hackernews.modify_facet_numbers",
+  "run_count": 3,
+  "extra_cli_args": [],
+  "assets": {
+    "hackernews-01.ndjson": {
+      "local_location": null,
+      "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/01.ndjson",
+      "sha256": "cd3627b86c064d865b6754848ed0e73ef1d8142752a25e5f0765c3a1296dd3ae"
     },
-    "precommands": [
-      {
-        "route": "indexes/movies/settings",
-        "method": "PATCH",
-        "body": {
-          "inline": {
-            "displayedAttributes": [
-              "title",
-              "by",
-              "score",
-              "time",
-              "text"
-            ],
-            "searchableAttributes": [
-              "title",
-              "text"
-            ],
-            "filterableAttributes": [
-              "by",
-              "kids",
-              "parent"
-            ],
-            "sortableAttributes": [
-              "score",
-              "time"
-            ]
-          }
-        },
-        "synchronous": "WaitForTask"
+    "hackernews-02.ndjson": {
+      "local_location": null,
+      "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/02.ndjson",
+      "sha256": "5d533b83bcf992201dace88b4d0c0be8b4df5225c6c4b763582d986844bcc23b"
+    },
+    "hackernews-03.ndjson": {
+      "local_location": null,
+      "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/03.ndjson",
+      "sha256": "f5f351a0d04a8a83643ace12cafa2b7ec8ca8cb7d46fd268e5126492a6c66f2a"
+    },
+    "hackernews-04.ndjson": {
+      "local_location": null,
+      "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/04.ndjson",
+      "sha256": "ac1915ee7ce53a6718548c255a6cc59969784b2570745dc5b739f714beda291a"
+    },
+    "hackernews-05.ndjson": {
+      "local_location": null,
+      "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/05.ndjson",
+      "sha256": "be31d5632602f798e62d1c10c83bdfda2b4deaa068477eacde05fdd247572b82"
+    },
+    "hackernews-02-modified-filters.ndjson": {
+      "local_location": null,
+      "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/02-modified-filters.ndjson",
+      "sha256": "1fcb6f89ddeff51c3fe7b86b3574f894ff9859a76cf056ab7e7dacc72970dabb"
+    }
+  },
+  "precommands": [
+    {
+      "route": "indexes/movies/settings",
+      "method": "PATCH",
+      "body": {
+        "inline": {
+          "displayedAttributes": [
+            "title",
+            "by",
+            "score",
+            "time",
+            "text"
+          ],
+          "searchableAttributes": [
+            "title",
+            "text"
+          ],
+          "filterableAttributes": [
+            "by",
+            "kids",
+            "parent"
+          ],
+          "sortableAttributes": [
+            "score",
+            "time"
+          ]
+        }
       },
+      "synchronous": "WaitForTask"
+    },
+    {
+      "route": "indexes/movies/documents",
+      "method": "POST",
+      "body": {
+        "asset": "hackernews-01.ndjson"
+      },
+      "synchronous": "WaitForResponse"
+    },
+    {
+      "route": "indexes/movies/documents",
+      "method": "POST",
+      "body": {
+        "asset": "hackernews-02.ndjson"
+      },
+      "synchronous": "WaitForResponse"
+    },
+    {
+      "route": "indexes/movies/documents",
+      "method": "POST",
+      "body": {
+        "asset": "hackernews-03.ndjson"
+      },
+      "synchronous": "WaitForResponse"
+    },
+    {
+      "route": "indexes/movies/documents",
+      "method": "POST",
+      "body": {
+        "asset": "hackernews-04.ndjson"
+      },
+      "synchronous": "WaitForTask"
+    }
+  ],
+  "commands": [
       {
         "route": "indexes/movies/documents",
         "method": "POST",
         "body": {
-          "asset": "hackernews-01.ndjson"
-        },
-        "synchronous": "WaitForResponse"
-      },
-      {
-        "route": "indexes/movies/documents",
-        "method": "POST",
-        "body": {
-          "asset": "hackernews-02.ndjson"
-        },
-        "synchronous": "WaitForResponse"
-      },
-      {
-        "route": "indexes/movies/documents",
-        "method": "POST",
-        "body": {
-          "asset": "hackernews-03.ndjson"
-        },
-        "synchronous": "WaitForResponse"
-      },
-      {
-        "route": "indexes/movies/documents",
-        "method": "POST",
-        "body": {
-          "asset": "hackernews-04.ndjson"
+          "asset": "hackernews-01-modified-filters.ndjson"
         },
         "synchronous": "WaitForTask"
       }
-    ],
-    "commands": [
-        {
-          "route": "indexes/movies/documents",
-          "method": "POST",
-          "body": {
-            "asset": "hackernews-01-modified-filters.ndjson"
-          },
-          "synchronous": "WaitForTask"
-        }
-    ]
-  }
+  ]
+}
   

--- a/workloads/hackernews-modify-facet-strings.json
+++ b/workloads/hackernews-modify-facet-strings.json
@@ -1,111 +1,111 @@
 {
-    "name": "hackernews.modify_facet_strings",
-    "run_count": 3,
-    "extra_cli_args": [],
-    "assets": {
-      "hackernews-01.ndjson": {
-        "local_location": null,
-        "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/01.ndjson",
-        "sha256": "cd3627b86c064d865b6754848ed0e73ef1d8142752a25e5f0765c3a1296dd3ae"
-      },
-      "hackernews-02.ndjson": {
-        "local_location": null,
-        "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/02.ndjson",
-        "sha256": "5d533b83bcf992201dace88b4d0c0be8b4df5225c6c4b763582d986844bcc23b"
-      },
-      "hackernews-03.ndjson": {
-        "local_location": null,
-        "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/03.ndjson",
-        "sha256": "f5f351a0d04a8a83643ace12cafa2b7ec8ca8cb7d46fd268e5126492a6c66f2a"
-      },
-      "hackernews-04.ndjson": {
-        "local_location": null,
-        "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/04.ndjson",
-        "sha256": "ac1915ee7ce53a6718548c255a6cc59969784b2570745dc5b739f714beda291a"
-      },
-      "hackernews-05.ndjson": {
-        "local_location": null,
-        "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/05.ndjson",
-        "sha256": "be31d5632602f798e62d1c10c83bdfda2b4deaa068477eacde05fdd247572b82"
-      },
-      "hackernews-01-modified-filters.ndjson": {
-        "local_location": null,
-        "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/01-modified-filters.ndjson",
-        "sha256": "b80c245ce1b1df80b9b38800f677f3bd11947ebc62716fb108269d50e796c35c"
-      }
+  "name": "hackernews.modify_facet_strings",
+  "run_count": 3,
+  "extra_cli_args": [],
+  "assets": {
+    "hackernews-01.ndjson": {
+      "local_location": null,
+      "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/01.ndjson",
+      "sha256": "cd3627b86c064d865b6754848ed0e73ef1d8142752a25e5f0765c3a1296dd3ae"
     },
-    "precommands": [
-      {
-        "route": "indexes/movies/settings",
-        "method": "PATCH",
-        "body": {
-          "inline": {
-            "displayedAttributes": [
-              "title",
-              "by",
-              "score",
-              "time",
-              "text"
-            ],
-            "searchableAttributes": [
-              "title",
-              "text"
-            ],
-            "filterableAttributes": [
-              "by",
-              "kids",
-              "parent"
-            ],
-            "sortableAttributes": [
-              "score",
-              "time"
-            ]
-          }
-        },
-        "synchronous": "WaitForTask"
+    "hackernews-02.ndjson": {
+      "local_location": null,
+      "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/02.ndjson",
+      "sha256": "5d533b83bcf992201dace88b4d0c0be8b4df5225c6c4b763582d986844bcc23b"
+    },
+    "hackernews-03.ndjson": {
+      "local_location": null,
+      "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/03.ndjson",
+      "sha256": "f5f351a0d04a8a83643ace12cafa2b7ec8ca8cb7d46fd268e5126492a6c66f2a"
+    },
+    "hackernews-04.ndjson": {
+      "local_location": null,
+      "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/04.ndjson",
+      "sha256": "ac1915ee7ce53a6718548c255a6cc59969784b2570745dc5b739f714beda291a"
+    },
+    "hackernews-05.ndjson": {
+      "local_location": null,
+      "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/05.ndjson",
+      "sha256": "be31d5632602f798e62d1c10c83bdfda2b4deaa068477eacde05fdd247572b82"
+    },
+    "hackernews-01-modified-filters.ndjson": {
+      "local_location": null,
+      "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/01-modified-filters.ndjson",
+      "sha256": "b80c245ce1b1df80b9b38800f677f3bd11947ebc62716fb108269d50e796c35c"
+    }
+  },
+  "precommands": [
+    {
+      "route": "indexes/movies/settings",
+      "method": "PATCH",
+      "body": {
+        "inline": {
+          "displayedAttributes": [
+            "title",
+            "by",
+            "score",
+            "time",
+            "text"
+          ],
+          "searchableAttributes": [
+            "title",
+            "text"
+          ],
+          "filterableAttributes": [
+            "by",
+            "kids",
+            "parent"
+          ],
+          "sortableAttributes": [
+            "score",
+            "time"
+          ]
+        }
       },
+      "synchronous": "WaitForTask"
+    },
+    {
+      "route": "indexes/movies/documents",
+      "method": "POST",
+      "body": {
+        "asset": "hackernews-01.ndjson"
+      },
+      "synchronous": "WaitForResponse"
+    },
+    {
+      "route": "indexes/movies/documents",
+      "method": "POST",
+      "body": {
+        "asset": "hackernews-02.ndjson"
+      },
+      "synchronous": "WaitForResponse"
+    },
+    {
+      "route": "indexes/movies/documents",
+      "method": "POST",
+      "body": {
+        "asset": "hackernews-03.ndjson"
+      },
+      "synchronous": "WaitForResponse"
+    },
+    {
+      "route": "indexes/movies/documents",
+      "method": "POST",
+      "body": {
+        "asset": "hackernews-04.ndjson"
+      },
+      "synchronous": "WaitForTask"
+    }
+  ],
+  "commands": [
       {
         "route": "indexes/movies/documents",
         "method": "POST",
         "body": {
-          "asset": "hackernews-01.ndjson"
-        },
-        "synchronous": "WaitForResponse"
-      },
-      {
-        "route": "indexes/movies/documents",
-        "method": "POST",
-        "body": {
-          "asset": "hackernews-02.ndjson"
-        },
-        "synchronous": "WaitForResponse"
-      },
-      {
-        "route": "indexes/movies/documents",
-        "method": "POST",
-        "body": {
-          "asset": "hackernews-03.ndjson"
-        },
-        "synchronous": "WaitForResponse"
-      },
-      {
-        "route": "indexes/movies/documents",
-        "method": "POST",
-        "body": {
-          "asset": "hackernews-04.ndjson"
+          "asset": "hackernews-01-modified-filters.ndjson"
         },
         "synchronous": "WaitForTask"
       }
-    ],
-    "commands": [
-        {
-          "route": "indexes/movies/documents",
-          "method": "POST",
-          "body": {
-            "asset": "hackernews-01-modified-filters.ndjson"
-          },
-          "synchronous": "WaitForTask"
-        }
-    ]
-  }
-  
+  ]
+}
+ 

--- a/workloads/hackernews-modify-facet-strings.json
+++ b/workloads/hackernews-modify-facet-strings.json
@@ -1,0 +1,111 @@
+{
+    "name": "hackernews.modify_facet_strings",
+    "run_count": 3,
+    "extra_cli_args": [],
+    "assets": {
+      "hackernews-01.ndjson": {
+        "local_location": null,
+        "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/01.ndjson",
+        "sha256": "cd3627b86c064d865b6754848ed0e73ef1d8142752a25e5f0765c3a1296dd3ae"
+      },
+      "hackernews-02.ndjson": {
+        "local_location": null,
+        "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/02.ndjson",
+        "sha256": "5d533b83bcf992201dace88b4d0c0be8b4df5225c6c4b763582d986844bcc23b"
+      },
+      "hackernews-03.ndjson": {
+        "local_location": null,
+        "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/03.ndjson",
+        "sha256": "f5f351a0d04a8a83643ace12cafa2b7ec8ca8cb7d46fd268e5126492a6c66f2a"
+      },
+      "hackernews-04.ndjson": {
+        "local_location": null,
+        "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/04.ndjson",
+        "sha256": "ac1915ee7ce53a6718548c255a6cc59969784b2570745dc5b739f714beda291a"
+      },
+      "hackernews-05.ndjson": {
+        "local_location": null,
+        "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/05.ndjson",
+        "sha256": "be31d5632602f798e62d1c10c83bdfda2b4deaa068477eacde05fdd247572b82"
+      },
+      "hackernews-01-modified-filters.ndjson": {
+        "local_location": null,
+        "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/01-modified-filters.ndjson",
+        "sha256": "b80c245ce1b1df80b9b38800f677f3bd11947ebc62716fb108269d50e796c35c"
+      }
+    },
+    "precommands": [
+      {
+        "route": "indexes/movies/settings",
+        "method": "PATCH",
+        "body": {
+          "inline": {
+            "displayedAttributes": [
+              "title",
+              "by",
+              "score",
+              "time",
+              "text"
+            ],
+            "searchableAttributes": [
+              "title",
+              "text"
+            ],
+            "filterableAttributes": [
+              "by",
+              "kids",
+              "parent"
+            ],
+            "sortableAttributes": [
+              "score",
+              "time"
+            ]
+          }
+        },
+        "synchronous": "WaitForTask"
+      },
+      {
+        "route": "indexes/movies/documents",
+        "method": "POST",
+        "body": {
+          "asset": "hackernews-01.ndjson"
+        },
+        "synchronous": "WaitForResponse"
+      },
+      {
+        "route": "indexes/movies/documents",
+        "method": "POST",
+        "body": {
+          "asset": "hackernews-02.ndjson"
+        },
+        "synchronous": "WaitForResponse"
+      },
+      {
+        "route": "indexes/movies/documents",
+        "method": "POST",
+        "body": {
+          "asset": "hackernews-03.ndjson"
+        },
+        "synchronous": "WaitForResponse"
+      },
+      {
+        "route": "indexes/movies/documents",
+        "method": "POST",
+        "body": {
+          "asset": "hackernews-04.ndjson"
+        },
+        "synchronous": "WaitForTask"
+      }
+    ],
+    "commands": [
+        {
+          "route": "indexes/movies/documents",
+          "method": "POST",
+          "body": {
+            "asset": "hackernews-01-modified-filters.ndjson"
+          },
+          "synchronous": "WaitForTask"
+        }
+    ]
+  }
+  

--- a/workloads/hackernews-modify-searchables.json
+++ b/workloads/hackernews-modify-searchables.json
@@ -1,71 +1,113 @@
 {
-    "name": "hackernews.modify_searchables",
-    "run_count": 3,
-    "extra_cli_args": [],
-    "assets": {
-      "hackernews-01.ndjson": {
-        "local_location": null,
-        "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/01.ndjson",
-        "sha256": "cd3627b86c064d865b6754848ed0e73ef1d8142752a25e5f0765c3a1296dd3ae"
-      },
-      "hackernews-02.ndjson": {
-        "local_location": null,
-        "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/02.ndjson",
-        "sha256": "5d533b83bcf992201dace88b4d0c0be8b4df5225c6c4b763582d986844bcc23b"
-      },
-      "hackernews-03.ndjson": {
-        "local_location": null,
-        "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/03.ndjson",
-        "sha256": "f5f351a0d04a8a83643ace12cafa2b7ec8ca8cb7d46fd268e5126492a6c66f2a"
-      },
-      "hackernews-04.ndjson": {
-        "local_location": null,
-        "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/04.ndjson",
-        "sha256": "ac1915ee7ce53a6718548c255a6cc59969784b2570745dc5b739f714beda291a"
-      },
-      "hackernews-05.ndjson": {
-        "local_location": null,
-        "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/05.ndjson",
-        "sha256": "be31d5632602f798e62d1c10c83bdfda2b4deaa068477eacde05fdd247572b82"
-      },
-      "hackernews-01-modified-searchables.ndjson": {
-        "local_location": null,
-        "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/01-modified-searchables.ndjson",
-        "sha256": "e5c08710c6af70031ac7212e0ba242c72ef29c8d4e1fce66c789544641452a7c"
-      },
-      "hackernews-02-modified-searchables.ndjson": {
-        "local_location": null,
-        "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/02-modified-searchables.ndjson",
-        "sha256": "098b029851117087b1e26ccb7ac408eda9bba54c3008213a2880d6fab607346e"
-      }
+  "name": "hackernews.modify_searchables",
+  "run_count": 3,
+  "extra_cli_args": [],
+  "assets": {
+    "hackernews-01.ndjson": {
+      "local_location": null,
+      "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/01.ndjson",
+      "sha256": "cd3627b86c064d865b6754848ed0e73ef1d8142752a25e5f0765c3a1296dd3ae"
     },
-    "precommands": [
+    "hackernews-02.ndjson": {
+      "local_location": null,
+      "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/02.ndjson",
+      "sha256": "5d533b83bcf992201dace88b4d0c0be8b4df5225c6c4b763582d986844bcc23b"
+    },
+    "hackernews-03.ndjson": {
+      "local_location": null,
+      "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/03.ndjson",
+      "sha256": "f5f351a0d04a8a83643ace12cafa2b7ec8ca8cb7d46fd268e5126492a6c66f2a"
+    },
+    "hackernews-04.ndjson": {
+      "local_location": null,
+      "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/04.ndjson",
+      "sha256": "ac1915ee7ce53a6718548c255a6cc59969784b2570745dc5b739f714beda291a"
+    },
+    "hackernews-05.ndjson": {
+      "local_location": null,
+      "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/05.ndjson",
+      "sha256": "be31d5632602f798e62d1c10c83bdfda2b4deaa068477eacde05fdd247572b82"
+    },
+    "hackernews-01-modified-searchables.ndjson": {
+      "local_location": null,
+      "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/01-modified-searchables.ndjson",
+      "sha256": "e5c08710c6af70031ac7212e0ba242c72ef29c8d4e1fce66c789544641452a7c"
+    },
+    "hackernews-02-modified-searchables.ndjson": {
+      "local_location": null,
+      "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/02-modified-searchables.ndjson",
+      "sha256": "098b029851117087b1e26ccb7ac408eda9bba54c3008213a2880d6fab607346e"
+    }
+  },
+  "precommands": [
+    {
+      "route": "indexes/movies/settings",
+      "method": "PATCH",
+      "body": {
+        "inline": {
+          "displayedAttributes": [
+            "title",
+            "by",
+            "score",
+            "time",
+            "text"
+          ],
+          "searchableAttributes": [
+            "title",
+            "text"
+          ],
+          "filterableAttributes": [
+            "by",
+            "kids",
+            "parent"
+          ],
+          "sortableAttributes": [
+            "score",
+            "time"
+          ]
+        }
+      },
+      "synchronous": "WaitForTask"
+    },
+    {
+      "route": "indexes/movies/documents",
+      "method": "POST",
+      "body": {
+        "asset": "hackernews-01.ndjson"
+      },
+      "synchronous": "WaitForResponse"
+    },
+    {
+      "route": "indexes/movies/documents",
+      "method": "POST",
+      "body": {
+        "asset": "hackernews-02.ndjson"
+      },
+      "synchronous": "WaitForResponse"
+    },
+    {
+      "route": "indexes/movies/documents",
+      "method": "POST",
+      "body": {
+        "asset": "hackernews-03.ndjson"
+      },
+      "synchronous": "WaitForResponse"
+    },
+    {
+      "route": "indexes/movies/documents",
+      "method": "POST",
+      "body": {
+        "asset": "hackernews-04.ndjson"
+      },
+      "synchronous": "WaitForTask"
+    }
+  ],
+  "commands": [
       {
-        "route": "indexes/movies/settings",
-        "method": "PATCH",
+        "route": "indexes/movies/documents",
+        "method": "POST",
         "body": {
-          "inline": {
-            "displayedAttributes": [
-              "title",
-              "by",
-              "score",
-              "time",
-              "text"
-            ],
-            "searchableAttributes": [
-              "title",
-              "text"
-            ],
-            "filterableAttributes": [
-              "by",
-              "kids",
-              "parent"
-            ],
-            "sortableAttributes": [
-              "score",
-              "time"
-            ]
-          }
+          "asset": "hackernews-01-modified-searchables.ndjson"
         },
         "synchronous": "WaitForTask"
       },
@@ -73,52 +115,9 @@
         "route": "indexes/movies/documents",
         "method": "POST",
         "body": {
-          "asset": "hackernews-01.ndjson"
-        },
-        "synchronous": "WaitForResponse"
-      },
-      {
-        "route": "indexes/movies/documents",
-        "method": "POST",
-        "body": {
-          "asset": "hackernews-02.ndjson"
-        },
-        "synchronous": "WaitForResponse"
-      },
-      {
-        "route": "indexes/movies/documents",
-        "method": "POST",
-        "body": {
-          "asset": "hackernews-03.ndjson"
-        },
-        "synchronous": "WaitForResponse"
-      },
-      {
-        "route": "indexes/movies/documents",
-        "method": "POST",
-        "body": {
-          "asset": "hackernews-04.ndjson"
+          "asset": "hackernews-02-modified-searchables.ndjson"
         },
         "synchronous": "WaitForTask"
       }
-    ],
-    "commands": [
-        {
-          "route": "indexes/movies/documents",
-          "method": "POST",
-          "body": {
-            "asset": "hackernews-01-modified-searchables.ndjson"
-          },
-          "synchronous": "WaitForTask"
-        },
-        {
-          "route": "indexes/movies/documents",
-          "method": "POST",
-          "body": {
-            "asset": "hackernews-02-modified-searchables.ndjson"
-          },
-          "synchronous": "WaitForTask"
-        }
-    ]
-  }
-  
+  ]
+}

--- a/workloads/hackernews-modify-searchables.json
+++ b/workloads/hackernews-modify-searchables.json
@@ -1,0 +1,124 @@
+{
+    "name": "hackernews.modify_searchables",
+    "run_count": 3,
+    "extra_cli_args": [],
+    "assets": {
+      "hackernews-01.ndjson": {
+        "local_location": null,
+        "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/01.ndjson",
+        "sha256": "cd3627b86c064d865b6754848ed0e73ef1d8142752a25e5f0765c3a1296dd3ae"
+      },
+      "hackernews-02.ndjson": {
+        "local_location": null,
+        "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/02.ndjson",
+        "sha256": "5d533b83bcf992201dace88b4d0c0be8b4df5225c6c4b763582d986844bcc23b"
+      },
+      "hackernews-03.ndjson": {
+        "local_location": null,
+        "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/03.ndjson",
+        "sha256": "f5f351a0d04a8a83643ace12cafa2b7ec8ca8cb7d46fd268e5126492a6c66f2a"
+      },
+      "hackernews-04.ndjson": {
+        "local_location": null,
+        "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/04.ndjson",
+        "sha256": "ac1915ee7ce53a6718548c255a6cc59969784b2570745dc5b739f714beda291a"
+      },
+      "hackernews-05.ndjson": {
+        "local_location": null,
+        "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/05.ndjson",
+        "sha256": "be31d5632602f798e62d1c10c83bdfda2b4deaa068477eacde05fdd247572b82"
+      },
+      "hackernews-01-modified-searchables.ndjson": {
+        "local_location": null,
+        "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/01-modified-searchables.ndjson",
+        "sha256": "e5c08710c6af70031ac7212e0ba242c72ef29c8d4e1fce66c789544641452a7c"
+      },
+      "hackernews-02-modified-searchables.ndjson": {
+        "local_location": null,
+        "remote_location": "https://milli-benchmarks.fra1.digitaloceanspaces.com/bench/datasets/hackernews/modification/02-modified-searchables.ndjson",
+        "sha256": "098b029851117087b1e26ccb7ac408eda9bba54c3008213a2880d6fab607346e"
+      }
+    },
+    "precommands": [
+      {
+        "route": "indexes/movies/settings",
+        "method": "PATCH",
+        "body": {
+          "inline": {
+            "displayedAttributes": [
+              "title",
+              "by",
+              "score",
+              "time",
+              "text"
+            ],
+            "searchableAttributes": [
+              "title",
+              "text"
+            ],
+            "filterableAttributes": [
+              "by",
+              "kids",
+              "parent"
+            ],
+            "sortableAttributes": [
+              "score",
+              "time"
+            ]
+          }
+        },
+        "synchronous": "WaitForTask"
+      },
+      {
+        "route": "indexes/movies/documents",
+        "method": "POST",
+        "body": {
+          "asset": "hackernews-01.ndjson"
+        },
+        "synchronous": "WaitForResponse"
+      },
+      {
+        "route": "indexes/movies/documents",
+        "method": "POST",
+        "body": {
+          "asset": "hackernews-02.ndjson"
+        },
+        "synchronous": "WaitForResponse"
+      },
+      {
+        "route": "indexes/movies/documents",
+        "method": "POST",
+        "body": {
+          "asset": "hackernews-03.ndjson"
+        },
+        "synchronous": "WaitForResponse"
+      },
+      {
+        "route": "indexes/movies/documents",
+        "method": "POST",
+        "body": {
+          "asset": "hackernews-04.ndjson"
+        },
+        "synchronous": "WaitForTask"
+      }
+    ],
+    "commands": [
+        {
+          "route": "indexes/movies/documents",
+          "method": "POST",
+          "body": {
+            "asset": "hackernews-01-modified-searchables.ndjson"
+          },
+          "synchronous": "WaitForTask"
+        },
+        {
+          "route": "indexes/movies/documents",
+          "method": "POST",
+          "body": {
+            "asset": "hackernews-02-modified-searchables.ndjson"
+          },
+          "synchronous": "WaitForTask"
+        }
+    ]
+  }
+  


### PR DESCRIPTION
Add 4 xtask bench workloads:
- `hackernews-add-new-documents`: adds new documents on a db already containing documents
- `hackernews-modify-facet-numbers`: modify filterable fields containing numbers of documents on a db already containing documents
- `hackernews-modify-facet-strings`: modify filterable fields containing strings of documents on a db already containing documents
- `hackernews-modify-searchables`: modify searchable fields of documents on a db already containing documents