### PR TITLE
Return docid in case of errors while rendering the document template

### DIFF
--- a/crates/milli/src/prompt/error.rs
+++ b/crates/milli/src/prompt/error.rs
@@ -38,6 +38,16 @@ pub struct RenderPromptError {
     pub fault: FaultSource,
 }
 impl RenderPromptError {
+    pub(crate) fn missing_context_with_external_docid(
+        external_docid: String,
+        inner: liquid::Error,
+    ) -> RenderPromptError {
+        Self {
+            kind: RenderPromptErrorKind::MissingContextWithExternalDocid(external_docid, inner),
+            fault: FaultSource::User,
+        }
+    }
+
     pub(crate) fn missing_context(inner: liquid::Error) -> RenderPromptError {
         Self { kind: RenderPromptErrorKind::MissingContext(inner), fault: FaultSource::User }
     }
@@ -47,6 +57,8 @@ impl RenderPromptError {
 pub enum RenderPromptErrorKind {
     #[error("missing field in document: {0}")]
     MissingContext(liquid::Error),
+    #[error("missing field in document `{0}`: {1}")]
+    MissingContextWithExternalDocid(String, liquid::Error),
 }
 
 impl From<RenderPromptError> for crate::Error {

--- a/crates/milli/src/update/new/extract/vectors/mod.rs
+++ b/crates/milli/src/update/new/extract/vectors/mod.rs
@@ -130,6 +130,7 @@ impl<'a, 'b, 'extractor> Extractor<'extractor> for EmbeddingExtractor<'a, 'b> {
                                 );
                             } else if new_vectors.regenerate {
                                 let new_rendered = prompt.render_document(
+                                    update.external_document_id(),
                                     update.current(
                                         &context.rtxn,
                                         context.index,
@@ -139,6 +140,7 @@ impl<'a, 'b, 'extractor> Extractor<'extractor> for EmbeddingExtractor<'a, 'b> {
                                     &context.doc_alloc,
                                 )?;
                                 let old_rendered = prompt.render_document(
+                                    update.external_document_id(),
                                     update.merged(
                                         &context.rtxn,
                                         context.index,
@@ -158,6 +160,7 @@ impl<'a, 'b, 'extractor> Extractor<'extractor> for EmbeddingExtractor<'a, 'b> {
                             }
                         } else if old_vectors.regenerate {
                             let old_rendered = prompt.render_document(
+                                update.external_document_id(),
                                 update.current(
                                     &context.rtxn,
                                     context.index,
@@ -167,6 +170,7 @@ impl<'a, 'b, 'extractor> Extractor<'extractor> for EmbeddingExtractor<'a, 'b> {
                                 &context.doc_alloc,
                             )?;
                             let new_rendered = prompt.render_document(
+                                update.external_document_id(),
                                 update.merged(
                                     &context.rtxn,
                                     context.index,
@@ -216,6 +220,7 @@ impl<'a, 'b, 'extractor> Extractor<'extractor> for EmbeddingExtractor<'a, 'b> {
                                 );
                             } else if new_vectors.regenerate {
                                 let rendered = prompt.render_document(
+                                    insertion.external_document_id(),
                                     insertion.inserted(),
                                     context.new_fields_ids_map,
                                     &context.doc_alloc,
@@ -229,6 +234,7 @@ impl<'a, 'b, 'extractor> Extractor<'extractor> for EmbeddingExtractor<'a, 'b> {
                             }
                         } else {
                             let rendered = prompt.render_document(
+                                insertion.external_document_id(),
                                 insertion.inserted(),
                                 context.new_fields_ids_map,
                                 &context.doc_alloc,


### PR DESCRIPTION
Improves error message:

Before: 

```
ERROR index_scheduler: Batch failed Index `mieli`: user error: missing field in document: liquid: Unknown index
  with:
    variable=doc
    requested index=title
    available indexes=by, id, kids, parent, text, time, type
```

After:

```
ERROR index_scheduler: Batch failed Index `mieli`: user error: missing field in document `11345147`: liquid: Unknown index
  with:
    variable=doc
    requested index=title
    available indexes=by, id, kids, parent, text, time, type
```