### PR TITLE
Documents database stats

### DIFF
--- a/crates/index-scheduler/src/index_mapper/mod.rs
+++ b/crates/index-scheduler/src/index_mapper/mod.rs
@@ -142,7 +142,7 @@ impl IndexStats {
         Ok(IndexStats {
             number_of_embeddings: Some(arroy_stats.number_of_embeddings),
             number_of_embedded_documents: Some(arroy_stats.documents.len()),
-            documents_database_stats: index.documents_database_stats(rtxn)?,
+            documents_database_stats: index.documents_stats(rtxn)?.unwrap_or_default(),
             database_size: index.on_disk_size()?,
             used_database_size: index.used_size()?,
             primary_key: index.primary_key(rtxn)?.map(|s| s.to_string()),

--- a/crates/index-scheduler/src/insta_snapshot.rs
+++ b/crates/index-scheduler/src/insta_snapshot.rs
@@ -365,7 +365,8 @@ pub fn snapshot_index_mapper(rtxn: &RoTxn, mapper: &IndexMapper) -> String {
         let stats = mapper.stats_of(rtxn, &name).unwrap();
         s.push_str(&format!(
             "{name}: {{ number_of_documents: {}, field_distribution: {:?} }}\n",
-            stats.number_of_documents, stats.field_distribution
+            stats.documents_database_stats.number_of_entries(),
+            stats.field_distribution
         ));
     }
 

--- a/crates/index-scheduler/src/scheduler/test.rs
+++ b/crates/index-scheduler/src/scheduler/test.rs
@@ -913,11 +913,7 @@ fn create_and_list_index() {
             "documents_database_stats": {
               "numberOfEntries": 0,
               "totalKeySize": 0,
-              "totalValueSize": 0,
-              "maxKeySize": 0,
-              "maxValueSize": 0,
-              "minKeySize": 0,
-              "minValueSize": 0
+              "totalValueSize": 0
             },
             "database_size": "[bytes]",
             "number_of_embeddings": 0,

--- a/crates/index-scheduler/src/scheduler/test.rs
+++ b/crates/index-scheduler/src/scheduler/test.rs
@@ -910,7 +910,15 @@ fn create_and_list_index() {
         [
           "kefir",
           {
-            "number_of_documents": 0,
+            "documents_database_stats": {
+              "numberOfEntries": 0,
+              "totalKeySize": 0,
+              "totalValueSize": 0,
+              "maxKeySize": 0,
+              "maxValueSize": 0,
+              "minKeySize": 0,
+              "minValueSize": 0
+            },
             "database_size": "[bytes]",
             "number_of_embeddings": 0,
             "number_of_embedded_documents": 0,

--- a/crates/meilisearch/src/routes/indexes/mod.rs
+++ b/crates/meilisearch/src/routes/indexes/mod.rs
@@ -496,8 +496,6 @@ pub struct IndexStats {
     pub number_of_documents: u64,
     /// Size of the documents database, in bytes.
     pub raw_document_db_size: u64,
-    /// Maximum size of a document in the documents database.
-    pub max_document_size: u64,
     /// Average size of a document in the documents database.
     pub avg_document_size: u64,
     /// Whether or not the index is currently ingesting document
@@ -518,7 +516,6 @@ impl From<index_scheduler::IndexStats> for IndexStats {
         IndexStats {
             number_of_documents: stats.inner_stats.documents_database_stats.number_of_entries(),
             raw_document_db_size: stats.inner_stats.documents_database_stats.total_value_size(),
-            max_document_size: stats.inner_stats.documents_database_stats.max_value_size(),
             avg_document_size: stats.inner_stats.documents_database_stats.average_value_size(),
             is_indexing: stats.is_indexing,
             number_of_embeddings: stats.inner_stats.number_of_embeddings,
@@ -541,6 +538,8 @@ impl From<index_scheduler::IndexStats> for IndexStats {
         (status = OK, description = "The stats of the index", body = IndexStats, content_type = "application/json", example = json!(
             {
                 "numberOfDocuments": 10,
+                "rawDocumentDbSize": 10,
+                "avgDocumentSize": 10,
                 "numberOfEmbeddings": 10,
                 "numberOfEmbeddedDocuments": 10,
                 "isIndexing": true,

--- a/crates/meilisearch/src/routes/indexes/mod.rs
+++ b/crates/meilisearch/src/routes/indexes/mod.rs
@@ -494,6 +494,12 @@ pub async fn delete_index(
 pub struct IndexStats {
     /// Number of documents in the index
     pub number_of_documents: u64,
+    /// Size of the documents database, in bytes.
+    pub raw_document_db_size: u64,
+    /// Maximum size of a document in the documents database.
+    pub max_document_size: u64,
+    /// Average size of a document in the documents database.
+    pub avg_document_size: u64,
     /// Whether or not the index is currently ingesting document
     pub is_indexing: bool,
     /// Number of embeddings in the index
@@ -510,7 +516,10 @@ pub struct IndexStats {
 impl From<index_scheduler::IndexStats> for IndexStats {
     fn from(stats: index_scheduler::IndexStats) -> Self {
         IndexStats {
-            number_of_documents: stats.inner_stats.number_of_documents,
+            number_of_documents: stats.inner_stats.documents_database_stats.number_of_entries(),
+            raw_document_db_size: stats.inner_stats.documents_database_stats.total_value_size(),
+            max_document_size: stats.inner_stats.documents_database_stats.max_value_size(),
+            avg_document_size: stats.inner_stats.documents_database_stats.average_value_size(),
             is_indexing: stats.is_indexing,
             number_of_embeddings: stats.inner_stats.number_of_embeddings,
             number_of_embedded_documents: stats.inner_stats.number_of_embedded_documents,

--- a/crates/meilisearch/src/routes/mod.rs
+++ b/crates/meilisearch/src/routes/mod.rs
@@ -392,6 +392,9 @@ pub struct Stats {
                 "indexes": {
                     "movies": {
                         "numberOfDocuments": 10,
+                        "rawDocumentDbSize": 100,
+                        "maxDocumentSize": 16,
+                        "avgDocumentSize": 10,
                         "isIndexing": true,
                         "fieldDistribution": {
                             "genre": 10,

--- a/crates/meilisearch/tests/documents/delete_documents.rs
+++ b/crates/meilisearch/tests/documents/delete_documents.rs
@@ -161,7 +161,6 @@ async fn delete_document_by_filter() {
     {
       "numberOfDocuments": 4,
       "rawDocumentDbSize": 42,
-      "maxDocumentSize": 13,
       "avgDocumentSize": 10,
       "isIndexing": false,
       "numberOfEmbeddings": 0,
@@ -213,7 +212,6 @@ async fn delete_document_by_filter() {
     {
       "numberOfDocuments": 2,
       "rawDocumentDbSize": 16,
-      "maxDocumentSize": 12,
       "avgDocumentSize": 8,
       "isIndexing": false,
       "numberOfEmbeddings": 0,
@@ -284,7 +282,6 @@ async fn delete_document_by_filter() {
     {
       "numberOfDocuments": 1,
       "rawDocumentDbSize": 12,
-      "maxDocumentSize": 12,
       "avgDocumentSize": 12,
       "isIndexing": false,
       "numberOfEmbeddings": 0,

--- a/crates/meilisearch/tests/documents/delete_documents.rs
+++ b/crates/meilisearch/tests/documents/delete_documents.rs
@@ -160,6 +160,9 @@ async fn delete_document_by_filter() {
     snapshot!(json_string!(stats), @r###"
     {
       "numberOfDocuments": 4,
+      "rawDocumentDbSize": 42,
+      "maxDocumentSize": 13,
+      "avgDocumentSize": 10,
       "isIndexing": false,
       "numberOfEmbeddings": 0,
       "numberOfEmbeddedDocuments": 0,
@@ -209,6 +212,9 @@ async fn delete_document_by_filter() {
     snapshot!(json_string!(stats), @r###"
     {
       "numberOfDocuments": 2,
+      "rawDocumentDbSize": 16,
+      "maxDocumentSize": 12,
+      "avgDocumentSize": 8,
       "isIndexing": false,
       "numberOfEmbeddings": 0,
       "numberOfEmbeddedDocuments": 0,
@@ -277,6 +283,9 @@ async fn delete_document_by_filter() {
     snapshot!(json_string!(stats), @r###"
     {
       "numberOfDocuments": 1,
+      "rawDocumentDbSize": 12,
+      "maxDocumentSize": 12,
+      "avgDocumentSize": 12,
       "isIndexing": false,
       "numberOfEmbeddings": 0,
       "numberOfEmbeddedDocuments": 0,

--- a/crates/meilisearch/tests/dumps/mod.rs
+++ b/crates/meilisearch/tests/dumps/mod.rs
@@ -32,6 +32,8 @@ async fn import_dump_v1_movie_raw() {
       @r###"
     {
       "numberOfDocuments": 53,
+      "rawDocumentDbSize": 21965,
+      "avgDocumentSize": 414,
       "isIndexing": false,
       "numberOfEmbeddings": 0,
       "numberOfEmbeddedDocuments": 0,
@@ -188,7 +190,6 @@ async fn import_dump_v1_movie_with_settings() {
     {
       "numberOfDocuments": 53,
       "rawDocumentDbSize": 21965,
-      "maxDocumentSize": 743,
       "avgDocumentSize": 414,
       "isIndexing": false,
       "numberOfEmbeddings": 0,
@@ -358,6 +359,8 @@ async fn import_dump_v1_rubygems_with_settings() {
       @r###"
     {
       "numberOfDocuments": 53,
+      "rawDocumentDbSize": 8606,
+      "avgDocumentSize": 162,
       "isIndexing": false,
       "numberOfEmbeddings": 0,
       "numberOfEmbeddedDocuments": 0,
@@ -523,6 +526,8 @@ async fn import_dump_v2_movie_raw() {
       @r###"
     {
       "numberOfDocuments": 53,
+      "rawDocumentDbSize": 21965,
+      "avgDocumentSize": 414,
       "isIndexing": false,
       "numberOfEmbeddings": 0,
       "numberOfEmbeddedDocuments": 0,
@@ -678,6 +683,8 @@ async fn import_dump_v2_movie_with_settings() {
       @r###"
     {
       "numberOfDocuments": 53,
+      "rawDocumentDbSize": 21965,
+      "avgDocumentSize": 414,
       "isIndexing": false,
       "numberOfEmbeddings": 0,
       "numberOfEmbeddedDocuments": 0,
@@ -843,6 +850,8 @@ async fn import_dump_v2_rubygems_with_settings() {
       @r###"
     {
       "numberOfDocuments": 53,
+      "rawDocumentDbSize": 8606,
+      "avgDocumentSize": 162,
       "isIndexing": false,
       "numberOfEmbeddings": 0,
       "numberOfEmbeddedDocuments": 0,
@@ -1005,6 +1014,8 @@ async fn import_dump_v3_movie_raw() {
       @r###"
     {
       "numberOfDocuments": 53,
+      "rawDocumentDbSize": 21965,
+      "avgDocumentSize": 414,
       "isIndexing": false,
       "numberOfEmbeddings": 0,
       "numberOfEmbeddedDocuments": 0,
@@ -1160,6 +1171,8 @@ async fn import_dump_v3_movie_with_settings() {
       @r###"
     {
       "numberOfDocuments": 53,
+      "rawDocumentDbSize": 21965,
+      "avgDocumentSize": 414,
       "isIndexing": false,
       "numberOfEmbeddings": 0,
       "numberOfEmbeddedDocuments": 0,
@@ -1325,6 +1338,8 @@ async fn import_dump_v3_rubygems_with_settings() {
       @r###"
     {
       "numberOfDocuments": 53,
+      "rawDocumentDbSize": 8606,
+      "avgDocumentSize": 162,
       "isIndexing": false,
       "numberOfEmbeddings": 0,
       "numberOfEmbeddedDocuments": 0,
@@ -1487,6 +1502,8 @@ async fn import_dump_v4_movie_raw() {
       @r###"
     {
       "numberOfDocuments": 53,
+      "rawDocumentDbSize": 21965,
+      "avgDocumentSize": 414,
       "isIndexing": false,
       "numberOfEmbeddings": 0,
       "numberOfEmbeddedDocuments": 0,
@@ -1642,6 +1659,8 @@ async fn import_dump_v4_movie_with_settings() {
       @r###"
     {
       "numberOfDocuments": 53,
+      "rawDocumentDbSize": 21965,
+      "avgDocumentSize": 414,
       "isIndexing": false,
       "numberOfEmbeddings": 0,
       "numberOfEmbeddedDocuments": 0,
@@ -1807,6 +1826,8 @@ async fn import_dump_v4_rubygems_with_settings() {
       @r###"
     {
       "numberOfDocuments": 53,
+      "rawDocumentDbSize": 8606,
+      "avgDocumentSize": 162,
       "isIndexing": false,
       "numberOfEmbeddings": 0,
       "numberOfEmbeddedDocuments": 0,
@@ -1976,6 +1997,8 @@ async fn import_dump_v5() {
     snapshot!(json_string!(stats), @r###"
     {
       "numberOfDocuments": 10,
+      "rawDocumentDbSize": 6782,
+      "avgDocumentSize": 678,
       "isIndexing": false,
       "numberOfEmbeddings": 0,
       "numberOfEmbeddedDocuments": 0,
@@ -2012,6 +2035,8 @@ async fn import_dump_v5() {
       @r###"
     {
       "numberOfDocuments": 10,
+      "rawDocumentDbSize": 6782,
+      "avgDocumentSize": 678,
       "isIndexing": false,
       "numberOfEmbeddings": 0,
       "numberOfEmbeddedDocuments": 0,

--- a/crates/meilisearch/tests/dumps/mod.rs
+++ b/crates/meilisearch/tests/dumps/mod.rs
@@ -187,6 +187,9 @@ async fn import_dump_v1_movie_with_settings() {
         @r###"
     {
       "numberOfDocuments": 53,
+      "rawDocumentDbSize": 21965,
+      "maxDocumentSize": 743,
+      "avgDocumentSize": 414,
       "isIndexing": false,
       "numberOfEmbeddings": 0,
       "numberOfEmbeddedDocuments": 0,

--- a/crates/meilisearch/tests/stats/mod.rs
+++ b/crates/meilisearch/tests/stats/mod.rs
@@ -113,6 +113,8 @@ async fn add_remove_embeddings() {
     snapshot!(json_string!(stats), @r###"
     {
       "numberOfDocuments": 2,
+      "rawDocumentDbSize": 27,
+      "avgDocumentSize": 13,
       "isIndexing": false,
       "numberOfEmbeddings": 5,
       "numberOfEmbeddedDocuments": 2,
@@ -136,6 +138,8 @@ async fn add_remove_embeddings() {
     snapshot!(json_string!(stats), @r###"
     {
       "numberOfDocuments": 2,
+      "rawDocumentDbSize": 27,
+      "avgDocumentSize": 13,
       "isIndexing": false,
       "numberOfEmbeddings": 3,
       "numberOfEmbeddedDocuments": 2,
@@ -159,6 +163,8 @@ async fn add_remove_embeddings() {
     snapshot!(json_string!(stats), @r###"
     {
       "numberOfDocuments": 2,
+      "rawDocumentDbSize": 27,
+      "avgDocumentSize": 13,
       "isIndexing": false,
       "numberOfEmbeddings": 2,
       "numberOfEmbeddedDocuments": 2,
@@ -183,6 +189,8 @@ async fn add_remove_embeddings() {
     snapshot!(json_string!(stats), @r###"
     {
       "numberOfDocuments": 2,
+      "rawDocumentDbSize": 27,
+      "avgDocumentSize": 13,
       "isIndexing": false,
       "numberOfEmbeddings": 2,
       "numberOfEmbeddedDocuments": 1,
@@ -231,6 +239,8 @@ async fn add_remove_embedded_documents() {
     snapshot!(json_string!(stats), @r###"
     {
       "numberOfDocuments": 2,
+      "rawDocumentDbSize": 27,
+      "avgDocumentSize": 13,
       "isIndexing": false,
       "numberOfEmbeddings": 5,
       "numberOfEmbeddedDocuments": 2,
@@ -250,6 +260,8 @@ async fn add_remove_embedded_documents() {
     snapshot!(json_string!(stats), @r###"
     {
       "numberOfDocuments": 1,
+      "rawDocumentDbSize": 13,
+      "avgDocumentSize": 13,
       "isIndexing": false,
       "numberOfEmbeddings": 3,
       "numberOfEmbeddedDocuments": 1,
@@ -281,6 +293,8 @@ async fn update_embedder_settings() {
     snapshot!(json_string!(stats), @r###"
     {
       "numberOfDocuments": 2,
+      "rawDocumentDbSize": 108,
+      "avgDocumentSize": 54,
       "isIndexing": false,
       "numberOfEmbeddings": 0,
       "numberOfEmbeddedDocuments": 0,
@@ -315,6 +329,8 @@ async fn update_embedder_settings() {
     snapshot!(json_string!(stats), @r###"
     {
       "numberOfDocuments": 2,
+      "rawDocumentDbSize": 108,
+      "avgDocumentSize": 54,
       "isIndexing": false,
       "numberOfEmbeddings": 3,
       "numberOfEmbeddedDocuments": 2,

--- a/crates/meilisearch/tests/upgrade/v1_12/v1_12_0.rs
+++ b/crates/meilisearch/tests/upgrade/v1_12/v1_12_0.rs
@@ -135,7 +135,6 @@ async fn check_the_index_scheduler(server: &Server) {
         "kefir": {
           "numberOfDocuments": 1,
           "rawDocumentDbSize": 109,
-          "maxDocumentSize": 109,
           "avgDocumentSize": 109,
           "isIndexing": false,
           "numberOfEmbeddings": 0,
@@ -220,7 +219,6 @@ async fn check_the_index_scheduler(server: &Server) {
         "kefir": {
           "numberOfDocuments": 1,
           "rawDocumentDbSize": 109,
-          "maxDocumentSize": 109,
           "avgDocumentSize": 109,
           "isIndexing": false,
           "numberOfEmbeddings": 0,
@@ -242,7 +240,6 @@ async fn check_the_index_scheduler(server: &Server) {
     {
       "numberOfDocuments": 1,
       "rawDocumentDbSize": 109,
-      "maxDocumentSize": 109,
       "avgDocumentSize": 109,
       "isIndexing": false,
       "numberOfEmbeddings": 0,

--- a/crates/meilisearch/tests/upgrade/v1_12/v1_12_0.rs
+++ b/crates/meilisearch/tests/upgrade/v1_12/v1_12_0.rs
@@ -134,6 +134,9 @@ async fn check_the_index_scheduler(server: &Server) {
       "indexes": {
         "kefir": {
           "numberOfDocuments": 1,
+          "rawDocumentDbSize": 109,
+          "maxDocumentSize": 109,
+          "avgDocumentSize": 109,
           "isIndexing": false,
           "numberOfEmbeddings": 0,
           "numberOfEmbeddedDocuments": 0,
@@ -216,6 +219,9 @@ async fn check_the_index_scheduler(server: &Server) {
       "indexes": {
         "kefir": {
           "numberOfDocuments": 1,
+          "rawDocumentDbSize": 109,
+          "maxDocumentSize": 109,
+          "avgDocumentSize": 109,
           "isIndexing": false,
           "numberOfEmbeddings": 0,
           "numberOfEmbeddedDocuments": 0,
@@ -235,6 +241,9 @@ async fn check_the_index_scheduler(server: &Server) {
     snapshot!(stats, @r###"
     {
       "numberOfDocuments": 1,
+      "rawDocumentDbSize": 109,
+      "maxDocumentSize": 109,
+      "avgDocumentSize": 109,
       "isIndexing": false,
       "numberOfEmbeddings": 0,
       "numberOfEmbeddedDocuments": 0,

--- a/crates/milli/src/database_stats.rs
+++ b/crates/milli/src/database_stats.rs
@@ -3,8 +3,6 @@ use heed::Database;
 use heed::RoTxn;
 use serde::{Deserialize, Serialize};
 
-use crate::Result;
-
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "camelCase")]
 /// The stats of a database.
@@ -15,14 +13,6 @@ pub struct DatabaseStats {
     total_key_size: u64,
     /// The total size of the values in the database.
     total_value_size: u64,
-    /// The maximum size of a key in the database.
-    max_key_size: u64,
-    /// The maximum size of a value in the database.
-    max_value_size: u64,
-    /// The minimum size of a key in the database.
-    min_key_size: u64,
-    /// The minimum size of a value in the database.
-    min_value_size: u64,
 }
 
 impl DatabaseStats {
@@ -30,36 +20,58 @@ impl DatabaseStats {
     ///
     /// This function iterates over the whole database and computes the stats.
     /// It is not efficient and should be cached somewhere.
-    pub(crate) fn new(database: Database<Bytes, Bytes>, rtxn: &RoTxn<'_>) -> Result<Self> {
-        let mut database_stats = Self {
-            number_of_entries: 0,
-            total_key_size: 0,
-            total_value_size: 0,
-            max_key_size: 0,
-            max_value_size: 0,
-            min_key_size: u64::MAX,
-            min_value_size: u64::MAX,
-        };
+    pub(crate) fn new(database: Database<Bytes, Bytes>, rtxn: &RoTxn<'_>) -> heed::Result<Self> {
+        let mut database_stats =
+            Self { number_of_entries: 0, total_key_size: 0, total_value_size: 0 };
 
         let mut iter = database.iter(rtxn)?;
         while let Some((key, value)) = iter.next().transpose()? {
             let key_size = key.len() as u64;
             let value_size = value.len() as u64;
-            database_stats.number_of_entries += 1;
             database_stats.total_key_size += key_size;
             database_stats.total_value_size += value_size;
-            database_stats.max_key_size = database_stats.max_key_size.max(key_size);
-            database_stats.max_value_size = database_stats.max_value_size.max(value_size);
-            database_stats.min_key_size = database_stats.min_key_size.min(key_size);
-            database_stats.min_value_size = database_stats.min_value_size.min(value_size);
         }
 
-        if database_stats.number_of_entries == 0 {
-            database_stats.min_key_size = 0;
-            database_stats.min_value_size = 0;
-        }
+        database_stats.number_of_entries = database.len(rtxn)?;
 
         Ok(database_stats)
+    }
+
+    /// Recomputes the stats of the database and returns the new stats.
+    ///
+    /// This function is used to update the stats of the database when some keys are modified.
+    /// It is more efficient than the `new` function because it does not iterate over the whole database but only the modified keys comparing the before and after states.
+    pub(crate) fn recompute<'a, I, K>(
+        mut stats: Self,
+        database: Database<Bytes, Bytes>,
+        before_rtxn: &RoTxn<'_>,
+        after_rtxn: &RoTxn<'_>,
+        modified_keys: I,
+    ) -> heed::Result<Self>
+    where
+        I: IntoIterator<Item = K>,
+        K: AsRef<[u8]>,
+    {
+        for key in modified_keys {
+            let key = key.as_ref();
+            if let Some(value) = database.get(after_rtxn, key)? {
+                let key_size = key.len() as u64;
+                let value_size = value.len() as u64;
+                stats.total_key_size = stats.total_key_size.saturating_add(key_size);
+                stats.total_value_size = stats.total_value_size.saturating_add(value_size);
+            }
+
+            if let Some(value) = database.get(before_rtxn, key)? {
+                let key_size = key.len() as u64;
+                let value_size = value.len() as u64;
+                stats.total_key_size = stats.total_key_size.saturating_sub(key_size);
+                stats.total_value_size = stats.total_value_size.saturating_sub(value_size);
+            }
+        }
+
+        stats.number_of_entries = database.len(after_rtxn)?;
+
+        Ok(stats)
     }
 
     pub fn average_key_size(&self) -> u64 {
@@ -80,21 +92,5 @@ impl DatabaseStats {
 
     pub fn total_value_size(&self) -> u64 {
         self.total_value_size
-    }
-
-    pub fn max_key_size(&self) -> u64 {
-        self.max_key_size
-    }
-
-    pub fn max_value_size(&self) -> u64 {
-        self.max_value_size
-    }
-
-    pub fn min_key_size(&self) -> u64 {
-        self.min_key_size
-    }
-
-    pub fn min_value_size(&self) -> u64 {
-        self.min_value_size
     }
 }

--- a/crates/milli/src/database_stats.rs
+++ b/crates/milli/src/database_stats.rs
@@ -41,7 +41,7 @@ impl DatabaseStats {
     ///
     /// This function is used to update the stats of the database when some keys are modified.
     /// It is more efficient than the `new` function because it does not iterate over the whole database but only the modified keys comparing the before and after states.
-    pub(crate) fn recompute<'a, I, K>(
+    pub(crate) fn recompute<I, K>(
         mut stats: Self,
         database: Database<Bytes, Bytes>,
         before_rtxn: &RoTxn<'_>,

--- a/crates/milli/src/database_stats.rs
+++ b/crates/milli/src/database_stats.rs
@@ -63,19 +63,11 @@ impl DatabaseStats {
     }
 
     pub fn average_key_size(&self) -> u64 {
-        if self.total_key_size == 0 {
-            0
-        } else {
-            self.total_key_size / self.number_of_entries
-        }
+        self.total_key_size.checked_div(self.number_of_entries).unwrap_or(0)
     }
 
     pub fn average_value_size(&self) -> u64 {
-        if self.total_value_size == 0 {
-            0
-        } else {
-            self.total_value_size / self.number_of_entries
-        }
+        self.total_value_size.checked_div(self.number_of_entries).unwrap_or(0)
     }
 
     pub fn number_of_entries(&self) -> u64 {

--- a/crates/milli/src/database_stats.rs
+++ b/crates/milli/src/database_stats.rs
@@ -1,0 +1,100 @@
+use heed::types::Bytes;
+use heed::Database;
+use heed::RoTxn;
+use serde::{Deserialize, Serialize};
+
+use crate::Result;
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "camelCase")]
+/// The stats of a database.
+pub struct DatabaseStats {
+    /// The number of entries in the database.
+    number_of_entries: u64,
+    /// The total size of the keys in the database.
+    total_key_size: u64,
+    /// The total size of the values in the database.
+    total_value_size: u64,
+    /// The maximum size of a key in the database.
+    max_key_size: u64,
+    /// The maximum size of a value in the database.
+    max_value_size: u64,
+    /// The minimum size of a key in the database.
+    min_key_size: u64,
+    /// The minimum size of a value in the database.
+    min_value_size: u64,
+}
+
+impl DatabaseStats {
+    /// Returns the stats of the database.
+    ///
+    /// This function iterates over the whole database and computes the stats.
+    /// It is not efficient and should be cached somewhere.
+    pub(crate) fn new<'a>(database: Database<Bytes, Bytes>, rtxn: &RoTxn<'a>) -> Result<Self> {
+        let mut database_stats = Self {
+            number_of_entries: 0,
+            total_key_size: 0,
+            total_value_size: 0,
+            max_key_size: 0,
+            max_value_size: 0,
+            min_key_size: u64::MAX,
+            min_value_size: u64::MAX,
+        };
+
+        let mut iter = database.iter(rtxn)?;
+        while let Some((key, value)) = iter.next().transpose()? {
+            let key_size = key.len() as u64;
+            let value_size = value.len() as u64;
+            database_stats.number_of_entries += 1;
+            database_stats.total_key_size += key_size;
+            database_stats.total_value_size += value_size;
+            database_stats.max_key_size = database_stats.max_key_size.max(key_size);
+            database_stats.max_value_size = database_stats.max_value_size.max(value_size);
+            database_stats.min_key_size = database_stats.min_key_size.min(key_size);
+            database_stats.min_value_size = database_stats.min_value_size.min(value_size);
+        }
+
+        if database_stats.number_of_entries == 0 {
+            database_stats.min_key_size = 0;
+            database_stats.min_value_size = 0;
+        }
+
+        Ok(database_stats)
+    }
+
+    pub fn average_key_size(&self) -> u64 {
+        self.total_key_size / self.number_of_entries
+    }
+
+    pub fn average_value_size(&self) -> u64 {
+        self.total_value_size / self.number_of_entries
+    }
+
+    pub fn number_of_entries(&self) -> u64 {
+        self.number_of_entries
+    }
+
+    pub fn total_key_size(&self) -> u64 {
+        self.total_key_size
+    }
+
+    pub fn total_value_size(&self) -> u64 {
+        self.total_value_size
+    }
+
+    pub fn max_key_size(&self) -> u64 {
+        self.max_key_size
+    }
+
+    pub fn max_value_size(&self) -> u64 {
+        self.max_value_size
+    }
+
+    pub fn min_key_size(&self) -> u64 {
+        self.min_key_size
+    }
+
+    pub fn min_value_size(&self) -> u64 {
+        self.min_value_size
+    }
+}

--- a/crates/milli/src/database_stats.rs
+++ b/crates/milli/src/database_stats.rs
@@ -30,7 +30,7 @@ impl DatabaseStats {
     ///
     /// This function iterates over the whole database and computes the stats.
     /// It is not efficient and should be cached somewhere.
-    pub(crate) fn new<'a>(database: Database<Bytes, Bytes>, rtxn: &RoTxn<'a>) -> Result<Self> {
+    pub(crate) fn new(database: Database<Bytes, Bytes>, rtxn: &RoTxn<'_>) -> Result<Self> {
         let mut database_stats = Self {
             number_of_entries: 0,
             total_key_size: 0,

--- a/crates/milli/src/database_stats.rs
+++ b/crates/milli/src/database_stats.rs
@@ -63,11 +63,19 @@ impl DatabaseStats {
     }
 
     pub fn average_key_size(&self) -> u64 {
-        self.total_key_size / self.number_of_entries
+        if self.total_key_size == 0 {
+            0
+        } else {
+            self.total_key_size / self.number_of_entries
+        }
     }
 
     pub fn average_value_size(&self) -> u64 {
-        self.total_value_size / self.number_of_entries
+        if self.total_value_size == 0 {
+            0
+        } else {
+            self.total_value_size / self.number_of_entries
+        }
     }
 
     pub fn number_of_entries(&self) -> u64 {

--- a/crates/milli/src/index.rs
+++ b/crates/milli/src/index.rs
@@ -406,7 +406,7 @@ impl Index {
 
     /// Returns the stats of the database.
     pub fn documents_database_stats(&self, rtxn: &RoTxn<'_>) -> Result<DatabaseStats> {
-        Ok(DatabaseStats::new(self.documents.remap_types::<Bytes, Bytes>(), rtxn)?)
+        DatabaseStats::new(self.documents.remap_types::<Bytes, Bytes>(), rtxn)
     }
 
     /* primary key */

--- a/crates/milli/src/index.rs
+++ b/crates/milli/src/index.rs
@@ -11,6 +11,7 @@ use rstar::RTree;
 use serde::{Deserialize, Serialize};
 
 use crate::constants::{self, RESERVED_VECTORS_FIELD_NAME};
+use crate::database_stats::DatabaseStats;
 use crate::documents::PrimaryKey;
 use crate::error::{InternalError, UserError};
 use crate::fields_ids_map::FieldsIdsMap;
@@ -401,6 +402,11 @@ impl Index {
             .remap_types::<Str, RoaringBitmapLenCodec>()
             .get(rtxn, main_key::DOCUMENTS_IDS_KEY)?;
         Ok(count.unwrap_or_default())
+    }
+
+    /// Returns the stats of the database.
+    pub fn documents_database_stats(&self, rtxn: &RoTxn<'_>) -> Result<DatabaseStats> {
+        Ok(DatabaseStats::new(self.documents.remap_types::<Bytes, Bytes>(), rtxn)?)
     }
 
     /* primary key */

--- a/crates/milli/src/index.rs
+++ b/crates/milli/src/index.rs
@@ -452,8 +452,7 @@ impl Index {
 
     /// Returns the stats of the documents database.
     pub fn documents_stats(&self, rtxn: &RoTxn<'_>) -> heed::Result<Option<DatabaseStats>> {
-        self
-            .main
+        self.main
             .remap_types::<Str, SerdeJson<DatabaseStats>>()
             .get(rtxn, main_key::DOCUMENTS_STATS)
     }

--- a/crates/milli/src/index.rs
+++ b/crates/milli/src/index.rs
@@ -75,6 +75,7 @@ pub mod main_key {
     pub const LOCALIZED_ATTRIBUTES_RULES: &str = "localized_attributes_rules";
     pub const FACET_SEARCH: &str = "facet_search";
     pub const PREFIX_SEARCH: &str = "prefix_search";
+    pub const DOCUMENTS_STATS: &str = "documents_stats";
 }
 
 pub mod db_name {
@@ -404,9 +405,58 @@ impl Index {
         Ok(count.unwrap_or_default())
     }
 
-    /// Returns the stats of the database.
-    pub fn documents_database_stats(&self, rtxn: &RoTxn<'_>) -> Result<DatabaseStats> {
-        DatabaseStats::new(self.documents.remap_types::<Bytes, Bytes>(), rtxn)
+    /// Updates the stats of the documents database based on the previous stats and the modified docids.
+    pub fn update_documents_stats(
+        &self,
+        wtxn: &mut RwTxn<'_>,
+        modified_docids: roaring::RoaringBitmap,
+    ) -> Result<()> {
+        let before_rtxn = self.read_txn()?;
+        let document_stats = match self.documents_stats(&before_rtxn)? {
+            Some(before_stats) => DatabaseStats::recompute(
+                before_stats,
+                self.documents.remap_types(),
+                &before_rtxn,
+                wtxn,
+                modified_docids.iter().map(|docid| docid.to_be_bytes()),
+            )?,
+            None => {
+                // This should never happen when there are already documents in the index, the documents stats should be present.
+                // If it happens, it means that the index was not properly initialized/upgraded.
+                debug_assert_eq!(
+                    self.documents.len(&before_rtxn)?,
+                    0,
+                    "The documents stats should be present when there are documents in the index"
+                );
+                tracing::warn!("No documents stats found, creating new ones");
+                DatabaseStats::new(self.documents.remap_types(), &*wtxn)?
+            }
+        };
+
+        self.put_documents_stats(wtxn, document_stats)?;
+        Ok(())
+    }
+
+    /// Writes the stats of the documents database.
+    pub fn put_documents_stats(
+        &self,
+        wtxn: &mut RwTxn<'_>,
+        stats: DatabaseStats,
+    ) -> heed::Result<()> {
+        eprintln!("putting documents stats: {:?}", stats);
+        self.main.remap_types::<Str, SerdeJson<DatabaseStats>>().put(
+            wtxn,
+            main_key::DOCUMENTS_STATS,
+            &stats,
+        )
+    }
+
+    /// Returns the stats of the documents database.
+    pub fn documents_stats(&self, rtxn: &RoTxn<'_>) -> heed::Result<Option<DatabaseStats>> {
+        dbg!(self
+            .main
+            .remap_types::<Str, SerdeJson<DatabaseStats>>()
+            .get(rtxn, main_key::DOCUMENTS_STATS))
     }
 
     /* primary key */

--- a/crates/milli/src/index.rs
+++ b/crates/milli/src/index.rs
@@ -453,10 +453,10 @@ impl Index {
 
     /// Returns the stats of the documents database.
     pub fn documents_stats(&self, rtxn: &RoTxn<'_>) -> heed::Result<Option<DatabaseStats>> {
-        dbg!(self
+        self
             .main
             .remap_types::<Str, SerdeJson<DatabaseStats>>()
-            .get(rtxn, main_key::DOCUMENTS_STATS))
+            .get(rtxn, main_key::DOCUMENTS_STATS)
     }
 
     /* primary key */

--- a/crates/milli/src/index.rs
+++ b/crates/milli/src/index.rs
@@ -443,7 +443,6 @@ impl Index {
         wtxn: &mut RwTxn<'_>,
         stats: DatabaseStats,
     ) -> heed::Result<()> {
-        eprintln!("putting documents stats: {:?}", stats);
         self.main.remap_types::<Str, SerdeJson<DatabaseStats>>().put(
             wtxn,
             main_key::DOCUMENTS_STATS,

--- a/crates/milli/src/lib.rs
+++ b/crates/milli/src/lib.rs
@@ -10,6 +10,7 @@ pub mod documents;
 
 mod asc_desc;
 mod criterion;
+pub mod database_stats;
 mod error;
 mod external_documents_ids;
 pub mod facet;

--- a/crates/milli/src/update/index_documents/typed_chunk.rs
+++ b/crates/milli/src/update/index_documents/typed_chunk.rs
@@ -129,6 +129,7 @@ pub(crate) fn write_typed_chunk_into_index(
     index: &Index,
     settings_diff: &InnerIndexSettingsDiff,
     typed_chunks: Vec<TypedChunk>,
+    modified_docids: &mut RoaringBitmap,
 ) -> Result<(RoaringBitmap, bool)> {
     let mut is_merged_database = false;
     match typed_chunks[0] {
@@ -214,6 +215,7 @@ pub(crate) fn write_typed_chunk_into_index(
                         kind: DocumentOperationKind::Create,
                     });
                     docids.insert(docid);
+                    modified_docids.insert(docid);
                 } else {
                     db.delete(wtxn, &docid)?;
                     operations.push(DocumentOperation {
@@ -222,6 +224,7 @@ pub(crate) fn write_typed_chunk_into_index(
                         kind: DocumentOperationKind::Delete,
                     });
                     docids.remove(docid);
+                    modified_docids.insert(docid);
                 }
             }
             let external_documents_docids = index.external_documents_ids();

--- a/crates/milli/src/update/new/extract/cache.rs
+++ b/crates/milli/src/update/new/extract/cache.rs
@@ -711,15 +711,17 @@ impl DelAddRoaringBitmap {
         DelAddRoaringBitmap { del, add }
     }
 
-    pub fn apply_to(&self, documents_ids: &mut RoaringBitmap) {
+    pub fn apply_to(&self, documents_ids: &mut RoaringBitmap, modified_docids: &mut RoaringBitmap) {
         let DelAddRoaringBitmap { del, add } = self;
 
         if let Some(del) = del {
             *documents_ids -= del;
+            *modified_docids |= del;
         }
 
         if let Some(add) = add {
             *documents_ids |= add;
+            *modified_docids |= add;
         }
     }
 }

--- a/crates/milli/src/update/new/indexer/extract.rs
+++ b/crates/milli/src/update/new/indexer/extract.rs
@@ -32,6 +32,7 @@ pub(super) fn extract_all<'pl, 'extractor, DC, MSP>(
     field_distribution: &mut BTreeMap<String, u64>,
     mut index_embeddings: Vec<IndexEmbeddingConfig>,
     document_ids: &mut RoaringBitmap,
+    modified_docids: &mut RoaringBitmap,
 ) -> Result<(FacetFieldIdsDelta, Vec<IndexEmbeddingConfig>)>
 where
     DC: DocumentChanges<'pl>,
@@ -70,7 +71,7 @@ where
                 // adding the delta should never cause a negative result, as we are removing fields that previously existed.
                 *current = current.saturating_add_signed(delta);
             }
-            document_extractor_data.docids_delta.apply_to(document_ids);
+            document_extractor_data.docids_delta.apply_to(document_ids, modified_docids);
         }
 
         field_distribution.retain(|_, v| *v != 0);
@@ -256,7 +257,7 @@ where
                     let Some(deladd) = data.remove(&config.name) else {
                         continue 'data;
                     };
-                    deladd.apply_to(&mut config.user_provided);
+                    deladd.apply_to(&mut config.user_provided, modified_docids);
                 }
             }
         }

--- a/crates/milli/src/update/new/indexer/write.rs
+++ b/crates/milli/src/update/new/indexer/write.rs
@@ -113,6 +113,7 @@ where
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(super) fn update_index(
     index: &Index,
     wtxn: &mut RwTxn<'_>,

--- a/crates/milli/src/update/new/indexer/write.rs
+++ b/crates/milli/src/update/new/indexer/write.rs
@@ -121,6 +121,7 @@ pub(super) fn update_index(
     embedders: EmbeddingConfigs,
     field_distribution: std::collections::BTreeMap<String, u64>,
     document_ids: roaring::RoaringBitmap,
+    modified_docids: roaring::RoaringBitmap,
 ) -> Result<()> {
     index.put_fields_ids_map(wtxn, new_fields_ids_map.as_fields_ids_map())?;
     if let Some(new_primary_key) = new_primary_key {
@@ -132,6 +133,7 @@ pub(super) fn update_index(
     index.put_field_distribution(wtxn, &field_distribution)?;
     index.put_documents_ids(wtxn, &document_ids)?;
     index.set_updated_at(wtxn, &OffsetDateTime::now_utc())?;
+    index.update_documents_stats(wtxn, modified_docids)?;
     Ok(())
 }
 

--- a/crates/milli/src/update/upgrade/v1_13.rs
+++ b/crates/milli/src/update/upgrade/v1_13.rs
@@ -2,13 +2,44 @@ use heed::RwTxn;
 
 use super::UpgradeIndex;
 use crate::constants::{VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH};
+use crate::database_stats::DatabaseStats;
 use crate::progress::Progress;
-use crate::{Index, Result};
+use crate::{make_enum_progress, Index, Result};
 
 #[allow(non_camel_case_types)]
-pub(super) struct V1_13_0_To_Current();
+pub(super) struct V1_13_0_To_V1_13_1();
 
-impl UpgradeIndex for V1_13_0_To_Current {
+impl UpgradeIndex for V1_13_0_To_V1_13_1 {
+    fn upgrade(
+        &self,
+        wtxn: &mut RwTxn,
+        index: &Index,
+        _original: (u32, u32, u32),
+        progress: Progress,
+    ) -> Result<bool> {
+        make_enum_progress! {
+            enum DocumentsStats {
+                CreatingDocumentsStats,
+            }
+        };
+
+        // Create the new documents stats.
+        progress.update_progress(DocumentsStats::CreatingDocumentsStats);
+        let stats = DatabaseStats::new(index.documents.remap_types(), wtxn)?;
+        index.put_documents_stats(wtxn, stats)?;
+
+        Ok(true)
+    }
+
+    fn target_version(&self) -> (u32, u32, u32) {
+        (1, 13, 1)
+    }
+}
+
+#[allow(non_camel_case_types)]
+pub(super) struct V1_13_1_To_Current();
+
+impl UpgradeIndex for V1_13_1_To_Current {
     fn upgrade(
         &self,
         _wtxn: &mut RwTxn,


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #5319

## List

- Create a DatabaseStats struct
- Compute and store the documents database stats in the IndexStats
- Force dumpless upgrade to update the index stats
- when a document addition/modification/deletion is made, we only recompute the database stats on the added/modified/deleted documents