### PR TITLE
Use BitPacker8x to measure performances

### DIFF
--- a/crates/milli/src/update/new/extract/cache.rs
+++ b/crates/milli/src/update/new/extract/cache.rs
@@ -69,7 +69,7 @@ use std::io::BufReader;
 use std::{io, iter, mem};
 
 use bumpalo::Bump;
-use bumparaw_collections::bbbul::{BitPacker, BitPacker4x};
+use bumparaw_collections::bbbul::{BitPacker, BitPacker8x};
 use bumparaw_collections::map::FrozenMap;
 use bumparaw_collections::{Bbbul, FrozenBbbul};
 use grenad::ReaderCursor;
@@ -189,13 +189,13 @@ impl<'extractor> BalancedCaches<'extractor> {
                         std::mem::transmute::<
                             &mut HashMap<
                                 &[u8],
-                                DelAddBbbul<BitPacker4x>, // from this
+                                DelAddBbbul<BitPacker8x>, // from this
                                 FxBuildHasher,
                                 &Bump,
                             >,
                             &mut HashMap<
                                 &[u8],
-                                FrozenDelAddBbbul<BitPacker4x>, // to that
+                                FrozenDelAddBbbul<BitPacker8x>, // to that
                                 FxBuildHasher,
                                 &Bump,
                             >,
@@ -227,13 +227,13 @@ impl<'extractor> BalancedCaches<'extractor> {
                         std::mem::transmute::<
                             &mut HashMap<
                                 &[u8],
-                                DelAddBbbul<BitPacker4x>, // from this
+                                DelAddBbbul<BitPacker8x>, // from this
                                 FxBuildHasher,
                                 &Bump,
                             >,
                             &mut HashMap<
                                 &[u8],
-                                FrozenDelAddBbbul<BitPacker4x>, // to that
+                                FrozenDelAddBbbul<BitPacker8x>, // to that
                                 FxBuildHasher,
                                 &Bump,
                             >,
@@ -253,7 +253,7 @@ struct NormalCaches<'extractor> {
     caches: Vec<
         HashMap<
             &'extractor [u8],
-            DelAddBbbul<'extractor, BitPacker4x>,
+            DelAddBbbul<'extractor, BitPacker8x>,
             FxBuildHasher,
             &'extractor Bump,
         >,
@@ -315,7 +315,7 @@ struct SpillingCaches<'extractor> {
     caches: Vec<
         HashMap<
             &'extractor [u8],
-            DelAddBbbul<'extractor, BitPacker4x>,
+            DelAddBbbul<'extractor, BitPacker8x>,
             FxBuildHasher,
             &'extractor Bump,
         >,
@@ -330,7 +330,7 @@ impl<'extractor> SpillingCaches<'extractor> {
         caches: Vec<
             HashMap<
                 &'extractor [u8],
-                DelAddBbbul<'extractor, BitPacker4x>,
+                DelAddBbbul<'extractor, BitPacker8x>,
                 FxBuildHasher,
                 &'extractor Bump,
             >,
@@ -451,7 +451,7 @@ pub struct FrozenCache<'a, 'extractor> {
         'a,
         'extractor,
         &'extractor [u8],
-        FrozenDelAddBbbul<'extractor, BitPacker4x>,
+        FrozenDelAddBbbul<'extractor, BitPacker8x>,
         FxBuildHasher,
     >,
     spilled: Vec<grenad::Reader<BufReader<File>>>,


### PR DESCRIPTION
This PR is an experiment using [a `BitPacker8x` instead of a `BitPacker4x`](https://docs.rs/bitpacking/latest/bitpacking/index.html) in [`Bbbul`](https://docs.rs/bumparaw-collections/latest/bumparaw_collections/bbbul/struct.Bbbul.html). Keep in mind that the benchmarks will show the performance of the benchmark machine, which is an intel machine (massive CPU: Intel(R) Xeon(R) E-2246G CPU @ 3.60GHz).