### PR TITLE
Parse ollama URL to adapt configuration depending on the endpoint

### DIFF
--- a/crates/meilisearch/tests/vector/settings.rs
+++ b/crates/meilisearch/tests/vector/settings.rs
@@ -277,3 +277,155 @@ async fn reset_embedder_documents() {
     }
     "###);
 }
+
+#[actix_rt::test]
+async fn ollama_url_checks() {
+    let server = super::get_server_vector().await;
+    let index = server.index("doggo");
+
+    let (response, code) = index
+  .update_settings(json!({
+    "embedders": { "ollama": {"source": "ollama", "model": "toto", "dimensions": 1, "url": "http://localhost:11434/api/embeddings"}},
+  }))
+  .await;
+    snapshot!(code, @"202 Accepted");
+    let response = server.wait_task(response.uid()).await;
+
+    snapshot!(response, @r###"
+    {
+      "uid": "[uid]",
+      "batchUid": "[batch_uid]",
+      "indexUid": "doggo",
+      "status": "succeeded",
+      "type": "settingsUpdate",
+      "canceledBy": null,
+      "details": {
+        "embedders": {
+          "ollama": {
+            "source": "ollama",
+            "model": "toto",
+            "dimensions": 1,
+            "url": "[url]"
+          }
+        }
+      },
+      "error": null,
+      "duration": "[duration]",
+      "enqueuedAt": "[date]",
+      "startedAt": "[date]",
+      "finishedAt": "[date]"
+    }
+    "###);
+
+    let (response, code) = index
+    .update_settings(json!({
+      "embedders": { "ollama": {"source": "ollama", "model": "toto", "dimensions": 1, "url": "http://localhost:11434/api/embed"}},
+    }))
+    .await;
+    snapshot!(code, @"202 Accepted");
+    let response = server.wait_task(response.uid()).await;
+
+    snapshot!(response, @r###"
+    {
+      "uid": "[uid]",
+      "batchUid": "[batch_uid]",
+      "indexUid": "doggo",
+      "status": "succeeded",
+      "type": "settingsUpdate",
+      "canceledBy": null,
+      "details": {
+        "embedders": {
+          "ollama": {
+            "source": "ollama",
+            "model": "toto",
+            "dimensions": 1,
+            "url": "[url]"
+          }
+        }
+      },
+      "error": null,
+      "duration": "[duration]",
+      "enqueuedAt": "[date]",
+      "startedAt": "[date]",
+      "finishedAt": "[date]"
+    }
+    "###);
+
+    let (response, code) = index
+      .update_settings(json!({
+        "embedders": { "ollama": {"source": "ollama", "model": "toto", "dimensions": 1, "url": "http://localhost:11434/api/embedd"}},
+      }))
+      .await;
+    snapshot!(code, @"202 Accepted");
+    let response = server.wait_task(response.uid()).await;
+
+    snapshot!(response, @r###"
+    {
+      "uid": "[uid]",
+      "batchUid": "[batch_uid]",
+      "indexUid": "doggo",
+      "status": "failed",
+      "type": "settingsUpdate",
+      "canceledBy": null,
+      "details": {
+        "embedders": {
+          "ollama": {
+            "source": "ollama",
+            "model": "toto",
+            "dimensions": 1,
+            "url": "[url]"
+          }
+        }
+      },
+      "error": {
+        "message": "Index `doggo`: Error while generating embeddings: user error: unsupported Ollama URL.\n  - For `ollama` sources, the URL must end with `/api/embed` or `/api/embeddings`\n  - Got `http://localhost:11434/api/embedd`",
+        "code": "vector_embedding_error",
+        "type": "invalid_request",
+        "link": "https://docs.meilisearch.com/errors#vector_embedding_error"
+      },
+      "duration": "[duration]",
+      "enqueuedAt": "[date]",
+      "startedAt": "[date]",
+      "finishedAt": "[date]"
+    }
+    "###);
+
+    let (response, code) = index
+        .update_settings(json!({
+          "embedders": { "ollama": {"source": "ollama", "model": "toto", "dimensions": 1, "url": "http://localhost:11434/v1/embeddings"}},
+        }))
+        .await;
+    snapshot!(code, @"202 Accepted");
+    let response = server.wait_task(response.uid()).await;
+
+    snapshot!(response, @r###"
+    {
+      "uid": "[uid]",
+      "batchUid": "[batch_uid]",
+      "indexUid": "doggo",
+      "status": "failed",
+      "type": "settingsUpdate",
+      "canceledBy": null,
+      "details": {
+        "embedders": {
+          "ollama": {
+            "source": "ollama",
+            "model": "toto",
+            "dimensions": 1,
+            "url": "[url]"
+          }
+        }
+      },
+      "error": {
+        "message": "Index `doggo`: Error while generating embeddings: user error: unsupported Ollama URL.\n  - For `ollama` sources, the URL must end with `/api/embed` or `/api/embeddings`\n  - Got `http://localhost:11434/v1/embeddings`",
+        "code": "vector_embedding_error",
+        "type": "invalid_request",
+        "link": "https://docs.meilisearch.com/errors#vector_embedding_error"
+      },
+      "duration": "[duration]",
+      "enqueuedAt": "[date]",
+      "startedAt": "[date]",
+      "finishedAt": "[date]"
+    }
+    "###);
+}

--- a/crates/milli/src/vector/error.rs
+++ b/crates/milli/src/vector/error.rs
@@ -67,7 +67,7 @@ pub enum EmbedErrorKind {
     #[error("could not authenticate against {embedding} server{server_reply}{hint}", embedding=match *.1 {
         ConfigurationSource::User => "embedding",
         ConfigurationSource::OpenAi => "OpenAI",
-        ConfigurationSource::Ollama => "ollama"
+        ConfigurationSource::Ollama => "Ollama"
     },
     server_reply=option_info(.0.as_deref(), "server replied with "),
     hint=match *.1 {
@@ -306,6 +306,10 @@ impl NewEmbedderError {
             fault: FaultSource::User,
         }
     }
+
+    pub(crate) fn ollama_unsupported_url(url: String) -> NewEmbedderError {
+        Self { kind: NewEmbedderErrorKind::OllamaUnsupportedUrl(url), fault: FaultSource::User }
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -369,6 +373,8 @@ pub enum NewEmbedderErrorKind {
     LoadModel(candle_core::Error),
     #[error("{0}")]
     CouldNotParseTemplate(String),
+    #[error("unsupported Ollama URL.\n  - For `ollama` sources, the URL must end with `/api/embed` or `/api/embeddings`\n  - Got `{0}`")]
+    OllamaUnsupportedUrl(String),
 }
 
 pub struct PossibleEmbeddingMistakes {


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #5002 

## What does this PR do?
- Parses `url` parameter of `ollama` to recognize supported endpoint and adapt the REST configuration to the recognized endpoint
- Throws a new error if no endpoint is recognized
- Add a test for the various recognized endpoints


Thanks to @Guikingone for the original report and PR