### PR TITLE
Fix corrupted task queue errors on index creation

### DIFF
--- a/crates/index-scheduler/src/index_mapper/mod.rs
+++ b/crates/index-scheduler/src/index_mapper/mod.rs
@@ -191,6 +191,11 @@ impl IndexMapper {
                         self.index_base_map_size,
                     )
                     .map_err(|e| Error::from_milli(e, Some(uuid.to_string())))?;
+                let index_rtxn = index.read_txn()?;
+                let stats = crate::index_mapper::IndexStats::new(&index, &index_rtxn)
+                    .map_err(|e| Error::from_milli(e, Some(name.to_string())))?;
+                self.store_stats_of(&mut wtxn, name, &stats)?;
+                drop(index_rtxn);
 
                 wtxn.commit()?;
 

--- a/crates/index-scheduler/src/scheduler/test.rs
+++ b/crates/index-scheduler/src/scheduler/test.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 
 use big_s::S;
 use meili_snap::{json_string, snapshot};
+use meilisearch_auth::AuthFilter;
 use meilisearch_types::milli::index::IndexEmbeddingConfig;
 use meilisearch_types::milli::update::IndexDocumentsMethod::*;
 use meilisearch_types::milli::{self};
@@ -875,4 +876,28 @@ fn cancel_processing_dump() {
 
     handle.advance_one_successful_batch();
     snapshot!(snapshot_index_scheduler(&index_scheduler), name: "cancel_processed");
+}
+
+#[test]
+fn create_and_list_index() {
+    let (index_scheduler, mut handle) = IndexScheduler::test(true, vec![]);
+
+    let index_creation =
+        KindWithContent::IndexCreation { index_uid: S("kefir"), primary_key: None };
+    let _ = index_scheduler.register(index_creation, None, false).unwrap();
+    handle.advance_till([Start, BatchCreated, InsideProcessBatch]);
+    // The index creation has not been started, the index should not exists
+
+    let err = index_scheduler.index("kefir").map(|_| ()).unwrap_err();
+    snapshot!(err, @"Index `kefir` not found.");
+    let empty = index_scheduler.get_paginated_indexes_stats(&AuthFilter::default(), 0, 20).unwrap();
+    snapshot!(format!("{empty:?}"), @"(0, [])");
+
+    // After advancing just once the index should've been created, the wtxn has been released and commited
+    // but the indexUpdate task has not been processed yet
+    handle.advance_till([InsideProcessBatch]);
+
+    index_scheduler.index("kefir").unwrap(); // Crash on corrupted task queue
+    let empty = index_scheduler.get_paginated_indexes_stats(&AuthFilter::default(), 0, 20).unwrap();
+    snapshot!(format!("{empty:?}"), @"");
 }

--- a/crates/index-scheduler/src/scheduler/test.rs
+++ b/crates/index-scheduler/src/scheduler/test.rs
@@ -897,7 +897,25 @@ fn create_and_list_index() {
     // but the indexUpdate task has not been processed yet
     handle.advance_till([InsideProcessBatch]);
 
-    index_scheduler.index("kefir").unwrap(); // Crash on corrupted task queue
-    let empty = index_scheduler.get_paginated_indexes_stats(&AuthFilter::default(), 0, 20).unwrap();
-    snapshot!(format!("{empty:?}"), @"");
+    index_scheduler.index("kefir").unwrap();
+    let list = index_scheduler.get_paginated_indexes_stats(&AuthFilter::default(), 0, 20).unwrap();
+    snapshot!(json_string!(list, { "[1][0][1].created_at" => "[date]", "[1][0][1].updated_at" => "[date]" }), @r#"
+    [
+      1,
+      [
+        [
+          "kefir",
+          {
+            "number_of_documents": 0,
+            "database_size": 24576,
+            "used_database_size": 8192,
+            "primary_key": null,
+            "field_distribution": {},
+            "created_at": "[date]",
+            "updated_at": "[date]"
+          }
+        ]
+      ]
+    ]
+    "#);
 }


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes https://github.com/meilisearch/meilisearch/issues/5238

## What does this PR do?
- Add a test that reproduces the issue and ensure we never introduce the bug again
- Fix the bug by storing the stats of the index upon creation instead of waiting for the update index task to do it
