### PR TITLE
Improve the panic message when deleting an unknown entry

### DIFF
--- a/crates/milli/src/update/new/indexer/mod.rs
+++ b/crates/milli/src/update/new/indexer/mod.rs
@@ -4,6 +4,7 @@ use std::sync::{OnceLock, RwLock};
 use std::thread::{self, Builder};
 
 use big_s::S;
+use bstr::ByteSlice as _;
 use bumparaw_collections::RawMap;
 use document_changes::{extract, DocumentChanges, IndexingContext};
 pub use document_deletion::DocumentDeletion;
@@ -583,7 +584,10 @@ fn write_from_bbqueue(
                     }
                     (key, None) => match database.delete(wtxn, key) {
                         Ok(false) => {
-                            unreachable!("We tried to delete an unknown key: {key:?}")
+                            unreachable!(
+                                "We tried to delete an unknown key from {database_name}: {:?}",
+                                key.as_bstr()
+                            )
                         }
                         Ok(_) => (),
                         Err(error) => {


### PR DESCRIPTION
This pull request is related to #5228 and improves the error message so that we can better debug the issue. It displays the database in which the deletion tentative happened and displays the key as an escaped string instead of an array of bytes.