### PR TITLE
Split Meilisearch Crate Tests in separate file

### DIFF
--- a/crates/meilisearch/src/routes/indexes/mod.rs
+++ b/crates/meilisearch/src/routes/indexes/mod.rs
@@ -28,6 +28,7 @@ use crate::Opt;
 pub mod documents;
 pub mod facet_search;
 pub mod search;
+#[cfg(test)]
 mod search_test;
 mod search_analytics;
 pub mod settings;

--- a/crates/meilisearch/src/routes/indexes/mod.rs
+++ b/crates/meilisearch/src/routes/indexes/mod.rs
@@ -28,9 +28,9 @@ use crate::Opt;
 pub mod documents;
 pub mod facet_search;
 pub mod search;
+mod search_analytics;
 #[cfg(test)]
 mod search_test;
-mod search_analytics;
 pub mod settings;
 mod settings_analytics;
 pub mod similar;

--- a/crates/meilisearch/src/routes/indexes/mod.rs
+++ b/crates/meilisearch/src/routes/indexes/mod.rs
@@ -28,6 +28,7 @@ use crate::Opt;
 pub mod documents;
 pub mod facet_search;
 pub mod search;
+mod search_test;
 mod search_analytics;
 pub mod settings;
 mod settings_analytics;

--- a/crates/meilisearch/src/routes/indexes/search.rs
+++ b/crates/meilisearch/src/routes/indexes/search.rs
@@ -356,4 +356,3 @@ pub fn search_kind(
         (_, None, Some(_)) => Err(MeilisearchHttpError::MissingSearchHybrid.into()),
     }
 }
-

--- a/crates/meilisearch/src/routes/indexes/search.rs
+++ b/crates/meilisearch/src/routes/indexes/search.rs
@@ -356,3 +356,4 @@ pub fn search_kind(
         (_, None, Some(_)) => Err(MeilisearchHttpError::MissingSearchHybrid.into()),
     }
 }
+

--- a/crates/meilisearch/src/routes/indexes/search.rs
+++ b/crates/meilisearch/src/routes/indexes/search.rs
@@ -198,7 +198,7 @@ impl TryFrom<SearchQueryGet> for SearchQuery {
 // TODO: TAMO: split on :asc, and :desc, instead of doing some weird things
 
 /// Transform the sort query parameter into something that matches the post expected format.
-fn fix_sort_query_parameters(sort_query: &str) -> Vec<String> {
+pub fn fix_sort_query_parameters(sort_query: &str) -> Vec<String> {
     let mut sort_parameters = Vec::new();
     let mut merge = false;
     for current_sort in sort_query.trim_matches('"').split(',').map(|s| s.trim()) {
@@ -354,32 +354,5 @@ pub fn search_kind(
         ),
 
         (_, None, Some(_)) => Err(MeilisearchHttpError::MissingSearchHybrid.into()),
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn test_fix_sort_query_parameters() {
-        let sort = fix_sort_query_parameters("_geoPoint(12, 13):asc");
-        assert_eq!(sort, vec!["_geoPoint(12,13):asc".to_string()]);
-        let sort = fix_sort_query_parameters("doggo:asc,_geoPoint(12.45,13.56):desc");
-        assert_eq!(sort, vec!["doggo:asc".to_string(), "_geoPoint(12.45,13.56):desc".to_string(),]);
-        let sort = fix_sort_query_parameters(
-            "doggo:asc , _geoPoint(12.45, 13.56, 2590352):desc , catto:desc",
-        );
-        assert_eq!(
-            sort,
-            vec![
-                "doggo:asc".to_string(),
-                "_geoPoint(12.45,13.56,2590352):desc".to_string(),
-                "catto:desc".to_string(),
-            ]
-        );
-        let sort = fix_sort_query_parameters("doggo:asc , _geoPoint(1, 2), catto:desc");
-        // This is ugly but eh, I don't want to write a full parser just for this unused route
-        assert_eq!(sort, vec!["doggo:asc".to_string(), "_geoPoint(1,2),catto:desc".to_string(),]);
     }
 }

--- a/crates/meilisearch/src/routes/indexes/search_test.rs
+++ b/crates/meilisearch/src/routes/indexes/search_test.rs
@@ -1,4 +1,3 @@
-#[cfg(test)]
 pub mod search_test {
     use crate::routes::indexes::search::fix_sort_query_parameters;
 

--- a/crates/meilisearch/src/routes/indexes/search_test.rs
+++ b/crates/meilisearch/src/routes/indexes/search_test.rs
@@ -1,0 +1,26 @@
+#[cfg(test)]
+pub mod search_test {
+    use crate::routes::indexes::search::fix_sort_query_parameters;
+
+    #[test]
+    fn test_fix_sort_query_parameters() {
+        let sort = fix_sort_query_parameters("_geoPoint(12, 13):asc");
+        assert_eq!(sort, vec!["_geoPoint(12,13):asc".to_string()]);
+        let sort = fix_sort_query_parameters("doggo:asc,_geoPoint(12.45,13.56):desc");
+        assert_eq!(sort, vec!["doggo:asc".to_string(), "_geoPoint(12.45,13.56):desc".to_string(),]);
+        let sort = fix_sort_query_parameters(
+            "doggo:asc , _geoPoint(12.45, 13.56, 2590352):desc , catto:desc",
+        );
+        assert_eq!(
+            sort,
+            vec![
+                "doggo:asc".to_string(),
+                "_geoPoint(12.45,13.56,2590352):desc".to_string(),
+                "catto:desc".to_string(),
+            ]
+        );
+        let sort = fix_sort_query_parameters("doggo:asc , _geoPoint(1, 2), catto:desc");
+        // This is ugly but eh, I don't want to write a full parser just for this unused route
+        assert_eq!(sort, vec!["doggo:asc".to_string(), "_geoPoint(1,2),catto:desc".to_string(),]);
+    }
+}

--- a/crates/meilisearch/src/routes/indexes/search_test.rs
+++ b/crates/meilisearch/src/routes/indexes/search_test.rs
@@ -1,25 +1,22 @@
-pub mod search_test {
-    use crate::routes::indexes::search::fix_sort_query_parameters;
+use crate::routes::indexes::search::fix_sort_query_parameters;
 
-    #[test]
-    fn test_fix_sort_query_parameters() {
-        let sort = fix_sort_query_parameters("_geoPoint(12, 13):asc");
-        assert_eq!(sort, vec!["_geoPoint(12,13):asc".to_string()]);
-        let sort = fix_sort_query_parameters("doggo:asc,_geoPoint(12.45,13.56):desc");
-        assert_eq!(sort, vec!["doggo:asc".to_string(), "_geoPoint(12.45,13.56):desc".to_string(),]);
-        let sort = fix_sort_query_parameters(
-            "doggo:asc , _geoPoint(12.45, 13.56, 2590352):desc , catto:desc",
-        );
-        assert_eq!(
-            sort,
-            vec![
-                "doggo:asc".to_string(),
-                "_geoPoint(12.45,13.56,2590352):desc".to_string(),
-                "catto:desc".to_string(),
-            ]
-        );
-        let sort = fix_sort_query_parameters("doggo:asc , _geoPoint(1, 2), catto:desc");
-        // This is ugly but eh, I don't want to write a full parser just for this unused route
-        assert_eq!(sort, vec!["doggo:asc".to_string(), "_geoPoint(1,2),catto:desc".to_string(),]);
-    }
+#[test]
+fn test_fix_sort_query_parameters() {
+    let sort = fix_sort_query_parameters("_geoPoint(12, 13):asc");
+    assert_eq!(sort, vec!["_geoPoint(12,13):asc".to_string()]);
+    let sort = fix_sort_query_parameters("doggo:asc,_geoPoint(12.45,13.56):desc");
+    assert_eq!(sort, vec!["doggo:asc".to_string(), "_geoPoint(12.45,13.56):desc".to_string(),]);
+    let sort =
+        fix_sort_query_parameters("doggo:asc , _geoPoint(12.45, 13.56, 2590352):desc , catto:desc");
+    assert_eq!(
+        sort,
+        vec![
+            "doggo:asc".to_string(),
+            "_geoPoint(12.45,13.56,2590352):desc".to_string(),
+            "catto:desc".to_string(),
+        ]
+    );
+    let sort = fix_sort_query_parameters("doggo:asc , _geoPoint(1, 2), catto:desc");
+    // This is ugly but eh, I don't want to write a full parser just for this unused route
+    assert_eq!(sort, vec!["doggo:asc".to_string(), "_geoPoint(1,2),catto:desc".to_string(),]);
 }


### PR DESCRIPTION
# Pull Request
Splits the tests for meilisearch crate in a separate file.

## Related issue
Partially solves #5116 

## What does this PR do?
- Splits the test for `/indexes/search.rs` into a separate file `indexes/search_test.rs` in meilisearch crate

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
