### PR TITLE
fix for rankingScoreThreshold changes the results' ranking

### DIFF
--- a/crates/milli/src/search/new/bucket_sort.rs
+++ b/crates/milli/src/search/new/bucket_sort.rs
@@ -178,6 +178,7 @@ pub fn bucket_sort<'ctx, Q: RankingRuleQueryTrait>(
                     if current_score < ranking_score_threshold {
                         all_candidates -= bucket | &ranking_rule_universes[cur_ranking_rule_index];
                         back!();
+                        cur_ranking_rule_index += 1;
                         continue;
                     }
                 }
@@ -213,6 +214,7 @@ pub fn bucket_sort<'ctx, Q: RankingRuleQueryTrait>(
             continue;
         }
 
+
         let Some(next_bucket) = ranking_rules[cur_ranking_rule_index].next_bucket(
             ctx,
             logger,
@@ -242,7 +244,9 @@ pub fn bucket_sort<'ctx, Q: RankingRuleQueryTrait>(
             if current_score < ranking_score_threshold {
                 all_candidates -=
                     next_bucket.candidates | &ranking_rule_universes[cur_ranking_rule_index];
+
                 back!();
+                cur_ranking_rule_index += 1;
                 continue;
             }
         }

--- a/crates/milli/src/search/new/bucket_sort.rs
+++ b/crates/milli/src/search/new/bucket_sort.rs
@@ -252,8 +252,8 @@ pub fn bucket_sort<'ctx, Q: RankingRuleQueryTrait>(
             || is_below_threshold
         {
             if is_below_threshold {
-                all_candidates -=
-                    next_bucket.candidates | &ranking_rule_universes[cur_ranking_rule_index];
+                all_candidates -= &next_bucket.candidates;
+                all_candidates -= &ranking_rule_universes[cur_ranking_rule_index];
             } else {
                 maybe_add_to_results!(next_bucket.candidates);
             }

--- a/crates/milli/src/search/new/bucket_sort.rs
+++ b/crates/milli/src/search/new/bucket_sort.rs
@@ -214,7 +214,6 @@ pub fn bucket_sort<'ctx, Q: RankingRuleQueryTrait>(
             continue;
         }
 
-
         let Some(next_bucket) = ranking_rules[cur_ranking_rule_index].next_bucket(
             ctx,
             logger,
@@ -244,7 +243,6 @@ pub fn bucket_sort<'ctx, Q: RankingRuleQueryTrait>(
             if current_score < ranking_score_threshold {
                 all_candidates -=
                     next_bucket.candidates | &ranking_rule_universes[cur_ranking_rule_index];
-
                 back!();
                 cur_ranking_rule_index += 1;
                 continue;


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes https://github.com/meilisearch/meilisearch/issues/4988

## What does this PR do?
- current behavior when current_score < ranking_score_threshold is -> back()! 
this would cause the cur_ranking_rule_index to point to already occupied index

suggest to add +1 to cur_ranking_rule_index so that cur_ranking_rule_index will point to not occupied index instead

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
