### PR TITLE
Remove hard coded task ids to prevent flaky tests

### DIFF
--- a/crates/meilisearch/src/option_test.rs
+++ b/crates/meilisearch/src/option_test.rs
@@ -1,5 +1,6 @@
-use crate::option::Opt;
 use clap::Parser;
+
+use crate::option::Opt;
 
 #[test]
 fn test_valid_opt() {

--- a/crates/meilisearch/tests/auth/tenant_token.rs
+++ b/crates/meilisearch/tests/auth/tenant_token.rs
@@ -100,11 +100,11 @@ macro_rules! compute_authorized_search {
         let index = server.index("sales");
         let documents = DOCUMENTS.clone();
         let (task1,_status_code) = index.add_documents(documents, None).await;
-        index.wait_task(task1.uid()).await;
+        index.wait_task(task1.uid()).await.succeeded();
         let (task2,_status_code) = index
             .update_settings(json!({"filterableAttributes": ["color"]}))
             .await;
-        index.wait_task(task2.uid()).await;
+        index.wait_task(task2.uid()).await.succeeded();
         drop(index);
 
         for key_content in ACCEPTED_KEYS.iter() {
@@ -147,7 +147,7 @@ macro_rules! compute_forbidden_search {
         let index = server.index("sales");
         let documents = DOCUMENTS.clone();
         let (task,_status_code) = index.add_documents(documents, None).await;
-        index.wait_task(task.uid()).await;
+        index.wait_task(task.uid()).await.succeeded();
         drop(index);
 
         for key_content in $parent_keys.iter() {

--- a/crates/meilisearch/tests/auth/tenant_token.rs
+++ b/crates/meilisearch/tests/auth/tenant_token.rs
@@ -146,7 +146,7 @@ macro_rules! compute_forbidden_search {
         server.use_admin_key("MASTER_KEY").await;
         let index = server.index("sales");
         let documents = DOCUMENTS.clone();
-        let (task,_status_code) = index.add_documents(documents, None).await;
+        let (task, _status_code) = index.add_documents(documents, None).await;
         index.wait_task(task.uid()).await.succeeded();
         drop(index);
 

--- a/crates/meilisearch/tests/auth/tenant_token.rs
+++ b/crates/meilisearch/tests/auth/tenant_token.rs
@@ -99,12 +99,12 @@ macro_rules! compute_authorized_search {
         server.use_admin_key("MASTER_KEY").await;
         let index = server.index("sales");
         let documents = DOCUMENTS.clone();
-        index.add_documents(documents, None).await;
-        index.wait_task(0).await;
-        index
+        let (task1,_status_code) = index.add_documents(documents, None).await;
+        index.wait_task(task1.uid()).await;
+        let (task2,_status_code) = index
             .update_settings(json!({"filterableAttributes": ["color"]}))
             .await;
-        index.wait_task(1).await;
+        index.wait_task(task2.uid()).await;
         drop(index);
 
         for key_content in ACCEPTED_KEYS.iter() {
@@ -146,8 +146,8 @@ macro_rules! compute_forbidden_search {
         server.use_admin_key("MASTER_KEY").await;
         let index = server.index("sales");
         let documents = DOCUMENTS.clone();
-        index.add_documents(documents, None).await;
-        index.wait_task(0).await;
+        let (task,_status_code) = index.add_documents(documents, None).await;
+        index.wait_task(task.uid()).await;
         drop(index);
 
         for key_content in $parent_keys.iter() {

--- a/crates/meilisearch/tests/auth/tenant_token_multi_search.rs
+++ b/crates/meilisearch/tests/auth/tenant_token_multi_search.rs
@@ -427,17 +427,17 @@ macro_rules! compute_forbidden_single_search {
         let (task,_status_code) = index
             .update_settings(json!({"filterableAttributes": ["color"]}))
             .await;
-        index.wait_task(task.uid()).await;
+        index.wait_task(task.uid()).await.succeeded();
         drop(index);
 
         let index = server.index("products");
         let documents = NESTED_DOCUMENTS.clone();
         let (task,_status_code) = index.add_documents(documents, None).await;
-        index.wait_task(task.uid()).await;
+        index.wait_task(task.uid()).await.succeeded();
         let (task,_status_code) = index
             .update_settings(json!({"filterableAttributes": ["doggos"]}))
             .await;
-        index.wait_task(task.uid()).await;
+        index.wait_task(task.uid()).await.succeeded();
         drop(index);
 
         assert_eq!($parent_keys.len(), $failed_query_indexes.len(), "keys != query_indexes");
@@ -499,21 +499,21 @@ macro_rules! compute_forbidden_multiple_search {
         let index = server.index("sales");
         let documents = DOCUMENTS.clone();
         let (task,_status_code) = index.add_documents(documents, None).await;
-        index.wait_task(task.uid()).await;
+        index.wait_task(task.uid()).await.succeeded();
         let (task,_status_code) = index
             .update_settings(json!({"filterableAttributes": ["color"]}))
             .await;
-        index.wait_task(task.uid()).await;
+        index.wait_task(task.uid()).await.succeeded();
         drop(index);
 
         let index = server.index("products");
         let documents = NESTED_DOCUMENTS.clone();
         let (task,_status_code) = index.add_documents(documents, None).await;
-        index.wait_task(task.uid()).await;
+        index.wait_task(task.uid()).await.succeeded();
         let (task,_status_code) = index
             .update_settings(json!({"filterableAttributes": ["doggos"]}))
             .await;
-        index.wait_task(task.uid()).await;
+        index.wait_task(task.uid()).await.succeeded();
         drop(index);
 
         assert_eq!($parent_keys.len(), $failed_query_indexes.len(), "keys != query_indexes");

--- a/crates/meilisearch/tests/auth/tenant_token_multi_search.rs
+++ b/crates/meilisearch/tests/auth/tenant_token_multi_search.rs
@@ -268,21 +268,21 @@ macro_rules! compute_authorized_single_search {
         let index = server.index("sales");
         let documents = DOCUMENTS.clone();
         let (add_task,_status_code) = index.add_documents(documents, None).await;
-        index.wait_task(add_task.uid()).await;
+        index.wait_task(add_task.uid()).await.succeeded();
         let (update_task,_status_code) = index
             .update_settings(json!({"filterableAttributes": ["color"]}))
             .await;
-        index.wait_task(update_task.uid()).await;
+        index.wait_task(update_task.uid()).await.succeeded();
         drop(index);
 
         let index = server.index("products");
         let documents = NESTED_DOCUMENTS.clone();
         let (add_task2,_status_code) = index.add_documents(documents, None).await;
-        index.wait_task(add_task2.uid()).await;
+        index.wait_task(add_task2.uid()).await.succeeded();
         let (update_task2,_status_code) = index
             .update_settings(json!({"filterableAttributes": ["doggos"]}))
             .await;
-        index.wait_task(update_task2.uid()).await;
+        index.wait_task(update_task2.uid()).await.succeeded();
         drop(index);
 
 
@@ -339,21 +339,21 @@ macro_rules! compute_authorized_multiple_search {
         let index = server.index("sales");
         let documents = DOCUMENTS.clone();
         let (task,_status_code) = index.add_documents(documents, None).await;
-        index.wait_task(task.uid()).await;
+        index.wait_task(task.uid()).await.succeeded();
         let (task,_status_code) = index
             .update_settings(json!({"filterableAttributes": ["color"]}))
             .await;
-        index.wait_task(task.uid()).await;
+        index.wait_task(task.uid()).await.succeeded();
         drop(index);
 
         let index = server.index("products");
         let documents = NESTED_DOCUMENTS.clone();
         let (task,_status_code) = index.add_documents(documents, None).await;
-        index.wait_task(task.uid()).await;
+        index.wait_task(task.uid()).await.succeeded();
         let (task,_status_code) = index
             .update_settings(json!({"filterableAttributes": ["doggos"]}))
             .await;
-        index.wait_task(task.uid()).await;
+        index.wait_task(task.uid()).await.succeeded();
         drop(index);
 
 
@@ -423,7 +423,7 @@ macro_rules! compute_forbidden_single_search {
         let index = server.index("sales");
         let documents = DOCUMENTS.clone();
         let (task,_status_code) = index.add_documents(documents, None).await;
-        index.wait_task(task.uid()).await;
+        index.wait_task(task.uid()).await.succeeded();
         let (task,_status_code) = index
             .update_settings(json!({"filterableAttributes": ["color"]}))
             .await;

--- a/crates/meilisearch/tests/auth/tenant_token_multi_search.rs
+++ b/crates/meilisearch/tests/auth/tenant_token_multi_search.rs
@@ -267,22 +267,22 @@ macro_rules! compute_authorized_single_search {
         server.use_admin_key("MASTER_KEY").await;
         let index = server.index("sales");
         let documents = DOCUMENTS.clone();
-        index.add_documents(documents, None).await;
-        index.wait_task(0).await;
-        index
+        let (add_task,_status_code) = index.add_documents(documents, None).await;
+        index.wait_task(add_task.uid()).await;
+        let (update_task,_status_code) = index
             .update_settings(json!({"filterableAttributes": ["color"]}))
             .await;
-        index.wait_task(1).await;
+        index.wait_task(update_task.uid()).await;
         drop(index);
 
         let index = server.index("products");
         let documents = NESTED_DOCUMENTS.clone();
-        index.add_documents(documents, None).await;
-        index.wait_task(2).await;
-        index
+        let (add_task2,_status_code) = index.add_documents(documents, None).await;
+        index.wait_task(add_task2.uid()).await;
+        let (update_task2,_status_code) = index
             .update_settings(json!({"filterableAttributes": ["doggos"]}))
             .await;
-        index.wait_task(3).await;
+        index.wait_task(update_task2.uid()).await;
         drop(index);
 
 
@@ -338,22 +338,22 @@ macro_rules! compute_authorized_multiple_search {
         server.use_admin_key("MASTER_KEY").await;
         let index = server.index("sales");
         let documents = DOCUMENTS.clone();
-        index.add_documents(documents, None).await;
-        index.wait_task(0).await;
-        index
+        let (task,_status_code) = index.add_documents(documents, None).await;
+        index.wait_task(task.uid()).await;
+        let (task,_status_code) = index
             .update_settings(json!({"filterableAttributes": ["color"]}))
             .await;
-        index.wait_task(1).await;
+        index.wait_task(task.uid()).await;
         drop(index);
 
         let index = server.index("products");
         let documents = NESTED_DOCUMENTS.clone();
-        index.add_documents(documents, None).await;
-        index.wait_task(2).await;
-        index
+        let (task,_status_code) = index.add_documents(documents, None).await;
+        index.wait_task(task.uid()).await;
+        let (task,_status_code) = index
             .update_settings(json!({"filterableAttributes": ["doggos"]}))
             .await;
-        index.wait_task(3).await;
+        index.wait_task(task.uid()).await;
         drop(index);
 
 
@@ -422,22 +422,22 @@ macro_rules! compute_forbidden_single_search {
         server.use_admin_key("MASTER_KEY").await;
         let index = server.index("sales");
         let documents = DOCUMENTS.clone();
-        index.add_documents(documents, None).await;
-        index.wait_task(0).await;
-        index
+        let (task,_status_code) = index.add_documents(documents, None).await;
+        index.wait_task(task.uid()).await;
+        let (task,_status_code) = index
             .update_settings(json!({"filterableAttributes": ["color"]}))
             .await;
-        index.wait_task(1).await;
+        index.wait_task(task.uid()).await;
         drop(index);
 
         let index = server.index("products");
         let documents = NESTED_DOCUMENTS.clone();
-        index.add_documents(documents, None).await;
-        index.wait_task(2).await;
-        index
+        let (task,_status_code) = index.add_documents(documents, None).await;
+        index.wait_task(task.uid()).await;
+        let (task,_status_code) = index
             .update_settings(json!({"filterableAttributes": ["doggos"]}))
             .await;
-        index.wait_task(3).await;
+        index.wait_task(task.uid()).await;
         drop(index);
 
         assert_eq!($parent_keys.len(), $failed_query_indexes.len(), "keys != query_indexes");
@@ -498,22 +498,22 @@ macro_rules! compute_forbidden_multiple_search {
         server.use_admin_key("MASTER_KEY").await;
         let index = server.index("sales");
         let documents = DOCUMENTS.clone();
-        index.add_documents(documents, None).await;
-        index.wait_task(0).await;
-        index
+        let (task,_status_code) = index.add_documents(documents, None).await;
+        index.wait_task(task.uid()).await;
+        let (task,_status_code) = index
             .update_settings(json!({"filterableAttributes": ["color"]}))
             .await;
-        index.wait_task(1).await;
+        index.wait_task(task.uid()).await;
         drop(index);
 
         let index = server.index("products");
         let documents = NESTED_DOCUMENTS.clone();
-        index.add_documents(documents, None).await;
-        index.wait_task(2).await;
-        index
+        let (task,_status_code) = index.add_documents(documents, None).await;
+        index.wait_task(task.uid()).await;
+        let (task,_status_code) = index
             .update_settings(json!({"filterableAttributes": ["doggos"]}))
             .await;
-        index.wait_task(3).await;
+        index.wait_task(task.uid()).await;
         drop(index);
 
         assert_eq!($parent_keys.len(), $failed_query_indexes.len(), "keys != query_indexes");

--- a/crates/meilisearch/tests/batches/mod.rs
+++ b/crates/meilisearch/tests/batches/mod.rs
@@ -168,12 +168,9 @@ async fn list_batches_status_filtered() {
 async fn list_batches_type_filtered() {
     let server = Server::new().await;
     let index = server.index("test");
-    let (task, _status_code) = index.create(None).await;
+    let (task, _) = index.create(None).await;
     index.wait_task(task.uid()).await.succeeded();
-    index
-        .add_documents(serde_json::from_str(include_str!("../assets/test_set.json")).unwrap(), None)
-        .await;
-
+    let (task, _) = index.delete().await;
     let (response, code) = index.filtered_batches(&["indexCreation"], &[], &[]).await;
     assert_eq!(code, 200, "{}", response);
     assert_eq!(response["results"].as_array().unwrap().len(), 1);

--- a/crates/meilisearch/tests/batches/mod.rs
+++ b/crates/meilisearch/tests/batches/mod.rs
@@ -143,22 +143,18 @@ async fn list_batches_status_filtered() {
     let index = server.index("test");
     let (task, _status_code) = index.create(None).await;
     index.wait_task(task.uid()).await.succeeded();
-    let (task, _status_code) = index
-        .add_documents(serde_json::from_str(include_str!("../assets/test_set.json")).unwrap(), None)
-        .await;
+    let (task, _status_code) = index.create(None).await;
+    index.wait_task(task.uid()).await.failed();
 
     let (response, code) = index.filtered_batches(&[], &["succeeded"], &[]).await;
     assert_eq!(code, 200, "{}", response);
     assert_eq!(response["results"].as_array().unwrap().len(), 1);
 
-    // We can't be sure that the update isn't already processed so we can't test this
-    // let (response, code) = index.filtered_batches(&[], &["processing"]).await;
-    // assert_eq!(code, 200, "{}", response);
-    // assert_eq!(response["results"].as_array().unwrap().len(), 1);
-
-    index.wait_task(task.uid()).await.succeeded();
-
     let (response, code) = index.filtered_batches(&[], &["succeeded"], &[]).await;
+    assert_eq!(code, 200, "{}", response);
+    assert_eq!(response["results"].as_array().unwrap().len(), 1);
+
+    let (response, code) = index.filtered_batches(&[], &["succeeded", "failed"], &[]).await;
     assert_eq!(code, 200, "{}", response);
     assert_eq!(response["results"].as_array().unwrap().len(), 2);
 }
@@ -176,9 +172,13 @@ async fn list_batches_type_filtered() {
     assert_eq!(response["results"].as_array().unwrap().len(), 1);
 
     let (response, code) =
-        index.filtered_batches(&["indexCreation", "documentAdditionOrUpdate"], &[], &[]).await;
+        index.filtered_batches(&["indexCreation", "IndexDeletion"], &[], &[]).await;
     assert_eq!(code, 200, "{}", response);
     assert_eq!(response["results"].as_array().unwrap().len(), 2);
+
+    let (response, code) = index.filtered_batches(&["indexCreation"], &[], &[]).await;
+    assert_eq!(code, 200, "{}", response);
+    assert_eq!(response["results"].as_array().unwrap().len(), 1);
 }
 
 #[actix_rt::test]
@@ -344,7 +344,7 @@ async fn test_summarized_delete_documents_by_batch() {
     let server = Server::new().await;
     let index = server.index("test");
     let (task, _status_code) = index.delete_batch(vec![1, 2, 3]).await;
-    index.wait_task(task.uid()).await.succeeded();
+    index.wait_task(task.uid()).await.failed();
     let (batch, _) = index.get_batch(0).await;
     assert_json_snapshot!(batch,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
@@ -414,7 +414,7 @@ async fn test_summarized_delete_documents_by_filter() {
 
     let (task, _status_code) =
         index.delete_document_by_filter(json!({ "filter": "doggo = bernese" })).await;
-    index.wait_task(task.uid()).await.succeeded();
+    index.wait_task(task.uid()).await.failed();
     let (batch, _) = index.get_batch(0).await;
     assert_json_snapshot!(batch,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
@@ -448,7 +448,7 @@ async fn test_summarized_delete_documents_by_filter() {
     index.create(None).await;
     let (task, _status_code) =
         index.delete_document_by_filter(json!({ "filter": "doggo = bernese" })).await;
-    index.wait_task(task.uid()).await.succeeded();
+    index.wait_task(task.uid()).await.failed();
     let (batch, _) = index.get_batch(2).await;
     assert_json_snapshot!(batch,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
@@ -519,13 +519,12 @@ async fn test_summarized_delete_document_by_id() {
     let server = Server::new().await;
     let index = server.index("test");
     let (task, _status_code) = index.delete_document(1).await;
-    index.wait_task(task.uid()).await.succeeded();
+    index.wait_task(task.uid()).await.failed();
     let (batch, _) = index.get_batch(0).await;
-    assert_json_snapshot!(batch,
-        { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
+    snapshot!(batch,
         @r#"
     {
-      "uid": 0,
+      "uid": "[uid]",
       "progress": null,
       "details": {
         "providedIds": 1,
@@ -672,7 +671,7 @@ async fn test_summarized_index_creation() {
     "#);
 
     let (task, _status_code) = index.create(Some("doggos")).await;
-    index.wait_task(task.uid()).await.succeeded();
+    index.wait_task(task.uid()).await.failed();
     let (batch, _) = index.get_batch(1).await;
     assert_json_snapshot!(batch,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
@@ -707,7 +706,7 @@ async fn test_summarized_index_deletion() {
     let server = Server::new().await;
     let index = server.index("test");
     let (ret, _code) = index.delete().await;
-    let batch = index.wait_task(ret.uid()).await;
+    let batch = index.wait_task(ret.uid()).await.failed();
     snapshot!(batch,
         @r###"
     {
@@ -738,7 +737,7 @@ async fn test_summarized_index_deletion() {
     // both batches may get autobatched and the deleted documents count will be wrong.
     let (ret, _code) =
         index.add_documents(json!({ "id": 42, "content": "doggos & fluff" }), Some("id")).await;
-    let batch = index.wait_task(ret.uid()).await;
+    let batch = index.wait_task(ret.uid()).await.succeeded();
     snapshot!(batch,
         @r###"
     {
@@ -761,7 +760,7 @@ async fn test_summarized_index_deletion() {
     "###);
 
     let (ret, _code) = index.delete().await;
-    let batch = index.wait_task(ret.uid()).await;
+    let batch = index.wait_task(ret.uid()).await.succeeded();
     snapshot!(batch,
         @r###"
     {
@@ -784,7 +783,7 @@ async fn test_summarized_index_deletion() {
 
     // What happens when you delete an index that doesn't exists.
     let (ret, _code) = index.delete().await;
-    let batch = index.wait_task(ret.uid()).await;
+    let batch = index.wait_task(ret.uid()).await.failed();
     snapshot!(batch,
         @r###"
     {
@@ -817,7 +816,7 @@ async fn test_summarized_index_update() {
     let index = server.index("test");
     // If the index doesn't exist yet, we should get errors with or without the primary key.
     let (task, _status_code) = index.update(None).await;
-    index.wait_task(task.uid()).await.succeeded();
+    index.wait_task(task.uid()).await.failed();
     let (batch, _) = index.get_batch(0).await;
     assert_json_snapshot!(batch,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
@@ -845,7 +844,7 @@ async fn test_summarized_index_update() {
     "#);
 
     let (task, _status_code) = index.update(Some("bones")).await;
-    index.wait_task(task.uid()).await.succeeded();
+    index.wait_task(task.uid()).await.failed();
     let (batch, _) = index.get_batch(1).await;
     assert_json_snapshot!(batch,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
@@ -944,7 +943,7 @@ async fn test_summarized_index_swap() {
             { "indexes": ["doggos", "cattos"] }
         ]))
         .await;
-    server.wait_task(task.uid()).await;
+    server.wait_task(task.uid()).await.failed();
     let (batch, _) = server.get_batch(0).await;
     assert_json_snapshot!(batch,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
@@ -985,33 +984,26 @@ async fn test_summarized_index_swap() {
             { "indexes": ["doggos", "cattos"] }
         ]))
         .await;
-    server.wait_task(task.uid()).await;
+    server.wait_task(task.uid()).await.succeeded();
     let (batch, _) = server.get_batch(1).await;
     assert_json_snapshot!(batch,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
         @r#"
     {
-      "uid": 3,
+      "uid": 1,
       "progress": null,
-      "details": {
-        "swaps": [
-          {
-            "indexes": [
-              "doggos",
-              "cattos"
-            ]
-          }
-        ]
-      },
+      "details": {},
       "stats": {
         "totalNbTasks": 1,
         "status": {
           "succeeded": 1
         },
         "types": {
-          "indexSwap": 1
+          "indexCreation": 1
         },
-        "indexUids": {}
+        "indexUids": {
+          "doggos": 1
+        }
       },
       "duration": "[duration]",
       "startedAt": "[date]",

--- a/crates/meilisearch/tests/batches/mod.rs
+++ b/crates/meilisearch/tests/batches/mod.rs
@@ -169,7 +169,8 @@ async fn list_batches_type_filtered() {
     let index = server.index("test");
     let (task, _) = index.create(None).await;
     index.wait_task(task.uid()).await.succeeded();
-    let (_task, _) = index.delete().await;
+    let (task, _) = index.delete().await;
+    index.wait_task(task.uid()).await.succeeded();
     let (response, code) = index.filtered_batches(&["indexCreation"], &[], &[]).await;
     assert_eq!(code, 200, "{}", response);
     assert_eq!(response["results"].as_array().unwrap().len(), 1);

--- a/crates/meilisearch/tests/batches/mod.rs
+++ b/crates/meilisearch/tests/batches/mod.rs
@@ -986,7 +986,7 @@ async fn test_summarized_index_swap() {
         ]))
         .await;
     server.wait_task(task.uid()).await;
-    let (batch, _) = server.get_batch(task.uid().to_u32().unwrap()).await;
+    let (batch, _) = server.get_batch(1).await;
     assert_json_snapshot!(batch,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
         @r#"
@@ -1029,8 +1029,7 @@ async fn test_summarized_batch_cancelation() {
     index.wait_task(task.uid()).await.succeeded();
     let (task, _status_code) = server.cancel_tasks("uids=0").await;
     index.wait_task(task.uid()).await.succeeded();
-    //TODO: create a get_batch function interface that accepts u64, and remove the following cast.
-    let (batch, _) = index.get_batch(task.uid().to_u32().unwrap()).await;
+    let (batch, _) = index.get_batch(1).await;
     assert_json_snapshot!(batch,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
         @r#"

--- a/crates/meilisearch/tests/batches/mod.rs
+++ b/crates/meilisearch/tests/batches/mod.rs
@@ -12,7 +12,7 @@ async fn error_get_unexisting_batch_status() {
     let server = Server::new().await;
     let index = server.index("test");
     let (task,_coder) =  index.create(None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (response, code) = index.get_batch(1).await;
 
     let expected_response = json!({
@@ -31,7 +31,7 @@ async fn get_batch_status() {
     let server = Server::new().await;
     let index = server.index("test");
     let (task, _status_code) = index.create(None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (_response, code) = index.get_batch(0).await;
     assert_eq!(code, 200);
 }
@@ -41,7 +41,7 @@ async fn list_batches() {
     let server = Server::new().await;
     let index = server.index("test");
     let (task,_status_code) = index.create(None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     index
         .add_documents(serde_json::from_str(include_str!("../assets/test_set.json")).unwrap(), None)
         .await;
@@ -98,7 +98,7 @@ async fn list_batches_with_star_filters() {
     let server = Server::new().await;
     let index = server.index("test");
     let (batch, _code) = index.create(None).await;
-    index.wait_task(batch.uid()).await;
+    index.wait_task(batch.uid()).await.succeeded();
     index
         .add_documents(serde_json::from_str(include_str!("../assets/test_set.json")).unwrap(), None)
         .await;
@@ -143,7 +143,7 @@ async fn list_batches_status_filtered() {
     let server = Server::new().await;
     let index = server.index("test");
     let (task,_status_code) = index.create(None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (task,_status_code) = index
         .add_documents(serde_json::from_str(include_str!("../assets/test_set.json")).unwrap(), None)
         .await;
@@ -157,7 +157,7 @@ async fn list_batches_status_filtered() {
     // assert_eq!(code, 200, "{}", response);
     // assert_eq!(response["results"].as_array().unwrap().len(), 1);
 
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = index.filtered_batches(&[], &["succeeded"], &[]).await;
     assert_eq!(code, 200, "{}", response);
@@ -169,7 +169,7 @@ async fn list_batches_type_filtered() {
     let server = Server::new().await;
     let index = server.index("test");
     let (task,_status_code) = index.create(None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     index
         .add_documents(serde_json::from_str(include_str!("../assets/test_set.json")).unwrap(), None)
         .await;
@@ -189,7 +189,7 @@ async fn list_batches_invalid_canceled_by_filter() {
     let server = Server::new().await;
     let index = server.index("test");
     let (task,_status_code) = index.create(None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     index
         .add_documents(serde_json::from_str(include_str!("../assets/test_set.json")).unwrap(), None)
         .await;
@@ -204,7 +204,7 @@ async fn list_batches_status_and_type_filtered() {
     let server = Server::new().await;
     let index = server.index("test");
     let (task,_status_code) = index.create(None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     index
         .add_documents(serde_json::from_str(include_str!("../assets/test_set.json")).unwrap(), None)
         .await;

--- a/crates/meilisearch/tests/batches/mod.rs
+++ b/crates/meilisearch/tests/batches/mod.rs
@@ -278,7 +278,7 @@ async fn test_summarized_document_addition_or_update() {
     let server = Server::new().await;
     let index = server.index("test");
     let (task,_status_code) = index.add_documents(json!({ "id": 42, "content": "doggos & fluff" }), None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (batch, _) = index.get_batch(0).await;
     assert_json_snapshot!(batch,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
@@ -309,7 +309,7 @@ async fn test_summarized_document_addition_or_update() {
     "#);
 
     let (task,_status_code) = index.add_documents(json!({ "id": 42, "content": "doggos & fluff" }), Some("id")).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (batch, _) = index.get_batch(1).await;
     assert_json_snapshot!(batch,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
@@ -345,7 +345,7 @@ async fn test_summarized_delete_documents_by_batch() {
     let server = Server::new().await;
     let index = server.index("test");
     let (task,_status_code) = index.delete_batch(vec![1, 2, 3]).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (batch, _) = index.get_batch(0).await;
     assert_json_snapshot!(batch,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
@@ -377,7 +377,7 @@ async fn test_summarized_delete_documents_by_batch() {
 
     index.create(None).await;
     let (task,_status_code) = index.delete_batch(vec![42]).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (batch, _) = index.get_batch(2).await;
     assert_json_snapshot!(batch,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
@@ -414,7 +414,7 @@ async fn test_summarized_delete_documents_by_filter() {
     let index = server.index("test");
 
     let (task,_status_code) = index.delete_document_by_filter(json!({ "filter": "doggo = bernese" })).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (batch, _) = index.get_batch(0).await;
     assert_json_snapshot!(batch,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
@@ -447,7 +447,7 @@ async fn test_summarized_delete_documents_by_filter() {
 
     index.create(None).await;
     let (task,_status_code) = index.delete_document_by_filter(json!({ "filter": "doggo = bernese" })).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (batch, _) = index.get_batch(2).await;
     assert_json_snapshot!(batch,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
@@ -480,7 +480,7 @@ async fn test_summarized_delete_documents_by_filter() {
 
     index.update_settings(json!({ "filterableAttributes": ["doggo"] })).await;
     let (task,_status_code) = index.delete_document_by_filter(json!({ "filter": "doggo = bernese" })).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (batch, _) = index.get_batch(4).await;
     assert_json_snapshot!(batch,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
@@ -517,7 +517,7 @@ async fn test_summarized_delete_document_by_id() {
     let server = Server::new().await;
     let index = server.index("test");
     let (task,_status_code) = index.delete_document(1).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (batch, _) = index.get_batch(0).await;
     assert_json_snapshot!(batch,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
@@ -549,7 +549,7 @@ async fn test_summarized_delete_document_by_id() {
 
     index.create(None).await;
     let (task,_status_code) = index.delete_document(42).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (batch, _) = index.get_batch(2).await;
     assert_json_snapshot!(batch,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
@@ -597,7 +597,7 @@ async fn test_summarized_settings_update() {
     "###);
 
     let (task,_status_code) = index.update_settings(json!({ "displayedAttributes": ["doggos", "name"], "filterableAttributes": ["age", "nb_paw_pads"], "sortableAttributes": ["iq"] })).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (batch, _) = index.get_batch(0).await;
     assert_json_snapshot!(batch,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
@@ -642,7 +642,7 @@ async fn test_summarized_index_creation() {
     let server = Server::new().await;
     let index = server.index("test");
     let (task,_status_code) = index.create(None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (batch, _) = index.get_batch(0).await;
     assert_json_snapshot!(batch,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
@@ -670,7 +670,7 @@ async fn test_summarized_index_creation() {
     "#);
 
     let (task,_status_code) = index.create(Some("doggos")).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (batch, _) = index.get_batch(1).await;
     assert_json_snapshot!(batch,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
@@ -815,7 +815,7 @@ async fn test_summarized_index_update() {
     let index = server.index("test");
     // If the index doesn't exist yet, we should get errors with or without the primary key.
     let (task,_status_code) = index.update(None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (batch, _) = index.get_batch(0).await;
     assert_json_snapshot!(batch,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
@@ -843,7 +843,7 @@ async fn test_summarized_index_update() {
     "#);
 
     let (task,_status_code) = index.update(Some("bones")).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (batch, _) = index.get_batch(1).await;
     assert_json_snapshot!(batch,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
@@ -876,7 +876,7 @@ async fn test_summarized_index_update() {
     index.create(None).await;
 
     let (task,_status_code) = index.update(None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (batch, _) = index.get_batch(3).await;
     assert_json_snapshot!(batch,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
@@ -904,7 +904,7 @@ async fn test_summarized_index_update() {
     "#);
 
     let (task,_status_code) = index.update(Some("bones")).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (batch, _) = index.get_batch(4).await;
     assert_json_snapshot!(batch,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
@@ -1024,9 +1024,9 @@ async fn test_summarized_batch_cancelation() {
     let index = server.index("doggos");
     // to avoid being flaky we're only going to cancel an already finished batch :(
     let (task,_status_code) = index.create(None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (task,_status_code) = server.cancel_tasks("uids=0").await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     //TODO: create a get_batch function interface that accepts u64, and remove the following cast.
     let (batch, _) = index.get_batch(task.uid().to_u32().unwrap()).await;
     assert_json_snapshot!(batch,
@@ -1063,9 +1063,9 @@ async fn test_summarized_batch_deletion() {
     let index = server.index("doggos");
     // to avoid being flaky we're only going to delete an already finished batch :(
     let (task,_status_code) = index.create(None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (task,_status_code) = server.delete_tasks("uids=0").await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (batch, _) = index.get_batch(1).await;
     assert_json_snapshot!(batch,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },

--- a/crates/meilisearch/tests/batches/mod.rs
+++ b/crates/meilisearch/tests/batches/mod.rs
@@ -11,7 +11,7 @@ use crate::json;
 async fn error_get_unexisting_batch_status() {
     let server = Server::new().await;
     let index = server.index("test");
-    let (task,_coder) =  index.create(None).await;
+    let (task, _coder) = index.create(None).await;
     index.wait_task(task.uid()).await.succeeded();
     let (response, code) = index.get_batch(1).await;
 
@@ -40,7 +40,7 @@ async fn get_batch_status() {
 async fn list_batches() {
     let server = Server::new().await;
     let index = server.index("test");
-    let (task,_status_code) = index.create(None).await;
+    let (task, _status_code) = index.create(None).await;
     index.wait_task(task.uid()).await.succeeded();
     index
         .add_documents(serde_json::from_str(include_str!("../assets/test_set.json")).unwrap(), None)
@@ -142,9 +142,9 @@ async fn list_batches_with_star_filters() {
 async fn list_batches_status_filtered() {
     let server = Server::new().await;
     let index = server.index("test");
-    let (task,_status_code) = index.create(None).await;
+    let (task, _status_code) = index.create(None).await;
     index.wait_task(task.uid()).await.succeeded();
-    let (task,_status_code) = index
+    let (task, _status_code) = index
         .add_documents(serde_json::from_str(include_str!("../assets/test_set.json")).unwrap(), None)
         .await;
 
@@ -168,7 +168,7 @@ async fn list_batches_status_filtered() {
 async fn list_batches_type_filtered() {
     let server = Server::new().await;
     let index = server.index("test");
-    let (task,_status_code) = index.create(None).await;
+    let (task, _status_code) = index.create(None).await;
     index.wait_task(task.uid()).await.succeeded();
     index
         .add_documents(serde_json::from_str(include_str!("../assets/test_set.json")).unwrap(), None)
@@ -188,7 +188,7 @@ async fn list_batches_type_filtered() {
 async fn list_batches_invalid_canceled_by_filter() {
     let server = Server::new().await;
     let index = server.index("test");
-    let (task,_status_code) = index.create(None).await;
+    let (task, _status_code) = index.create(None).await;
     index.wait_task(task.uid()).await.succeeded();
     index
         .add_documents(serde_json::from_str(include_str!("../assets/test_set.json")).unwrap(), None)
@@ -203,7 +203,7 @@ async fn list_batches_invalid_canceled_by_filter() {
 async fn list_batches_status_and_type_filtered() {
     let server = Server::new().await;
     let index = server.index("test");
-    let (task,_status_code) = index.create(None).await;
+    let (task, _status_code) = index.create(None).await;
     index.wait_task(task.uid()).await.succeeded();
     index
         .add_documents(serde_json::from_str(include_str!("../assets/test_set.json")).unwrap(), None)
@@ -277,7 +277,8 @@ async fn list_batch_filter_error() {
 async fn test_summarized_document_addition_or_update() {
     let server = Server::new().await;
     let index = server.index("test");
-    let (task,_status_code) = index.add_documents(json!({ "id": 42, "content": "doggos & fluff" }), None).await;
+    let (task, _status_code) =
+        index.add_documents(json!({ "id": 42, "content": "doggos & fluff" }), None).await;
     index.wait_task(task.uid()).await.succeeded();
     let (batch, _) = index.get_batch(0).await;
     assert_json_snapshot!(batch,
@@ -308,7 +309,8 @@ async fn test_summarized_document_addition_or_update() {
     }
     "#);
 
-    let (task,_status_code) = index.add_documents(json!({ "id": 42, "content": "doggos & fluff" }), Some("id")).await;
+    let (task, _status_code) =
+        index.add_documents(json!({ "id": 42, "content": "doggos & fluff" }), Some("id")).await;
     index.wait_task(task.uid()).await.succeeded();
     let (batch, _) = index.get_batch(1).await;
     assert_json_snapshot!(batch,
@@ -344,7 +346,7 @@ async fn test_summarized_document_addition_or_update() {
 async fn test_summarized_delete_documents_by_batch() {
     let server = Server::new().await;
     let index = server.index("test");
-    let (task,_status_code) = index.delete_batch(vec![1, 2, 3]).await;
+    let (task, _status_code) = index.delete_batch(vec![1, 2, 3]).await;
     index.wait_task(task.uid()).await.succeeded();
     let (batch, _) = index.get_batch(0).await;
     assert_json_snapshot!(batch,
@@ -376,7 +378,7 @@ async fn test_summarized_delete_documents_by_batch() {
     "#);
 
     index.create(None).await;
-    let (task,_status_code) = index.delete_batch(vec![42]).await;
+    let (task, _status_code) = index.delete_batch(vec![42]).await;
     index.wait_task(task.uid()).await.succeeded();
     let (batch, _) = index.get_batch(2).await;
     assert_json_snapshot!(batch,
@@ -413,7 +415,8 @@ async fn test_summarized_delete_documents_by_filter() {
     let server = Server::new().await;
     let index = server.index("test");
 
-    let (task,_status_code) = index.delete_document_by_filter(json!({ "filter": "doggo = bernese" })).await;
+    let (task, _status_code) =
+        index.delete_document_by_filter(json!({ "filter": "doggo = bernese" })).await;
     index.wait_task(task.uid()).await.succeeded();
     let (batch, _) = index.get_batch(0).await;
     assert_json_snapshot!(batch,
@@ -446,7 +449,8 @@ async fn test_summarized_delete_documents_by_filter() {
     "#);
 
     index.create(None).await;
-    let (task,_status_code) = index.delete_document_by_filter(json!({ "filter": "doggo = bernese" })).await;
+    let (task, _status_code) =
+        index.delete_document_by_filter(json!({ "filter": "doggo = bernese" })).await;
     index.wait_task(task.uid()).await.succeeded();
     let (batch, _) = index.get_batch(2).await;
     assert_json_snapshot!(batch,
@@ -479,7 +483,8 @@ async fn test_summarized_delete_documents_by_filter() {
     "#);
 
     index.update_settings(json!({ "filterableAttributes": ["doggo"] })).await;
-    let (task,_status_code) = index.delete_document_by_filter(json!({ "filter": "doggo = bernese" })).await;
+    let (task, _status_code) =
+        index.delete_document_by_filter(json!({ "filter": "doggo = bernese" })).await;
     index.wait_task(task.uid()).await.succeeded();
     let (batch, _) = index.get_batch(4).await;
     assert_json_snapshot!(batch,
@@ -516,7 +521,7 @@ async fn test_summarized_delete_documents_by_filter() {
 async fn test_summarized_delete_document_by_id() {
     let server = Server::new().await;
     let index = server.index("test");
-    let (task,_status_code) = index.delete_document(1).await;
+    let (task, _status_code) = index.delete_document(1).await;
     index.wait_task(task.uid()).await.succeeded();
     let (batch, _) = index.get_batch(0).await;
     assert_json_snapshot!(batch,
@@ -548,7 +553,7 @@ async fn test_summarized_delete_document_by_id() {
     "#);
 
     index.create(None).await;
-    let (task,_status_code) = index.delete_document(42).await;
+    let (task, _status_code) = index.delete_document(42).await;
     index.wait_task(task.uid()).await.succeeded();
     let (batch, _) = index.get_batch(2).await;
     assert_json_snapshot!(batch,
@@ -641,7 +646,7 @@ async fn test_summarized_settings_update() {
 async fn test_summarized_index_creation() {
     let server = Server::new().await;
     let index = server.index("test");
-    let (task,_status_code) = index.create(None).await;
+    let (task, _status_code) = index.create(None).await;
     index.wait_task(task.uid()).await.succeeded();
     let (batch, _) = index.get_batch(0).await;
     assert_json_snapshot!(batch,
@@ -669,7 +674,7 @@ async fn test_summarized_index_creation() {
     }
     "#);
 
-    let (task,_status_code) = index.create(Some("doggos")).await;
+    let (task, _status_code) = index.create(Some("doggos")).await;
     index.wait_task(task.uid()).await.succeeded();
     let (batch, _) = index.get_batch(1).await;
     assert_json_snapshot!(batch,
@@ -814,7 +819,7 @@ async fn test_summarized_index_update() {
     let server = Server::new().await;
     let index = server.index("test");
     // If the index doesn't exist yet, we should get errors with or without the primary key.
-    let (task,_status_code) = index.update(None).await;
+    let (task, _status_code) = index.update(None).await;
     index.wait_task(task.uid()).await.succeeded();
     let (batch, _) = index.get_batch(0).await;
     assert_json_snapshot!(batch,
@@ -842,7 +847,7 @@ async fn test_summarized_index_update() {
     }
     "#);
 
-    let (task,_status_code) = index.update(Some("bones")).await;
+    let (task, _status_code) = index.update(Some("bones")).await;
     index.wait_task(task.uid()).await.succeeded();
     let (batch, _) = index.get_batch(1).await;
     assert_json_snapshot!(batch,
@@ -875,7 +880,7 @@ async fn test_summarized_index_update() {
     // And run the same two tests once the index do exists.
     index.create(None).await;
 
-    let (task,_status_code) = index.update(None).await;
+    let (task, _status_code) = index.update(None).await;
     index.wait_task(task.uid()).await.succeeded();
     let (batch, _) = index.get_batch(3).await;
     assert_json_snapshot!(batch,
@@ -903,7 +908,7 @@ async fn test_summarized_index_update() {
     }
     "#);
 
-    let (task,_status_code) = index.update(Some("bones")).await;
+    let (task, _status_code) = index.update(Some("bones")).await;
     index.wait_task(task.uid()).await.succeeded();
     let (batch, _) = index.get_batch(4).await;
     assert_json_snapshot!(batch,
@@ -937,7 +942,7 @@ async fn test_summarized_index_update() {
 #[actix_web::test]
 async fn test_summarized_index_swap() {
     let server = Server::new().await;
-    let (task,_status_code) = server
+    let (task, _status_code) = server
         .index_swap(json!([
             { "indexes": ["doggos", "cattos"] }
         ]))
@@ -977,7 +982,7 @@ async fn test_summarized_index_swap() {
     "#);
 
     server.index("doggos").create(None).await;
-    let (task,_status_code) = server.index("cattos").create(None).await;
+    let (task, _status_code) = server.index("cattos").create(None).await;
     server
         .index_swap(json!([
             { "indexes": ["doggos", "cattos"] }
@@ -1023,9 +1028,9 @@ async fn test_summarized_batch_cancelation() {
     let server = Server::new().await;
     let index = server.index("doggos");
     // to avoid being flaky we're only going to cancel an already finished batch :(
-    let (task,_status_code) = index.create(None).await;
+    let (task, _status_code) = index.create(None).await;
     index.wait_task(task.uid()).await.succeeded();
-    let (task,_status_code) = server.cancel_tasks("uids=0").await;
+    let (task, _status_code) = server.cancel_tasks("uids=0").await;
     index.wait_task(task.uid()).await.succeeded();
     //TODO: create a get_batch function interface that accepts u64, and remove the following cast.
     let (batch, _) = index.get_batch(task.uid().to_u32().unwrap()).await;
@@ -1062,9 +1067,9 @@ async fn test_summarized_batch_deletion() {
     let server = Server::new().await;
     let index = server.index("doggos");
     // to avoid being flaky we're only going to delete an already finished batch :(
-    let (task,_status_code) = index.create(None).await;
+    let (task, _status_code) = index.create(None).await;
     index.wait_task(task.uid()).await.succeeded();
-    let (task,_status_code) = server.delete_tasks("uids=0").await;
+    let (task, _status_code) = server.delete_tasks("uids=0").await;
     index.wait_task(task.uid()).await.succeeded();
     let (batch, _) = index.get_batch(1).await;
     assert_json_snapshot!(batch,
@@ -1098,7 +1103,7 @@ async fn test_summarized_batch_deletion() {
 #[actix_web::test]
 async fn test_summarized_dump_creation() {
     let server = Server::new().await;
-    let (task,_status_code) = server.create_dump().await;
+    let (task, _status_code) = server.create_dump().await;
     server.wait_task(task.uid()).await;
     let (batch, _) = server.get_batch(0).await;
     assert_json_snapshot!(batch,

--- a/crates/meilisearch/tests/batches/mod.rs
+++ b/crates/meilisearch/tests/batches/mod.rs
@@ -1,6 +1,5 @@
 mod errors;
 
-use byte_unit::rust_decimal::prelude::ToPrimitive;
 use meili_snap::insta::assert_json_snapshot;
 use meili_snap::snapshot;
 
@@ -170,7 +169,7 @@ async fn list_batches_type_filtered() {
     let index = server.index("test");
     let (task, _) = index.create(None).await;
     index.wait_task(task.uid()).await.succeeded();
-    let (task, _) = index.delete().await;
+    let (_task, _) = index.delete().await;
     let (response, code) = index.filtered_batches(&["indexCreation"], &[], &[]).await;
     assert_eq!(code, 200, "{}", response);
     assert_eq!(response["results"].as_array().unwrap().len(), 1);

--- a/crates/meilisearch/tests/common/mod.rs
+++ b/crates/meilisearch/tests/common/mod.rs
@@ -46,11 +46,11 @@ impl Value {
 
     // Panic if the json doesn't contain the `status` field set to "succeeded"
     #[track_caller]
-    pub fn succeeded(&self) -> &Self {
+    pub fn succeeded(&self) -> Self {
         if !self.is_success() {
             panic!("Called succeeded on {}", serde_json::to_string_pretty(&self.0).unwrap());
         }
-        self
+        self.clone()
     }
 
     /// Return `true` if the `status` field is set to `failed`.
@@ -65,11 +65,11 @@ impl Value {
 
     // Panic if the json doesn't contain the `status` field set to "succeeded"
     #[track_caller]
-    pub fn failed(&self) -> &Self {
+    pub fn failed(&self) -> Self {
         if !self.is_fail() {
             panic!("Called failed on {}", serde_json::to_string_pretty(&self.0).unwrap());
         }
-        self
+        self.clone()
     }
 }
 

--- a/crates/meilisearch/tests/common/mod.rs
+++ b/crates/meilisearch/tests/common/mod.rs
@@ -426,7 +426,7 @@ pub async fn shared_index_with_test_set() -> &'static Index<'static, Shared> {
                 )
                 .await;
             assert_eq!(code, 202);
-            index.wait_task(response.uid()).await;
+            index.wait_task(response.uid()).await.succeeded();
             index
         })
         .await

--- a/crates/meilisearch/tests/documents/add_documents.rs
+++ b/crates/meilisearch/tests/documents/add_documents.rs
@@ -981,7 +981,7 @@ async fn add_documents_no_index_creation() {
     snapshot!(code, @"202 Accepted");
     assert_eq!(response["taskUid"], 0);
 
-    index.wait_task(response.uid()).await;
+    index.wait_task(response.uid()).await.succeeded();
 
     let (response, code) = index.get_task(0).await;
     snapshot!(code, @"200 OK");
@@ -1060,7 +1060,7 @@ async fn document_addition_with_primary_key() {
     }
     "###);
 
-    index.wait_task(response.uid()).await;
+    index.wait_task(response.uid()).await.succeeded();
 
     let (response, code) = index.get_task(response.uid()).await;
     snapshot!(code, @"200 OK");
@@ -1170,7 +1170,7 @@ async fn replace_document() {
     }
     "###);
 
-    index.wait_task(response.uid()).await;
+    index.wait_task(response.uid()).await.succeeded();
 
     let documents = json!([
         {
@@ -1182,7 +1182,7 @@ async fn replace_document() {
     let (task, code) = index.add_documents(documents, None).await;
     snapshot!(code,@"202 Accepted");
 
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
@@ -1275,7 +1275,7 @@ async fn error_add_documents_bad_document_id() {
         }
     ]);
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (response, code) = index.get_task(1).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
@@ -1391,7 +1391,7 @@ async fn error_add_documents_missing_document_id() {
         }
     ]);
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (response, code) = index.get_task(1).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
@@ -1742,7 +1742,7 @@ async fn add_documents_invalid_geo_field() {
     ]);
 
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (response, code) = index.get_task(2).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
@@ -1780,7 +1780,7 @@ async fn add_documents_invalid_geo_field() {
     ]);
 
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (response, code) = index.get_task(3).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
@@ -1818,7 +1818,7 @@ async fn add_documents_invalid_geo_field() {
     ]);
 
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (response, code) = index.get_task(4).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
@@ -1856,7 +1856,7 @@ async fn add_documents_invalid_geo_field() {
     ]);
 
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
@@ -1894,7 +1894,7 @@ async fn add_documents_invalid_geo_field() {
     ]);
 
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
@@ -1932,7 +1932,7 @@ async fn add_documents_invalid_geo_field() {
     ]);
 
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
@@ -1970,7 +1970,7 @@ async fn add_documents_invalid_geo_field() {
     ]);
 
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
@@ -2008,7 +2008,7 @@ async fn add_documents_invalid_geo_field() {
     ]);
 
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
@@ -2046,7 +2046,7 @@ async fn add_documents_invalid_geo_field() {
     ]);
 
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
@@ -2084,7 +2084,7 @@ async fn add_documents_invalid_geo_field() {
     ]);
 
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
@@ -2122,7 +2122,7 @@ async fn add_documents_invalid_geo_field() {
     ]);
 
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
@@ -2160,7 +2160,7 @@ async fn add_documents_invalid_geo_field() {
     ]);
 
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
@@ -2410,7 +2410,7 @@ async fn error_primary_key_inference() {
     ]);
 
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (response, code) = index.get_task(0).await;
     assert_eq!(code, 200);
 
@@ -2451,7 +2451,7 @@ async fn error_primary_key_inference() {
     ]);
 
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (response, code) = index.get_task(task.uid()).await;
     assert_eq!(code, 200);
 
@@ -2490,7 +2490,7 @@ async fn error_primary_key_inference() {
     ]);
 
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (response, code) = index.get_task(task.uid()).await;
     assert_eq!(code, 200);
 
@@ -2529,12 +2529,12 @@ async fn add_documents_with_primary_key_twice() {
     ]);
 
     let (task,_status_code) = index.add_documents(documents.clone(), Some("title")).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (response, _code) = index.get_task(task.uid()).await;
     assert_eq!(response["status"], "succeeded");
 
     let (task,_status_code) = index.add_documents(documents, Some("title")).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (response, _code) = index.get_task(task.uid()).await;
     assert_eq!(response["status"], "succeeded");
 }

--- a/crates/meilisearch/tests/documents/add_documents.rs
+++ b/crates/meilisearch/tests/documents/add_documents.rs
@@ -1274,8 +1274,8 @@ async fn error_add_documents_bad_document_id() {
         }
     ]);
     let (task, _status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await.succeeded();
-    let (response, code) = index.get_task(1).await;
+    index.wait_task(task.uid()).await.failed();
+    let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
         @r###"
@@ -1311,7 +1311,7 @@ async fn error_add_documents_bad_document_id() {
         }
     ]);
     let (value, _code) = index.add_documents(documents, None).await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.failed();
     let (response, code) = index.get_task(value.uid()).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
@@ -1348,7 +1348,7 @@ async fn error_add_documents_bad_document_id() {
         }
     ]);
     let (value, _code) = index.add_documents(documents, None).await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.failed();
     let (response, code) = index.get_task(value.uid()).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
@@ -1390,8 +1390,8 @@ async fn error_add_documents_missing_document_id() {
         }
     ]);
     let (task, _status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await.succeeded();
-    let (response, code) = index.get_task(1).await;
+    index.wait_task(task.uid()).await.failed();
+    let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
         @r###"
@@ -1439,7 +1439,7 @@ async fn error_document_field_limit_reached_in_one_document() {
     let (response, code) = index.update_documents(documents, Some("id")).await;
     snapshot!(code, @"202 Accepted");
 
-    let response = index.wait_task(response.uid()).await;
+    let response = index.wait_task(response.uid()).await.failed();
     snapshot!(code, @"202 Accepted");
     // Documents without a primary key are not accepted.
     snapshot!(response,
@@ -1741,8 +1741,8 @@ async fn add_documents_invalid_geo_field() {
     ]);
 
     let (task, _status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await.succeeded();
-    let (response, code) = index.get_task(2).await;
+    index.wait_task(task.uid()).await.failed();
+    let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
         @r###"
@@ -1779,8 +1779,8 @@ async fn add_documents_invalid_geo_field() {
     ]);
 
     let (task, _status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await.succeeded();
-    let (response, code) = index.get_task(3).await;
+    index.wait_task(task.uid()).await.failed();
+    let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
         @r###"
@@ -1817,8 +1817,8 @@ async fn add_documents_invalid_geo_field() {
     ]);
 
     let (task, _status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await.succeeded();
-    let (response, code) = index.get_task(4).await;
+    index.wait_task(task.uid()).await.failed();
+    let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
         @r###"
@@ -1855,7 +1855,7 @@ async fn add_documents_invalid_geo_field() {
     ]);
 
     let (task, _status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await.succeeded();
+    index.wait_task(task.uid()).await.failed();
     let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
@@ -1893,7 +1893,7 @@ async fn add_documents_invalid_geo_field() {
     ]);
 
     let (task, _status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await.succeeded();
+    index.wait_task(task.uid()).await.failed();
     let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
@@ -1931,7 +1931,7 @@ async fn add_documents_invalid_geo_field() {
     ]);
 
     let (task, _status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await.succeeded();
+    index.wait_task(task.uid()).await.failed();
     let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
@@ -1969,7 +1969,7 @@ async fn add_documents_invalid_geo_field() {
     ]);
 
     let (task, _status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await.succeeded();
+    index.wait_task(task.uid()).await.failed();
     let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
@@ -2007,7 +2007,7 @@ async fn add_documents_invalid_geo_field() {
     ]);
 
     let (task, _status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await.succeeded();
+    index.wait_task(task.uid()).await.failed();
     let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
@@ -2045,7 +2045,7 @@ async fn add_documents_invalid_geo_field() {
     ]);
 
     let (task, _status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await.succeeded();
+    index.wait_task(task.uid()).await.failed();
     let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
@@ -2083,7 +2083,7 @@ async fn add_documents_invalid_geo_field() {
     ]);
 
     let (task, _status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await.succeeded();
+    index.wait_task(task.uid()).await.failed();
     let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
@@ -2121,7 +2121,7 @@ async fn add_documents_invalid_geo_field() {
     ]);
 
     let (task, _status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await.succeeded();
+    index.wait_task(task.uid()).await.failed();
     let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
@@ -2159,7 +2159,7 @@ async fn add_documents_invalid_geo_field() {
     ]);
 
     let (task, _status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await.succeeded();
+    index.wait_task(task.uid()).await.failed();
     let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
@@ -2200,7 +2200,7 @@ async fn add_documents_invalid_geo_field() {
 
     let (response, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    let response = index.wait_task(response.uid()).await;
+    let response = index.wait_task(response.uid()).await.failed();
     snapshot!(json_string!(response, { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
         @r###"
     {
@@ -2237,7 +2237,7 @@ async fn add_documents_invalid_geo_field() {
 
     let (response, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    let response = index.wait_task(response.uid()).await;
+    let response = index.wait_task(response.uid()).await.failed();
     snapshot!(json_string!(response, { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
         @r###"
     {
@@ -2274,7 +2274,7 @@ async fn add_documents_invalid_geo_field() {
 
     let (response, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    let response = index.wait_task(response.uid()).await;
+    let response = index.wait_task(response.uid()).await.failed();
     snapshot!(json_string!(response, { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
         @r###"
     {
@@ -2318,7 +2318,7 @@ async fn add_invalid_geo_and_then_settings() {
     ]);
     let (ret, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    let ret = index.wait_task(ret.uid()).await;
+    let ret = index.wait_task(ret.uid()).await.succeeded();
     snapshot!(ret, @r###"
     {
       "uid": "[uid]",
@@ -2341,7 +2341,7 @@ async fn add_invalid_geo_and_then_settings() {
 
     let (ret, code) = index.update_settings(json!({ "sortableAttributes": ["_geo"] })).await;
     snapshot!(code, @"202 Accepted");
-    let ret = index.wait_task(ret.uid()).await;
+    let ret = index.wait_task(ret.uid()).await.failed();
     snapshot!(ret, @r###"
     {
       "uid": "[uid]",
@@ -2409,8 +2409,8 @@ async fn error_primary_key_inference() {
     ]);
 
     let (task, _status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await.succeeded();
-    let (response, code) = index.get_task(0).await;
+    index.wait_task(task.uid()).await.failed();
+    let (response, code) = index.get_task(task.uid()).await;
     assert_eq!(code, 200);
 
     snapshot!(json_string!(response, { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
@@ -2450,7 +2450,7 @@ async fn error_primary_key_inference() {
     ]);
 
     let (task, _status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await.succeeded();
+    index.wait_task(task.uid()).await.failed();
     let (response, code) = index.get_task(task.uid()).await;
     assert_eq!(code, 200);
 

--- a/crates/meilisearch/tests/documents/add_documents.rs
+++ b/crates/meilisearch/tests/documents/add_documents.rs
@@ -1,5 +1,4 @@
 use actix_web::test;
-use actix_web::web::resource;
 use meili_snap::{json_string, snapshot};
 use meilisearch::Opt;
 use time::format_description::well_known::Rfc3339;

--- a/crates/meilisearch/tests/documents/add_documents.rs
+++ b/crates/meilisearch/tests/documents/add_documents.rs
@@ -1274,7 +1274,7 @@ async fn error_add_documents_bad_document_id() {
             "content": "foobar"
         }
     ]);
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
     let (response, code) = index.get_task(1).await;
     snapshot!(code, @"200 OK");
@@ -1390,7 +1390,7 @@ async fn error_add_documents_missing_document_id() {
             "content": "foobar"
         }
     ]);
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
     let (response, code) = index.get_task(1).await;
     snapshot!(code, @"200 OK");
@@ -1702,7 +1702,7 @@ async fn add_documents_with_geo_field() {
         },
     ]);
 
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     let response = index.wait_task(task.uid()).await;
     snapshot!(json_string!(response, { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
         @r###"
@@ -1741,7 +1741,7 @@ async fn add_documents_invalid_geo_field() {
         }
     ]);
 
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
     let (response, code) = index.get_task(2).await;
     snapshot!(code, @"200 OK");
@@ -1779,7 +1779,7 @@ async fn add_documents_invalid_geo_field() {
         }
     ]);
 
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
     let (response, code) = index.get_task(3).await;
     snapshot!(code, @"200 OK");
@@ -1817,7 +1817,7 @@ async fn add_documents_invalid_geo_field() {
         }
     ]);
 
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
     let (response, code) = index.get_task(4).await;
     snapshot!(code, @"200 OK");
@@ -1855,7 +1855,7 @@ async fn add_documents_invalid_geo_field() {
         }
     ]);
 
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
     let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
@@ -1893,7 +1893,7 @@ async fn add_documents_invalid_geo_field() {
         }
     ]);
 
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
     let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
@@ -1931,7 +1931,7 @@ async fn add_documents_invalid_geo_field() {
         }
     ]);
 
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
     let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
@@ -1969,7 +1969,7 @@ async fn add_documents_invalid_geo_field() {
         }
     ]);
 
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
     let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
@@ -2007,7 +2007,7 @@ async fn add_documents_invalid_geo_field() {
         }
     ]);
 
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
     let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
@@ -2045,7 +2045,7 @@ async fn add_documents_invalid_geo_field() {
         }
     ]);
 
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
     let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
@@ -2083,7 +2083,7 @@ async fn add_documents_invalid_geo_field() {
         }
     ]);
 
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
     let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
@@ -2121,7 +2121,7 @@ async fn add_documents_invalid_geo_field() {
         }
     ]);
 
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
     let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
@@ -2159,7 +2159,7 @@ async fn add_documents_invalid_geo_field() {
         }
     ]);
 
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
     let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
@@ -2409,7 +2409,7 @@ async fn error_primary_key_inference() {
         }
     ]);
 
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
     let (response, code) = index.get_task(0).await;
     assert_eq!(code, 200);
@@ -2450,7 +2450,7 @@ async fn error_primary_key_inference() {
         }
     ]);
 
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
     let (response, code) = index.get_task(task.uid()).await;
     assert_eq!(code, 200);
@@ -2489,7 +2489,7 @@ async fn error_primary_key_inference() {
         }
     ]);
 
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
     let (response, code) = index.get_task(task.uid()).await;
     assert_eq!(code, 200);
@@ -2528,12 +2528,12 @@ async fn add_documents_with_primary_key_twice() {
         }
     ]);
 
-    let (task,_status_code) = index.add_documents(documents.clone(), Some("title")).await;
+    let (task, _status_code) = index.add_documents(documents.clone(), Some("title")).await;
     index.wait_task(task.uid()).await.succeeded();
     let (response, _code) = index.get_task(task.uid()).await;
     assert_eq!(response["status"], "succeeded");
 
-    let (task,_status_code) = index.add_documents(documents, Some("title")).await;
+    let (task, _status_code) = index.add_documents(documents, Some("title")).await;
     index.wait_task(task.uid()).await.succeeded();
     let (response, _code) = index.get_task(task.uid()).await;
     assert_eq!(response["status"], "succeeded");

--- a/crates/meilisearch/tests/documents/delete_documents.rs
+++ b/crates/meilisearch/tests/documents/delete_documents.rs
@@ -31,10 +31,10 @@ async fn delete_one_document() {
     let server = Server::new().await;
     let index = server.index("test");
     let (task,_status_code) = index.add_documents(json!([{ "id": 0, "content": "foobar" }]), None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (task,status_code) = server.index("test").delete_document(0).await;
     assert_eq!(status_code, 202);
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (_response, code) = index.get_document(0, None).await;
     assert_eq!(code, 404);
@@ -62,7 +62,7 @@ async fn clear_all_documents() {
             None,
         )
         .await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (task, code) = index.clear_all_documents().await;
     assert_eq!(code, 202);
 
@@ -77,13 +77,13 @@ async fn clear_all_documents_empty_index() {
     let server = Server::new().await;
     let index = server.index("test");
     let (task,_status_code) = index.create(None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (task, code) = index.clear_all_documents().await;
     assert_eq!(code, 202);
 
     let _update = index.wait_task(task.uid()).await;
     let (response, code) = index.get_all_documents(GetAllDocumentsOptions::default()).await;
-    index.wait_task(response.uid()).await;
+    index.wait_task(response.uid()).await.succeeded();
     assert_eq!(code, 200);
     assert!(response["results"].as_array().unwrap().is_empty());
 }
@@ -112,7 +112,7 @@ async fn delete_batch() {
     let server = Server::new().await;
     let index = server.index("test");
     let (task,_status_code) = index.add_documents(json!([{ "id": 1, "content": "foobar" }, { "id": 0, "content": "foobar" }, { "id": 3, "content": "foobar" }]), Some("id")).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (task, code) = index.delete_batch(vec![1, 0]).await;
     assert_eq!(code, 202);
 
@@ -128,7 +128,7 @@ async fn delete_no_document_batch() {
     let server = Server::new().await;
     let index = server.index("test");
     let (task,_status_code) = index.add_documents(json!([{ "id": 1, "content": "foobar" }, { "id": 0, "content": "foobar" }, { "id": 3, "content": "foobar" }]), Some("id")).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (_response, code) = index.delete_batch(vec![]).await;
     assert_eq!(code, 202, "{}", _response);
 
@@ -154,7 +154,7 @@ async fn delete_document_by_filter() {
             Some("id"),
         )
         .await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (stats, _) = index.stats().await;
     snapshot!(json_string!(stats), @r###"
@@ -315,7 +315,7 @@ async fn delete_document_by_complex_filter() {
             Some("id"),
         )
         .await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (response, code) = index
         .delete_document_by_filter(
             json!({ "filter": ["color != red", "color != green", "color EXISTS"] }),

--- a/crates/meilisearch/tests/documents/delete_documents.rs
+++ b/crates/meilisearch/tests/documents/delete_documents.rs
@@ -84,7 +84,6 @@ async fn clear_all_documents_empty_index() {
 
     let _update = index.wait_task(task.uid()).await;
     let (response, code) = index.get_all_documents(GetAllDocumentsOptions::default()).await;
-    index.wait_task(response.uid()).await.succeeded();
     assert_eq!(code, 200);
     assert!(response["results"].as_array().unwrap().is_empty());
 }

--- a/crates/meilisearch/tests/documents/delete_documents.rs
+++ b/crates/meilisearch/tests/documents/delete_documents.rs
@@ -7,10 +7,10 @@ use crate::json;
 async fn delete_one_document_unexisting_index() {
     let server = Server::new().await;
     let index = server.index("test");
-    let (_response, code) = index.delete_document(0).await;
+    let (task, code) = index.delete_document(0).await;
     assert_eq!(code, 202);
 
-    let response = index.wait_task(0).await;
+    let response = index.wait_task(task.uid()).await;
 
     assert_eq!(response["status"], "failed");
 }
@@ -22,7 +22,7 @@ async fn delete_one_unexisting_document() {
     index.create(None).await;
     let (response, code) = index.delete_document(0).await;
     assert_eq!(code, 202, "{}", response);
-    let update = index.wait_task(0).await;
+    let update = index.wait_task(response.uid()).await;
     assert_eq!(update["status"], "succeeded");
 }
 
@@ -30,11 +30,11 @@ async fn delete_one_unexisting_document() {
 async fn delete_one_document() {
     let server = Server::new().await;
     let index = server.index("test");
-    index.add_documents(json!([{ "id": 0, "content": "foobar" }]), None).await;
-    index.wait_task(0).await;
-    let (_response, code) = server.index("test").delete_document(0).await;
-    assert_eq!(code, 202);
-    index.wait_task(1).await;
+    let (task,_status_code) = index.add_documents(json!([{ "id": 0, "content": "foobar" }]), None).await;
+    index.wait_task(task.uid()).await;
+    let (task,status_code) = server.index("test").delete_document(0).await;
+    assert_eq!(status_code, 202);
+    index.wait_task(task.uid()).await;
 
     let (_response, code) = index.get_document(0, None).await;
     assert_eq!(code, 404);
@@ -44,10 +44,10 @@ async fn delete_one_document() {
 async fn clear_all_documents_unexisting_index() {
     let server = Server::new().await;
     let index = server.index("test");
-    let (_response, code) = index.clear_all_documents().await;
+    let (task, code) = index.clear_all_documents().await;
     assert_eq!(code, 202);
 
-    let response = index.wait_task(0).await;
+    let response = index.wait_task(task.uid()).await;
 
     assert_eq!(response["status"], "failed");
 }
@@ -56,17 +56,17 @@ async fn clear_all_documents_unexisting_index() {
 async fn clear_all_documents() {
     let server = Server::new().await;
     let index = server.index("test");
-    index
+    let (task,_status_code) = index
         .add_documents(
             json!([{ "id": 1, "content": "foobar" }, { "id": 0, "content": "foobar" }]),
             None,
         )
         .await;
-    index.wait_task(0).await;
-    let (_response, code) = index.clear_all_documents().await;
+    index.wait_task(task.uid()).await;
+    let (task, code) = index.clear_all_documents().await;
     assert_eq!(code, 202);
 
-    let _update = index.wait_task(1).await;
+    let _update = index.wait_task(task.uid()).await;
     let (response, code) = index.get_all_documents(GetAllDocumentsOptions::default()).await;
     assert_eq!(code, 200);
     assert!(response["results"].as_array().unwrap().is_empty());
@@ -76,13 +76,14 @@ async fn clear_all_documents() {
 async fn clear_all_documents_empty_index() {
     let server = Server::new().await;
     let index = server.index("test");
-    index.create(None).await;
-
-    let (_response, code) = index.clear_all_documents().await;
+    let (task,_status_code) = index.create(None).await;
+    index.wait_task(task.uid()).await;
+    let (task, code) = index.clear_all_documents().await;
     assert_eq!(code, 202);
 
-    let _update = index.wait_task(0).await;
+    let _update = index.wait_task(task.uid()).await;
     let (response, code) = index.get_all_documents(GetAllDocumentsOptions::default()).await;
+    index.wait_task(response.uid()).await;
     assert_eq!(code, 200);
     assert!(response["results"].as_array().unwrap().is_empty());
 }
@@ -91,7 +92,7 @@ async fn clear_all_documents_empty_index() {
 async fn error_delete_batch_unexisting_index() {
     let server = Server::new().await;
     let index = server.index("test");
-    let (_, code) = index.delete_batch(vec![]).await;
+    let (task, code) = index.delete_batch(vec![]).await;
     let expected_response = json!({
         "message": "Index `test` not found.",
         "code": "index_not_found",
@@ -100,7 +101,7 @@ async fn error_delete_batch_unexisting_index() {
     });
     assert_eq!(code, 202);
 
-    let response = index.wait_task(0).await;
+    let response = index.wait_task(task.uid()).await;
 
     assert_eq!(response["status"], "failed");
     assert_eq!(response["error"], expected_response);
@@ -110,12 +111,12 @@ async fn error_delete_batch_unexisting_index() {
 async fn delete_batch() {
     let server = Server::new().await;
     let index = server.index("test");
-    index.add_documents(json!([{ "id": 1, "content": "foobar" }, { "id": 0, "content": "foobar" }, { "id": 3, "content": "foobar" }]), Some("id")).await;
-    index.wait_task(0).await;
-    let (_response, code) = index.delete_batch(vec![1, 0]).await;
+    let (task,_status_code) = index.add_documents(json!([{ "id": 1, "content": "foobar" }, { "id": 0, "content": "foobar" }, { "id": 3, "content": "foobar" }]), Some("id")).await;
+    index.wait_task(task.uid()).await;
+    let (task, code) = index.delete_batch(vec![1, 0]).await;
     assert_eq!(code, 202);
 
-    let _update = index.wait_task(1).await;
+    let _update = index.wait_task(task.uid()).await;
     let (response, code) = index.get_all_documents(GetAllDocumentsOptions::default()).await;
     assert_eq!(code, 200);
     assert_eq!(response["results"].as_array().unwrap().len(), 1);
@@ -126,12 +127,12 @@ async fn delete_batch() {
 async fn delete_no_document_batch() {
     let server = Server::new().await;
     let index = server.index("test");
-    index.add_documents(json!([{ "id": 1, "content": "foobar" }, { "id": 0, "content": "foobar" }, { "id": 3, "content": "foobar" }]), Some("id")).await;
-    index.wait_task(0).await;
+    let (task,_status_code) = index.add_documents(json!([{ "id": 1, "content": "foobar" }, { "id": 0, "content": "foobar" }, { "id": 3, "content": "foobar" }]), Some("id")).await;
+    index.wait_task(task.uid()).await;
     let (_response, code) = index.delete_batch(vec![]).await;
     assert_eq!(code, 202, "{}", _response);
 
-    let _update = index.wait_task(1).await;
+    let _update = index.wait_task(_response.uid()).await;
     let (response, code) = index.get_all_documents(GetAllDocumentsOptions::default()).await;
     assert_eq!(code, 200);
     assert_eq!(response["results"].as_array().unwrap().len(), 3);
@@ -142,7 +143,7 @@ async fn delete_document_by_filter() {
     let server = Server::new().await;
     let index = server.index("doggo");
     index.update_settings_filterable_attributes(json!(["color"])).await;
-    index
+    let (task,_status_code) = index
         .add_documents(
             json!([
                 { "id": 0, "color": "red" },
@@ -153,7 +154,7 @@ async fn delete_document_by_filter() {
             Some("id"),
         )
         .await;
-    index.wait_task(1).await;
+    index.wait_task(task.uid()).await;
 
     let (stats, _) = index.stats().await;
     snapshot!(json_string!(stats), @r###"
@@ -180,7 +181,7 @@ async fn delete_document_by_filter() {
     }
     "###);
 
-    let response = index.wait_task(2).await;
+    let response = index.wait_task(response.uid()).await;
     snapshot!(json_string!(response, { ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]", ".duration" => "[duration]" }), @r###"
     {
       "uid": 2,
@@ -246,7 +247,7 @@ async fn delete_document_by_filter() {
     }
     "###);
 
-    let response = index.wait_task(3).await;
+    let response = index.wait_task(response.uid()).await;
     snapshot!(json_string!(response, { ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]", ".duration" => "[duration]" }), @r###"
     {
       "uid": 3,
@@ -302,7 +303,7 @@ async fn delete_document_by_complex_filter() {
     let server = Server::new().await;
     let index = server.index("doggo");
     index.update_settings_filterable_attributes(json!(["color"])).await;
-    index
+    let (task,_status_code) = index
         .add_documents(
             json!([
                 { "id": 0, "color": "red" },
@@ -314,7 +315,7 @@ async fn delete_document_by_complex_filter() {
             Some("id"),
         )
         .await;
-    index.wait_task(1).await;
+    index.wait_task(task.uid()).await;
     let (response, code) = index
         .delete_document_by_filter(
             json!({ "filter": ["color != red", "color != green", "color EXISTS"] }),
@@ -331,7 +332,7 @@ async fn delete_document_by_complex_filter() {
     }
     "###);
 
-    let response = index.wait_task(2).await;
+    let response = index.wait_task(response.uid()).await;
     snapshot!(json_string!(response, { ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]", ".duration" => "[duration]" }), @r###"
     {
       "uid": 2,
@@ -390,7 +391,7 @@ async fn delete_document_by_complex_filter() {
     }
     "###);
 
-    let response = index.wait_task(3).await;
+    let response = index.wait_task(response.uid()).await;
     snapshot!(json_string!(response, { ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]", ".duration" => "[duration]" }), @r###"
     {
       "uid": 3,

--- a/crates/meilisearch/tests/documents/delete_documents.rs
+++ b/crates/meilisearch/tests/documents/delete_documents.rs
@@ -30,9 +30,10 @@ async fn delete_one_unexisting_document() {
 async fn delete_one_document() {
     let server = Server::new().await;
     let index = server.index("test");
-    let (task,_status_code) = index.add_documents(json!([{ "id": 0, "content": "foobar" }]), None).await;
+    let (task, _status_code) =
+        index.add_documents(json!([{ "id": 0, "content": "foobar" }]), None).await;
     index.wait_task(task.uid()).await.succeeded();
-    let (task,status_code) = server.index("test").delete_document(0).await;
+    let (task, status_code) = server.index("test").delete_document(0).await;
     assert_eq!(status_code, 202);
     index.wait_task(task.uid()).await.succeeded();
 
@@ -56,7 +57,7 @@ async fn clear_all_documents_unexisting_index() {
 async fn clear_all_documents() {
     let server = Server::new().await;
     let index = server.index("test");
-    let (task,_status_code) = index
+    let (task, _status_code) = index
         .add_documents(
             json!([{ "id": 1, "content": "foobar" }, { "id": 0, "content": "foobar" }]),
             None,
@@ -76,7 +77,7 @@ async fn clear_all_documents() {
 async fn clear_all_documents_empty_index() {
     let server = Server::new().await;
     let index = server.index("test");
-    let (task,_status_code) = index.create(None).await;
+    let (task, _status_code) = index.create(None).await;
     index.wait_task(task.uid()).await.succeeded();
     let (task, code) = index.clear_all_documents().await;
     assert_eq!(code, 202);
@@ -143,7 +144,7 @@ async fn delete_document_by_filter() {
     let server = Server::new().await;
     let index = server.index("doggo");
     index.update_settings_filterable_attributes(json!(["color"])).await;
-    let (task,_status_code) = index
+    let (task, _status_code) = index
         .add_documents(
             json!([
                 { "id": 0, "color": "red" },
@@ -303,7 +304,7 @@ async fn delete_document_by_complex_filter() {
     let server = Server::new().await;
     let index = server.index("doggo");
     index.update_settings_filterable_attributes(json!(["color"])).await;
-    let (task,_status_code) = index
+    let (task, _status_code) = index
         .add_documents(
             json!([
                 { "id": 0, "color": "red" },

--- a/crates/meilisearch/tests/index/create_index.rs
+++ b/crates/meilisearch/tests/index/create_index.rs
@@ -131,7 +131,7 @@ async fn create_index_with_invalid_primary_key() {
     let (response, code) = index.add_documents(documents, Some("title")).await;
     assert_eq!(code, 202);
 
-    index.wait_task(response.uid()).await;
+    index.wait_task(response.uid()).await.succeeded();
 
     let (response, code) = index.get().await;
     assert_eq!(code, 200);
@@ -142,7 +142,7 @@ async fn create_index_with_invalid_primary_key() {
     let (response, code) = index.add_documents(documents, Some("id")).await;
     assert_eq!(code, 202);
 
-    index.wait_task(response.uid()).await;
+    index.wait_task(response.uid()).await.succeeded();
 
     let (response, code) = index.get().await;
     assert_eq!(code, 200);

--- a/crates/meilisearch/tests/index/create_index.rs
+++ b/crates/meilisearch/tests/index/create_index.rs
@@ -115,7 +115,7 @@ async fn create_index_with_primary_key() {
 
     assert_eq!(response["status"], "enqueued");
 
-    let response = index.wait_task(response.uid()).await;
+    let response = index.wait_task(response.uid()).await.succeeded();
 
     assert_eq!(response["status"], "succeeded");
     assert_eq!(response["type"], "indexCreation");
@@ -130,8 +130,7 @@ async fn create_index_with_invalid_primary_key() {
     let index = server.unique_index();
     let (response, code) = index.add_documents(documents, Some("title")).await;
     assert_eq!(code, 202);
-
-    index.wait_task(response.uid()).await.succeeded();
+    index.wait_task(response.uid()).await.failed();
 
     let (response, code) = index.get().await;
     assert_eq!(code, 200);
@@ -141,8 +140,7 @@ async fn create_index_with_invalid_primary_key() {
 
     let (response, code) = index.add_documents(documents, Some("id")).await;
     assert_eq!(code, 202);
-
-    index.wait_task(response.uid()).await.succeeded();
+    index.wait_task(response.uid()).await.failed();
 
     let (response, code) = index.get().await;
     assert_eq!(code, 200);

--- a/crates/meilisearch/tests/index/get_index.rs
+++ b/crates/meilisearch/tests/index/get_index.rs
@@ -7,11 +7,11 @@ use crate::common::Server;
 async fn create_and_get_index() {
     let server = Server::new().await;
     let index = server.index("test");
-    let (_, code) = index.create(None).await;
+    let (task, code) = index.create(None).await;
 
     assert_eq!(code, 202);
 
-    index.wait_task(0).await;
+    index.wait_task(task.uid()).await;
 
     let (response, code) = index.get().await;
 
@@ -55,9 +55,9 @@ async fn no_index_return_empty_list() {
 async fn list_multiple_indexes() {
     let server = Server::new().await;
     server.index("test").create(None).await;
-    server.index("test1").create(Some("key")).await;
+    let (task,_status_code) = server.index("test1").create(Some("key")).await;
 
-    server.index("test").wait_task(1).await;
+    server.index("test").wait_task(task.uid()).await;
 
     let (response, code) = server.list_indexes(None, None).await;
     assert_eq!(code, 200);

--- a/crates/meilisearch/tests/index/get_index.rs
+++ b/crates/meilisearch/tests/index/get_index.rs
@@ -11,7 +11,7 @@ async fn create_and_get_index() {
 
     assert_eq!(code, 202);
 
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = index.get().await;
 
@@ -57,7 +57,7 @@ async fn list_multiple_indexes() {
     server.index("test").create(None).await;
     let (task,_status_code) = server.index("test1").create(Some("key")).await;
 
-    server.index("test").wait_task(task.uid()).await;
+    server.index("test").wait_task(task.uid()).await.succeeded();
 
     let (response, code) = server.list_indexes(None, None).await;
     assert_eq!(code, 200);

--- a/crates/meilisearch/tests/index/get_index.rs
+++ b/crates/meilisearch/tests/index/get_index.rs
@@ -55,7 +55,7 @@ async fn no_index_return_empty_list() {
 async fn list_multiple_indexes() {
     let server = Server::new().await;
     server.index("test").create(None).await;
-    let (task,_status_code) = server.index("test1").create(Some("key")).await;
+    let (task, _status_code) = server.index("test1").create(Some("key")).await;
 
     server.index("test").wait_task(task.uid()).await.succeeded();
 

--- a/crates/meilisearch/tests/index/stats.rs
+++ b/crates/meilisearch/tests/index/stats.rs
@@ -5,11 +5,11 @@ use crate::json;
 async fn stats() {
     let server = Server::new().await;
     let index = server.index("test");
-    let (_, code) = index.create(Some("id")).await;
+    let (task, code) = index.create(Some("id")).await;
 
     assert_eq!(code, 202);
 
-    index.wait_task(0).await;
+    index.wait_task(task.uid()).await;
 
     let (response, code) = index.stats().await;
 
@@ -33,7 +33,7 @@ async fn stats() {
     assert_eq!(code, 202);
     assert_eq!(response["taskUid"], 1);
 
-    index.wait_task(1).await;
+    index.wait_task(response.uid()).await;
 
     let (response, code) = index.stats().await;
 

--- a/crates/meilisearch/tests/index/stats.rs
+++ b/crates/meilisearch/tests/index/stats.rs
@@ -9,7 +9,7 @@ async fn stats() {
 
     assert_eq!(code, 202);
 
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = index.stats().await;
 
@@ -33,7 +33,7 @@ async fn stats() {
     assert_eq!(code, 202);
     assert_eq!(response["taskUid"], 1);
 
-    index.wait_task(response.uid()).await;
+    index.wait_task(response.uid()).await.succeeded();
 
     let (response, code) = index.stats().await;
 

--- a/crates/meilisearch/tests/index/update_index.rs
+++ b/crates/meilisearch/tests/index/update_index.rs
@@ -13,9 +13,9 @@ async fn update_primary_key() {
 
     assert_eq!(code, 202);
 
-    index.update(Some("primary")).await;
+    let (task,_status_code) = index.update(Some("primary")).await;
 
-    let response = index.wait_task(1).await;
+    let response = index.wait_task(task.uid()).await;
 
     assert_eq!(response["status"], "succeeded");
 
@@ -46,9 +46,9 @@ async fn create_and_update_with_different_encoding() {
     assert_eq!(code, 202);
 
     let index = server.index_with_encoder("test", Encoder::Brotli);
-    index.update(Some("primary")).await;
+    let (task,_status_code) = index.update(Some("primary")).await;
 
-    let response = index.wait_task(1).await;
+    let response = index.wait_task(task.uid()).await;
 
     assert_eq!(response["status"], "succeeded");
 }
@@ -57,17 +57,17 @@ async fn create_and_update_with_different_encoding() {
 async fn update_nothing() {
     let server = Server::new().await;
     let index = server.index("test");
-    let (_, code) = index.create(None).await;
+    let (task1, code) = index.create(None).await;
 
     assert_eq!(code, 202);
 
-    index.wait_task(0).await;
+    index.wait_task(task1.uid()).await;
 
-    let (_, code) = index.update(None).await;
+    let (task2, code) = index.update(None).await;
 
     assert_eq!(code, 202);
 
-    let response = index.wait_task(1).await;
+    let response = index.wait_task(task2.uid()).await;
 
     assert_eq!(response["status"], "succeeded");
 }
@@ -88,11 +88,11 @@ async fn error_update_existing_primary_key() {
     ]);
     index.add_documents(documents, None).await;
 
-    let (_, code) = index.update(Some("primary")).await;
+    let (task, code) = index.update(Some("primary")).await;
 
     assert_eq!(code, 202);
 
-    let response = index.wait_task(2).await;
+    let response = index.wait_task(task.uid()).await;
 
     let expected_response = json!({
         "message": "Index `test`: Index already has a primary key: `id`.",
@@ -107,11 +107,11 @@ async fn error_update_existing_primary_key() {
 #[actix_rt::test]
 async fn error_update_unexisting_index() {
     let server = Server::new().await;
-    let (_, code) = server.index("test").update(None).await;
+    let (task, code) = server.index("test").update(None).await;
 
     assert_eq!(code, 202);
 
-    let response = server.index("test").wait_task(0).await;
+    let response = server.index("test").wait_task(task.uid()).await;
 
     let expected_response = json!({
         "message": "Index `test` not found.",

--- a/crates/meilisearch/tests/index/update_index.rs
+++ b/crates/meilisearch/tests/index/update_index.rs
@@ -61,7 +61,7 @@ async fn update_nothing() {
 
     assert_eq!(code, 202);
 
-    index.wait_task(task1.uid()).await;
+    index.wait_task(task1.uid()).await.succeeded();
 
     let (task2, code) = index.update(None).await;
 

--- a/crates/meilisearch/tests/index/update_index.rs
+++ b/crates/meilisearch/tests/index/update_index.rs
@@ -13,7 +13,7 @@ async fn update_primary_key() {
 
     assert_eq!(code, 202);
 
-    let (task,_status_code) = index.update(Some("primary")).await;
+    let (task, _status_code) = index.update(Some("primary")).await;
 
     let response = index.wait_task(task.uid()).await;
 
@@ -46,7 +46,7 @@ async fn create_and_update_with_different_encoding() {
     assert_eq!(code, 202);
 
     let index = server.index_with_encoder("test", Encoder::Brotli);
-    let (task,_status_code) = index.update(Some("primary")).await;
+    let (task, _status_code) = index.update(Some("primary")).await;
 
     let response = index.wait_task(task.uid()).await;
 

--- a/crates/meilisearch/tests/logs/mod.rs
+++ b/crates/meilisearch/tests/logs/mod.rs
@@ -94,7 +94,7 @@ async fn basic_test_log_stream_route() {
       "enqueuedAt": "[date]"
     }
     "###);
-    server.wait_task(ret.uid()).await;
+    server.wait_task(ret.uid()).await.succeeded();
 
     let req = actix_web::test::TestRequest::delete().uri("/logs/stream");
     let req = req.to_request();

--- a/crates/meilisearch/tests/search/distinct.rs
+++ b/crates/meilisearch/tests/search/distinct.rs
@@ -151,8 +151,8 @@ async fn distinct_search_with_offset_no_ranking() {
 
     let documents = DOCUMENTS.clone();
     index.add_documents(documents, Some(DOCUMENT_PRIMARY_KEY)).await;
-    index.update_distinct_attribute(json!(DOCUMENT_DISTINCT_KEY)).await;
-    index.wait_task(1).await;
+    let (task,_status_code) = index.update_distinct_attribute(json!(DOCUMENT_DISTINCT_KEY)).await;
+    index.wait_task(task.uid()).await;
 
     fn get_hits(response: &Value) -> Vec<&str> {
         let hits_array = response["hits"].as_array().unwrap();
@@ -210,8 +210,8 @@ async fn distinct_search_with_pagination_no_ranking() {
 
     let documents = DOCUMENTS.clone();
     index.add_documents(documents, Some(DOCUMENT_PRIMARY_KEY)).await;
-    index.update_distinct_attribute(json!(DOCUMENT_DISTINCT_KEY)).await;
-    index.wait_task(1).await;
+    let (task,_status_code) = index.update_distinct_attribute(json!(DOCUMENT_DISTINCT_KEY)).await;
+    index.wait_task(task.uid()).await;
 
     fn get_hits(response: &Value) -> Vec<&str> {
         let hits_array = response["hits"].as_array().unwrap();

--- a/crates/meilisearch/tests/search/distinct.rs
+++ b/crates/meilisearch/tests/search/distinct.rs
@@ -151,7 +151,7 @@ async fn distinct_search_with_offset_no_ranking() {
 
     let documents = DOCUMENTS.clone();
     index.add_documents(documents, Some(DOCUMENT_PRIMARY_KEY)).await;
-    let (task,_status_code) = index.update_distinct_attribute(json!(DOCUMENT_DISTINCT_KEY)).await;
+    let (task, _status_code) = index.update_distinct_attribute(json!(DOCUMENT_DISTINCT_KEY)).await;
     index.wait_task(task.uid()).await.succeeded();
 
     fn get_hits(response: &Value) -> Vec<&str> {
@@ -210,7 +210,7 @@ async fn distinct_search_with_pagination_no_ranking() {
 
     let documents = DOCUMENTS.clone();
     index.add_documents(documents, Some(DOCUMENT_PRIMARY_KEY)).await;
-    let (task,_status_code) = index.update_distinct_attribute(json!(DOCUMENT_DISTINCT_KEY)).await;
+    let (task, _status_code) = index.update_distinct_attribute(json!(DOCUMENT_DISTINCT_KEY)).await;
     index.wait_task(task.uid()).await.succeeded();
 
     fn get_hits(response: &Value) -> Vec<&str> {

--- a/crates/meilisearch/tests/search/distinct.rs
+++ b/crates/meilisearch/tests/search/distinct.rs
@@ -152,7 +152,7 @@ async fn distinct_search_with_offset_no_ranking() {
     let documents = DOCUMENTS.clone();
     index.add_documents(documents, Some(DOCUMENT_PRIMARY_KEY)).await;
     let (task,_status_code) = index.update_distinct_attribute(json!(DOCUMENT_DISTINCT_KEY)).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     fn get_hits(response: &Value) -> Vec<&str> {
         let hits_array = response["hits"].as_array().unwrap();
@@ -211,7 +211,7 @@ async fn distinct_search_with_pagination_no_ranking() {
     let documents = DOCUMENTS.clone();
     index.add_documents(documents, Some(DOCUMENT_PRIMARY_KEY)).await;
     let (task,_status_code) = index.update_distinct_attribute(json!(DOCUMENT_DISTINCT_KEY)).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     fn get_hits(response: &Value) -> Vec<&str> {
         let hits_array = response["hits"].as_array().unwrap();

--- a/crates/meilisearch/tests/search/errors.rs
+++ b/crates/meilisearch/tests/search/errors.rs
@@ -640,7 +640,7 @@ async fn filter_invalid_syntax_object() {
     let index = server.unique_index();
 
     let (task, _code) = index.update_settings(json!({"filterableAttributes": ["title"]})).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     index
         .search(json!({"filter": "title & Glass"}), |response, code| {
@@ -663,7 +663,7 @@ async fn filter_invalid_syntax_array() {
     let index = server.unique_index();
 
     let (task, _code) = index.update_settings(json!({"filterableAttributes": ["title"]})).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     index
         .search(json!({"filter": ["title & Glass"]}), |response, code| {
@@ -686,7 +686,7 @@ async fn filter_invalid_syntax_string() {
     let index = server.unique_index();
 
     let (task, _code) = index.update_settings(json!({"filterableAttributes": ["title"]})).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let expected_response = json!({
         "message": "Found unexpected characters at the end of the filter: `XOR title = Glass`. You probably forgot an `OR` or an `AND` rule.\n15:32 title = Glass XOR title = Glass",

--- a/crates/meilisearch/tests/search/errors.rs
+++ b/crates/meilisearch/tests/search/errors.rs
@@ -708,7 +708,7 @@ async fn filter_invalid_attribute_array() {
     let index = server.unique_index();
 
     let (task, _code) = index.update_settings(json!({"filterableAttributes": ["title"]})).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let expected_response = json!({
         "message": format!("Index `{}`: Attribute `many` is not filterable. Available filterable attributes are: `title`.\n1:5 many = Glass", index.uid),
@@ -730,7 +730,7 @@ async fn filter_invalid_attribute_string() {
     let index = server.unique_index();
 
     let (task, _code) = index.update_settings(json!({"filterableAttributes": ["title"]})).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let expected_response = json!({
         "message": format!("Index `{}`: Attribute `many` is not filterable. Available filterable attributes are: `title`.\n1:5 many = Glass", index.uid),
@@ -752,7 +752,7 @@ async fn filter_reserved_geo_attribute_array() {
     let index = server.unique_index();
 
     let (task, _code) = index.update_settings(json!({"filterableAttributes": ["title"]})).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let expected_response = json!({
         "message": "`_geo` is a reserved keyword and thus can't be used as a filter expression. Use the `_geoRadius(latitude, longitude, distance)` or `_geoBoundingBox([latitude, longitude], [latitude, longitude])` built-in rules to filter on `_geo` coordinates.\n1:13 _geo = Glass",
@@ -774,7 +774,7 @@ async fn filter_reserved_geo_attribute_string() {
     let index = server.unique_index();
 
     let (task, _code) = index.update_settings(json!({"filterableAttributes": ["title"]})).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let expected_response = json!({
         "message": "`_geo` is a reserved keyword and thus can't be used as a filter expression. Use the `_geoRadius(latitude, longitude, distance)` or `_geoBoundingBox([latitude, longitude], [latitude, longitude])` built-in rules to filter on `_geo` coordinates.\n1:13 _geo = Glass",
@@ -796,7 +796,7 @@ async fn filter_reserved_attribute_array() {
     let index = server.unique_index();
 
     let (task, _code) = index.update_settings(json!({"filterableAttributes": ["title"]})).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let expected_response = json!({
         "message": "`_geoDistance` is a reserved keyword and thus can't be used as a filter expression. Use the `_geoRadius(latitude, longitude, distance)` or `_geoBoundingBox([latitude, longitude], [latitude, longitude])` built-in rules to filter on `_geo` coordinates.\n1:21 _geoDistance = Glass",
@@ -818,7 +818,7 @@ async fn filter_reserved_attribute_string() {
     let index = server.unique_index();
 
     let (task, _code) = index.update_settings(json!({"filterableAttributes": ["title"]})).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let expected_response = json!({
        "message": "`_geoDistance` is a reserved keyword and thus can't be used as a filter expression. Use the `_geoRadius(latitude, longitude, distance)` or `_geoBoundingBox([latitude, longitude], [latitude, longitude])` built-in rules to filter on `_geo` coordinates.\n1:21 _geoDistance = Glass",
@@ -840,7 +840,7 @@ async fn filter_reserved_geo_point_array() {
     let index = server.unique_index();
 
     let (task, _code) = index.update_settings(json!({"filterableAttributes": ["title"]})).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let expected_response = json!({
         "message": "`_geoPoint` is a reserved keyword and thus can't be used as a filter expression. Use the `_geoRadius(latitude, longitude, distance)` or `_geoBoundingBox([latitude, longitude], [latitude, longitude])` built-in rules to filter on `_geo` coordinates.\n1:18 _geoPoint = Glass",

--- a/crates/meilisearch/tests/search/errors.rs
+++ b/crates/meilisearch/tests/search/errors.rs
@@ -862,7 +862,7 @@ async fn filter_reserved_geo_point_string() {
     let index = server.unique_index();
 
     let (task, _code) = index.update_settings(json!({"filterableAttributes": ["title"]})).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let expected_response = json!({
        "message": "`_geoPoint` is a reserved keyword and thus can't be used as a filter expression. Use the `_geoRadius(latitude, longitude, distance)` or `_geoBoundingBox([latitude, longitude], [latitude, longitude])` built-in rules to filter on `_geo` coordinates.\n1:18 _geoPoint = Glass",
@@ -884,7 +884,7 @@ async fn sort_geo_reserved_attribute() {
     let index = server.unique_index();
 
     let (task, _code) = index.update_settings(json!({"sortableAttributes": ["id"]})).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let expected_response = json!({
         "message": "`_geo` is a reserved keyword and thus can't be used as a sort expression. Use the _geoPoint(latitude, longitude) built-in rule to sort on _geo field coordinates.",
@@ -911,7 +911,7 @@ async fn sort_reserved_attribute() {
     let index = server.unique_index();
 
     let (task, _code) = index.update_settings(json!({"sortableAttributes": ["id"]})).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let expected_response = json!({
         "message": "`_geoDistance` is a reserved keyword and thus can't be used as a sort expression.",
@@ -1095,7 +1095,7 @@ async fn distinct_at_search_time() {
     assert_eq!(code, 400);
 
     let (task, _) = index.update_settings_filterable_attributes(json!(["color", "machin"])).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let expected_response = json!({
         "message": format!("Index `{}`: Attribute `doggo.truc` is not filterable and thus, cannot be used as distinct attribute. Available filterable attributes are: `color, machin`.", index.uid),
@@ -1109,7 +1109,7 @@ async fn distinct_at_search_time() {
     assert_eq!(code, 400);
 
     let (task, _) = index.update_settings_displayed_attributes(json!(["color"])).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let expected_response = json!({
         "message": format!("Index `{}`: Attribute `doggo.truc` is not filterable and thus, cannot be used as distinct attribute. Available filterable attributes are: `color, <..hidden-attributes>`.", index.uid),

--- a/crates/meilisearch/tests/search/facet_search.rs
+++ b/crates/meilisearch/tests/search/facet_search.rs
@@ -281,7 +281,7 @@ async fn facet_search_dont_support_words() {
     let documents = DOCUMENTS.clone();
     index.update_settings_filterable_attributes(json!(["genres"])).await;
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) =
         index.facet_search(json!({"facetName": "genres", "facetQuery": "words"})).await;
@@ -299,7 +299,7 @@ async fn simple_facet_search_with_sort_by_count() {
     index.update_settings_faceting(json!({ "sortFacetValuesBy": { "*": "count" } })).await;
     index.update_settings_filterable_attributes(json!(["genres"])).await;
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) =
         index.facet_search(json!({"facetName": "genres", "facetQuery": "a"})).await;

--- a/crates/meilisearch/tests/search/facet_search.rs
+++ b/crates/meilisearch/tests/search/facet_search.rs
@@ -41,8 +41,8 @@ async fn simple_facet_search() {
 
     let documents = DOCUMENTS.clone();
     index.update_settings_filterable_attributes(json!(["genres"])).await;
-    let (response, _code) = index.add_documents(documents, None).await;
-    index.wait_task(response.uid()).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let (response, code) =
         index.facet_search(json!({"facetName": "genres", "facetQuery": "a"})).await;
@@ -175,8 +175,8 @@ async fn advanced_facet_search() {
     let documents = DOCUMENTS.clone();
     index.update_settings_filterable_attributes(json!(["genres"])).await;
     index.update_settings_typo_tolerance(json!({ "enabled": false })).await;
-    let (response, _code) = index.add_documents(documents, None).await;
-    index.wait_task(response.uid()).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let (response, code) =
         index.facet_search(json!({"facetName": "genres", "facetQuery": "adventre"})).await;
@@ -199,8 +199,8 @@ async fn more_advanced_facet_search() {
     let documents = DOCUMENTS.clone();
     index.update_settings_filterable_attributes(json!(["genres"])).await;
     index.update_settings_typo_tolerance(json!({ "disableOnWords": ["adventre"] })).await;
-    let (response, _code) = index.add_documents(documents, None).await;
-    index.wait_task(response.uid()).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let (response, code) =
         index.facet_search(json!({"facetName": "genres", "facetQuery": "adventre"})).await;
@@ -223,8 +223,8 @@ async fn simple_facet_search_with_max_values() {
     let documents = DOCUMENTS.clone();
     index.update_settings_faceting(json!({ "maxValuesPerFacet": 1 })).await;
     index.update_settings_filterable_attributes(json!(["genres"])).await;
-    let (response, _code) = index.add_documents(documents, None).await;
-    index.wait_task(response.uid()).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let (response, code) =
         index.facet_search(json!({"facetName": "genres", "facetQuery": "a"})).await;
@@ -245,8 +245,8 @@ async fn simple_facet_search_by_count_with_max_values() {
         )
         .await;
     index.update_settings_filterable_attributes(json!(["genres"])).await;
-    let (response, _code) = index.add_documents(documents, None).await;
-    index.wait_task(response.uid()).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let (response, code) =
         index.facet_search(json!({"facetName": "genres", "facetQuery": "a"})).await;
@@ -261,8 +261,8 @@ async fn non_filterable_facet_search_error() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    let (response, _code) = index.add_documents(documents, None).await;
-    index.wait_task(response.uid()).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let (response, code) =
         index.facet_search(json!({"facetName": "genres", "facetQuery": "a"})).await;
@@ -280,8 +280,8 @@ async fn facet_search_dont_support_words() {
 
     let documents = DOCUMENTS.clone();
     index.update_settings_filterable_attributes(json!(["genres"])).await;
-    let (response, _code) = index.add_documents(documents, None).await;
-    index.wait_task(response.uid()).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let (response, code) =
         index.facet_search(json!({"facetName": "genres", "facetQuery": "words"})).await;
@@ -298,8 +298,8 @@ async fn simple_facet_search_with_sort_by_count() {
     let documents = DOCUMENTS.clone();
     index.update_settings_faceting(json!({ "sortFacetValuesBy": { "*": "count" } })).await;
     index.update_settings_filterable_attributes(json!(["genres"])).await;
-    let (response, _code) = index.add_documents(documents, None).await;
-    index.wait_task(response.uid()).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let (response, code) =
         index.facet_search(json!({"facetName": "genres", "facetQuery": "a"})).await;

--- a/crates/meilisearch/tests/search/facet_search.rs
+++ b/crates/meilisearch/tests/search/facet_search.rs
@@ -42,7 +42,7 @@ async fn simple_facet_search() {
     let documents = DOCUMENTS.clone();
     index.update_settings_filterable_attributes(json!(["genres"])).await;
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) =
         index.facet_search(json!({"facetName": "genres", "facetQuery": "a"})).await;
@@ -176,7 +176,7 @@ async fn advanced_facet_search() {
     index.update_settings_filterable_attributes(json!(["genres"])).await;
     index.update_settings_typo_tolerance(json!({ "enabled": false })).await;
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) =
         index.facet_search(json!({"facetName": "genres", "facetQuery": "adventre"})).await;
@@ -200,7 +200,7 @@ async fn more_advanced_facet_search() {
     index.update_settings_filterable_attributes(json!(["genres"])).await;
     index.update_settings_typo_tolerance(json!({ "disableOnWords": ["adventre"] })).await;
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) =
         index.facet_search(json!({"facetName": "genres", "facetQuery": "adventre"})).await;
@@ -224,7 +224,7 @@ async fn simple_facet_search_with_max_values() {
     index.update_settings_faceting(json!({ "maxValuesPerFacet": 1 })).await;
     index.update_settings_filterable_attributes(json!(["genres"])).await;
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) =
         index.facet_search(json!({"facetName": "genres", "facetQuery": "a"})).await;
@@ -246,7 +246,7 @@ async fn simple_facet_search_by_count_with_max_values() {
         .await;
     index.update_settings_filterable_attributes(json!(["genres"])).await;
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) =
         index.facet_search(json!({"facetName": "genres", "facetQuery": "a"})).await;
@@ -262,7 +262,7 @@ async fn non_filterable_facet_search_error() {
 
     let documents = DOCUMENTS.clone();
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) =
         index.facet_search(json!({"facetName": "genres", "facetQuery": "a"})).await;

--- a/crates/meilisearch/tests/search/facet_search.rs
+++ b/crates/meilisearch/tests/search/facet_search.rs
@@ -41,7 +41,7 @@ async fn simple_facet_search() {
 
     let documents = DOCUMENTS.clone();
     index.update_settings_filterable_attributes(json!(["genres"])).await;
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) =
@@ -175,7 +175,7 @@ async fn advanced_facet_search() {
     let documents = DOCUMENTS.clone();
     index.update_settings_filterable_attributes(json!(["genres"])).await;
     index.update_settings_typo_tolerance(json!({ "enabled": false })).await;
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) =
@@ -199,7 +199,7 @@ async fn more_advanced_facet_search() {
     let documents = DOCUMENTS.clone();
     index.update_settings_filterable_attributes(json!(["genres"])).await;
     index.update_settings_typo_tolerance(json!({ "disableOnWords": ["adventre"] })).await;
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) =
@@ -223,7 +223,7 @@ async fn simple_facet_search_with_max_values() {
     let documents = DOCUMENTS.clone();
     index.update_settings_faceting(json!({ "maxValuesPerFacet": 1 })).await;
     index.update_settings_filterable_attributes(json!(["genres"])).await;
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) =
@@ -245,7 +245,7 @@ async fn simple_facet_search_by_count_with_max_values() {
         )
         .await;
     index.update_settings_filterable_attributes(json!(["genres"])).await;
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) =
@@ -261,7 +261,7 @@ async fn non_filterable_facet_search_error() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) =
@@ -280,7 +280,7 @@ async fn facet_search_dont_support_words() {
 
     let documents = DOCUMENTS.clone();
     index.update_settings_filterable_attributes(json!(["genres"])).await;
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) =
@@ -298,7 +298,7 @@ async fn simple_facet_search_with_sort_by_count() {
     let documents = DOCUMENTS.clone();
     index.update_settings_faceting(json!({ "sortFacetValuesBy": { "*": "count" } })).await;
     index.update_settings_filterable_attributes(json!(["genres"])).await;
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) =

--- a/crates/meilisearch/tests/search/formatted.rs
+++ b/crates/meilisearch/tests/search/formatted.rs
@@ -596,7 +596,7 @@ async fn test_cjk_highlight() {
         { "id": 1, "title": "大卫到了扫罗那里" },
     ]);
     let (response, _) = index.add_documents(documents, None).await;
-    index.wait_task(response.uid()).await;
+    index.wait_task(response.uid()).await.succeeded();
 
     index
         .search(json!({"q": "で", "attributesToHighlight": ["title"]}), |response, code| {

--- a/crates/meilisearch/tests/search/formatted.rs
+++ b/crates/meilisearch/tests/search/formatted.rs
@@ -65,7 +65,7 @@ async fn formatted_contain_wildcard() {
 
     let documents = NESTED_DOCUMENTS.clone();
     let (response, _) = index.add_documents(documents, None).await;
-    index.wait_task(response.uid()).await;
+    index.wait_task(response.uid()).await.succeeded();
 
     index.search(json!({ "q": "pésti", "attributesToRetrieve": ["father", "mother"], "attributesToHighlight": ["father", "mother", "*"], "attributesToCrop": ["doggos"], "showMatchesPosition": true }),
         |response, code|
@@ -398,7 +398,7 @@ async fn displayedattr_2_smol() {
 
     let documents = NESTED_DOCUMENTS.clone();
     let (response, _) = index.add_documents(documents, None).await;
-    index.wait_task(response.uid()).await;
+    index.wait_task(response.uid()).await.succeeded();
 
     index
         .search(json!({ "attributesToRetrieve": ["father", "id"], "attributesToHighlight": ["mother"], "attributesToCrop": ["cattos"] }),

--- a/crates/meilisearch/tests/search/geo.rs
+++ b/crates/meilisearch/tests/search/geo.rs
@@ -47,7 +47,7 @@ async fn geo_sort_with_geo_strings() {
     index.update_settings_filterable_attributes(json!(["_geo"])).await;
     index.update_settings_sortable_attributes(json!(["_geo"])).await;
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     index
         .search(
@@ -128,7 +128,7 @@ async fn bug_4640() {
     index.add_documents(documents, None).await;
     index.update_settings_filterable_attributes(json!(["_geo"])).await;
     let (ret, _code) = index.update_settings_sortable_attributes(json!(["_geo"])).await;
-    index.wait_task(ret.uid()).await;
+    index.wait_task(ret.uid()).await.succeeded();
 
     // Sort the document with the second one first
     index

--- a/crates/meilisearch/tests/search/geo.rs
+++ b/crates/meilisearch/tests/search/geo.rs
@@ -46,8 +46,8 @@ async fn geo_sort_with_geo_strings() {
     let documents = DOCUMENTS.clone();
     index.update_settings_filterable_attributes(json!(["_geo"])).await;
     index.update_settings_sortable_attributes(json!(["_geo"])).await;
-    index.add_documents(documents, None).await;
-    index.wait_task(2).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     index
         .search(

--- a/crates/meilisearch/tests/search/geo.rs
+++ b/crates/meilisearch/tests/search/geo.rs
@@ -46,7 +46,7 @@ async fn geo_sort_with_geo_strings() {
     let documents = DOCUMENTS.clone();
     index.update_settings_filterable_attributes(json!(["_geo"])).await;
     index.update_settings_sortable_attributes(json!(["_geo"])).await;
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     index

--- a/crates/meilisearch/tests/search/hybrid.rs
+++ b/crates/meilisearch/tests/search/hybrid.rs
@@ -30,11 +30,11 @@ async fn index_with_documents_user_provided<'a>(
                 "dimensions": 2}}} ))
         .await;
     assert_eq!(202, code, "{:?}", response);
-    index.wait_task(response.uid()).await;
+    index.wait_task(response.uid()).await.succeeded();
 
     let (response, code) = index.add_documents(documents.clone(), None).await;
     assert_eq!(202, code, "{:?}", response);
-    index.wait_task(response.uid()).await;
+    index.wait_task(response.uid()).await.succeeded();
     index
 }
 
@@ -63,11 +63,11 @@ async fn index_with_documents_hf<'a>(server: &'a Server, documents: &Value) -> I
         }}} ))
         .await;
     assert_eq!(202, code, "{:?}", response);
-    index.wait_task(response.uid()).await;
+    index.wait_task(response.uid()).await.succeeded();
 
     let (response, code) = index.add_documents(documents.clone(), None).await;
     assert_eq!(202, code, "{:?}", response);
-    index.wait_task(response.uid()).await;
+    index.wait_task(response.uid()).await.succeeded();
     index
 }
 

--- a/crates/meilisearch/tests/search/hybrid.rs
+++ b/crates/meilisearch/tests/search/hybrid.rs
@@ -573,7 +573,7 @@ async fn retrieve_vectors() {
         .update_settings(json!({ "displayedAttributes": ["id", "title", "desc", "_vectors"]} ))
         .await;
     assert_eq!(202, code, "{:?}", response);
-    index.wait_task(response.uid()).await;
+    index.wait_task(response.uid()).await.succeeded();
 
     let (response, code) = index
         .search_post(
@@ -623,7 +623,7 @@ async fn retrieve_vectors() {
     let (response, code) =
         index.update_settings(json!({ "displayedAttributes": ["id", "title", "desc"]} )).await;
     assert_eq!(202, code, "{:?}", response);
-    index.wait_task(response.uid()).await;
+    index.wait_task(response.uid()).await.succeeded();
 
     let (response, code) = index
         .search_post(

--- a/crates/meilisearch/tests/search/locales.rs
+++ b/crates/meilisearch/tests/search/locales.rs
@@ -98,7 +98,7 @@ async fn simple_search() {
             json!({"searchableAttributes": ["name_en", "name_ja", "name_zh", "author_en", "author_ja", "author_zh", "description_en", "description_ja", "description_zh"]}),
         )
         .await;
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     // english
@@ -220,7 +220,7 @@ async fn force_locales() {
       "enqueuedAt": "[date]"
     }
     "###);
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     // chinese detection
@@ -298,7 +298,7 @@ async fn force_locales_with_pattern() {
       "enqueuedAt": "[date]"
     }
     "###);
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     // chinese detection
@@ -374,7 +374,7 @@ async fn force_locales_with_pattern_nested() {
       "enqueuedAt": "[date]"
     }
     "###);
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     // chinese
@@ -449,7 +449,7 @@ async fn force_different_locales_with_pattern() {
       "enqueuedAt": "[date]"
     }
     "###);
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     // force chinese
@@ -527,7 +527,7 @@ async fn auto_infer_locales_at_search_with_attributes_to_search_on() {
       "enqueuedAt": "[date]"
     }
     "###);
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     // auto infer any language
@@ -601,7 +601,7 @@ async fn auto_infer_locales_at_search() {
       "enqueuedAt": "[date]"
     }
     "###);
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     index
@@ -700,7 +700,7 @@ async fn force_different_locales_with_pattern_nested() {
       "enqueuedAt": "[date]"
     }
     "###);
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     // chinese
@@ -778,7 +778,7 @@ async fn settings_change() {
 
     let index = server.index("test");
     let documents = NESTED_DOCUMENTS.clone();
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
     let (response, _) = index
         .update_settings(json!({
@@ -915,7 +915,7 @@ async fn invalid_locales() {
             json!({"searchableAttributes": ["name_en", "name_ja", "name_zh", "author_en", "author_ja", "author_zh", "description_en", "description_ja", "description_zh"]}),
         )
         .await;
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = index.search_post(json!({"q": "Atta", "locales": ["invalid"]})).await;
@@ -1033,7 +1033,7 @@ async fn simple_facet_search() {
       "enqueuedAt": "[date]"
     }
     "###);
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let (response, _) = index
@@ -1095,7 +1095,7 @@ async fn facet_search_with_localized_attributes() {
       "enqueuedAt": "[date]"
     }
     "###);
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let (response, _) = index

--- a/crates/meilisearch/tests/search/locales.rs
+++ b/crates/meilisearch/tests/search/locales.rs
@@ -98,8 +98,8 @@ async fn simple_search() {
             json!({"searchableAttributes": ["name_en", "name_ja", "name_zh", "author_en", "author_ja", "author_zh", "description_en", "description_ja", "description_zh"]}),
         )
         .await;
-    index.add_documents(documents, None).await;
-    index.wait_task(1).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     // english
     index
@@ -220,8 +220,8 @@ async fn force_locales() {
       "enqueuedAt": "[date]"
     }
     "###);
-    index.add_documents(documents, None).await;
-    index.wait_task(1).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     // chinese detection
     index
@@ -298,8 +298,8 @@ async fn force_locales_with_pattern() {
       "enqueuedAt": "[date]"
     }
     "###);
-    index.add_documents(documents, None).await;
-    index.wait_task(1).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     // chinese detection
     index
@@ -374,8 +374,8 @@ async fn force_locales_with_pattern_nested() {
       "enqueuedAt": "[date]"
     }
     "###);
-    index.add_documents(documents, None).await;
-    index.wait_task(1).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     // chinese
     index
@@ -449,8 +449,8 @@ async fn force_different_locales_with_pattern() {
       "enqueuedAt": "[date]"
     }
     "###);
-    index.add_documents(documents, None).await;
-    index.wait_task(1).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     // force chinese
     index
@@ -527,8 +527,8 @@ async fn auto_infer_locales_at_search_with_attributes_to_search_on() {
       "enqueuedAt": "[date]"
     }
     "###);
-    index.add_documents(documents, None).await;
-    index.wait_task(1).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     // auto infer any language
     index
@@ -601,8 +601,8 @@ async fn auto_infer_locales_at_search() {
       "enqueuedAt": "[date]"
     }
     "###);
-    index.add_documents(documents, None).await;
-    index.wait_task(1).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     index
         .search(
@@ -700,8 +700,8 @@ async fn force_different_locales_with_pattern_nested() {
       "enqueuedAt": "[date]"
     }
     "###);
-    index.add_documents(documents, None).await;
-    index.wait_task(1).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     // chinese
     index
@@ -778,8 +778,8 @@ async fn settings_change() {
 
     let index = server.index("test");
     let documents = NESTED_DOCUMENTS.clone();
-    index.add_documents(documents, None).await;
-    index.wait_task(0).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
     let (response, _) = index
         .update_settings(json!({
             "searchableAttributes": ["document_en", "document_ja", "document_zh"],
@@ -798,7 +798,7 @@ async fn settings_change() {
       "enqueuedAt": "[date]"
     }
     "###);
-    index.wait_task(1).await;
+    index.wait_task(response.uid()).await;
 
     // chinese
     index
@@ -861,7 +861,7 @@ async fn settings_change() {
       "enqueuedAt": "[date]"
     }
     "###);
-    index.wait_task(2).await;
+    index.wait_task(response.uid()).await;
 
     // chinese
     index
@@ -915,8 +915,8 @@ async fn invalid_locales() {
             json!({"searchableAttributes": ["name_en", "name_ja", "name_zh", "author_en", "author_ja", "author_zh", "description_en", "description_ja", "description_zh"]}),
         )
         .await;
-    index.add_documents(documents, None).await;
-    index.wait_task(1).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let (response, code) = index.search_post(json!({"q": "Atta", "locales": ["invalid"]})).await;
     snapshot!(code, @"400 Bad Request");
@@ -1033,8 +1033,8 @@ async fn simple_facet_search() {
       "enqueuedAt": "[date]"
     }
     "###);
-    index.add_documents(documents, None).await;
-    index.wait_task(1).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let (response, _) = index
         .facet_search(json!({"facetName": "name_zh", "facetQuery": "進撃", "locales": ["cmn"]}))
@@ -1095,8 +1095,8 @@ async fn facet_search_with_localized_attributes() {
       "enqueuedAt": "[date]"
     }
     "###);
-    index.add_documents(documents, None).await;
-    index.wait_task(1).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let (response, _) = index
         .facet_search(json!({"facetName": "name_zh", "facetQuery": "进击", "locales": ["cmn"]}))
@@ -1165,7 +1165,7 @@ async fn swedish_search() {
             ]
         }))
         .await;
-    index.wait_task(1).await;
+    index.wait_task(_response.uid()).await;
 
     // infer swedish
     index
@@ -1286,7 +1286,7 @@ async fn german_search() {
             ]
         }))
         .await;
-    index.wait_task(1).await;
+    index.wait_task(_response.uid()).await;
 
     // infer swedish
     index

--- a/crates/meilisearch/tests/search/locales.rs
+++ b/crates/meilisearch/tests/search/locales.rs
@@ -99,7 +99,7 @@ async fn simple_search() {
         )
         .await;
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     // english
     index
@@ -221,7 +221,7 @@ async fn force_locales() {
     }
     "###);
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     // chinese detection
     index
@@ -299,7 +299,7 @@ async fn force_locales_with_pattern() {
     }
     "###);
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     // chinese detection
     index
@@ -375,7 +375,7 @@ async fn force_locales_with_pattern_nested() {
     }
     "###);
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     // chinese
     index
@@ -450,7 +450,7 @@ async fn force_different_locales_with_pattern() {
     }
     "###);
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     // force chinese
     index

--- a/crates/meilisearch/tests/search/locales.rs
+++ b/crates/meilisearch/tests/search/locales.rs
@@ -1096,7 +1096,7 @@ async fn facet_search_with_localized_attributes() {
     }
     "###);
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (response, _) = index
         .facet_search(json!({"facetName": "name_zh", "facetQuery": "进击", "locales": ["cmn"]}))
@@ -1165,7 +1165,7 @@ async fn swedish_search() {
             ]
         }))
         .await;
-    index.wait_task(_response.uid()).await;
+    index.wait_task(_response.uid()).await.succeeded();
 
     // infer swedish
     index
@@ -1286,7 +1286,7 @@ async fn german_search() {
             ]
         }))
         .await;
-    index.wait_task(_response.uid()).await;
+    index.wait_task(_response.uid()).await.succeeded();
 
     // infer swedish
     index

--- a/crates/meilisearch/tests/search/locales.rs
+++ b/crates/meilisearch/tests/search/locales.rs
@@ -528,7 +528,7 @@ async fn auto_infer_locales_at_search_with_attributes_to_search_on() {
     }
     "###);
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     // auto infer any language
     index
@@ -602,7 +602,7 @@ async fn auto_infer_locales_at_search() {
     }
     "###);
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     index
         .search(
@@ -701,7 +701,7 @@ async fn force_different_locales_with_pattern_nested() {
     }
     "###);
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     // chinese
     index
@@ -779,7 +779,7 @@ async fn settings_change() {
     let index = server.index("test");
     let documents = NESTED_DOCUMENTS.clone();
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (response, _) = index
         .update_settings(json!({
             "searchableAttributes": ["document_en", "document_ja", "document_zh"],
@@ -798,7 +798,7 @@ async fn settings_change() {
       "enqueuedAt": "[date]"
     }
     "###);
-    index.wait_task(response.uid()).await;
+    index.wait_task(response.uid()).await.succeeded();
 
     // chinese
     index
@@ -861,7 +861,7 @@ async fn settings_change() {
       "enqueuedAt": "[date]"
     }
     "###);
-    index.wait_task(response.uid()).await;
+    index.wait_task(response.uid()).await.succeeded();
 
     // chinese
     index
@@ -916,7 +916,7 @@ async fn invalid_locales() {
         )
         .await;
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = index.search_post(json!({"q": "Atta", "locales": ["invalid"]})).await;
     snapshot!(code, @"400 Bad Request");
@@ -1034,7 +1034,7 @@ async fn simple_facet_search() {
     }
     "###);
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (response, _) = index
         .facet_search(json!({"facetName": "name_zh", "facetQuery": "進撃", "locales": ["cmn"]}))

--- a/crates/meilisearch/tests/search/matching_strategy.rs
+++ b/crates/meilisearch/tests/search/matching_strategy.rs
@@ -9,7 +9,7 @@ async fn index_with_documents<'a>(server: &'a Server, documents: &Value) -> Inde
     let index = server.index("test");
 
     let(task,_status_code) =index.add_documents(documents.clone(), None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     index
 }
 

--- a/crates/meilisearch/tests/search/matching_strategy.rs
+++ b/crates/meilisearch/tests/search/matching_strategy.rs
@@ -8,7 +8,7 @@ use crate::json;
 async fn index_with_documents<'a>(server: &'a Server, documents: &Value) -> Index<'a> {
     let index = server.index("test");
 
-    let(task,_status_code) =index.add_documents(documents.clone(), None).await;
+    let (task, _status_code) = index.add_documents(documents.clone(), None).await;
     index.wait_task(task.uid()).await.succeeded();
     index
 }

--- a/crates/meilisearch/tests/search/matching_strategy.rs
+++ b/crates/meilisearch/tests/search/matching_strategy.rs
@@ -8,8 +8,8 @@ use crate::json;
 async fn index_with_documents<'a>(server: &'a Server, documents: &Value) -> Index<'a> {
     let index = server.index("test");
 
-    index.add_documents(documents.clone(), None).await;
-    index.wait_task(0).await;
+    let(task,_status_code) =index.add_documents(documents.clone(), None).await;
+    index.wait_task(task.uid()).await;
     index
 }
 

--- a/crates/meilisearch/tests/search/mod.rs
+++ b/crates/meilisearch/tests/search/mod.rs
@@ -138,7 +138,7 @@ async fn phrase_search_with_stop_word() {
     meili_snap::snapshot!(code, @"202 Accepted");
 
     let documents = DOCUMENTS.clone();
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     index
@@ -218,10 +218,11 @@ async fn negative_special_cases_search() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
-    let (task,_status_code) = index.update_settings(json!({"synonyms": { "escape": ["gläss"] }})).await;
+    let (task, _status_code) =
+        index.update_settings(json!({"synonyms": { "escape": ["gläss"] }})).await;
     index.wait_task(task.uid()).await.succeeded();
 
     // There is a synonym for escape -> glass but we don't want "escape", only the derivates: glass
@@ -247,7 +248,7 @@ async fn test_kanji_language_detection() {
         { "id": 1, "title": "東京のお寿司。" },
         { "id": 2, "title": "הַשּׁוּעָל הַמָּהִיר (״הַחוּם״) לֹא יָכוֹל לִקְפֹּץ 9.94 מֶטְרִים, נָכוֹן? ברר, 1.5°C- בַּחוּץ!" }
     ]);
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     index
@@ -270,10 +271,10 @@ async fn test_thai_language() {
         { "id": 1, "title": "สบู่สมุนไพรชาเขียว 100 กรัม จำนวน 6 ก้อน" },
         { "id": 2, "title": "สบู่สมุนไพรฝางแดงผสมว่านหางจรเข้ 100 กรัม จำนวน 6 ก้อน" }
     ]);
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
-    let (task,_status_code) = index.update_settings(json!({"rankingRules": ["exactness"]})).await;
+    let (task, _status_code) = index.update_settings(json!({"rankingRules": ["exactness"]})).await;
     index.wait_task(task.uid()).await.succeeded();
 
     index
@@ -607,7 +608,7 @@ async fn displayed_attributes() {
     index.update_settings(json!({ "displayedAttributes": ["title"] })).await;
 
     let documents = DOCUMENTS.clone();
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) =
@@ -622,7 +623,7 @@ async fn placeholder_search_is_hard_limited() {
     let index = server.index("test");
 
     let documents: Vec<_> = (0..1200).map(|i| json!({ "id": i, "text": "I am unique!" })).collect();
-    let (task,_status_code) = index.add_documents(documents.into(), None).await;
+    let (task, _status_code) = index.add_documents(documents.into(), None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     index
@@ -650,7 +651,8 @@ async fn placeholder_search_is_hard_limited() {
         )
         .await;
 
-    let (task,_status_code) = index.update_settings(json!({ "pagination": { "maxTotalHits": 10_000 } })).await;
+    let (task, _status_code) =
+        index.update_settings(json!({ "pagination": { "maxTotalHits": 10_000 } })).await;
     index.wait_task(task.uid()).await.succeeded();
 
     index
@@ -685,7 +687,7 @@ async fn search_is_hard_limited() {
     let index = server.index("test");
 
     let documents: Vec<_> = (0..1200).map(|i| json!({ "id": i, "text": "I am unique!" })).collect();
-    let (task,_status_code) = index.add_documents(documents.into(), None).await;
+    let (task, _status_code) = index.add_documents(documents.into(), None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     index
@@ -715,7 +717,8 @@ async fn search_is_hard_limited() {
         )
         .await;
 
-    let (task,_status_code) = index.update_settings(json!({ "pagination": { "maxTotalHits": 10_000 } })).await;
+    let (task, _status_code) =
+        index.update_settings(json!({ "pagination": { "maxTotalHits": 10_000 } })).await;
     index.wait_task(task.uid()).await.succeeded();
 
     index
@@ -754,7 +757,7 @@ async fn faceting_max_values_per_facet() {
     index.update_settings(json!({ "filterableAttributes": ["number"] })).await;
 
     let documents: Vec<_> = (0..10_000).map(|id| json!({ "id": id, "number": id * 10 })).collect();
-    let (task,_status_code) = index.add_documents(json!(documents), None).await;
+    let (task, _status_code) = index.add_documents(json!(documents), None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     index
@@ -770,7 +773,8 @@ async fn faceting_max_values_per_facet() {
         )
         .await;
 
-    let (task,_status_code) = index.update_settings(json!({ "faceting": { "maxValuesPerFacet": 10_000 } })).await;
+    let (task, _status_code) =
+        index.update_settings(json!({ "faceting": { "maxValuesPerFacet": 10_000 } })).await;
     index.wait_task(task.uid()).await.succeeded();
 
     index
@@ -1162,7 +1166,7 @@ async fn experimental_feature_vector_store() {
 
     let documents = DOCUMENTS.clone();
 
-    let (task,_status_code) = index.add_documents(json!(documents), None).await;
+    let (task, _status_code) = index.add_documents(json!(documents), None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = index
@@ -1369,7 +1373,7 @@ async fn camelcased_words() {
         { "id": 3, "title": "TestAb" },
         { "id": 4, "title": "testab" },
     ]);
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     index
@@ -1587,12 +1591,13 @@ async fn simple_search_with_strange_synonyms() {
     let server = Server::new().await;
     let index = server.index("test");
 
-    let (task,_status_code) = index.update_settings(json!({ "synonyms": {"&": ["to"], "to": ["&"]} })).await;
+    let (task, _status_code) =
+        index.update_settings(json!({ "synonyms": {"&": ["to"], "to": ["&"]} })).await;
     let r = index.wait_task(task.uid()).await;
     meili_snap::snapshot!(r["status"], @r###""succeeded""###);
 
     let documents = DOCUMENTS.clone();
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     index
@@ -1679,7 +1684,7 @@ async fn change_attributes_settings() {
     index.update_settings(json!({ "searchableAttributes": ["father", "mother"] })).await;
 
     let documents = NESTED_DOCUMENTS.clone();
-    let (task,_status_code) = index.add_documents(json!(documents), None).await;
+    let (task, _status_code) = index.add_documents(json!(documents), None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let (task,_status_code) =

--- a/crates/meilisearch/tests/search/mod.rs
+++ b/crates/meilisearch/tests/search/mod.rs
@@ -248,7 +248,7 @@ async fn test_kanji_language_detection() {
         { "id": 2, "title": "הַשּׁוּעָל הַמָּהִיר (״הַחוּם״) לֹא יָכוֹל לִקְפֹּץ 9.94 מֶטְרִים, נָכוֹן? ברר, 1.5°C- בַּחוּץ!" }
     ]);
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     index
         .search(json!({"q": "東京"}), |response, code| {
@@ -271,10 +271,10 @@ async fn test_thai_language() {
         { "id": 2, "title": "สบู่สมุนไพรฝางแดงผสมว่านหางจรเข้ 100 กรัม จำนวน 6 ก้อน" }
     ]);
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (task,_status_code) = index.update_settings(json!({"rankingRules": ["exactness"]})).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     index
         .search(json!({"q": "สบู"}), |response, code| {
@@ -608,7 +608,7 @@ async fn displayed_attributes() {
 
     let documents = DOCUMENTS.clone();
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) =
         index.search_post(json!({ "attributesToRetrieve": ["title", "id"] })).await;

--- a/crates/meilisearch/tests/search/mod.rs
+++ b/crates/meilisearch/tests/search/mod.rs
@@ -138,8 +138,8 @@ async fn phrase_search_with_stop_word() {
     meili_snap::snapshot!(code, @"202 Accepted");
 
     let documents = DOCUMENTS.clone();
-    index.add_documents(documents, None).await;
-    index.wait_task(1).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     index
         .search(json!({"q": "how \"to\" train \"the" }), |response, code| {
@@ -218,11 +218,11 @@ async fn negative_special_cases_search() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    index.add_documents(documents, None).await;
-    index.wait_task(0).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
-    index.update_settings(json!({"synonyms": { "escape": ["gläss"] }})).await;
-    index.wait_task(1).await;
+    let (task,_status_code) = index.update_settings(json!({"synonyms": { "escape": ["gläss"] }})).await;
+    index.wait_task(task.uid()).await;
 
     // There is a synonym for escape -> glass but we don't want "escape", only the derivates: glass
     index
@@ -247,8 +247,8 @@ async fn test_kanji_language_detection() {
         { "id": 1, "title": "東京のお寿司。" },
         { "id": 2, "title": "הַשּׁוּעָל הַמָּהִיר (״הַחוּם״) לֹא יָכוֹל לִקְפֹּץ 9.94 מֶטְרִים, נָכוֹן? ברר, 1.5°C- בַּחוּץ!" }
     ]);
-    index.add_documents(documents, None).await;
-    index.wait_task(0).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     index
         .search(json!({"q": "東京"}), |response, code| {
@@ -270,11 +270,11 @@ async fn test_thai_language() {
         { "id": 1, "title": "สบู่สมุนไพรชาเขียว 100 กรัม จำนวน 6 ก้อน" },
         { "id": 2, "title": "สบู่สมุนไพรฝางแดงผสมว่านหางจรเข้ 100 กรัม จำนวน 6 ก้อน" }
     ]);
-    index.add_documents(documents, None).await;
-    index.wait_task(0).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
-    index.update_settings(json!({"rankingRules": ["exactness"]})).await;
-    index.wait_task(1).await;
+    let (task,_status_code) = index.update_settings(json!({"rankingRules": ["exactness"]})).await;
+    index.wait_task(task.uid()).await;
 
     index
         .search(json!({"q": "สบู"}), |response, code| {
@@ -329,9 +329,9 @@ async fn search_with_filter_string_notation() {
     meili_snap::snapshot!(code, @"202 Accepted");
 
     let documents = DOCUMENTS.clone();
-    let (_, code) = index.add_documents(documents, None).await;
+    let (task, code) = index.add_documents(documents, None).await;
     meili_snap::snapshot!(code, @"202 Accepted");
-    let res = index.wait_task(1).await;
+    let res = index.wait_task(task.uid()).await;
     meili_snap::snapshot!(res["status"], @r###""succeeded""###);
 
     index
@@ -353,9 +353,9 @@ async fn search_with_filter_string_notation() {
     meili_snap::snapshot!(code, @"202 Accepted");
 
     let documents = NESTED_DOCUMENTS.clone();
-    let (_, code) = index.add_documents(documents, None).await;
+    let (task, code) = index.add_documents(documents, None).await;
     meili_snap::snapshot!(code, @"202 Accepted");
-    let res = index.wait_task(3).await;
+    let res = index.wait_task(task.uid()).await;
     meili_snap::snapshot!(res["status"], @r###""succeeded""###);
 
     index
@@ -607,8 +607,8 @@ async fn displayed_attributes() {
     index.update_settings(json!({ "displayedAttributes": ["title"] })).await;
 
     let documents = DOCUMENTS.clone();
-    index.add_documents(documents, None).await;
-    index.wait_task(1).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let (response, code) =
         index.search_post(json!({ "attributesToRetrieve": ["title", "id"] })).await;
@@ -622,8 +622,8 @@ async fn placeholder_search_is_hard_limited() {
     let index = server.index("test");
 
     let documents: Vec<_> = (0..1200).map(|i| json!({ "id": i, "text": "I am unique!" })).collect();
-    index.add_documents(documents.into(), None).await;
-    index.wait_task(0).await;
+    let (task,_status_code) = index.add_documents(documents.into(), None).await;
+    index.wait_task(task.uid()).await;
 
     index
         .search(
@@ -650,8 +650,8 @@ async fn placeholder_search_is_hard_limited() {
         )
         .await;
 
-    index.update_settings(json!({ "pagination": { "maxTotalHits": 10_000 } })).await;
-    index.wait_task(1).await;
+    let (task,_status_code) = index.update_settings(json!({ "pagination": { "maxTotalHits": 10_000 } })).await;
+    index.wait_task(task.uid()).await;
 
     index
         .search(
@@ -685,8 +685,8 @@ async fn search_is_hard_limited() {
     let index = server.index("test");
 
     let documents: Vec<_> = (0..1200).map(|i| json!({ "id": i, "text": "I am unique!" })).collect();
-    index.add_documents(documents.into(), None).await;
-    index.wait_task(0).await;
+    let (task,_status_code) = index.add_documents(documents.into(), None).await;
+    index.wait_task(task.uid()).await;
 
     index
         .search(
@@ -715,8 +715,8 @@ async fn search_is_hard_limited() {
         )
         .await;
 
-    index.update_settings(json!({ "pagination": { "maxTotalHits": 10_000 } })).await;
-    index.wait_task(1).await;
+    let (task,_status_code) = index.update_settings(json!({ "pagination": { "maxTotalHits": 10_000 } })).await;
+    index.wait_task(task.uid()).await;
 
     index
         .search(
@@ -754,8 +754,8 @@ async fn faceting_max_values_per_facet() {
     index.update_settings(json!({ "filterableAttributes": ["number"] })).await;
 
     let documents: Vec<_> = (0..10_000).map(|id| json!({ "id": id, "number": id * 10 })).collect();
-    index.add_documents(json!(documents), None).await;
-    index.wait_task(1).await;
+    let (task,_status_code) = index.add_documents(json!(documents), None).await;
+    index.wait_task(task.uid()).await;
 
     index
         .search(
@@ -770,8 +770,8 @@ async fn faceting_max_values_per_facet() {
         )
         .await;
 
-    index.update_settings(json!({ "faceting": { "maxValuesPerFacet": 10_000 } })).await;
-    index.wait_task(2).await;
+    let (task,_status_code) = index.update_settings(json!({ "faceting": { "maxValuesPerFacet": 10_000 } })).await;
+    index.wait_task(task.uid()).await;
 
     index
         .search(
@@ -1162,8 +1162,8 @@ async fn experimental_feature_vector_store() {
 
     let documents = DOCUMENTS.clone();
 
-    index.add_documents(json!(documents), None).await;
-    index.wait_task(0).await;
+    let (task,_status_code) = index.add_documents(json!(documents), None).await;
+    index.wait_task(task.uid()).await;
 
     let (response, code) = index
         .search_post(json!({
@@ -1369,8 +1369,8 @@ async fn camelcased_words() {
         { "id": 3, "title": "TestAb" },
         { "id": 4, "title": "testab" },
     ]);
-    index.add_documents(documents, None).await;
-    index.wait_task(0).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     index
         .search(json!({"q": "deLonghi"}), |response, code| {
@@ -1587,13 +1587,13 @@ async fn simple_search_with_strange_synonyms() {
     let server = Server::new().await;
     let index = server.index("test");
 
-    index.update_settings(json!({ "synonyms": {"&": ["to"], "to": ["&"]} })).await;
-    let r = index.wait_task(0).await;
+    let (task,_status_code) = index.update_settings(json!({ "synonyms": {"&": ["to"], "to": ["&"]} })).await;
+    let r = index.wait_task(task.uid()).await;
     meili_snap::snapshot!(r["status"], @r###""succeeded""###);
 
     let documents = DOCUMENTS.clone();
-    index.add_documents(documents, None).await;
-    index.wait_task(1).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     index
         .search(json!({"q": "How to train"}), |response, code| {
@@ -1679,11 +1679,12 @@ async fn change_attributes_settings() {
     index.update_settings(json!({ "searchableAttributes": ["father", "mother"] })).await;
 
     let documents = NESTED_DOCUMENTS.clone();
-    index.add_documents(json!(documents), None).await;
-    index.wait_task(1).await;
+    let (task,_status_code) = index.add_documents(json!(documents), None).await;
+    index.wait_task(task.uid()).await;
 
-    index.update_settings(json!({ "searchableAttributes": ["father", "mother", "doggos"], "filterableAttributes": ["doggos"] })).await;
-    index.wait_task(2).await;
+    let (task,_status_code) =
+        index.update_settings(json!({ "searchableAttributes": ["father", "mother", "doggos"], "filterableAttributes": ["doggos"] })).await;
+    index.wait_task(task.uid()).await;
 
     // search
     index

--- a/crates/meilisearch/tests/search/mod.rs
+++ b/crates/meilisearch/tests/search/mod.rs
@@ -623,7 +623,7 @@ async fn placeholder_search_is_hard_limited() {
 
     let documents: Vec<_> = (0..1200).map(|i| json!({ "id": i, "text": "I am unique!" })).collect();
     let (task,_status_code) = index.add_documents(documents.into(), None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     index
         .search(
@@ -651,7 +651,7 @@ async fn placeholder_search_is_hard_limited() {
         .await;
 
     let (task,_status_code) = index.update_settings(json!({ "pagination": { "maxTotalHits": 10_000 } })).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     index
         .search(
@@ -686,7 +686,7 @@ async fn search_is_hard_limited() {
 
     let documents: Vec<_> = (0..1200).map(|i| json!({ "id": i, "text": "I am unique!" })).collect();
     let (task,_status_code) = index.add_documents(documents.into(), None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     index
         .search(
@@ -716,7 +716,7 @@ async fn search_is_hard_limited() {
         .await;
 
     let (task,_status_code) = index.update_settings(json!({ "pagination": { "maxTotalHits": 10_000 } })).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     index
         .search(
@@ -755,7 +755,7 @@ async fn faceting_max_values_per_facet() {
 
     let documents: Vec<_> = (0..10_000).map(|id| json!({ "id": id, "number": id * 10 })).collect();
     let (task,_status_code) = index.add_documents(json!(documents), None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     index
         .search(
@@ -771,7 +771,7 @@ async fn faceting_max_values_per_facet() {
         .await;
 
     let (task,_status_code) = index.update_settings(json!({ "faceting": { "maxValuesPerFacet": 10_000 } })).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     index
         .search(
@@ -795,7 +795,7 @@ async fn test_score_details() {
     let documents = DOCUMENTS.clone();
 
     let res = index.add_documents(json!(documents), None).await;
-    index.wait_task(res.0.uid()).await;
+    index.wait_task(res.0.uid()).await.succeeded();
 
     index
         .search(
@@ -868,7 +868,7 @@ async fn test_score() {
     let documents = SCORE_DOCUMENTS.clone();
 
     let res = index.add_documents(json!(documents), None).await;
-    index.wait_task(res.0.uid()).await;
+    index.wait_task(res.0.uid()).await.succeeded();
 
     index
         .search(
@@ -921,7 +921,7 @@ async fn test_score_threshold() {
     let documents = SCORE_DOCUMENTS.clone();
 
     let res = index.add_documents(json!(documents), None).await;
-    index.wait_task(res.0.uid()).await;
+    index.wait_task(res.0.uid()).await.succeeded();
 
     index
         .search(
@@ -1077,7 +1077,7 @@ async fn test_degraded_score_details() {
     index.add_documents(json!(documents), None).await;
     // We can't really use anything else than 0ms here; otherwise, the test will get flaky.
     let (res, _code) = index.update_settings(json!({ "searchCutoffMs": 0 })).await;
-    index.wait_task(res.uid()).await;
+    index.wait_task(res.uid()).await.succeeded();
 
     index
         .search(
@@ -1163,7 +1163,7 @@ async fn experimental_feature_vector_store() {
     let documents = DOCUMENTS.clone();
 
     let (task,_status_code) = index.add_documents(json!(documents), None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = index
         .search_post(json!({
@@ -1370,7 +1370,7 @@ async fn camelcased_words() {
         { "id": 4, "title": "testab" },
     ]);
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     index
         .search(json!({"q": "deLonghi"}), |response, code| {
@@ -1593,7 +1593,7 @@ async fn simple_search_with_strange_synonyms() {
 
     let documents = DOCUMENTS.clone();
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     index
         .search(json!({"q": "How to train"}), |response, code| {
@@ -1680,11 +1680,11 @@ async fn change_attributes_settings() {
 
     let documents = NESTED_DOCUMENTS.clone();
     let (task,_status_code) = index.add_documents(json!(documents), None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (task,_status_code) =
         index.update_settings(json!({ "searchableAttributes": ["father", "mother", "doggos"], "filterableAttributes": ["doggos"] })).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     // search
     index

--- a/crates/meilisearch/tests/search/mod.rs
+++ b/crates/meilisearch/tests/search/mod.rs
@@ -139,7 +139,7 @@ async fn phrase_search_with_stop_word() {
 
     let documents = DOCUMENTS.clone();
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     index
         .search(json!({"q": "how \"to\" train \"the" }), |response, code| {
@@ -219,10 +219,10 @@ async fn negative_special_cases_search() {
 
     let documents = DOCUMENTS.clone();
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (task,_status_code) = index.update_settings(json!({"synonyms": { "escape": ["gläss"] }})).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     // There is a synonym for escape -> glass but we don't want "escape", only the derivates: glass
     index

--- a/crates/meilisearch/tests/search/multi.rs
+++ b/crates/meilisearch/tests/search/multi.rs
@@ -89,8 +89,8 @@ async fn simple_search_single_index() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    index.add_documents(documents, None).await;
-    index.wait_task(0).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let (response, code) = server
         .multi_search(json!({"queries": [
@@ -161,8 +161,8 @@ async fn federation_single_search_single_index() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    index.add_documents(documents, None).await;
-    index.wait_task(0).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let (response, code) = server
         .multi_search(json!({"federation": {}, "queries": [
@@ -208,8 +208,8 @@ async fn federation_multiple_search_single_index() {
     let index = server.index("test");
 
     let documents = SCORE_DOCUMENTS.clone();
-    index.add_documents(documents, None).await;
-    index.wait_task(0).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let (response, code) = server
         .multi_search(json!({"federation": {}, "queries": [
@@ -283,8 +283,8 @@ async fn federation_two_search_single_index() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    index.add_documents(documents, None).await;
-    index.wait_task(0).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let (response, code) = server
         .multi_search(json!({"federation": {}, "queries": [
@@ -351,8 +351,8 @@ async fn simple_search_missing_index_uid() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    index.add_documents(documents, None).await;
-    index.wait_task(0).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let (response, code) = server
         .multi_search(json!({"queries": [
@@ -376,8 +376,8 @@ async fn federation_simple_search_missing_index_uid() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    index.add_documents(documents, None).await;
-    index.wait_task(0).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let (response, code) = server
         .multi_search(json!({"federation": {}, "queries": [
@@ -401,8 +401,8 @@ async fn simple_search_illegal_index_uid() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    index.add_documents(documents, None).await;
-    index.wait_task(0).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let (response, code) = server
         .multi_search(json!({"queries": [
@@ -426,8 +426,8 @@ async fn federation_search_illegal_index_uid() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    index.add_documents(documents, None).await;
-    index.wait_task(0).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let (response, code) = server
         .multi_search(json!({"federation": {}, "queries": [
@@ -451,13 +451,13 @@ async fn simple_search_two_indexes() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    index.add_documents(documents, None).await;
-    index.wait_task(0).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let index = server.index("nested");
     let documents = NESTED_DOCUMENTS.clone();
-    index.add_documents(documents, None).await;
-    index.wait_task(1).await;
+    let (add_task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(add_task.uid()).await;
 
     let (response, code) = server
         .multi_search(json!({"queries": [
@@ -558,13 +558,13 @@ async fn federation_two_search_two_indexes() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    index.add_documents(documents, None).await;
-    index.wait_task(0).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let index = server.index("nested");
     let documents = NESTED_DOCUMENTS.clone();
-    index.add_documents(documents, None).await;
-    index.wait_task(1).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let (response, code) = server
         .multi_search(json!({"federation": {}, "queries": [
@@ -666,18 +666,18 @@ async fn federation_multiple_search_multiple_indexes() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    index.add_documents(documents, None).await;
-    index.wait_task(0).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let index = server.index("nested");
     let documents = NESTED_DOCUMENTS.clone();
-    index.add_documents(documents, None).await;
-    index.wait_task(1).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let index = server.index("score");
     let documents = SCORE_DOCUMENTS.clone();
-    index.add_documents(documents, None).await;
-    index.wait_task(2).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let (response, code) = server
         .multi_search(json!({"federation": {}, "queries": [
@@ -924,8 +924,8 @@ async fn search_one_index_doesnt_exist() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    index.add_documents(documents, None).await;
-    index.wait_task(0).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let (response, code) = server
         .multi_search(json!({"queries": [
@@ -950,8 +950,8 @@ async fn federation_one_index_doesnt_exist() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    index.add_documents(documents, None).await;
-    index.wait_task(0).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let (response, code) = server
         .multi_search(json!({"federation": {}, "queries": [
@@ -1021,13 +1021,13 @@ async fn search_one_query_error() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    index.add_documents(documents, None).await;
-    index.wait_task(0).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let index = server.index("nested");
     let documents = NESTED_DOCUMENTS.clone();
-    index.add_documents(documents, None).await;
-    index.wait_task(1).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let (response, code) = server
         .multi_search(json!({"queries": [
@@ -1053,13 +1053,13 @@ async fn federation_one_query_error() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    index.add_documents(documents, None).await;
-    index.wait_task(0).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let index = server.index("nested");
     let documents = NESTED_DOCUMENTS.clone();
-    index.add_documents(documents, None).await;
-    index.wait_task(1).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let (response, code) = server
         .multi_search(json!({"federation": {}, "queries": [
@@ -1085,13 +1085,13 @@ async fn federation_one_query_sort_error() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    index.add_documents(documents, None).await;
-    index.wait_task(0).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let index = server.index("nested");
     let documents = NESTED_DOCUMENTS.clone();
-    index.add_documents(documents, None).await;
-    index.wait_task(1).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let (response, code) = server
         .multi_search(json!({"federation": {}, "queries": [
@@ -1117,13 +1117,13 @@ async fn search_multiple_query_errors() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    index.add_documents(documents, None).await;
-    index.wait_task(0).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let index = server.index("nested");
     let documents = NESTED_DOCUMENTS.clone();
-    index.add_documents(documents, None).await;
-    index.wait_task(1).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let (response, code) = server
         .multi_search(json!({"queries": [
@@ -1149,13 +1149,13 @@ async fn federation_multiple_query_errors() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    index.add_documents(documents, None).await;
-    index.wait_task(0).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let index = server.index("nested");
     let documents = NESTED_DOCUMENTS.clone();
-    index.add_documents(documents, None).await;
-    index.wait_task(1).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let (response, code) = server
         .multi_search(json!({"queries": [
@@ -1181,13 +1181,13 @@ async fn federation_multiple_query_sort_errors() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    index.add_documents(documents, None).await;
-    index.wait_task(0).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let index = server.index("nested");
     let documents = NESTED_DOCUMENTS.clone();
-    index.add_documents(documents, None).await;
-    index.wait_task(1).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let (response, code) = server
         .multi_search(json!({"queries": [
@@ -1213,13 +1213,13 @@ async fn federation_multiple_query_errors_interleaved() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    index.add_documents(documents, None).await;
-    index.wait_task(0).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let index = server.index("nested");
     let documents = NESTED_DOCUMENTS.clone();
-    index.add_documents(documents, None).await;
-    index.wait_task(1).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let (response, code) = server
         .multi_search(json!({"queries": [
@@ -1246,13 +1246,13 @@ async fn federation_multiple_query_sort_errors_interleaved() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    index.add_documents(documents, None).await;
-    index.wait_task(0).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let index = server.index("nested");
     let documents = NESTED_DOCUMENTS.clone();
-    index.add_documents(documents, None).await;
-    index.wait_task(1).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let (response, code) = server
         .multi_search(json!({"queries": [
@@ -3020,18 +3020,18 @@ async fn federation_limit_offset() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    index.add_documents(documents, None).await;
-    index.wait_task(0).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let index = server.index("nested");
     let documents = NESTED_DOCUMENTS.clone();
-    index.add_documents(documents, None).await;
-    index.wait_task(1).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let index = server.index("score");
     let documents = SCORE_DOCUMENTS.clone();
-    index.add_documents(documents, None).await;
-    index.wait_task(2).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
     {
         let (response, code) = server
             .multi_search(json!({"federation": {}, "queries": [
@@ -3338,18 +3338,18 @@ async fn federation_formatting() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    index.add_documents(documents, None).await;
-    index.wait_task(0).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let index = server.index("nested");
     let documents = NESTED_DOCUMENTS.clone();
-    index.add_documents(documents, None).await;
-    index.wait_task(1).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
 
     let index = server.index("score");
     let documents = SCORE_DOCUMENTS.clone();
-    index.add_documents(documents, None).await;
-    index.wait_task(2).await;
+    let (task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(task.uid()).await;
     {
         let (response, code) = server
             .multi_search(json!({"federation": {}, "queries": [

--- a/crates/meilisearch/tests/search/multi.rs
+++ b/crates/meilisearch/tests/search/multi.rs
@@ -564,7 +564,7 @@ async fn federation_two_search_two_indexes() {
     let index = server.index("nested");
     let documents = NESTED_DOCUMENTS.clone();
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = server
         .multi_search(json!({"federation": {}, "queries": [
@@ -667,17 +667,17 @@ async fn federation_multiple_search_multiple_indexes() {
 
     let documents = DOCUMENTS.clone();
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let index = server.index("nested");
     let documents = NESTED_DOCUMENTS.clone();
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let index = server.index("score");
     let documents = SCORE_DOCUMENTS.clone();
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = server
         .multi_search(json!({"federation": {}, "queries": [
@@ -925,7 +925,7 @@ async fn search_one_index_doesnt_exist() {
 
     let documents = DOCUMENTS.clone();
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = server
         .multi_search(json!({"queries": [
@@ -951,7 +951,7 @@ async fn federation_one_index_doesnt_exist() {
 
     let documents = DOCUMENTS.clone();
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = server
         .multi_search(json!({"federation": {}, "queries": [
@@ -1022,12 +1022,12 @@ async fn search_one_query_error() {
 
     let documents = DOCUMENTS.clone();
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let index = server.index("nested");
     let documents = NESTED_DOCUMENTS.clone();
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = server
         .multi_search(json!({"queries": [
@@ -1054,12 +1054,12 @@ async fn federation_one_query_error() {
 
     let documents = DOCUMENTS.clone();
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let index = server.index("nested");
     let documents = NESTED_DOCUMENTS.clone();
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = server
         .multi_search(json!({"federation": {}, "queries": [
@@ -1086,12 +1086,12 @@ async fn federation_one_query_sort_error() {
 
     let documents = DOCUMENTS.clone();
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let index = server.index("nested");
     let documents = NESTED_DOCUMENTS.clone();
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = server
         .multi_search(json!({"federation": {}, "queries": [
@@ -1118,12 +1118,12 @@ async fn search_multiple_query_errors() {
 
     let documents = DOCUMENTS.clone();
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let index = server.index("nested");
     let documents = NESTED_DOCUMENTS.clone();
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = server
         .multi_search(json!({"queries": [
@@ -1150,12 +1150,12 @@ async fn federation_multiple_query_errors() {
 
     let documents = DOCUMENTS.clone();
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let index = server.index("nested");
     let documents = NESTED_DOCUMENTS.clone();
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = server
         .multi_search(json!({"queries": [

--- a/crates/meilisearch/tests/search/multi.rs
+++ b/crates/meilisearch/tests/search/multi.rs
@@ -89,7 +89,7 @@ async fn simple_search_single_index() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = server
@@ -161,7 +161,7 @@ async fn federation_single_search_single_index() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = server
@@ -208,7 +208,7 @@ async fn federation_multiple_search_single_index() {
     let index = server.index("test");
 
     let documents = SCORE_DOCUMENTS.clone();
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = server
@@ -283,7 +283,7 @@ async fn federation_two_search_single_index() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = server
@@ -351,7 +351,7 @@ async fn simple_search_missing_index_uid() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = server
@@ -376,7 +376,7 @@ async fn federation_simple_search_missing_index_uid() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = server
@@ -401,7 +401,7 @@ async fn simple_search_illegal_index_uid() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = server
@@ -426,7 +426,7 @@ async fn federation_search_illegal_index_uid() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = server
@@ -451,12 +451,12 @@ async fn simple_search_two_indexes() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let index = server.index("nested");
     let documents = NESTED_DOCUMENTS.clone();
-    let (add_task,_status_code) = index.add_documents(documents, None).await;
+    let (add_task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(add_task.uid()).await.succeeded();
 
     let (response, code) = server
@@ -558,12 +558,12 @@ async fn federation_two_search_two_indexes() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let index = server.index("nested");
     let documents = NESTED_DOCUMENTS.clone();
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = server
@@ -666,17 +666,17 @@ async fn federation_multiple_search_multiple_indexes() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let index = server.index("nested");
     let documents = NESTED_DOCUMENTS.clone();
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let index = server.index("score");
     let documents = SCORE_DOCUMENTS.clone();
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = server
@@ -924,7 +924,7 @@ async fn search_one_index_doesnt_exist() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = server
@@ -950,7 +950,7 @@ async fn federation_one_index_doesnt_exist() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = server
@@ -1021,12 +1021,12 @@ async fn search_one_query_error() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let index = server.index("nested");
     let documents = NESTED_DOCUMENTS.clone();
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = server
@@ -1053,12 +1053,12 @@ async fn federation_one_query_error() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let index = server.index("nested");
     let documents = NESTED_DOCUMENTS.clone();
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = server
@@ -1085,12 +1085,12 @@ async fn federation_one_query_sort_error() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let index = server.index("nested");
     let documents = NESTED_DOCUMENTS.clone();
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = server
@@ -1117,12 +1117,12 @@ async fn search_multiple_query_errors() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let index = server.index("nested");
     let documents = NESTED_DOCUMENTS.clone();
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = server
@@ -1149,12 +1149,12 @@ async fn federation_multiple_query_errors() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let index = server.index("nested");
     let documents = NESTED_DOCUMENTS.clone();
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = server
@@ -1181,12 +1181,12 @@ async fn federation_multiple_query_sort_errors() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let index = server.index("nested");
     let documents = NESTED_DOCUMENTS.clone();
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = server
@@ -1213,12 +1213,12 @@ async fn federation_multiple_query_errors_interleaved() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let index = server.index("nested");
     let documents = NESTED_DOCUMENTS.clone();
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = server
@@ -1246,12 +1246,12 @@ async fn federation_multiple_query_sort_errors_interleaved() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let index = server.index("nested");
     let documents = NESTED_DOCUMENTS.clone();
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = server
@@ -3020,17 +3020,17 @@ async fn federation_limit_offset() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let index = server.index("nested");
     let documents = NESTED_DOCUMENTS.clone();
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let index = server.index("score");
     let documents = SCORE_DOCUMENTS.clone();
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
     {
         let (response, code) = server
@@ -3338,17 +3338,17 @@ async fn federation_formatting() {
     let index = server.index("test");
 
     let documents = DOCUMENTS.clone();
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let index = server.index("nested");
     let documents = NESTED_DOCUMENTS.clone();
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let index = server.index("score");
     let documents = SCORE_DOCUMENTS.clone();
-    let (task,_status_code) = index.add_documents(documents, None).await;
+    let (task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(task.uid()).await.succeeded();
     {
         let (response, code) = server

--- a/crates/meilisearch/tests/search/multi.rs
+++ b/crates/meilisearch/tests/search/multi.rs
@@ -1182,12 +1182,12 @@ async fn federation_multiple_query_sort_errors() {
 
     let documents = DOCUMENTS.clone();
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let index = server.index("nested");
     let documents = NESTED_DOCUMENTS.clone();
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = server
         .multi_search(json!({"queries": [
@@ -1214,12 +1214,12 @@ async fn federation_multiple_query_errors_interleaved() {
 
     let documents = DOCUMENTS.clone();
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let index = server.index("nested");
     let documents = NESTED_DOCUMENTS.clone();
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = server
         .multi_search(json!({"queries": [
@@ -1247,12 +1247,12 @@ async fn federation_multiple_query_sort_errors_interleaved() {
 
     let documents = DOCUMENTS.clone();
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let index = server.index("nested");
     let documents = NESTED_DOCUMENTS.clone();
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = server
         .multi_search(json!({"queries": [
@@ -1280,14 +1280,14 @@ async fn federation_filter() {
 
     let documents = FRUITS_DOCUMENTS.clone();
     let (value, _) = index.add_documents(documents, None).await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let (value, _) = index
         .update_settings(
             json!({"searchableAttributes": ["name"], "filterableAttributes": ["BOOST"]}),
         )
         .await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let (response, code) = server
         .multi_search(json!({"federation": {}, "queries": [
@@ -1348,7 +1348,7 @@ async fn federation_sort_same_indexes_same_criterion_same_direction() {
 
     let documents = NESTED_DOCUMENTS.clone();
     let (value, _) = index.add_documents(documents, None).await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let (value, _) = index
         .update_settings(json!({
@@ -1363,7 +1363,7 @@ async fn federation_sort_same_indexes_same_criterion_same_direction() {
           ]
         }))
         .await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     // two identical placeholder search should have all results from first query
     let (response, code) = server
@@ -1611,7 +1611,7 @@ async fn federation_sort_same_indexes_same_criterion_opposite_direction() {
 
     let documents = NESTED_DOCUMENTS.clone();
     let (value, _) = index.add_documents(documents, None).await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let (value, _) = index
         .update_settings(json!({
@@ -1626,7 +1626,7 @@ async fn federation_sort_same_indexes_same_criterion_opposite_direction() {
           ]
         }))
         .await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     // two identical placeholder search should have all results from first query
     let (response, code) = server
@@ -1671,7 +1671,7 @@ async fn federation_sort_same_indexes_different_criterion_same_direction() {
 
     let documents = NESTED_DOCUMENTS.clone();
     let (value, _) = index.add_documents(documents, None).await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let (value, _) = index
         .update_settings(json!({
@@ -1686,7 +1686,7 @@ async fn federation_sort_same_indexes_different_criterion_same_direction() {
           ]
         }))
         .await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     // return mothers and fathers ordered accross fields.
     let (response, code) = server
@@ -1935,7 +1935,7 @@ async fn federation_sort_same_indexes_different_criterion_opposite_direction() {
 
     let documents = NESTED_DOCUMENTS.clone();
     let (value, _) = index.add_documents(documents, None).await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let (value, _) = index
         .update_settings(json!({
@@ -1950,7 +1950,7 @@ async fn federation_sort_same_indexes_different_criterion_opposite_direction() {
           ]
         }))
         .await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     // two identical placeholder search should have all results from first query
     let (response, code) = server
@@ -1995,7 +1995,7 @@ async fn federation_sort_different_indexes_same_criterion_same_direction() {
 
     let documents = DOCUMENTS.clone();
     let (value, _) = index.add_documents(documents, None).await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let (value, _) = index
         .update_settings(json!({
@@ -2010,13 +2010,13 @@ async fn federation_sort_different_indexes_same_criterion_same_direction() {
           ]
         }))
         .await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let index = server.index("batman");
 
     let documents = SCORE_DOCUMENTS.clone();
     let (value, _) = index.add_documents(documents, None).await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let (value, _) = index
         .update_settings(json!({
@@ -2031,7 +2031,7 @@ async fn federation_sort_different_indexes_same_criterion_same_direction() {
           ]
         }))
         .await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     // return titles ordered accross indexes
     let (response, code) = server
@@ -2307,7 +2307,7 @@ async fn federation_sort_different_ranking_rules() {
 
     let documents = DOCUMENTS.clone();
     let (value, _) = index.add_documents(documents, None).await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let (value, _) = index
         .update_settings(json!({
@@ -2322,13 +2322,13 @@ async fn federation_sort_different_ranking_rules() {
           ]
         }))
         .await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let index = server.index("batman");
 
     let documents = SCORE_DOCUMENTS.clone();
     let (value, _) = index.add_documents(documents, None).await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let (value, _) = index
         .update_settings(json!({
@@ -2343,7 +2343,7 @@ async fn federation_sort_different_ranking_rules() {
           ]
         }))
         .await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     // return titles ordered accross indexes
     let (response, code) = server
@@ -2546,7 +2546,7 @@ async fn federation_sort_different_indexes_same_criterion_opposite_direction() {
 
     let documents = DOCUMENTS.clone();
     let (value, _) = index.add_documents(documents, None).await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let (value, _) = index
         .update_settings(json!({
@@ -2561,13 +2561,13 @@ async fn federation_sort_different_indexes_same_criterion_opposite_direction() {
           ]
         }))
         .await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let index = server.index("batman");
 
     let documents = SCORE_DOCUMENTS.clone();
     let (value, _) = index.add_documents(documents, None).await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let (value, _) = index
         .update_settings(json!({
@@ -2582,7 +2582,7 @@ async fn federation_sort_different_indexes_same_criterion_opposite_direction() {
           ]
         }))
         .await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     // all results from query 0
     let (response, code) = server
@@ -2628,7 +2628,7 @@ async fn federation_sort_different_indexes_different_criterion_same_direction() 
 
     let documents = DOCUMENTS.clone();
     let (value, _) = index.add_documents(documents, None).await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let (value, _) = index
         .update_settings(json!({
@@ -2643,13 +2643,13 @@ async fn federation_sort_different_indexes_different_criterion_same_direction() 
           ]
         }))
         .await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let index = server.index("batman");
 
     let documents = SCORE_DOCUMENTS.clone();
     let (value, _) = index.add_documents(documents, None).await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let (value, _) = index
         .update_settings(json!({
@@ -2664,7 +2664,7 @@ async fn federation_sort_different_indexes_different_criterion_same_direction() 
           ]
         }))
         .await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     // return titles ordered accross indexes
     let (response, code) = server
@@ -2940,7 +2940,7 @@ async fn federation_sort_different_indexes_different_criterion_opposite_directio
 
     let documents = DOCUMENTS.clone();
     let (value, _) = index.add_documents(documents, None).await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let (value, _) = index
         .update_settings(json!({
@@ -2955,13 +2955,13 @@ async fn federation_sort_different_indexes_different_criterion_opposite_directio
           ]
         }))
         .await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let index = server.index("batman");
 
     let documents = SCORE_DOCUMENTS.clone();
     let (value, _) = index.add_documents(documents, None).await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let (value, _) = index
         .update_settings(json!({
@@ -2976,7 +2976,7 @@ async fn federation_sort_different_indexes_different_criterion_opposite_directio
           ]
         }))
         .await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     // all results from query 0 first
     let (response, code) = server
@@ -3021,17 +3021,17 @@ async fn federation_limit_offset() {
 
     let documents = DOCUMENTS.clone();
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let index = server.index("nested");
     let documents = NESTED_DOCUMENTS.clone();
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let index = server.index("score");
     let documents = SCORE_DOCUMENTS.clone();
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     {
         let (response, code) = server
             .multi_search(json!({"federation": {}, "queries": [
@@ -3339,17 +3339,17 @@ async fn federation_formatting() {
 
     let documents = DOCUMENTS.clone();
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let index = server.index("nested");
     let documents = NESTED_DOCUMENTS.clone();
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let index = server.index("score");
     let documents = SCORE_DOCUMENTS.clone();
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     {
         let (response, code) = server
             .multi_search(json!({"federation": {}, "queries": [
@@ -3685,14 +3685,14 @@ async fn federation_invalid_weight() {
 
     let documents = FRUITS_DOCUMENTS.clone();
     let (value, _) = index.add_documents(documents, None).await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let (value, _) = index
         .update_settings(
             json!({"searchableAttributes": ["name"], "filterableAttributes": ["BOOST"]}),
         )
         .await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let (response, code) = server
         .multi_search(json!({"federation": {}, "queries": [
@@ -3719,14 +3719,14 @@ async fn federation_null_weight() {
 
     let documents = FRUITS_DOCUMENTS.clone();
     let (value, _) = index.add_documents(documents, None).await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let (value, _) = index
         .update_settings(
             json!({"searchableAttributes": ["name"], "filterableAttributes": ["BOOST"]}),
         )
         .await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let (response, code) = server
         .multi_search(json!({"federation": {}, "queries": [
@@ -3787,7 +3787,7 @@ async fn federation_federated_contains_pagination() {
 
     let documents = FRUITS_DOCUMENTS.clone();
     let (value, _) = index.add_documents(documents, None).await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     // fail when a federated query contains "limit"
     let (response, code) = server
@@ -3867,11 +3867,11 @@ async fn federation_federated_contains_facets() {
         )
         .await;
 
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let documents = FRUITS_DOCUMENTS.clone();
     let (value, _) = index.add_documents(documents, None).await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     // empty facets are actually OK
     let (response, code) = server
@@ -3951,7 +3951,7 @@ async fn federation_non_faceted_for_an_index() {
         )
         .await;
 
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let index = server.index("fruits-no-name");
 
@@ -3961,17 +3961,17 @@ async fn federation_non_faceted_for_an_index() {
         )
         .await;
 
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let index = server.index("fruits-no-facets");
 
     let (value, _) = index.update_settings(json!({"searchableAttributes": ["name"]})).await;
 
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let documents = FRUITS_DOCUMENTS.clone();
     let (value, _) = index.add_documents(documents, None).await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     // fails
     let (response, code) = server
@@ -4071,7 +4071,7 @@ async fn federation_non_federated_contains_federation_option() {
 
     let documents = FRUITS_DOCUMENTS.clone();
     let (value, _) = index.add_documents(documents, None).await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     // fail when a non-federated query contains "federationOptions"
     let (response, code) = server
@@ -4116,12 +4116,12 @@ async fn federation_vector_single_index() {
           }
         }}))
         .await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let documents = VECTOR_DOCUMENTS.clone();
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     // same embedder
     let (response, code) = server
@@ -4320,12 +4320,12 @@ async fn federation_vector_two_indexes() {
           },
         }}))
         .await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let documents = VECTOR_DOCUMENTS.clone();
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let index = server.index("vectors-sentiment");
 
@@ -4337,12 +4337,12 @@ async fn federation_vector_two_indexes() {
           }
         }}))
         .await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let documents = VECTOR_DOCUMENTS.clone();
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let (response, code) = server
         .multi_search(json!({"federation": {}, "queries": [
@@ -4802,7 +4802,7 @@ async fn federation_facets_different_indexes_same_facet() {
 
     let documents = DOCUMENTS.clone();
     let (value, _) = index.add_documents(documents, None).await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let (value, _) = index
         .update_settings(json!({
@@ -4818,13 +4818,13 @@ async fn federation_facets_different_indexes_same_facet() {
           ]
         }))
         .await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let index = server.index("batman");
 
     let documents = SCORE_DOCUMENTS.clone();
     let (value, _) = index.add_documents(documents, None).await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let (value, _) = index
         .update_settings(json!({
@@ -4840,13 +4840,13 @@ async fn federation_facets_different_indexes_same_facet() {
           ]
         }))
         .await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let index = server.index("batman-2");
 
     let documents = SCORE_DOCUMENTS.clone();
     let (value, _) = index.add_documents(documents, None).await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let (value, _) = index
         .update_settings(json!({
@@ -4862,7 +4862,7 @@ async fn federation_facets_different_indexes_same_facet() {
           ]
         }))
         .await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     // return titles ordered accross indexes
     let (response, code) = server
@@ -5369,7 +5369,7 @@ async fn federation_facets_same_indexes() {
 
     let documents = NESTED_DOCUMENTS.clone();
     let (value, _) = index.add_documents(documents, None).await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let (value, _) = index
         .update_settings(json!({
@@ -5384,13 +5384,13 @@ async fn federation_facets_same_indexes() {
           ]
         }))
         .await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let index = server.index("doggos-2");
 
     let documents = NESTED_DOCUMENTS.clone();
     let (value, _) = index.add_documents(documents, None).await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let (value, _) = index
         .update_settings(json!({
@@ -5405,7 +5405,7 @@ async fn federation_facets_same_indexes() {
           ]
         }))
         .await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let (response, code) = server
         .multi_search(json!({"federation": {
@@ -5670,7 +5670,7 @@ async fn federation_inconsistent_merge_order() {
 
     let documents = DOCUMENTS.clone();
     let (value, _) = index.add_documents(documents, None).await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let (value, _) = index
         .update_settings(json!({
@@ -5686,13 +5686,13 @@ async fn federation_inconsistent_merge_order() {
           ]
         }))
         .await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let index = server.index("movies-2");
 
     let documents = DOCUMENTS.clone();
     let (value, _) = index.add_documents(documents, None).await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let (value, _) = index
         .update_settings(json!({
@@ -5711,13 +5711,13 @@ async fn federation_inconsistent_merge_order() {
           }
         }))
         .await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let index = server.index("batman");
 
     let documents = SCORE_DOCUMENTS.clone();
     let (value, _) = index.add_documents(documents, None).await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let (value, _) = index
         .update_settings(json!({
@@ -5733,7 +5733,7 @@ async fn federation_inconsistent_merge_order() {
           ]
         }))
         .await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     // without merging, it works
     let (response, code) = server

--- a/crates/meilisearch/tests/search/multi.rs
+++ b/crates/meilisearch/tests/search/multi.rs
@@ -90,7 +90,7 @@ async fn simple_search_single_index() {
 
     let documents = DOCUMENTS.clone();
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = server
         .multi_search(json!({"queries": [
@@ -162,7 +162,7 @@ async fn federation_single_search_single_index() {
 
     let documents = DOCUMENTS.clone();
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = server
         .multi_search(json!({"federation": {}, "queries": [
@@ -209,7 +209,7 @@ async fn federation_multiple_search_single_index() {
 
     let documents = SCORE_DOCUMENTS.clone();
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = server
         .multi_search(json!({"federation": {}, "queries": [
@@ -284,7 +284,7 @@ async fn federation_two_search_single_index() {
 
     let documents = DOCUMENTS.clone();
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = server
         .multi_search(json!({"federation": {}, "queries": [
@@ -352,7 +352,7 @@ async fn simple_search_missing_index_uid() {
 
     let documents = DOCUMENTS.clone();
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = server
         .multi_search(json!({"queries": [
@@ -377,7 +377,7 @@ async fn federation_simple_search_missing_index_uid() {
 
     let documents = DOCUMENTS.clone();
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = server
         .multi_search(json!({"federation": {}, "queries": [
@@ -402,7 +402,7 @@ async fn simple_search_illegal_index_uid() {
 
     let documents = DOCUMENTS.clone();
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = server
         .multi_search(json!({"queries": [
@@ -427,7 +427,7 @@ async fn federation_search_illegal_index_uid() {
 
     let documents = DOCUMENTS.clone();
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = server
         .multi_search(json!({"federation": {}, "queries": [
@@ -452,12 +452,12 @@ async fn simple_search_two_indexes() {
 
     let documents = DOCUMENTS.clone();
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let index = server.index("nested");
     let documents = NESTED_DOCUMENTS.clone();
     let (add_task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(add_task.uid()).await;
+    index.wait_task(add_task.uid()).await.succeeded();
 
     let (response, code) = server
         .multi_search(json!({"queries": [
@@ -559,7 +559,7 @@ async fn federation_two_search_two_indexes() {
 
     let documents = DOCUMENTS.clone();
     let (task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let index = server.index("nested");
     let documents = NESTED_DOCUMENTS.clone();

--- a/crates/meilisearch/tests/search/restrict_searchable.rs
+++ b/crates/meilisearch/tests/search/restrict_searchable.rs
@@ -1,3 +1,4 @@
+use actix_web::web::resource;
 use meili_snap::{json_string, snapshot};
 use once_cell::sync::Lazy;
 
@@ -64,8 +65,8 @@ async fn search_no_searchable_attribute_set() {
         )
         .await;
 
-    index.update_settings_searchable_attributes(json!(["*"])).await;
-    index.wait_task(1).await;
+    let (task,_status_code) = index.update_settings_searchable_attributes(json!(["*"])).await;
+    index.wait_task(task.uid()).await;
 
     index
         .search(
@@ -77,8 +78,8 @@ async fn search_no_searchable_attribute_set() {
         )
         .await;
 
-    index.update_settings_searchable_attributes(json!(["*"])).await;
-    index.wait_task(2).await;
+    let (task,_status_code) = index.update_settings_searchable_attributes(json!(["*"])).await;
+    index.wait_task(task.uid()).await;
 
     index
         .search(
@@ -108,8 +109,8 @@ async fn search_on_all_attributes() {
 async fn search_on_all_attributes_restricted_set() {
     let server = Server::new().await;
     let index = index_with_documents(&server, &SIMPLE_SEARCH_DOCUMENTS).await;
-    index.update_settings_searchable_attributes(json!(["title"])).await;
-    index.wait_task(1).await;
+    let (task,_status_code) = index.update_settings_searchable_attributes(json!(["title"])).await;
+    index.wait_task(task.uid()).await;
 
     index
         .search(json!({"q": "Captain Marvel", "attributesToSearchOn": ["*"]}), |response, code| {
@@ -191,8 +192,8 @@ async fn word_ranking_rule_order() {
 async fn word_ranking_rule_order_exact_words() {
     let server = Server::new().await;
     let index = index_with_documents(&server, &SIMPLE_SEARCH_DOCUMENTS).await;
-    index.update_settings_typo_tolerance(json!({"disableOnWords": ["Captain", "Marvel"]})).await;
-    index.wait_task(1).await;
+    let (task,_status_code) = index.update_settings_typo_tolerance(json!({"disableOnWords": ["Captain", "Marvel"]})).await;
+    index.wait_task(task.uid()).await;
 
     // simple search should return 2 documents (ids: 2 and 3).
     index
@@ -358,7 +359,7 @@ async fn search_on_exact_field() {
     let (response, code) =
         index.update_settings_typo_tolerance(json!({ "disableOnAttributes": ["exact"] })).await;
     assert_eq!(202, code, "{:?}", response);
-    index.wait_task(1).await;
+    index.wait_task(response.uid()).await;
     // Searching on an exact attribute should only return the document matching without typo.
     index
         .search(json!({"q": "Marvel", "attributesToSearchOn": ["exact"]}), |response, code| {

--- a/crates/meilisearch/tests/search/restrict_searchable.rs
+++ b/crates/meilisearch/tests/search/restrict_searchable.rs
@@ -1,4 +1,3 @@
-use actix_web::web::resource;
 use meili_snap::{json_string, snapshot};
 use once_cell::sync::Lazy;
 

--- a/crates/meilisearch/tests/search/restrict_searchable.rs
+++ b/crates/meilisearch/tests/search/restrict_searchable.rs
@@ -66,7 +66,7 @@ async fn search_no_searchable_attribute_set() {
         .await;
 
     let (task,_status_code) = index.update_settings_searchable_attributes(json!(["*"])).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     index
         .search(
@@ -79,7 +79,7 @@ async fn search_no_searchable_attribute_set() {
         .await;
 
     let (task,_status_code) = index.update_settings_searchable_attributes(json!(["*"])).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     index
         .search(
@@ -110,7 +110,7 @@ async fn search_on_all_attributes_restricted_set() {
     let server = Server::new().await;
     let index = index_with_documents(&server, &SIMPLE_SEARCH_DOCUMENTS).await;
     let (task,_status_code) = index.update_settings_searchable_attributes(json!(["title"])).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     index
         .search(json!({"q": "Captain Marvel", "attributesToSearchOn": ["*"]}), |response, code| {
@@ -193,7 +193,7 @@ async fn word_ranking_rule_order_exact_words() {
     let server = Server::new().await;
     let index = index_with_documents(&server, &SIMPLE_SEARCH_DOCUMENTS).await;
     let (task,_status_code) = index.update_settings_typo_tolerance(json!({"disableOnWords": ["Captain", "Marvel"]})).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     // simple search should return 2 documents (ids: 2 and 3).
     index
@@ -359,7 +359,7 @@ async fn search_on_exact_field() {
     let (response, code) =
         index.update_settings_typo_tolerance(json!({ "disableOnAttributes": ["exact"] })).await;
     assert_eq!(202, code, "{:?}", response);
-    index.wait_task(response.uid()).await;
+    index.wait_task(response.uid()).await.succeeded();
     // Searching on an exact attribute should only return the document matching without typo.
     index
         .search(json!({"q": "Marvel", "attributesToSearchOn": ["exact"]}), |response, code| {

--- a/crates/meilisearch/tests/search/restrict_searchable.rs
+++ b/crates/meilisearch/tests/search/restrict_searchable.rs
@@ -65,7 +65,7 @@ async fn search_no_searchable_attribute_set() {
         )
         .await;
 
-    let (task,_status_code) = index.update_settings_searchable_attributes(json!(["*"])).await;
+    let (task, _status_code) = index.update_settings_searchable_attributes(json!(["*"])).await;
     index.wait_task(task.uid()).await.succeeded();
 
     index
@@ -78,7 +78,7 @@ async fn search_no_searchable_attribute_set() {
         )
         .await;
 
-    let (task,_status_code) = index.update_settings_searchable_attributes(json!(["*"])).await;
+    let (task, _status_code) = index.update_settings_searchable_attributes(json!(["*"])).await;
     index.wait_task(task.uid()).await.succeeded();
 
     index
@@ -109,7 +109,7 @@ async fn search_on_all_attributes() {
 async fn search_on_all_attributes_restricted_set() {
     let server = Server::new().await;
     let index = index_with_documents(&server, &SIMPLE_SEARCH_DOCUMENTS).await;
-    let (task,_status_code) = index.update_settings_searchable_attributes(json!(["title"])).await;
+    let (task, _status_code) = index.update_settings_searchable_attributes(json!(["title"])).await;
     index.wait_task(task.uid()).await.succeeded();
 
     index
@@ -192,7 +192,9 @@ async fn word_ranking_rule_order() {
 async fn word_ranking_rule_order_exact_words() {
     let server = Server::new().await;
     let index = index_with_documents(&server, &SIMPLE_SEARCH_DOCUMENTS).await;
-    let (task,_status_code) = index.update_settings_typo_tolerance(json!({"disableOnWords": ["Captain", "Marvel"]})).await;
+    let (task, _status_code) = index
+        .update_settings_typo_tolerance(json!({"disableOnWords": ["Captain", "Marvel"]}))
+        .await;
     index.wait_task(task.uid()).await.succeeded();
 
     // simple search should return 2 documents (ids: 2 and 3).

--- a/crates/meilisearch/tests/settings/distinct.rs
+++ b/crates/meilisearch/tests/settings/distinct.rs
@@ -13,7 +13,7 @@ async fn set_and_reset_distinct_attribute() {
 
     assert_eq!(response["distinctAttribute"], "test");
 
-    let (task2,_status_code) = index.update_settings(json!({ "distinctAttribute": null })).await;
+    let (task2, _status_code) = index.update_settings(json!({ "distinctAttribute": null })).await;
 
     index.wait_task(task2.uid()).await.succeeded();
 
@@ -34,7 +34,7 @@ async fn set_and_reset_distinct_attribute_with_dedicated_route() {
 
     assert_eq!(response, "test");
 
-    let (update_task2,_status_code) = index.update_distinct_attribute(json!(null)).await;
+    let (update_task2, _status_code) = index.update_distinct_attribute(json!(null)).await;
 
     index.wait_task(update_task2.uid()).await.succeeded();
 

--- a/crates/meilisearch/tests/settings/distinct.rs
+++ b/crates/meilisearch/tests/settings/distinct.rs
@@ -6,16 +6,16 @@ async fn set_and_reset_distinct_attribute() {
     let server = Server::new().await;
     let index = server.index("test");
 
-    let (_response, _code) = index.update_settings(json!({ "distinctAttribute": "test"})).await;
-    index.wait_task(0).await;
+    let (task1, _code) = index.update_settings(json!({ "distinctAttribute": "test"})).await;
+    index.wait_task(task1.uid()).await;
 
     let (response, _) = index.settings().await;
 
     assert_eq!(response["distinctAttribute"], "test");
 
-    index.update_settings(json!({ "distinctAttribute": null })).await;
+    let (task2,_status_code) = index.update_settings(json!({ "distinctAttribute": null })).await;
 
-    index.wait_task(1).await;
+    index.wait_task(task2.uid()).await;
 
     let (response, _) = index.settings().await;
 
@@ -27,16 +27,16 @@ async fn set_and_reset_distinct_attribute_with_dedicated_route() {
     let server = Server::new().await;
     let index = server.index("test");
 
-    let (_response, _code) = index.update_distinct_attribute(json!("test")).await;
-    index.wait_task(0).await;
+    let (update_task1, _code) = index.update_distinct_attribute(json!("test")).await;
+    index.wait_task(update_task1.uid()).await;
 
     let (response, _) = index.get_distinct_attribute().await;
 
     assert_eq!(response, "test");
 
-    index.update_distinct_attribute(json!(null)).await;
+    let (update_task2,_status_code) = index.update_distinct_attribute(json!(null)).await;
 
-    index.wait_task(1).await;
+    index.wait_task(update_task2.uid()).await;
 
     let (response, _) = index.get_distinct_attribute().await;
 

--- a/crates/meilisearch/tests/settings/distinct.rs
+++ b/crates/meilisearch/tests/settings/distinct.rs
@@ -7,7 +7,7 @@ async fn set_and_reset_distinct_attribute() {
     let index = server.index("test");
 
     let (task1, _code) = index.update_settings(json!({ "distinctAttribute": "test"})).await;
-    index.wait_task(task1.uid()).await;
+    index.wait_task(task1.uid()).await.succeeded();
 
     let (response, _) = index.settings().await;
 
@@ -15,7 +15,7 @@ async fn set_and_reset_distinct_attribute() {
 
     let (task2,_status_code) = index.update_settings(json!({ "distinctAttribute": null })).await;
 
-    index.wait_task(task2.uid()).await;
+    index.wait_task(task2.uid()).await.succeeded();
 
     let (response, _) = index.settings().await;
 
@@ -28,7 +28,7 @@ async fn set_and_reset_distinct_attribute_with_dedicated_route() {
     let index = server.index("test");
 
     let (update_task1, _code) = index.update_distinct_attribute(json!("test")).await;
-    index.wait_task(update_task1.uid()).await;
+    index.wait_task(update_task1.uid()).await.succeeded();
 
     let (response, _) = index.get_distinct_attribute().await;
 
@@ -36,7 +36,7 @@ async fn set_and_reset_distinct_attribute_with_dedicated_route() {
 
     let (update_task2,_status_code) = index.update_distinct_attribute(json!(null)).await;
 
-    index.wait_task(update_task2.uid()).await;
+    index.wait_task(update_task2.uid()).await.succeeded();
 
     let (response, _) = index.get_distinct_attribute().await;
 

--- a/crates/meilisearch/tests/settings/get_settings.rs
+++ b/crates/meilisearch/tests/settings/get_settings.rs
@@ -250,7 +250,7 @@ async fn secrets_are_hidden_in_settings() {
 
     let index = server.index("test");
     let (response, _code) = index.create(None).await;
-    index.wait_task(response.uid()).await;
+    index.wait_task(response.uid()).await.succeeded();
 
     let (response, code) = index
         .update_settings(json!({
@@ -379,14 +379,14 @@ async fn test_partial_update() {
     let server = Server::new().await;
     let index = server.index("test");
     let (task, _code) = index.update_settings(json!({"displayedAttributes": ["foo"]})).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (response, code) = index.settings().await;
     assert_eq!(code, 200);
     assert_eq!(response["displayedAttributes"], json!(["foo"]));
     assert_eq!(response["searchableAttributes"], json!(["*"]));
 
     let (task, _) = index.update_settings(json!({"searchableAttributes": ["bar"]})).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = index.settings().await;
     assert_eq!(code, 200);
@@ -422,12 +422,12 @@ async fn reset_all_settings() {
     let (response, code) = index.add_documents(documents, None).await;
     assert_eq!(code, 202);
     assert_eq!(response["taskUid"], 0);
-    index.wait_task(response.uid()).await;
+    index.wait_task(response.uid()).await.succeeded();
 
     let (update_task,_status_code) = index
         .update_settings(json!({"displayedAttributes": ["name", "age"], "searchableAttributes": ["name"], "stopWords": ["the"], "filterableAttributes": ["age"], "synonyms": {"puppy": ["dog", "doggo", "potat"] }}))
         .await;
-    index.wait_task(update_task.uid()).await;
+    index.wait_task(update_task.uid()).await.succeeded();
     let (response, code) = index.settings().await;
     assert_eq!(code, 200);
     assert_eq!(response["displayedAttributes"], json!(["name", "age"]));
@@ -437,7 +437,7 @@ async fn reset_all_settings() {
     assert_eq!(response["filterableAttributes"], json!(["age"]));
 
     let (delete_task,_status_code) = index.delete_settings().await;
-    index.wait_task(delete_task.uid()).await;
+    index.wait_task(delete_task.uid()).await.succeeded();
 
     let (response, code) = index.settings().await;
     assert_eq!(code, 200);
@@ -507,7 +507,7 @@ async fn set_and_reset_distinct_attribute_with_dedicated_route() {
     let index = server.index("test");
 
     let (task, _code) = index.update_distinct_attribute(json!("test")).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (response, _) = index.get_distinct_attribute().await;
 
@@ -515,7 +515,7 @@ async fn set_and_reset_distinct_attribute_with_dedicated_route() {
 
     let (task,_status_code) = index.update_distinct_attribute(json!(null)).await;
 
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (response, _) = index.get_distinct_attribute().await;
 

--- a/crates/meilisearch/tests/settings/get_settings.rs
+++ b/crates/meilisearch/tests/settings/get_settings.rs
@@ -436,7 +436,7 @@ async fn reset_all_settings() {
     assert_eq!(response["synonyms"], json!({"puppy": ["dog", "doggo", "potat"] }));
     assert_eq!(response["filterableAttributes"], json!(["age"]));
 
-    let (delete_task,_status_code) = index.delete_settings().await;
+    let (delete_task, _status_code) = index.delete_settings().await;
     index.wait_task(delete_task.uid()).await.succeeded();
 
     let (response, code) = index.settings().await;
@@ -462,7 +462,7 @@ async fn update_setting_unexisting_index() {
     assert_eq!(response["status"], "succeeded");
     let (_response, code) = index.get().await;
     assert_eq!(code, 200);
-    let (task,_status_code) = index.delete_settings().await;
+    let (task, _status_code) = index.delete_settings().await;
     let response = index.wait_task(task.uid()).await;
     assert_eq!(response["status"], "succeeded");
 }
@@ -513,7 +513,7 @@ async fn set_and_reset_distinct_attribute_with_dedicated_route() {
 
     assert_eq!(response, "test");
 
-    let (task,_status_code) = index.update_distinct_attribute(json!(null)).await;
+    let (task, _status_code) = index.update_distinct_attribute(json!(null)).await;
 
     index.wait_task(task.uid()).await.succeeded();
 

--- a/crates/meilisearch/tests/settings/get_settings.rs
+++ b/crates/meilisearch/tests/settings/get_settings.rs
@@ -193,7 +193,7 @@ async fn get_settings() {
     let server = Server::new().await;
     let index = server.index("test");
     let (response, _code) = index.create(None).await;
-    index.wait_task(response.uid()).await;
+    index.wait_task(response.uid()).await.succeeded();
     let (response, code) = index.settings().await;
     assert_eq!(code, 200);
     let settings = response.as_object().unwrap();

--- a/crates/meilisearch/tests/settings/get_settings.rs
+++ b/crates/meilisearch/tests/settings/get_settings.rs
@@ -378,15 +378,15 @@ async fn error_update_settings_unknown_field() {
 async fn test_partial_update() {
     let server = Server::new().await;
     let index = server.index("test");
-    let (_response, _code) = index.update_settings(json!({"displayedAttributes": ["foo"]})).await;
-    index.wait_task(0).await;
+    let (task, _code) = index.update_settings(json!({"displayedAttributes": ["foo"]})).await;
+    index.wait_task(task.uid()).await;
     let (response, code) = index.settings().await;
     assert_eq!(code, 200);
     assert_eq!(response["displayedAttributes"], json!(["foo"]));
     assert_eq!(response["searchableAttributes"], json!(["*"]));
 
-    let (_response, _) = index.update_settings(json!({"searchableAttributes": ["bar"]})).await;
-    index.wait_task(1).await;
+    let (task, _) = index.update_settings(json!({"searchableAttributes": ["bar"]})).await;
+    index.wait_task(task.uid()).await;
 
     let (response, code) = index.settings().await;
     assert_eq!(code, 200);
@@ -398,10 +398,10 @@ async fn test_partial_update() {
 async fn error_delete_settings_unexisting_index() {
     let server = Server::new().await;
     let index = server.index("test");
-    let (_response, code) = index.delete_settings().await;
+    let (task, code) = index.delete_settings().await;
     assert_eq!(code, 202);
 
-    let response = index.wait_task(0).await;
+    let response = index.wait_task(task.uid()).await;
 
     assert_eq!(response["status"], "failed");
 }
@@ -422,12 +422,12 @@ async fn reset_all_settings() {
     let (response, code) = index.add_documents(documents, None).await;
     assert_eq!(code, 202);
     assert_eq!(response["taskUid"], 0);
-    index.wait_task(0).await;
+    index.wait_task(response.uid()).await;
 
-    index
+    let (update_task,_status_code) = index
         .update_settings(json!({"displayedAttributes": ["name", "age"], "searchableAttributes": ["name"], "stopWords": ["the"], "filterableAttributes": ["age"], "synonyms": {"puppy": ["dog", "doggo", "potat"] }}))
         .await;
-    index.wait_task(1).await;
+    index.wait_task(update_task.uid()).await;
     let (response, code) = index.settings().await;
     assert_eq!(code, 200);
     assert_eq!(response["displayedAttributes"], json!(["name", "age"]));
@@ -436,8 +436,8 @@ async fn reset_all_settings() {
     assert_eq!(response["synonyms"], json!({"puppy": ["dog", "doggo", "potat"] }));
     assert_eq!(response["filterableAttributes"], json!(["age"]));
 
-    index.delete_settings().await;
-    index.wait_task(2).await;
+    let (delete_task,_status_code) = index.delete_settings().await;
+    index.wait_task(delete_task.uid()).await;
 
     let (response, code) = index.settings().await;
     assert_eq!(code, 200);
@@ -456,14 +456,14 @@ async fn reset_all_settings() {
 async fn update_setting_unexisting_index() {
     let server = Server::new().await;
     let index = server.index("test");
-    let (_response, code) = index.update_settings(json!({})).await;
+    let (task, code) = index.update_settings(json!({})).await;
     assert_eq!(code, 202);
-    let response = index.wait_task(0).await;
+    let response = index.wait_task(task.uid()).await;
     assert_eq!(response["status"], "succeeded");
     let (_response, code) = index.get().await;
     assert_eq!(code, 200);
-    index.delete_settings().await;
-    let response = index.wait_task(1).await;
+    let (task,_status_code) = index.delete_settings().await;
+    let response = index.wait_task(task.uid()).await;
     assert_eq!(response["status"], "succeeded");
 }
 
@@ -506,16 +506,16 @@ async fn set_and_reset_distinct_attribute_with_dedicated_route() {
     let server = Server::new().await;
     let index = server.index("test");
 
-    let (_response, _code) = index.update_distinct_attribute(json!("test")).await;
-    index.wait_task(0).await;
+    let (task, _code) = index.update_distinct_attribute(json!("test")).await;
+    index.wait_task(task.uid()).await;
 
     let (response, _) = index.get_distinct_attribute().await;
 
     assert_eq!(response, "test");
 
-    index.update_distinct_attribute(json!(null)).await;
+    let (task,_status_code) = index.update_distinct_attribute(json!(null)).await;
 
-    index.wait_task(1).await;
+    index.wait_task(task.uid()).await;
 
     let (response, _) = index.get_distinct_attribute().await;
 

--- a/crates/meilisearch/tests/settings/proximity_settings.rs
+++ b/crates/meilisearch/tests/settings/proximity_settings.rs
@@ -29,7 +29,7 @@ async fn attribute_scale_search() {
     let server = Server::new().await;
     let index = server.index("test");
 
-    let (task,_status_code) = index.add_documents(DOCUMENTS.clone(), None).await;
+    let (task, _status_code) = index.add_documents(DOCUMENTS.clone(), None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = index
@@ -102,7 +102,7 @@ async fn attribute_scale_phrase_search() {
     let server = Server::new().await;
     let index = server.index("test");
 
-    let (task,_status_code) = index.add_documents(DOCUMENTS.clone(), None).await;
+    let (task, _status_code) = index.add_documents(DOCUMENTS.clone(), None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let (task, _code) = index
@@ -170,7 +170,7 @@ async fn word_scale_set_and_reset() {
     let server = Server::new().await;
     let index = server.index("test");
 
-    let (task,_status_code) = index.add_documents(DOCUMENTS.clone(), None).await;
+    let (task, _status_code) = index.add_documents(DOCUMENTS.clone(), None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     // Set and reset the setting ensuring the swap between the 2 settings is applied.
@@ -285,7 +285,7 @@ async fn attribute_scale_default_ranking_rules() {
     let server = Server::new().await;
     let index = server.index("test");
 
-    let (task,_status_code) = index.add_documents(DOCUMENTS.clone(), None).await;
+    let (task, _status_code) = index.add_documents(DOCUMENTS.clone(), None).await;
     index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = index

--- a/crates/meilisearch/tests/settings/proximity_settings.rs
+++ b/crates/meilisearch/tests/settings/proximity_settings.rs
@@ -30,7 +30,7 @@ async fn attribute_scale_search() {
     let index = server.index("test");
 
     let (task,_status_code) = index.add_documents(DOCUMENTS.clone(), None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = index
         .update_settings(json!({
@@ -39,7 +39,7 @@ async fn attribute_scale_search() {
         }))
         .await;
     assert_eq!("202", code.as_str(), "{:?}", response);
-    index.wait_task(response.uid()).await;
+    index.wait_task(response.uid()).await.succeeded();
 
     // the expected order is [1, 3, 2] instead of [3, 1, 2]
     // because the attribute scale doesn't make the difference between 1 and 3.
@@ -103,7 +103,7 @@ async fn attribute_scale_phrase_search() {
     let index = server.index("test");
 
     let (task,_status_code) = index.add_documents(DOCUMENTS.clone(), None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (task, _code) = index
         .update_settings(json!({
@@ -111,7 +111,7 @@ async fn attribute_scale_phrase_search() {
             "rankingRules": ["words", "typo", "proximity"],
         }))
         .await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     // the expected order is [1, 3] instead of [3, 1]
     // because the attribute scale doesn't make the difference between 1 and 3.
@@ -171,7 +171,7 @@ async fn word_scale_set_and_reset() {
     let index = server.index("test");
 
     let (task,_status_code) = index.add_documents(DOCUMENTS.clone(), None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     // Set and reset the setting ensuring the swap between the 2 settings is applied.
     let (update_task1, _code) = index
@@ -180,7 +180,7 @@ async fn word_scale_set_and_reset() {
             "rankingRules": ["words", "typo", "proximity"],
         }))
         .await;
-    index.wait_task(update_task1.uid()).await;
+    index.wait_task(update_task1.uid()).await.succeeded();
 
     let (update_task2, _code) = index
         .update_settings(json!({
@@ -188,7 +188,7 @@ async fn word_scale_set_and_reset() {
             "rankingRules": ["words", "typo", "proximity"],
         }))
         .await;
-    index.wait_task(update_task2.uid()).await;
+    index.wait_task(update_task2.uid()).await.succeeded();
 
     // [3, 1, 2]
     index
@@ -286,7 +286,7 @@ async fn attribute_scale_default_ranking_rules() {
     let index = server.index("test");
 
     let (task,_status_code) = index.add_documents(DOCUMENTS.clone(), None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = index
         .update_settings(json!({
@@ -294,7 +294,7 @@ async fn attribute_scale_default_ranking_rules() {
         }))
         .await;
     assert_eq!("202", code.as_str(), "{:?}", response);
-    index.wait_task(response.uid()).await;
+    index.wait_task(response.uid()).await.succeeded();
 
     // the expected order is [3, 1, 2]
     index

--- a/crates/meilisearch/tests/settings/proximity_settings.rs
+++ b/crates/meilisearch/tests/settings/proximity_settings.rs
@@ -29,8 +29,8 @@ async fn attribute_scale_search() {
     let server = Server::new().await;
     let index = server.index("test");
 
-    index.add_documents(DOCUMENTS.clone(), None).await;
-    index.wait_task(0).await;
+    let (task,_status_code) = index.add_documents(DOCUMENTS.clone(), None).await;
+    index.wait_task(task.uid()).await;
 
     let (response, code) = index
         .update_settings(json!({
@@ -39,7 +39,7 @@ async fn attribute_scale_search() {
         }))
         .await;
     assert_eq!("202", code.as_str(), "{:?}", response);
-    index.wait_task(1).await;
+    index.wait_task(response.uid()).await;
 
     // the expected order is [1, 3, 2] instead of [3, 1, 2]
     // because the attribute scale doesn't make the difference between 1 and 3.
@@ -102,16 +102,16 @@ async fn attribute_scale_phrase_search() {
     let server = Server::new().await;
     let index = server.index("test");
 
-    index.add_documents(DOCUMENTS.clone(), None).await;
-    index.wait_task(0).await;
+    let (task,_status_code) = index.add_documents(DOCUMENTS.clone(), None).await;
+    index.wait_task(task.uid()).await;
 
-    let (_response, _code) = index
+    let (task, _code) = index
         .update_settings(json!({
             "proximityPrecision": "byAttribute",
             "rankingRules": ["words", "typo", "proximity"],
         }))
         .await;
-    index.wait_task(1).await;
+    index.wait_task(task.uid()).await;
 
     // the expected order is [1, 3] instead of [3, 1]
     // because the attribute scale doesn't make the difference between 1 and 3.
@@ -170,25 +170,25 @@ async fn word_scale_set_and_reset() {
     let server = Server::new().await;
     let index = server.index("test");
 
-    index.add_documents(DOCUMENTS.clone(), None).await;
-    index.wait_task(0).await;
+    let (task,_status_code) = index.add_documents(DOCUMENTS.clone(), None).await;
+    index.wait_task(task.uid()).await;
 
     // Set and reset the setting ensuring the swap between the 2 settings is applied.
-    let (_response, _code) = index
+    let (update_task1, _code) = index
         .update_settings(json!({
             "proximityPrecision": "byAttribute",
             "rankingRules": ["words", "typo", "proximity"],
         }))
         .await;
-    index.wait_task(1).await;
+    index.wait_task(update_task1.uid()).await;
 
-    let (_response, _code) = index
+    let (update_task2, _code) = index
         .update_settings(json!({
             "proximityPrecision": "byWord",
             "rankingRules": ["words", "typo", "proximity"],
         }))
         .await;
-    index.wait_task(2).await;
+    index.wait_task(update_task2.uid()).await;
 
     // [3, 1, 2]
     index
@@ -285,8 +285,8 @@ async fn attribute_scale_default_ranking_rules() {
     let server = Server::new().await;
     let index = server.index("test");
 
-    index.add_documents(DOCUMENTS.clone(), None).await;
-    index.wait_task(0).await;
+    let (task,_status_code) = index.add_documents(DOCUMENTS.clone(), None).await;
+    index.wait_task(task.uid()).await;
 
     let (response, code) = index
         .update_settings(json!({
@@ -294,7 +294,7 @@ async fn attribute_scale_default_ranking_rules() {
         }))
         .await;
     assert_eq!("202", code.as_str(), "{:?}", response);
-    index.wait_task(1).await;
+    index.wait_task(response.uid()).await;
 
     // the expected order is [3, 1, 2]
     index

--- a/crates/meilisearch/tests/settings/tokenizer_customization.rs
+++ b/crates/meilisearch/tests/settings/tokenizer_customization.rs
@@ -38,7 +38,7 @@ async fn set_and_reset() {
     ]
     "###);
 
-    let (task,_status_code) = index
+    let (task, _status_code) = index
         .update_settings(json!({
             "nonSeparatorTokens": null,
             "separatorTokens": null,
@@ -74,7 +74,7 @@ async fn set_and_search() {
     let server = Server::new().await;
     let index = server.index("test");
 
-    let (add_task,_status_code) = index.add_documents(documents, None).await;
+    let (add_task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(add_task.uid()).await.succeeded();
 
     let (update_task, _code) = index
@@ -228,7 +228,7 @@ async fn advanced_synergies() {
     let server = Server::new().await;
     let index = server.index("test");
 
-    let (add_task,_status_code) = index.add_documents(documents, None).await;
+    let (add_task, _status_code) = index.add_documents(documents, None).await;
     index.wait_task(add_task.uid()).await.succeeded();
 
     let (update_task, _code) = index

--- a/crates/meilisearch/tests/settings/tokenizer_customization.rs
+++ b/crates/meilisearch/tests/settings/tokenizer_customization.rs
@@ -16,7 +16,7 @@ async fn set_and_reset() {
             "dictionary": ["J.R.R.", "J. R. R."],
         }))
         .await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (response, _) = index.settings().await;
     snapshot!(json_string!(response["nonSeparatorTokens"]), @r###"
@@ -46,7 +46,7 @@ async fn set_and_reset() {
         }))
         .await;
 
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (response, _) = index.settings().await;
     snapshot!(json_string!(response["nonSeparatorTokens"]), @"[]");
@@ -75,7 +75,7 @@ async fn set_and_search() {
     let index = server.index("test");
 
     let (add_task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(add_task.uid()).await;
+    index.wait_task(add_task.uid()).await.succeeded();
 
     let (update_task, _code) = index
         .update_settings(json!({
@@ -84,7 +84,7 @@ async fn set_and_search() {
             "dictionary": ["#", "A#", "B#", "C#", "D#", "E#", "F#", "G#"],
         }))
         .await;
-    index.wait_task(update_task.uid()).await;
+    index.wait_task(update_task.uid()).await.succeeded();
 
     index
         .search(json!({"q": "&", "attributesToHighlight": ["content"]}), |response, code| {
@@ -229,7 +229,7 @@ async fn advanced_synergies() {
     let index = server.index("test");
 
     let (add_task,_status_code) = index.add_documents(documents, None).await;
-    index.wait_task(add_task.uid()).await;
+    index.wait_task(add_task.uid()).await.succeeded();
 
     let (update_task, _code) = index
         .update_settings(json!({

--- a/crates/meilisearch/tests/settings/tokenizer_customization.rs
+++ b/crates/meilisearch/tests/settings/tokenizer_customization.rs
@@ -1,4 +1,3 @@
-use actix_web::web::resource;
 use meili_snap::{json_string, snapshot};
 
 use crate::common::Server;

--- a/crates/meilisearch/tests/settings/tokenizer_customization.rs
+++ b/crates/meilisearch/tests/settings/tokenizer_customization.rs
@@ -244,7 +244,7 @@ async fn advanced_synergies() {
             }
         }))
         .await;
-    index.wait_task(update_task.uid()).await;
+    index.wait_task(update_task.uid()).await.succeeded();
 
     index
         .search(json!({"q": "J.R.R.", "attributesToHighlight": ["content"]}), |response, code| {
@@ -354,7 +354,7 @@ async fn advanced_synergies() {
             "dictionary": ["J.R.R.", "J. R. R.", "J.K.", "J. K."],
         }))
         .await;
-    index.wait_task(_response.uid()).await;
+    index.wait_task(_response.uid()).await.succeeded();
 
     index
         .search(json!({"q": "jk", "attributesToHighlight": ["content"]}), |response, code| {

--- a/crates/meilisearch/tests/settings/tokenizer_customization.rs
+++ b/crates/meilisearch/tests/settings/tokenizer_customization.rs
@@ -1,3 +1,4 @@
+use actix_web::web::resource;
 use meili_snap::{json_string, snapshot};
 
 use crate::common::Server;
@@ -8,14 +9,14 @@ async fn set_and_reset() {
     let server = Server::new().await;
     let index = server.index("test");
 
-    let (_response, _code) = index
+    let (task, _code) = index
         .update_settings(json!({
             "nonSeparatorTokens": ["#", "&"],
             "separatorTokens": ["&sep", "<br/>"],
             "dictionary": ["J.R.R.", "J. R. R."],
         }))
         .await;
-    index.wait_task(0).await;
+    index.wait_task(task.uid()).await;
 
     let (response, _) = index.settings().await;
     snapshot!(json_string!(response["nonSeparatorTokens"]), @r###"
@@ -37,7 +38,7 @@ async fn set_and_reset() {
     ]
     "###);
 
-    index
+    let (task,_status_code) = index
         .update_settings(json!({
             "nonSeparatorTokens": null,
             "separatorTokens": null,
@@ -45,7 +46,7 @@ async fn set_and_reset() {
         }))
         .await;
 
-    index.wait_task(1).await;
+    index.wait_task(task.uid()).await;
 
     let (response, _) = index.settings().await;
     snapshot!(json_string!(response["nonSeparatorTokens"]), @"[]");
@@ -73,17 +74,17 @@ async fn set_and_search() {
     let server = Server::new().await;
     let index = server.index("test");
 
-    index.add_documents(documents, None).await;
-    index.wait_task(0).await;
+    let (add_task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(add_task.uid()).await;
 
-    let (_response, _code) = index
+    let (update_task, _code) = index
         .update_settings(json!({
             "nonSeparatorTokens": ["#", "&"],
             "separatorTokens": ["<br/>", "&sep"],
             "dictionary": ["#", "A#", "B#", "C#", "D#", "E#", "F#", "G#"],
         }))
         .await;
-    index.wait_task(1).await;
+    index.wait_task(update_task.uid()).await;
 
     index
         .search(json!({"q": "&", "attributesToHighlight": ["content"]}), |response, code| {
@@ -227,10 +228,10 @@ async fn advanced_synergies() {
     let server = Server::new().await;
     let index = server.index("test");
 
-    index.add_documents(documents, None).await;
-    index.wait_task(0).await;
+    let (add_task,_status_code) = index.add_documents(documents, None).await;
+    index.wait_task(add_task.uid()).await;
 
-    let (_response, _code) = index
+    let (update_task, _code) = index
         .update_settings(json!({
             "dictionary": ["J.R.R.", "J. R. R."],
             "synonyms": {
@@ -243,7 +244,7 @@ async fn advanced_synergies() {
             }
         }))
         .await;
-    index.wait_task(1).await;
+    index.wait_task(update_task.uid()).await;
 
     index
         .search(json!({"q": "J.R.R.", "attributesToHighlight": ["content"]}), |response, code| {
@@ -353,7 +354,7 @@ async fn advanced_synergies() {
             "dictionary": ["J.R.R.", "J. R. R.", "J.K.", "J. K."],
         }))
         .await;
-    index.wait_task(2).await;
+    index.wait_task(_response.uid()).await;
 
     index
         .search(json!({"q": "jk", "attributesToHighlight": ["content"]}), |response, code| {

--- a/crates/meilisearch/tests/similar/errors.rs
+++ b/crates/meilisearch/tests/similar/errors.rs
@@ -324,7 +324,7 @@ async fn similar_bad_filter() {
     let documents = DOCUMENTS.clone();
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let (response, code) =
         index.similar_post(json!({ "id": 287947, "filter": true, "embedder": "manual" })).await;
@@ -362,7 +362,7 @@ async fn filter_invalid_syntax_object() {
     let documents = DOCUMENTS.clone();
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     index
         .similar(json!({"id": 287947, "filter": "title & Glass", "embedder": "manual"}), |response, code| {
@@ -401,7 +401,7 @@ async fn filter_invalid_syntax_array() {
     let documents = DOCUMENTS.clone();
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     index
         .similar(json!({"id": 287947, "filter": ["title & Glass"], "embedder": "manual"}), |response, code| {
@@ -440,7 +440,7 @@ async fn filter_invalid_syntax_string() {
     let documents = DOCUMENTS.clone();
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let expected_response = json!({
         "message": "Found unexpected characters at the end of the filter: `XOR title = Glass`. You probably forgot an `OR` or an `AND` rule.\n15:32 title = Glass XOR title = Glass",
@@ -481,7 +481,7 @@ async fn filter_invalid_attribute_array() {
     let documents = DOCUMENTS.clone();
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let expected_response = json!({
         "message": "Attribute `many` is not filterable. Available filterable attributes are: `title`.\n1:5 many = Glass",
@@ -522,7 +522,7 @@ async fn filter_invalid_attribute_string() {
     let documents = DOCUMENTS.clone();
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let expected_response = json!({
         "message": "Attribute `many` is not filterable. Available filterable attributes are: `title`.\n1:5 many = Glass",
@@ -563,7 +563,7 @@ async fn filter_reserved_geo_attribute_array() {
     let documents = DOCUMENTS.clone();
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let expected_response = json!({
         "message": "`_geo` is a reserved keyword and thus can't be used as a filter expression. Use the `_geoRadius(latitude, longitude, distance)` or `_geoBoundingBox([latitude, longitude], [latitude, longitude])` built-in rules to filter on `_geo` coordinates.\n1:13 _geo = Glass",
@@ -604,7 +604,7 @@ async fn filter_reserved_geo_attribute_string() {
     let documents = DOCUMENTS.clone();
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let expected_response = json!({
         "message": "`_geo` is a reserved keyword and thus can't be used as a filter expression. Use the `_geoRadius(latitude, longitude, distance)` or `_geoBoundingBox([latitude, longitude], [latitude, longitude])` built-in rules to filter on `_geo` coordinates.\n1:13 _geo = Glass",
@@ -645,7 +645,7 @@ async fn filter_reserved_attribute_array() {
     let documents = DOCUMENTS.clone();
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let expected_response = json!({
         "message": "`_geoDistance` is a reserved keyword and thus can't be used as a filter expression. Use the `_geoRadius(latitude, longitude, distance)` or `_geoBoundingBox([latitude, longitude], [latitude, longitude])` built-in rules to filter on `_geo` coordinates.\n1:21 _geoDistance = Glass",
@@ -686,7 +686,7 @@ async fn filter_reserved_attribute_string() {
     let documents = DOCUMENTS.clone();
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let expected_response = json!({
        "message": "`_geoDistance` is a reserved keyword and thus can't be used as a filter expression. Use the `_geoRadius(latitude, longitude, distance)` or `_geoBoundingBox([latitude, longitude], [latitude, longitude])` built-in rules to filter on `_geo` coordinates.\n1:21 _geoDistance = Glass",
@@ -727,7 +727,7 @@ async fn filter_reserved_geo_point_array() {
     let documents = DOCUMENTS.clone();
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let expected_response = json!({
         "message": "`_geoPoint` is a reserved keyword and thus can't be used as a filter expression. Use the `_geoRadius(latitude, longitude, distance)` or `_geoBoundingBox([latitude, longitude], [latitude, longitude])` built-in rules to filter on `_geo` coordinates.\n1:18 _geoPoint = Glass",
@@ -768,7 +768,7 @@ async fn filter_reserved_geo_point_string() {
     let documents = DOCUMENTS.clone();
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let expected_response = json!({
        "message": "`_geoPoint` is a reserved keyword and thus can't be used as a filter expression. Use the `_geoRadius(latitude, longitude, distance)` or `_geoBoundingBox([latitude, longitude], [latitude, longitude])` built-in rules to filter on `_geo` coordinates.\n1:18 _geoPoint = Glass",

--- a/crates/meilisearch/tests/similar/mod.rs
+++ b/crates/meilisearch/tests/similar/mod.rs
@@ -77,7 +77,7 @@ async fn basic() {
     let documents = DOCUMENTS.clone();
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     index
         .similar(
@@ -274,7 +274,7 @@ async fn ranking_score_threshold() {
     let documents = DOCUMENTS.clone();
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     index
         .similar(
@@ -555,7 +555,7 @@ async fn filter() {
     let documents = DOCUMENTS.clone();
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     index
         .similar(

--- a/crates/meilisearch/tests/similar/mod.rs
+++ b/crates/meilisearch/tests/similar/mod.rs
@@ -684,7 +684,7 @@ async fn limit_and_offset() {
     let documents = DOCUMENTS.clone();
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     index
         .similar(

--- a/crates/meilisearch/tests/snapshot/mod.rs
+++ b/crates/meilisearch/tests/snapshot/mod.rs
@@ -56,7 +56,7 @@ async fn perform_snapshot() {
     let (task, code) = server.index("test1").create(Some("prim")).await;
     meili_snap::snapshot!(code, @"202 Accepted");
 
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     // wait for the _next task_ to process, aka the snapshot that should be enqueued at some point
 

--- a/crates/meilisearch/tests/snapshot/mod.rs
+++ b/crates/meilisearch/tests/snapshot/mod.rs
@@ -129,10 +129,10 @@ async fn perform_on_demand_snapshot() {
 
     index.load_test_set().await;
 
-    let (task, _) = server.index("doggo").create(Some("bone")).await;
+    let (task,_status_code) = server.index("doggo").create(Some("bone")).await;
     index.wait_task(task.uid()).await.succeeded();
 
-    let (task, _) = server.index("doggo").create(Some("bone")).await;
+    let (task,_status_code) = server.index("doggo").create(Some("bone")).await;
     index.wait_task(task.uid()).await.failed();
 
     let (task, code) = server.create_snapshot().await;

--- a/crates/meilisearch/tests/snapshot/mod.rs
+++ b/crates/meilisearch/tests/snapshot/mod.rs
@@ -129,10 +129,10 @@ async fn perform_on_demand_snapshot() {
 
     index.load_test_set().await;
 
-    let (task,_status_code) = server.index("doggo").create(Some("bone")).await;
+    let (task, _status_code) = server.index("doggo").create(Some("bone")).await;
     index.wait_task(task.uid()).await.succeeded();
 
-    let (task,_status_code) = server.index("doggo").create(Some("bone")).await;
+    let (task, _status_code) = server.index("doggo").create(Some("bone")).await;
     index.wait_task(task.uid()).await.failed();
 
     let (task, code) = server.create_snapshot().await;

--- a/crates/meilisearch/tests/stats/mod.rs
+++ b/crates/meilisearch/tests/stats/mod.rs
@@ -28,10 +28,10 @@ async fn test_healthyness() {
 async fn stats() {
     let server = Server::new().await;
     let index = server.index("test");
-    let (_, code) = index.create(Some("id")).await;
+    let (task, code) = index.create(Some("id")).await;
 
     assert_eq!(code, 202);
-    index.wait_task(0).await;
+    index.wait_task(task.uid()).await;
 
     let (response, code) = server.stats().await;
 
@@ -57,7 +57,7 @@ async fn stats() {
     assert_eq!(code, 202, "{}", response);
     assert_eq!(response["taskUid"], 1);
 
-    index.wait_task(1).await;
+    index.wait_task(response.uid()).await;
 
     let timestamp = OffsetDateTime::now_utc();
     let (response, code) = server.stats().await;

--- a/crates/meilisearch/tests/stats/mod.rs
+++ b/crates/meilisearch/tests/stats/mod.rs
@@ -31,7 +31,7 @@ async fn stats() {
     let (task, code) = index.create(Some("id")).await;
 
     assert_eq!(code, 202);
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = server.stats().await;
 
@@ -57,7 +57,7 @@ async fn stats() {
     assert_eq!(code, 202, "{}", response);
     assert_eq!(response["taskUid"], 1);
 
-    index.wait_task(response.uid()).await;
+    index.wait_task(response.uid()).await.succeeded();
 
     let timestamp = OffsetDateTime::now_utc();
     let (response, code) = server.stats().await;

--- a/crates/meilisearch/tests/swap_indexes/mod.rs
+++ b/crates/meilisearch/tests/swap_indexes/mod.rs
@@ -15,7 +15,7 @@ async fn swap_indexes() {
     let (res, code) = b.add_documents(json!({ "id": 1, "index": "b"}), None).await;
     snapshot!(code, @"202 Accepted");
     snapshot!(res["taskUid"], @"1");
-    server.wait_task(1).await;
+    server.wait_task(res.uid()).await;
 
     let (tasks, code) = server.tasks().await;
     snapshot!(code, @"200 OK");
@@ -67,7 +67,7 @@ async fn swap_indexes() {
     let (res, code) = server.index_swap(json!([{ "indexes": ["a", "b"] }])).await;
     snapshot!(code, @"202 Accepted");
     snapshot!(res["taskUid"], @"2");
-    server.wait_task(2).await;
+    server.wait_task(res.uid()).await;
 
     let (tasks, code) = server.tasks().await;
     snapshot!(code, @"200 OK");
@@ -159,7 +159,7 @@ async fn swap_indexes() {
     let (res, code) = d.add_documents(json!({ "id": 1, "index": "d"}), None).await;
     snapshot!(code, @"202 Accepted");
     snapshot!(res["taskUid"], @"4");
-    server.wait_task(4).await;
+    server.wait_task(res.uid()).await;
 
     // ensure the index creation worked properly
     let (tasks, code) = server.tasks_filter("limit=2").await;
@@ -215,7 +215,7 @@ async fn swap_indexes() {
         server.index_swap(json!([{ "indexes": ["a", "b"] }, { "indexes": ["c", "d"] } ])).await;
     snapshot!(res["taskUid"], @"5");
     snapshot!(code, @"202 Accepted");
-    server.wait_task(5).await;
+    server.wait_task(res.uid()).await;
 
     // ensure the index creation worked properly
     let (tasks, code) = server.tasks().await;

--- a/crates/meilisearch/tests/tasks/mod.rs
+++ b/crates/meilisearch/tests/tasks/mod.rs
@@ -13,8 +13,8 @@ use crate::json;
 async fn error_get_unexisting_task_status() {
     let server = Server::new().await;
     let index = server.index("test");
-    index.create(None).await;
-    index.wait_task(0).await;
+    let (task,_status_code) = index.create(None).await;
+    index.wait_task(task.uid()).await;
     let (response, code) = index.get_task(1).await;
 
     let expected_response = json!({
@@ -32,8 +32,8 @@ async fn error_get_unexisting_task_status() {
 async fn get_task_status() {
     let server = Server::new().await;
     let index = server.index("test");
-    index.create(None).await;
-    index
+    let (create_task,_status_code) = index.create(None).await;
+    let (add_task,_status_code) = index
         .add_documents(
             json!([{
                 "id": 1,
@@ -42,8 +42,8 @@ async fn get_task_status() {
             None,
         )
         .await;
-    index.wait_task(0).await;
-    let (_response, code) = index.get_task(1).await;
+    index.wait_task(create_task.uid()).await;
+    let (_response, code) = index.get_task(add_task.uid()).await;
     assert_eq!(code, 200);
     // TODO check response format, as per #48
 }
@@ -52,8 +52,8 @@ async fn get_task_status() {
 async fn list_tasks() {
     let server = Server::new().await;
     let index = server.index("test");
-    index.create(None).await;
-    index.wait_task(0).await;
+    let (task,_status_code) = index.create(None).await;
+    index.wait_task(task.uid()).await;
     index
         .add_documents(serde_json::from_str(include_str!("../assets/test_set.json")).unwrap(), None)
         .await;
@@ -149,8 +149,8 @@ async fn list_tasks_with_star_filters() {
 async fn list_tasks_status_filtered() {
     let server = Server::new().await;
     let index = server.index("test");
-    index.create(None).await;
-    index.wait_task(0).await;
+    let (task,_status_code) = index.create(None).await;
+    index.wait_task(task.uid()).await;
     index
         .add_documents(serde_json::from_str(include_str!("../assets/test_set.json")).unwrap(), None)
         .await;
@@ -164,7 +164,7 @@ async fn list_tasks_status_filtered() {
     // assert_eq!(code, 200, "{}", response);
     // assert_eq!(response["results"].as_array().unwrap().len(), 1);
 
-    index.wait_task(1).await;
+    index.wait_task(response.uid()).await;
 
     let (response, code) = index.filtered_tasks(&[], &["succeeded"], &[]).await;
     assert_eq!(code, 200, "{}", response);
@@ -175,8 +175,8 @@ async fn list_tasks_status_filtered() {
 async fn list_tasks_type_filtered() {
     let server = Server::new().await;
     let index = server.index("test");
-    index.create(None).await;
-    index.wait_task(0).await;
+    let (task,_status_code) = index.create(None).await;
+    index.wait_task(task.uid()).await;
     index
         .add_documents(serde_json::from_str(include_str!("../assets/test_set.json")).unwrap(), None)
         .await;
@@ -195,8 +195,8 @@ async fn list_tasks_type_filtered() {
 async fn list_tasks_invalid_canceled_by_filter() {
     let server = Server::new().await;
     let index = server.index("test");
-    index.create(None).await;
-    index.wait_task(0).await;
+    let (task,_status_code) = index.create(None).await;
+    index.wait_task(task.uid()).await;
     index
         .add_documents(serde_json::from_str(include_str!("../assets/test_set.json")).unwrap(), None)
         .await;
@@ -210,8 +210,8 @@ async fn list_tasks_invalid_canceled_by_filter() {
 async fn list_tasks_status_and_type_filtered() {
     let server = Server::new().await;
     let index = server.index("test");
-    index.create(None).await;
-    index.wait_task(0).await;
+    let (task,_status_code) = index.create(None).await;
+    index.wait_task(task.uid()).await;
     index
         .add_documents(serde_json::from_str(include_str!("../assets/test_set.json")).unwrap(), None)
         .await;
@@ -278,8 +278,8 @@ async fn test_summarized_task_view() {
 async fn test_summarized_document_addition_or_update() {
     let server = Server::new().await;
     let index = server.index("test");
-    index.add_documents(json!({ "id": 42, "content": "doggos & fluff" }), None).await;
-    index.wait_task(0).await;
+    let (task,_status_code) = index.add_documents(json!({ "id": 42, "content": "doggos & fluff" }), None).await;
+    index.wait_task(task.uid()).await;
     let (task, _) = index.get_task(0).await;
     assert_json_snapshot!(task,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
@@ -303,8 +303,8 @@ async fn test_summarized_document_addition_or_update() {
     }
     "###);
 
-    index.add_documents(json!({ "id": 42, "content": "doggos & fluff" }), Some("id")).await;
-    index.wait_task(1).await;
+    let (task,_status_code) = index.add_documents(json!({ "id": 42, "content": "doggos & fluff" }), Some("id")).await;
+    index.wait_task(task.uid()).await;
     let (task, _) = index.get_task(1).await;
     assert_json_snapshot!(task,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
@@ -333,8 +333,8 @@ async fn test_summarized_document_addition_or_update() {
 async fn test_summarized_delete_documents_by_batch() {
     let server = Server::new().await;
     let index = server.index("test");
-    index.delete_batch(vec![1, 2, 3]).await;
-    index.wait_task(0).await;
+    let (task,_status_code) = index.delete_batch(vec![1, 2, 3]).await;
+    index.wait_task(task.uid()).await;
     let (task, _) = index.get_task(0).await;
     assert_json_snapshot!(task,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
@@ -365,9 +365,9 @@ async fn test_summarized_delete_documents_by_batch() {
     "###);
 
     index.create(None).await;
-    index.delete_batch(vec![42]).await;
-    index.wait_task(2).await;
-    let (task, _) = index.get_task(2).await;
+    let (del_task,_status_code) = index.delete_batch(vec![42]).await;
+    index.wait_task(del_task.uid()).await;
+    let (task, _) = index.get_task(del_task.uid()).await;
     assert_json_snapshot!(task,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
         @r###"
@@ -397,9 +397,9 @@ async fn test_summarized_delete_documents_by_filter() {
     let server = Server::new().await;
     let index = server.index("test");
 
-    index.delete_document_by_filter(json!({ "filter": "doggo = bernese" })).await;
-    index.wait_task(0).await;
-    let (task, _) = index.get_task(0).await;
+    let (task,_status_code) = index.delete_document_by_filter(json!({ "filter": "doggo = bernese" })).await;
+    index.wait_task(task.uid()).await;
+    let (task, _) = index.get_task(task.uid()).await;
     assert_json_snapshot!(task,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
         @r###"
@@ -429,9 +429,9 @@ async fn test_summarized_delete_documents_by_filter() {
     "###);
 
     index.create(None).await;
-    index.delete_document_by_filter(json!({ "filter": "doggo = bernese" })).await;
-    index.wait_task(2).await;
-    let (task, _) = index.get_task(2).await;
+    let (task,_status_code) = index.delete_document_by_filter(json!({ "filter": "doggo = bernese" })).await;
+    index.wait_task(task.uid()).await;
+    let (task, _) = index.get_task(task.uid()).await;
     assert_json_snapshot!(task,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
         @r###"
@@ -461,9 +461,9 @@ async fn test_summarized_delete_documents_by_filter() {
     "###);
 
     index.update_settings(json!({ "filterableAttributes": ["doggo"] })).await;
-    index.delete_document_by_filter(json!({ "filter": "doggo = bernese" })).await;
-    index.wait_task(4).await;
-    let (task, _) = index.get_task(4).await;
+    let (task,_status_code) = index.delete_document_by_filter(json!({ "filter": "doggo = bernese" })).await;
+    index.wait_task(task.uid()).await;
+    let (task, _) = index.get_task(task.uid()).await;
     assert_json_snapshot!(task,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
         @r###"
@@ -492,9 +492,9 @@ async fn test_summarized_delete_documents_by_filter() {
 async fn test_summarized_delete_document_by_id() {
     let server = Server::new().await;
     let index = server.index("test");
-    index.delete_document(1).await;
-    index.wait_task(0).await;
-    let (task, _) = index.get_task(0).await;
+    let (task,_status_code) = index.delete_document(1).await;
+    index.wait_task(task.uid()).await;
+    let (task, _) = index.get_task(task.uid()).await;
     assert_json_snapshot!(task,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
         @r###"
@@ -524,9 +524,9 @@ async fn test_summarized_delete_document_by_id() {
     "###);
 
     index.create(None).await;
-    index.delete_document(42).await;
-    index.wait_task(2).await;
-    let (task, _) = index.get_task(2).await;
+    let (task,_status_code) = index.delete_document(42).await;
+    index.wait_task(task.uid()).await;
+    let (task, _) = index.get_task(task.uid()).await;
     assert_json_snapshot!(task,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
         @r###"
@@ -567,9 +567,9 @@ async fn test_summarized_settings_update() {
     }
     "###);
 
-    index.update_settings(json!({ "displayedAttributes": ["doggos", "name"], "filterableAttributes": ["age", "nb_paw_pads"], "sortableAttributes": ["iq"] })).await;
-    index.wait_task(0).await;
-    let (task, _) = index.get_task(0).await;
+    let (task,_status_code) = index.update_settings(json!({ "displayedAttributes": ["doggos", "name"], "filterableAttributes": ["age", "nb_paw_pads"], "sortableAttributes": ["iq"] })).await;
+    index.wait_task(task.uid()).await;
+    let (task, _) = index.get_task(task.uid()).await;
     assert_json_snapshot!(task,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
         @r###"
@@ -606,9 +606,9 @@ async fn test_summarized_settings_update() {
 async fn test_summarized_index_creation() {
     let server = Server::new().await;
     let index = server.index("test");
-    index.create(None).await;
-    index.wait_task(0).await;
-    let (task, _) = index.get_task(0).await;
+    let (task,_status_code) = index.create(None).await;
+    index.wait_task(task.uid()).await;
+    let (task, _) = index.get_task(task.uid()).await;
     assert_json_snapshot!(task,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
         @r###"
@@ -630,9 +630,9 @@ async fn test_summarized_index_creation() {
     }
     "###);
 
-    index.create(Some("doggos")).await;
-    index.wait_task(1).await;
-    let (task, _) = index.get_task(1).await;
+    let (task,_status_code) = index.create(Some("doggos")).await;
+    index.wait_task(task.uid()).await;
+    let (task, _) = index.get_task(task.uid()).await;
     assert_json_snapshot!(task,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
         @r###"
@@ -774,9 +774,9 @@ async fn test_summarized_index_update() {
     let server = Server::new().await;
     let index = server.index("test");
     // If the index doesn't exist yet, we should get errors with or without the primary key.
-    index.update(None).await;
-    index.wait_task(0).await;
-    let (task, _) = index.get_task(0).await;
+    let (task,_status_code) = index.update(None).await;
+    index.wait_task(task.uid()).await;
+    let (task, _) = index.get_task(task.uid()).await;
     assert_json_snapshot!(task,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
         @r###"
@@ -803,9 +803,9 @@ async fn test_summarized_index_update() {
     }
     "###);
 
-    index.update(Some("bones")).await;
-    index.wait_task(1).await;
-    let (task, _) = index.get_task(1).await;
+    let (task,_status_code) = index.update(Some("bones")).await;
+    index.wait_task(task.uid()).await;
+    let (task, _) = index.get_task(task.uid()).await;
     assert_json_snapshot!(task,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
         @r###"
@@ -835,9 +835,9 @@ async fn test_summarized_index_update() {
     // And run the same two tests once the index do exists.
     index.create(None).await;
 
-    index.update(None).await;
-    index.wait_task(3).await;
-    let (task, _) = index.get_task(3).await;
+    let (task,_status_code) = index.update(None).await;
+    index.wait_task(task.uid()).await;
+    let (task, _) = index.get_task(task.uid()).await;
     assert_json_snapshot!(task,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
         @r###"
@@ -859,9 +859,9 @@ async fn test_summarized_index_update() {
     }
     "###);
 
-    index.update(Some("bones")).await;
-    index.wait_task(4).await;
-    let (task, _) = index.get_task(4).await;
+    let (task,_status_code) = index.update(Some("bones")).await;
+    index.wait_task(task.uid()).await;
+    let (task, _) = index.get_task(task.uid()).await;
     assert_json_snapshot!(task,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
         @r###"
@@ -887,13 +887,13 @@ async fn test_summarized_index_update() {
 #[actix_web::test]
 async fn test_summarized_index_swap() {
     let server = Server::new().await;
-    server
+    let (task,_status_code) = server
         .index_swap(json!([
             { "indexes": ["doggos", "cattos"] }
         ]))
         .await;
-    server.wait_task(0).await;
-    let (task, _) = server.get_task(0).await;
+    server.wait_task(task.uid()).await;
+    let (task, _) = server.get_task(task.uid()).await;
     assert_json_snapshot!(task,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
         @r###"
@@ -928,14 +928,14 @@ async fn test_summarized_index_swap() {
     "###);
 
     server.index("doggos").create(None).await;
-    server.index("cattos").create(None).await;
+    let (task,_status_code) = server.index("cattos").create(None).await;
     server
         .index_swap(json!([
             { "indexes": ["doggos", "cattos"] }
         ]))
         .await;
-    server.wait_task(3).await;
-    let (task, _) = server.get_task(3).await;
+    server.wait_task(task.uid()).await;
+    let (task, _) = server.get_task(task.uid()).await;
     assert_json_snapshot!(task,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
         @r###"
@@ -970,11 +970,11 @@ async fn test_summarized_task_cancelation() {
     let server = Server::new().await;
     let index = server.index("doggos");
     // to avoid being flaky we're only going to cancel an already finished task :(
-    index.create(None).await;
-    index.wait_task(0).await;
-    server.cancel_tasks("uids=0").await;
-    index.wait_task(1).await;
-    let (task, _) = index.get_task(1).await;
+    let (task,_status_code) = index.create(None).await;
+    index.wait_task(task.uid()).await;
+    let (task,_status_code) = server.cancel_tasks("uids=0").await;
+    index.wait_task(task.uid()).await;
+    let (task, _) = index.get_task(task.uid()).await;
     assert_json_snapshot!(task,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
         @r###"
@@ -1004,11 +1004,11 @@ async fn test_summarized_task_deletion() {
     let server = Server::new().await;
     let index = server.index("doggos");
     // to avoid being flaky we're only going to delete an already finished task :(
-    index.create(None).await;
-    index.wait_task(0).await;
-    server.delete_tasks("uids=0").await;
-    index.wait_task(1).await;
-    let (task, _) = index.get_task(1).await;
+    let (task,_status_code) = index.create(None).await;
+    index.wait_task(task.uid()).await;
+    let (task,_status_code) = server.delete_tasks("uids=0").await;
+    index.wait_task(task.uid()).await;
+    let (task, _) = index.get_task(task.uid()).await;
     assert_json_snapshot!(task,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
         @r###"
@@ -1036,9 +1036,9 @@ async fn test_summarized_task_deletion() {
 #[actix_web::test]
 async fn test_summarized_dump_creation() {
     let server = Server::new().await;
-    server.create_dump().await;
-    server.wait_task(0).await;
-    let (task, _) = server.get_task(0).await;
+    let (task,_status_code) = server.create_dump().await;
+    server.wait_task(task.uid()).await;
+    let (task, _) = server.get_task(task.uid()).await;
     assert_json_snapshot!(task,
         { ".details.dumpUid" => "[dumpUid]", ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
         @r###"

--- a/crates/meilisearch/tests/tasks/mod.rs
+++ b/crates/meilisearch/tests/tasks/mod.rs
@@ -14,7 +14,7 @@ async fn error_get_unexisting_task_status() {
     let server = Server::new().await;
     let index = server.index("test");
     let (task,_status_code) = index.create(None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (response, code) = index.get_task(1).await;
 
     let expected_response = json!({
@@ -42,7 +42,7 @@ async fn get_task_status() {
             None,
         )
         .await;
-    index.wait_task(create_task.uid()).await;
+    index.wait_task(create_task.uid()).await.succeeded();
     let (_response, code) = index.get_task(add_task.uid()).await;
     assert_eq!(code, 200);
     // TODO check response format, as per #48
@@ -53,7 +53,7 @@ async fn list_tasks() {
     let server = Server::new().await;
     let index = server.index("test");
     let (task,_status_code) = index.create(None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     index
         .add_documents(serde_json::from_str(include_str!("../assets/test_set.json")).unwrap(), None)
         .await;
@@ -105,7 +105,7 @@ async fn list_tasks_with_star_filters() {
     let server = Server::new().await;
     let index = server.index("test");
     let (task, _code) = index.create(None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     index
         .add_documents(serde_json::from_str(include_str!("../assets/test_set.json")).unwrap(), None)
         .await;
@@ -150,7 +150,7 @@ async fn list_tasks_status_filtered() {
     let server = Server::new().await;
     let index = server.index("test");
     let (task,_status_code) = index.create(None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     index
         .add_documents(serde_json::from_str(include_str!("../assets/test_set.json")).unwrap(), None)
         .await;
@@ -164,7 +164,7 @@ async fn list_tasks_status_filtered() {
     // assert_eq!(code, 200, "{}", response);
     // assert_eq!(response["results"].as_array().unwrap().len(), 1);
 
-    index.wait_task(response.uid()).await;
+    index.wait_task(response.uid()).await.succeeded();
 
     let (response, code) = index.filtered_tasks(&[], &["succeeded"], &[]).await;
     assert_eq!(code, 200, "{}", response);
@@ -176,7 +176,7 @@ async fn list_tasks_type_filtered() {
     let server = Server::new().await;
     let index = server.index("test");
     let (task,_status_code) = index.create(None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     index
         .add_documents(serde_json::from_str(include_str!("../assets/test_set.json")).unwrap(), None)
         .await;
@@ -196,7 +196,7 @@ async fn list_tasks_invalid_canceled_by_filter() {
     let server = Server::new().await;
     let index = server.index("test");
     let (task,_status_code) = index.create(None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     index
         .add_documents(serde_json::from_str(include_str!("../assets/test_set.json")).unwrap(), None)
         .await;
@@ -211,7 +211,7 @@ async fn list_tasks_status_and_type_filtered() {
     let server = Server::new().await;
     let index = server.index("test");
     let (task,_status_code) = index.create(None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     index
         .add_documents(serde_json::from_str(include_str!("../assets/test_set.json")).unwrap(), None)
         .await;
@@ -279,7 +279,7 @@ async fn test_summarized_document_addition_or_update() {
     let server = Server::new().await;
     let index = server.index("test");
     let (task,_status_code) = index.add_documents(json!({ "id": 42, "content": "doggos & fluff" }), None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (task, _) = index.get_task(0).await;
     assert_json_snapshot!(task,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },

--- a/crates/meilisearch/tests/tasks/mod.rs
+++ b/crates/meilisearch/tests/tasks/mod.rs
@@ -13,7 +13,7 @@ use crate::json;
 async fn error_get_unexisting_task_status() {
     let server = Server::new().await;
     let index = server.index("test");
-    let (task,_status_code) = index.create(None).await;
+    let (task, _status_code) = index.create(None).await;
     index.wait_task(task.uid()).await.succeeded();
     let (response, code) = index.get_task(1).await;
 
@@ -32,8 +32,8 @@ async fn error_get_unexisting_task_status() {
 async fn get_task_status() {
     let server = Server::new().await;
     let index = server.index("test");
-    let (create_task,_status_code) = index.create(None).await;
-    let (add_task,_status_code) = index
+    let (create_task, _status_code) = index.create(None).await;
+    let (add_task, _status_code) = index
         .add_documents(
             json!([{
                 "id": 1,
@@ -52,7 +52,7 @@ async fn get_task_status() {
 async fn list_tasks() {
     let server = Server::new().await;
     let index = server.index("test");
-    let (task,_status_code) = index.create(None).await;
+    let (task, _status_code) = index.create(None).await;
     index.wait_task(task.uid()).await.succeeded();
     index
         .add_documents(serde_json::from_str(include_str!("../assets/test_set.json")).unwrap(), None)
@@ -149,7 +149,7 @@ async fn list_tasks_with_star_filters() {
 async fn list_tasks_status_filtered() {
     let server = Server::new().await;
     let index = server.index("test");
-    let (task,_status_code) = index.create(None).await;
+    let (task, _status_code) = index.create(None).await;
     index.wait_task(task.uid()).await.succeeded();
     index
         .add_documents(serde_json::from_str(include_str!("../assets/test_set.json")).unwrap(), None)
@@ -175,7 +175,7 @@ async fn list_tasks_status_filtered() {
 async fn list_tasks_type_filtered() {
     let server = Server::new().await;
     let index = server.index("test");
-    let (task,_status_code) = index.create(None).await;
+    let (task, _status_code) = index.create(None).await;
     index.wait_task(task.uid()).await.succeeded();
     index
         .add_documents(serde_json::from_str(include_str!("../assets/test_set.json")).unwrap(), None)
@@ -195,7 +195,7 @@ async fn list_tasks_type_filtered() {
 async fn list_tasks_invalid_canceled_by_filter() {
     let server = Server::new().await;
     let index = server.index("test");
-    let (task,_status_code) = index.create(None).await;
+    let (task, _status_code) = index.create(None).await;
     index.wait_task(task.uid()).await.succeeded();
     index
         .add_documents(serde_json::from_str(include_str!("../assets/test_set.json")).unwrap(), None)
@@ -210,7 +210,7 @@ async fn list_tasks_invalid_canceled_by_filter() {
 async fn list_tasks_status_and_type_filtered() {
     let server = Server::new().await;
     let index = server.index("test");
-    let (task,_status_code) = index.create(None).await;
+    let (task, _status_code) = index.create(None).await;
     index.wait_task(task.uid()).await.succeeded();
     index
         .add_documents(serde_json::from_str(include_str!("../assets/test_set.json")).unwrap(), None)
@@ -278,7 +278,8 @@ async fn test_summarized_task_view() {
 async fn test_summarized_document_addition_or_update() {
     let server = Server::new().await;
     let index = server.index("test");
-    let (task,_status_code) = index.add_documents(json!({ "id": 42, "content": "doggos & fluff" }), None).await;
+    let (task, _status_code) =
+        index.add_documents(json!({ "id": 42, "content": "doggos & fluff" }), None).await;
     index.wait_task(task.uid()).await.succeeded();
     let (task, _) = index.get_task(0).await;
     assert_json_snapshot!(task,
@@ -303,7 +304,8 @@ async fn test_summarized_document_addition_or_update() {
     }
     "###);
 
-    let (task,_status_code) = index.add_documents(json!({ "id": 42, "content": "doggos & fluff" }), Some("id")).await;
+    let (task, _status_code) =
+        index.add_documents(json!({ "id": 42, "content": "doggos & fluff" }), Some("id")).await;
     index.wait_task(task.uid()).await.succeeded();
     let (task, _) = index.get_task(1).await;
     assert_json_snapshot!(task,
@@ -333,7 +335,7 @@ async fn test_summarized_document_addition_or_update() {
 async fn test_summarized_delete_documents_by_batch() {
     let server = Server::new().await;
     let index = server.index("test");
-    let (task,_status_code) = index.delete_batch(vec![1, 2, 3]).await;
+    let (task, _status_code) = index.delete_batch(vec![1, 2, 3]).await;
     index.wait_task(task.uid()).await.succeeded();
     let (task, _) = index.get_task(0).await;
     assert_json_snapshot!(task,
@@ -365,7 +367,7 @@ async fn test_summarized_delete_documents_by_batch() {
     "###);
 
     index.create(None).await;
-    let (del_task,_status_code) = index.delete_batch(vec![42]).await;
+    let (del_task, _status_code) = index.delete_batch(vec![42]).await;
     index.wait_task(del_task.uid()).await.succeeded();
     let (task, _) = index.get_task(del_task.uid()).await;
     assert_json_snapshot!(task,
@@ -397,7 +399,8 @@ async fn test_summarized_delete_documents_by_filter() {
     let server = Server::new().await;
     let index = server.index("test");
 
-    let (task,_status_code) = index.delete_document_by_filter(json!({ "filter": "doggo = bernese" })).await;
+    let (task, _status_code) =
+        index.delete_document_by_filter(json!({ "filter": "doggo = bernese" })).await;
     index.wait_task(task.uid()).await.succeeded();
     let (task, _) = index.get_task(task.uid()).await;
     assert_json_snapshot!(task,
@@ -429,7 +432,8 @@ async fn test_summarized_delete_documents_by_filter() {
     "###);
 
     index.create(None).await;
-    let (task,_status_code) = index.delete_document_by_filter(json!({ "filter": "doggo = bernese" })).await;
+    let (task, _status_code) =
+        index.delete_document_by_filter(json!({ "filter": "doggo = bernese" })).await;
     index.wait_task(task.uid()).await.succeeded();
     let (task, _) = index.get_task(task.uid()).await;
     assert_json_snapshot!(task,
@@ -461,7 +465,8 @@ async fn test_summarized_delete_documents_by_filter() {
     "###);
 
     index.update_settings(json!({ "filterableAttributes": ["doggo"] })).await;
-    let (task,_status_code) = index.delete_document_by_filter(json!({ "filter": "doggo = bernese" })).await;
+    let (task, _status_code) =
+        index.delete_document_by_filter(json!({ "filter": "doggo = bernese" })).await;
     index.wait_task(task.uid()).await.succeeded();
     let (task, _) = index.get_task(task.uid()).await;
     assert_json_snapshot!(task,
@@ -492,7 +497,7 @@ async fn test_summarized_delete_documents_by_filter() {
 async fn test_summarized_delete_document_by_id() {
     let server = Server::new().await;
     let index = server.index("test");
-    let (task,_status_code) = index.delete_document(1).await;
+    let (task, _status_code) = index.delete_document(1).await;
     index.wait_task(task.uid()).await.succeeded();
     let (task, _) = index.get_task(task.uid()).await;
     assert_json_snapshot!(task,
@@ -524,7 +529,7 @@ async fn test_summarized_delete_document_by_id() {
     "###);
 
     index.create(None).await;
-    let (task,_status_code) = index.delete_document(42).await;
+    let (task, _status_code) = index.delete_document(42).await;
     index.wait_task(task.uid()).await.succeeded();
     let (task, _) = index.get_task(task.uid()).await;
     assert_json_snapshot!(task,
@@ -606,7 +611,7 @@ async fn test_summarized_settings_update() {
 async fn test_summarized_index_creation() {
     let server = Server::new().await;
     let index = server.index("test");
-    let (task,_status_code) = index.create(None).await;
+    let (task, _status_code) = index.create(None).await;
     index.wait_task(task.uid()).await.succeeded();
     let (task, _) = index.get_task(task.uid()).await;
     assert_json_snapshot!(task,
@@ -630,7 +635,7 @@ async fn test_summarized_index_creation() {
     }
     "###);
 
-    let (task,_status_code) = index.create(Some("doggos")).await;
+    let (task, _status_code) = index.create(Some("doggos")).await;
     index.wait_task(task.uid()).await.succeeded();
     let (task, _) = index.get_task(task.uid()).await;
     assert_json_snapshot!(task,
@@ -774,7 +779,7 @@ async fn test_summarized_index_update() {
     let server = Server::new().await;
     let index = server.index("test");
     // If the index doesn't exist yet, we should get errors with or without the primary key.
-    let (task,_status_code) = index.update(None).await;
+    let (task, _status_code) = index.update(None).await;
     index.wait_task(task.uid()).await.succeeded();
     let (task, _) = index.get_task(task.uid()).await;
     assert_json_snapshot!(task,
@@ -803,7 +808,7 @@ async fn test_summarized_index_update() {
     }
     "###);
 
-    let (task,_status_code) = index.update(Some("bones")).await;
+    let (task, _status_code) = index.update(Some("bones")).await;
     index.wait_task(task.uid()).await.succeeded();
     let (task, _) = index.get_task(task.uid()).await;
     assert_json_snapshot!(task,
@@ -835,7 +840,7 @@ async fn test_summarized_index_update() {
     // And run the same two tests once the index do exists.
     index.create(None).await;
 
-    let (task,_status_code) = index.update(None).await;
+    let (task, _status_code) = index.update(None).await;
     index.wait_task(task.uid()).await.succeeded();
     let (task, _) = index.get_task(task.uid()).await;
     assert_json_snapshot!(task,
@@ -859,7 +864,7 @@ async fn test_summarized_index_update() {
     }
     "###);
 
-    let (task,_status_code) = index.update(Some("bones")).await;
+    let (task, _status_code) = index.update(Some("bones")).await;
     index.wait_task(task.uid()).await.succeeded();
     let (task, _) = index.get_task(task.uid()).await;
     assert_json_snapshot!(task,
@@ -887,7 +892,7 @@ async fn test_summarized_index_update() {
 #[actix_web::test]
 async fn test_summarized_index_swap() {
     let server = Server::new().await;
-    let (task,_status_code) = server
+    let (task, _status_code) = server
         .index_swap(json!([
             { "indexes": ["doggos", "cattos"] }
         ]))
@@ -928,7 +933,7 @@ async fn test_summarized_index_swap() {
     "###);
 
     server.index("doggos").create(None).await;
-    let (task,_status_code) = server.index("cattos").create(None).await;
+    let (task, _status_code) = server.index("cattos").create(None).await;
     server
         .index_swap(json!([
             { "indexes": ["doggos", "cattos"] }
@@ -970,9 +975,9 @@ async fn test_summarized_task_cancelation() {
     let server = Server::new().await;
     let index = server.index("doggos");
     // to avoid being flaky we're only going to cancel an already finished task :(
-    let (task,_status_code) = index.create(None).await;
+    let (task, _status_code) = index.create(None).await;
     index.wait_task(task.uid()).await.succeeded();
-    let (task,_status_code) = server.cancel_tasks("uids=0").await;
+    let (task, _status_code) = server.cancel_tasks("uids=0").await;
     index.wait_task(task.uid()).await.succeeded();
     let (task, _) = index.get_task(task.uid()).await;
     assert_json_snapshot!(task,
@@ -1004,9 +1009,9 @@ async fn test_summarized_task_deletion() {
     let server = Server::new().await;
     let index = server.index("doggos");
     // to avoid being flaky we're only going to delete an already finished task :(
-    let (task,_status_code) = index.create(None).await;
+    let (task, _status_code) = index.create(None).await;
     index.wait_task(task.uid()).await.succeeded();
-    let (task,_status_code) = server.delete_tasks("uids=0").await;
+    let (task, _status_code) = server.delete_tasks("uids=0").await;
     index.wait_task(task.uid()).await.succeeded();
     let (task, _) = index.get_task(task.uid()).await;
     assert_json_snapshot!(task,
@@ -1036,7 +1041,7 @@ async fn test_summarized_task_deletion() {
 #[actix_web::test]
 async fn test_summarized_dump_creation() {
     let server = Server::new().await;
-    let (task,_status_code) = server.create_dump().await;
+    let (task, _status_code) = server.create_dump().await;
     server.wait_task(task.uid()).await;
     let (task, _) = server.get_task(task.uid()).await;
     assert_json_snapshot!(task,

--- a/crates/meilisearch/tests/tasks/mod.rs
+++ b/crates/meilisearch/tests/tasks/mod.rs
@@ -607,7 +607,7 @@ async fn test_summarized_index_creation() {
     let server = Server::new().await;
     let index = server.index("test");
     let (task,_status_code) = index.create(None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (task, _) = index.get_task(task.uid()).await;
     assert_json_snapshot!(task,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
@@ -631,7 +631,7 @@ async fn test_summarized_index_creation() {
     "###);
 
     let (task,_status_code) = index.create(Some("doggos")).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (task, _) = index.get_task(task.uid()).await;
     assert_json_snapshot!(task,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
@@ -775,7 +775,7 @@ async fn test_summarized_index_update() {
     let index = server.index("test");
     // If the index doesn't exist yet, we should get errors with or without the primary key.
     let (task,_status_code) = index.update(None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (task, _) = index.get_task(task.uid()).await;
     assert_json_snapshot!(task,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
@@ -804,7 +804,7 @@ async fn test_summarized_index_update() {
     "###);
 
     let (task,_status_code) = index.update(Some("bones")).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (task, _) = index.get_task(task.uid()).await;
     assert_json_snapshot!(task,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
@@ -836,7 +836,7 @@ async fn test_summarized_index_update() {
     index.create(None).await;
 
     let (task,_status_code) = index.update(None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (task, _) = index.get_task(task.uid()).await;
     assert_json_snapshot!(task,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
@@ -860,7 +860,7 @@ async fn test_summarized_index_update() {
     "###);
 
     let (task,_status_code) = index.update(Some("bones")).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (task, _) = index.get_task(task.uid()).await;
     assert_json_snapshot!(task,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
@@ -892,7 +892,7 @@ async fn test_summarized_index_swap() {
             { "indexes": ["doggos", "cattos"] }
         ]))
         .await;
-    server.wait_task(task.uid()).await;
+    server.wait_task(task.uid()).await.succeeded();
     let (task, _) = server.get_task(task.uid()).await;
     assert_json_snapshot!(task,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
@@ -934,7 +934,7 @@ async fn test_summarized_index_swap() {
             { "indexes": ["doggos", "cattos"] }
         ]))
         .await;
-    server.wait_task(task.uid()).await;
+    server.wait_task(task.uid()).await.succeeded();
     let (task, _) = server.get_task(task.uid()).await;
     assert_json_snapshot!(task,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
@@ -971,9 +971,9 @@ async fn test_summarized_task_cancelation() {
     let index = server.index("doggos");
     // to avoid being flaky we're only going to cancel an already finished task :(
     let (task,_status_code) = index.create(None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (task,_status_code) = server.cancel_tasks("uids=0").await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (task, _) = index.get_task(task.uid()).await;
     assert_json_snapshot!(task,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
@@ -1005,9 +1005,9 @@ async fn test_summarized_task_deletion() {
     let index = server.index("doggos");
     // to avoid being flaky we're only going to delete an already finished task :(
     let (task,_status_code) = index.create(None).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (task,_status_code) = server.delete_tasks("uids=0").await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (task, _) = index.get_task(task.uid()).await;
     assert_json_snapshot!(task,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },

--- a/crates/meilisearch/tests/tasks/mod.rs
+++ b/crates/meilisearch/tests/tasks/mod.rs
@@ -304,7 +304,7 @@ async fn test_summarized_document_addition_or_update() {
     "###);
 
     let (task,_status_code) = index.add_documents(json!({ "id": 42, "content": "doggos & fluff" }), Some("id")).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (task, _) = index.get_task(1).await;
     assert_json_snapshot!(task,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
@@ -334,7 +334,7 @@ async fn test_summarized_delete_documents_by_batch() {
     let server = Server::new().await;
     let index = server.index("test");
     let (task,_status_code) = index.delete_batch(vec![1, 2, 3]).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (task, _) = index.get_task(0).await;
     assert_json_snapshot!(task,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
@@ -366,7 +366,7 @@ async fn test_summarized_delete_documents_by_batch() {
 
     index.create(None).await;
     let (del_task,_status_code) = index.delete_batch(vec![42]).await;
-    index.wait_task(del_task.uid()).await;
+    index.wait_task(del_task.uid()).await.succeeded();
     let (task, _) = index.get_task(del_task.uid()).await;
     assert_json_snapshot!(task,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
@@ -398,7 +398,7 @@ async fn test_summarized_delete_documents_by_filter() {
     let index = server.index("test");
 
     let (task,_status_code) = index.delete_document_by_filter(json!({ "filter": "doggo = bernese" })).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (task, _) = index.get_task(task.uid()).await;
     assert_json_snapshot!(task,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
@@ -430,7 +430,7 @@ async fn test_summarized_delete_documents_by_filter() {
 
     index.create(None).await;
     let (task,_status_code) = index.delete_document_by_filter(json!({ "filter": "doggo = bernese" })).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (task, _) = index.get_task(task.uid()).await;
     assert_json_snapshot!(task,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
@@ -462,7 +462,7 @@ async fn test_summarized_delete_documents_by_filter() {
 
     index.update_settings(json!({ "filterableAttributes": ["doggo"] })).await;
     let (task,_status_code) = index.delete_document_by_filter(json!({ "filter": "doggo = bernese" })).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (task, _) = index.get_task(task.uid()).await;
     assert_json_snapshot!(task,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
@@ -493,7 +493,7 @@ async fn test_summarized_delete_document_by_id() {
     let server = Server::new().await;
     let index = server.index("test");
     let (task,_status_code) = index.delete_document(1).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (task, _) = index.get_task(task.uid()).await;
     assert_json_snapshot!(task,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
@@ -525,7 +525,7 @@ async fn test_summarized_delete_document_by_id() {
 
     index.create(None).await;
     let (task,_status_code) = index.delete_document(42).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (task, _) = index.get_task(task.uid()).await;
     assert_json_snapshot!(task,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },
@@ -568,7 +568,7 @@ async fn test_summarized_settings_update() {
     "###);
 
     let (task,_status_code) = index.update_settings(json!({ "displayedAttributes": ["doggos", "name"], "filterableAttributes": ["age", "nb_paw_pads"], "sortableAttributes": ["iq"] })).await;
-    index.wait_task(task.uid()).await;
+    index.wait_task(task.uid()).await.succeeded();
     let (task, _) = index.get_task(task.uid()).await;
     assert_json_snapshot!(task,
         { ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" },

--- a/crates/meilisearch/tests/vector/mod.rs
+++ b/crates/meilisearch/tests/vector/mod.rs
@@ -55,7 +55,7 @@ async fn add_remove_user_provided() {
         }))
         .await;
     snapshot!(code, @"202 Accepted");
-    server.wait_task(response.uid()).await;
+    server.wait_task(response.uid()).await.succeeded();
 
     let documents = json!([
       {"id": 0, "name": "kefir", "_vectors": { "manual": [0, 0, 0] }},

--- a/crates/meilisearch/tests/vector/mod.rs
+++ b/crates/meilisearch/tests/vector/mod.rs
@@ -618,7 +618,7 @@ async fn clear_documents() {
     let index = generate_default_user_provided_documents(&server).await;
 
     let (value, _code) = index.clear_all_documents().await;
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     // Make sure the documents DB has been cleared
     let (documents, _code) = index

--- a/crates/meilisearch/tests/vector/mod.rs
+++ b/crates/meilisearch/tests/vector/mod.rs
@@ -63,7 +63,7 @@ async fn add_remove_user_provided() {
     ]);
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let (documents, _code) = index
         .get_all_documents(GetAllDocumentsOptions { retrieve_vectors: true, ..Default::default() })
@@ -116,7 +116,7 @@ async fn add_remove_user_provided() {
     ]);
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let (documents, _code) = index
         .get_all_documents(GetAllDocumentsOptions { retrieve_vectors: true, ..Default::default() })
@@ -159,7 +159,7 @@ async fn add_remove_user_provided() {
 
     let (value, code) = index.delete_document(0).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     let (documents, _code) = index
         .get_all_documents(GetAllDocumentsOptions { retrieve_vectors: true, ..Default::default() })
@@ -221,7 +221,7 @@ async fn generate_default_user_provided_documents(server: &Server) -> Index {
     ]);
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(value.uid()).await;
+    index.wait_task(value.uid()).await.succeeded();
 
     index
 }

--- a/crates/meilisearch/tests/vector/settings.rs
+++ b/crates/meilisearch/tests/vector/settings.rs
@@ -73,7 +73,7 @@ async fn update_embedder() {
         }))
         .await;
     snapshot!(code, @"202 Accepted");
-    server.wait_task(response.uid()).await;
+    server.wait_task(response.uid()).await.succeeded();
 
     let (response, code) = index
         .update_settings(json!({


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes partial #4840

## What does this PR do?
- Mainly scan the test code for any hard coded task Id and replace it by the returned task Id once the action or task is performed on an index.
- PS: _PR is not split by files as it has one theme applied to all tests which make it easy to review_ 


## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
