### PR TITLE
Fix batch details

### DIFF
--- a/crates/index-scheduler/src/batch.rs
+++ b/crates/index-scheduler/src/batch.rs
@@ -496,8 +496,7 @@ impl IndexScheduler {
 
         // 5. We make a batch from the unprioritised tasks. Start by taking the next enqueued task.
         let task_id = if let Some(task_id) = enqueued.min() { task_id } else { return Ok(None) };
-        let mut task = self.get_task(rtxn, task_id)?.ok_or(Error::CorruptedTaskQueue)?;
-        current_batch.processing(Some(&mut task));
+        let task = self.get_task(rtxn, task_id)?.ok_or(Error::CorruptedTaskQueue)?;
 
         // If the task is not associated with any index, verify that it is an index swap and
         // create the batch directly. Otherwise, get the index name associated with the task

--- a/crates/index-scheduler/src/lib.rs
+++ b/crates/index-scheduler/src/lib.rs
@@ -4335,7 +4335,7 @@ mod tests {
           "stats": {
             "totalNbTasks": 2,
             "status": {
-              "enqueued": 2
+              "processing": 2
             },
             "types": {
               "indexCreation": 2

--- a/crates/index-scheduler/src/lib.rs
+++ b/crates/index-scheduler/src/lib.rs
@@ -4333,15 +4333,15 @@ mod tests {
             "primaryKey": "mouse"
           },
           "stats": {
-            "totalNbTasks": 2,
+            "totalNbTasks": 1,
             "status": {
-              "processing": 2
+              "processing": 1
             },
             "types": {
-              "indexCreation": 2
+              "indexCreation": 1
             },
             "indexUids": {
-              "catto": 2
+              "catto": 1
             }
           },
           "startedAt": "1970-01-01T00:00:00Z",

--- a/crates/index-scheduler/src/utils.rs
+++ b/crates/index-scheduler/src/utils.rs
@@ -67,7 +67,7 @@ impl ProcessingBatch {
             task.batch_uid = Some(self.uid);
             // We don't store the statuses in the map since they're all enqueued but we must
             // still store them in the stats since that can be displayed.
-            *self.stats.status.entry(task.status).or_default() += 1;
+            *self.stats.status.entry(Status::Processing).or_default() += 1;
 
             self.kinds.insert(task.kind.as_kind());
             *self.stats.types.entry(task.kind.as_kind()).or_default() += 1;


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes https://github.com/meilisearch/meilisearch/issues/5079
Fixes https://github.com/meilisearch/meilisearch/issues/5112

## What does this PR do?
- Make the processing tasks actually processing in the stats of the batch instead of enqueued
- Stop counting one extra task for all non-prioritized batches in the stats
- Add a test