### PR TITLE
Improve AI logging

### DIFF
--- a/crates/milli/README.md
+++ b/crates/milli/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img alt="the milli logo" src="../assets/milli-logo.svg">
+  <img alt="the milli logo" src="../../assets/milli-logo.svg">
 </p>
 
 <p align="center">a concurrent indexer combined with fast and relevant search algorithms</p>

--- a/crates/milli/src/search/new/mod.rs
+++ b/crates/milli/src/search/new/mod.rs
@@ -563,7 +563,7 @@ fn resolve_sort_criteria<'ctx, Query: RankingRuleQueryTrait>(
     Ok(())
 }
 
-#[tracing::instrument(level = "trace", skip_all, target = "search::universe")]
+#[tracing::instrument(level = "debug", skip_all, target = "search::universe")]
 pub fn filtered_universe(
     index: &Index,
     txn: &RoTxn<'_>,

--- a/crates/milli/src/search/new/vector_sort.rs
+++ b/crates/milli/src/search/new/vector_sort.rs
@@ -66,7 +66,7 @@ impl<'ctx, Q: RankingRuleQueryTrait> RankingRule<'ctx, Q> for VectorSort<Q> {
         "vector_sort".to_owned()
     }
 
-    #[tracing::instrument(level = "debug", skip_all, target = "search::vector_sort")]
+    #[tracing::instrument(level = "trace", skip_all, target = "search::vector_sort")]
     fn start_iteration(
         &mut self,
         ctx: &mut SearchContext<'ctx>,
@@ -83,7 +83,7 @@ impl<'ctx, Q: RankingRuleQueryTrait> RankingRule<'ctx, Q> for VectorSort<Q> {
     }
 
     #[allow(clippy::only_used_in_recursion)]
-    #[tracing::instrument(level = "debug", skip_all, target = "search::vector_sort")]
+    #[tracing::instrument(level = "trace", skip_all, target = "search::vector_sort")]
     fn next_bucket(
         &mut self,
         ctx: &mut SearchContext<'ctx>,

--- a/crates/milli/src/search/new/vector_sort.rs
+++ b/crates/milli/src/search/new/vector_sort.rs
@@ -66,7 +66,7 @@ impl<'ctx, Q: RankingRuleQueryTrait> RankingRule<'ctx, Q> for VectorSort<Q> {
         "vector_sort".to_owned()
     }
 
-    #[tracing::instrument(level = "trace", skip_all, target = "search::vector_sort")]
+    #[tracing::instrument(level = "debug", skip_all, target = "search::vector_sort")]
     fn start_iteration(
         &mut self,
         ctx: &mut SearchContext<'ctx>,

--- a/crates/milli/src/search/new/vector_sort.rs
+++ b/crates/milli/src/search/new/vector_sort.rs
@@ -83,7 +83,7 @@ impl<'ctx, Q: RankingRuleQueryTrait> RankingRule<'ctx, Q> for VectorSort<Q> {
     }
 
     #[allow(clippy::only_used_in_recursion)]
-    #[tracing::instrument(level = "trace", skip_all, target = "search::vector_sort")]
+    #[tracing::instrument(level = "debug", skip_all, target = "search::vector_sort")]
     fn next_bucket(
         &mut self,
         ctx: &mut SearchContext<'ctx>,

--- a/crates/milli/src/update/new/indexer/extract.rs
+++ b/crates/milli/src/update/new/indexer/extract.rs
@@ -234,7 +234,7 @@ where
         );
         let mut datastore = ThreadLocal::with_capacity(rayon::current_num_threads());
         {
-            let span = tracing::trace_span!(target: "indexing::documents::extract", "vectors");
+            let span = tracing::debug_span!(target: "indexing::documents::extract", "vectors");
             let _entered = span.enter();
 
             extract(
@@ -247,7 +247,7 @@ where
             )?;
         }
         {
-            let span = tracing::trace_span!(target: "indexing::documents::merge", "vectors");
+            let span = tracing::debug_span!(target: "indexing::documents::merge", "vectors");
             let _entered = span.enter();
 
             for config in &mut index_embeddings {

--- a/crates/milli/src/update/new/indexer/write.rs
+++ b/crates/milli/src/update/new/indexer/write.rs
@@ -76,7 +76,7 @@ pub(super) fn write_to_db(
     Ok(())
 }
 
-#[tracing::instrument(level = "trace", skip_all, target = "indexing::vectors")]
+#[tracing::instrument(level = "debug", skip_all, target = "indexing::vectors")]
 pub(super) fn build_vectors<MSP>(
     index: &Index,
     wtxn: &mut RwTxn<'_>,

--- a/crates/milli/src/vector/mod.rs
+++ b/crates/milli/src/vector/mod.rs
@@ -611,6 +611,7 @@ impl Embedder {
         }
     }
 
+    #[tracing::instrument(level = "debug", skip_all, target = "search")]
     pub fn embed_one(
         &self,
         text: String,


### PR DESCRIPTION
This PR fixes #5285 and brings the changes from #5233 to simplify debugging indexation and search performance issues related to AI. The following texts can be found in the logs to debug and understand performance issues:

 - `embed_one: search` represents the time we spent waiting for the embedding generation, i.e., OpenAI, local HuggingFace, Ollama.
 - `filtered_universe: search::universe` the time spent filtering the documents.
 - ~`next_bucket: search::vector_sort` is the time spent finding the nearest neighbors (ANNs) in the vector store (arroy), locally~ was being triggered too many times.
 - `indexing::vectors` is the time arroy spends indexing the new vectors for a batch.
 - `documents::extract vectors` and `documents::merge vectors` to see the time spent generating and writing the embeddings.