### PR TITLE
tests: split tests in separate file

### DIFF
--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -30,6 +30,8 @@ use milli::{
 use regex::Regex;
 use serde::Serialize;
 use serde_json::{json, Value};
+#[cfg(test)]
+mod mod_test;
 
 use crate::error::MeilisearchHttpError;
 
@@ -1557,7 +1559,7 @@ pub fn perform_similar(
     Ok(result)
 }
 
-fn insert_geo_distance(sorts: &[String], document: &mut Document) {
+pub fn insert_geo_distance(sorts: &[String], document: &mut Document) {
     lazy_static::lazy_static! {
         static ref GEO_REGEX: Regex =
             Regex::new(r"_geoPoint\(\s*([[:digit:].\-]+)\s*,\s*([[:digit:].\-]+)\s*\)").unwrap();

--- a/crates/meilisearch/src/search/mod_test.rs
+++ b/crates/meilisearch/src/search/mod_test.rs
@@ -1,0 +1,113 @@
+use crate::search::insert_geo_distance;
+use meilisearch_types::Document;
+use serde_json::json;
+
+#[test]
+fn test_insert_geo_distance() {
+    let value: Document = serde_json::from_str(
+        r#"{
+          "_geo": {
+            "lat": 50.629973371633746,
+            "lng": 3.0569447399419567
+          },
+          "city": "Lille",
+          "id": "1"
+        }"#,
+    )
+    .unwrap();
+
+    let sorters = &["_geoPoint(50.629973371633746,3.0569447399419567):desc".to_string()];
+    let mut document = value.clone();
+    insert_geo_distance(sorters, &mut document);
+    assert_eq!(document.get("_geoDistance"), Some(&json!(0)));
+
+    let sorters = &["_geoPoint(50.629973371633746, 3.0569447399419567):asc".to_string()];
+    let mut document = value.clone();
+    insert_geo_distance(sorters, &mut document);
+    assert_eq!(document.get("_geoDistance"), Some(&json!(0)));
+
+    let sorters = &["_geoPoint(   50.629973371633746   ,  3.0569447399419567   ):desc".to_string()];
+    let mut document = value.clone();
+    insert_geo_distance(sorters, &mut document);
+    assert_eq!(document.get("_geoDistance"), Some(&json!(0)));
+
+    let sorters = &[
+        "prix:asc",
+        "villeneuve:desc",
+        "_geoPoint(50.629973371633746, 3.0569447399419567):asc",
+        "ubu:asc",
+    ]
+    .map(|s| s.to_string());
+    let mut document = value.clone();
+    insert_geo_distance(sorters, &mut document);
+    assert_eq!(document.get("_geoDistance"), Some(&json!(0)));
+
+    // only the first geoPoint is used to compute the distance
+    let sorters = &[
+        "chien:desc",
+        "_geoPoint(50.629973371633746, 3.0569447399419567):asc",
+        "pangolin:desc",
+        "_geoPoint(100.0, -80.0):asc",
+        "chat:asc",
+    ]
+    .map(|s| s.to_string());
+    let mut document = value.clone();
+    insert_geo_distance(sorters, &mut document);
+    assert_eq!(document.get("_geoDistance"), Some(&json!(0)));
+
+    // there was no _geoPoint so nothing is inserted in the document
+    let sorters = &["chien:asc".to_string()];
+    let mut document = value;
+    insert_geo_distance(sorters, &mut document);
+    assert_eq!(document.get("_geoDistance"), None);
+}
+
+#[test]
+fn test_insert_geo_distance_with_coords_as_string() {
+    let value: Document = serde_json::from_str(
+        r#"{
+          "_geo": {
+            "lat": "50",
+            "lng": 3
+          }
+        }"#,
+    )
+    .unwrap();
+
+    let sorters = &["_geoPoint(50,3):desc".to_string()];
+    let mut document = value.clone();
+    insert_geo_distance(sorters, &mut document);
+    assert_eq!(document.get("_geoDistance"), Some(&json!(0)));
+
+    let value: Document = serde_json::from_str(
+        r#"{
+          "_geo": {
+            "lat": "50",
+            "lng": "3"
+          },
+          "id": "1"
+        }"#,
+    )
+    .unwrap();
+
+    let sorters = &["_geoPoint(50,3):desc".to_string()];
+    let mut document = value.clone();
+    insert_geo_distance(sorters, &mut document);
+    assert_eq!(document.get("_geoDistance"), Some(&json!(0)));
+
+    let value: Document = serde_json::from_str(
+        r#"{
+          "_geo": {
+            "lat": 50,
+            "lng": "3"
+          },
+          "id": "1"
+        }"#,
+    )
+    .unwrap();
+
+    let sorters = &["_geoPoint(50,3):desc".to_string()];
+    let mut document = value.clone();
+    insert_geo_distance(sorters, &mut document);
+    assert_eq!(document.get("_geoDistance"), Some(&json!(0)));
+}

--- a/crates/meilisearch/src/search/mod_test.rs
+++ b/crates/meilisearch/src/search/mod_test.rs
@@ -1,6 +1,7 @@
-use crate::search::insert_geo_distance;
 use meilisearch_types::Document;
 use serde_json::json;
+
+use crate::search::insert_geo_distance;
 
 #[test]
 fn test_insert_geo_distance() {


### PR DESCRIPTION
# Pull Request
Splits the tests for meilisearch search crate in a separate testfile.

## Related issue
Partially solves #5116.

## Related Pull Requests
https://github.com/meilisearch/meilisearch/pull/5134

## What does this PR do?
- Splits the test for `/search/mod.rs` into a separate file `search/mod_test.rs` in meilisearch crate

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
