### PR TITLE
Yield the BBQueue writing loop

### DIFF
--- a/crates/milli/src/update/new/channel.rs
+++ b/crates/milli/src/update/new/channel.rs
@@ -661,6 +661,11 @@ where
         if sender.is_disconnected() {
             return Err(Error::InternalError(InternalError::AbortedIndexation));
         }
+
+        // We prefer to yield and allow the writing thread
+        // to do its job, especially beneficial when there
+        // is only one CPU core available.
+        std::thread::yield_now();
     }
 }
 


### PR DESCRIPTION
We prefer yielding to let the writing thread do its job instead of spin looping.