### PR TITLE
Introduce a compaction subcommand in meilitool

### DIFF
--- a/crates/meilitool/src/main.rs
+++ b/crates/meilitool/src/main.rs
@@ -443,7 +443,7 @@ fn compact_index(db_path: PathBuf, index_name: &str) -> anyhow::Result<()> {
         drop(new_file);
 
         println!("Everything's done 🎉");
-        return Ok(())
+        return Ok(());
     }
 
     bail!("Target index {index_name} not found!")

--- a/crates/meilitool/src/main.rs
+++ b/crates/meilitool/src/main.rs
@@ -3,7 +3,7 @@ use std::io::BufWriter;
 use std::path::PathBuf;
 use std::time::Instant;
 
-use anyhow::Context;
+use anyhow::{bail, Context};
 use clap::{Parser, Subcommand};
 use dump::{DumpWriter, IndexMetadata};
 use file_store::FileStore;

--- a/crates/meilitool/src/main.rs
+++ b/crates/meilitool/src/main.rs
@@ -443,7 +443,8 @@ fn compact_index(db_path: PathBuf, index_name: &str) -> anyhow::Result<()> {
         drop(new_file);
 
         println!("Everything's done 🎉");
+        return Ok(())
     }
 
-    Ok(())
+    bail!("Target index {index_name} not found!")
 }

--- a/crates/meilitool/src/main.rs
+++ b/crates/meilitool/src/main.rs
@@ -398,7 +398,7 @@ fn compact_index(db_path: PathBuf, index_name: &str) -> anyhow::Result<()> {
         }
 
         let index_path = db_path.join("indexes").join(uuid.to_string());
-        let index = Index::new(EnvOpenOptions::new(), &index_path).with_context(|| {
+        let index = Index::new(EnvOpenOptions::new(), &index_path, false).with_context(|| {
             format!("While trying to open the index at path {:?}", index_path.display())
         })?;
 

--- a/crates/meilitool/src/main.rs
+++ b/crates/meilitool/src/main.rs
@@ -95,9 +95,9 @@ enum Command {
     ///
     /// Note that the compaction will open the index, copy and compact the index into another file
     /// **on the same disk as the index** and replace the previous index with the newly compacted
-    /// one. Which means that the disk must have enough room for at most two time the index size.
+    /// one. This means that the disk must have enough room for at most two times the index size.
     ///
-    /// To make sure not to loose any data, this tool takes a mutable transaction on the index
+    /// To make sure not to lose any data, this tool takes a mutable transaction on the index
     /// before running the copy and compaction. This way the current indexation must finish before
     /// the compaction operation can start. Once the compaction is done, the big index is replaced
     /// by the compacted one and the mutable transaction is released.


### PR DESCRIPTION
This PR proposes a change to the meilitool helper, introducing the `compact-index` subcommand to reduce the size of the indexes.

While working on this tool, I discovered that the current heed `Env::copy_to_file` API is not very temp file friendly and [could be improved](https://github.com/meilisearch/heed/issues/306).