### PR TITLE
Make xtasks be able to use the specified binary

### DIFF
--- a/crates/meilisearch/src/main.rs
+++ b/crates/meilisearch/src/main.rs
@@ -129,6 +129,11 @@ async fn try_main() -> anyhow::Result<()> {
 
     print_launch_resume(&opt, analytics.clone(), config_read_from);
 
+    tokio::spawn(async move {
+        tokio::signal::ctrl_c().await.unwrap();
+        std::process::exit(77);
+    });
+
     run_http(index_scheduler, auth_controller, opt, log_handle, Arc::new(analytics)).await?;
 
     Ok(())

--- a/crates/meilisearch/src/main.rs
+++ b/crates/meilisearch/src/main.rs
@@ -131,7 +131,7 @@ async fn try_main() -> anyhow::Result<()> {
 
     tokio::spawn(async move {
         tokio::signal::ctrl_c().await.unwrap();
-        std::process::exit(77);
+        std::process::exit(130);
     });
 
     run_http(index_scheduler, auth_controller, opt, log_handle, Arc::new(analytics)).await?;

--- a/crates/xtask/src/bench/meili_process.rs
+++ b/crates/xtask/src/bench/meili_process.rs
@@ -37,17 +37,8 @@ pub async fn start(
     master_key: Option<&str>,
     workload: &Workload,
     asset_folder: &str,
+    mut command: tokio::process::Command,
 ) -> anyhow::Result<tokio::process::Child> {
-    let mut command = tokio::process::Command::new("cargo");
-    command
-        .arg("run")
-        .arg("--release")
-        .arg("-p")
-        .arg("meilisearch")
-        .arg("--bin")
-        .arg("meilisearch")
-        .arg("--");
-
     command.arg("--db-path").arg("./_xtask_benchmark.ms");
     if let Some(master_key) = master_key {
         command.arg("--master-key").arg(master_key);

--- a/crates/xtask/src/bench/meili_process.rs
+++ b/crates/xtask/src/bench/meili_process.rs
@@ -1,23 +1,56 @@
 use std::collections::BTreeMap;
+use std::time::Duration;
 
 use anyhow::{bail, Context as _};
+use tokio::process::Command;
+use tokio::time;
 
 use super::assets::Asset;
 use super::client::Client;
 use super::workload::Workload;
 
 pub async fn kill(mut meilisearch: tokio::process::Child) {
-    if let Err(error) = meilisearch.kill().await {
-        tracing::warn!(
-            error = &error as &dyn std::error::Error,
-            "while terminating Meilisearch server"
-        )
+    let Some(id) = meilisearch.id() else { return };
+
+    match Command::new("kill").args(["--signal=TERM", &id.to_string()]).spawn() {
+        Ok(mut cmd) => {
+            let Err(error) = cmd.wait().await else { return };
+            tracing::warn!(
+                error = &error as &dyn std::error::Error,
+                "while awaiting the Meilisearch server kill"
+            );
+        }
+        Err(error) => {
+            tracing::warn!(
+                error = &error as &dyn std::error::Error,
+                "while terminating Meilisearch server with a kill -s TERM"
+            );
+            if let Err(error) = meilisearch.kill().await {
+                tracing::warn!(
+                    error = &error as &dyn std::error::Error,
+                    "while terminating Meilisearch server"
+                )
+            }
+            return;
+        }
+    };
+
+    match time::timeout(Duration::from_secs(5), meilisearch.wait()).await {
+        Ok(_) => (),
+        Err(_) => {
+            if let Err(error) = meilisearch.kill().await {
+                tracing::warn!(
+                    error = &error as &dyn std::error::Error,
+                    "while terminating Meilisearch server"
+                )
+            }
+        }
     }
 }
 
 #[tracing::instrument]
 pub async fn build() -> anyhow::Result<()> {
-    let mut command = tokio::process::Command::new("cargo");
+    let mut command = Command::new("cargo");
     command.arg("build").arg("--release").arg("-p").arg("meilisearch");
 
     command.kill_on_drop(true);
@@ -37,7 +70,7 @@ pub async fn start(
     master_key: Option<&str>,
     workload: &Workload,
     asset_folder: &str,
-    mut command: tokio::process::Command,
+    mut command: Command,
 ) -> anyhow::Result<tokio::process::Child> {
     command.arg("--db-path").arg("./_xtask_benchmark.ms");
     if let Some(master_key) = master_key {
@@ -77,7 +110,7 @@ async fn wait_for_health(
 
             return Ok(());
         }
-        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        time::sleep(Duration::from_millis(500)).await;
         // check whether the Meilisearch instance exited early (cut the wait)
         if let Some(exit_code) =
             meilisearch.try_wait().context("cannot check Meilisearch server process status")?

--- a/crates/xtask/src/bench/mod.rs
+++ b/crates/xtask/src/bench/mod.rs
@@ -86,6 +86,10 @@ pub struct BenchDeriveArgs {
     /// The maximum time in seconds we allow for fetching the task queue before timing out.
     #[arg(long, default_value_t = 60)]
     tasks_queue_timeout_secs: u64,
+
+    /// The path to the binary to run. By default it compiles the binary with cargo.
+    #[arg(long)]
+    binary_path: Option<PathBuf>,
 }
 
 pub fn run(args: BenchDeriveArgs) -> anyhow::Result<()> {
@@ -170,6 +174,7 @@ pub fn run(args: BenchDeriveArgs) -> anyhow::Result<()> {
                     args.master_key.as_deref(),
                     workload,
                     &args,
+                    args.binary_path.as_deref(),
                 )
                 .await?;
 

--- a/crates/xtask/src/bench/mod.rs
+++ b/crates/xtask/src/bench/mod.rs
@@ -87,7 +87,9 @@ pub struct BenchDeriveArgs {
     #[arg(long, default_value_t = 60)]
     tasks_queue_timeout_secs: u64,
 
-    /// The path to the binary to run. By default it compiles the binary with cargo.
+    /// The path to the binary to run.
+    ///
+    /// If unspecified, runs `cargo run` after building Meilisearch with `cargo build`.
     #[arg(long)]
     binary_path: Option<PathBuf>,
 }


### PR DESCRIPTION
Makes it possible to specify the binary to run. It is useful to run PGO optimized binaries.