### PR TITLE
Get multiple documents by ids

### DIFF
--- a/crates/meilisearch-types/src/error.rs
+++ b/crates/meilisearch-types/src/error.rs
@@ -384,7 +384,6 @@ UnsupportedMediaType                  , InvalidRequest       , UNSUPPORTED_MEDIA
 // Experimental features
 VectorEmbeddingError                  , InvalidRequest       , BAD_REQUEST ;
 NotFoundSimilarId                     , InvalidRequest       , BAD_REQUEST ;
-NotFoundDocumentId                    , InvalidRequest       , BAD_REQUEST ;
 InvalidDocumentEditionContext         , InvalidRequest       , BAD_REQUEST ;
 InvalidDocumentEditionFunctionFilter  , InvalidRequest       , BAD_REQUEST ;
 EditDocumentsByFunctionError          , InvalidRequest       , BAD_REQUEST

--- a/crates/meilisearch-types/src/error.rs
+++ b/crates/meilisearch-types/src/error.rs
@@ -241,6 +241,7 @@ InvalidDocumentGeoField               , InvalidRequest       , BAD_REQUEST ;
 InvalidVectorDimensions               , InvalidRequest       , BAD_REQUEST ;
 InvalidVectorsType                    , InvalidRequest       , BAD_REQUEST ;
 InvalidDocumentId                     , InvalidRequest       , BAD_REQUEST ;
+InvalidDocumentIds                    , InvalidRequest       , BAD_REQUEST ;
 InvalidDocumentLimit                  , InvalidRequest       , BAD_REQUEST ;
 InvalidDocumentOffset                 , InvalidRequest       , BAD_REQUEST ;
 InvalidSearchEmbedder                 , InvalidRequest       , BAD_REQUEST ;
@@ -383,6 +384,7 @@ UnsupportedMediaType                  , InvalidRequest       , UNSUPPORTED_MEDIA
 // Experimental features
 VectorEmbeddingError                  , InvalidRequest       , BAD_REQUEST ;
 NotFoundSimilarId                     , InvalidRequest       , BAD_REQUEST ;
+NotFoundDocumentId                    , InvalidRequest       , BAD_REQUEST ;
 InvalidDocumentEditionContext         , InvalidRequest       , BAD_REQUEST ;
 InvalidDocumentEditionFunctionFilter  , InvalidRequest       , BAD_REQUEST ;
 EditDocumentsByFunctionError          , InvalidRequest       , BAD_REQUEST

--- a/crates/meilisearch/src/routes/indexes/documents.rs
+++ b/crates/meilisearch/src/routes/indexes/documents.rs
@@ -623,7 +623,7 @@ fn documents_by_query(
         let mut parsed_ids = Vec::with_capacity(ids.len());
         for (index, id) in ids.into_iter().enumerate() {
             let id = id.try_into().map_err(|error| {
-                let msg = format!("In `.ids[{index}]`:{error}");
+                let msg = format!("In `.ids[{index}]`: {error}");
                 ResponseError::from_msg(msg, Code::InvalidDocumentIds)
             })?;
             parsed_ids.push(id)

--- a/crates/meilisearch/src/routes/indexes/documents.rs
+++ b/crates/meilisearch/src/routes/indexes/documents.rs
@@ -1513,11 +1513,9 @@ fn retrieve_documents<S: AsRef<str>>(
     let mut candidates = if let Some(ids) = ids {
         let external_document_ids = index.external_documents_ids();
         let mut candidates = RoaringBitmap::new();
-        for (index, id) in ids.iter().enumerate() {
+        for id in ids.iter() {
             let Some(docid) = external_document_ids.get(&rtxn, id)? else {
-                let error = MeilisearchHttpError::DocumentNotFound(id.clone().into_inner());
-                let msg = format!("In `.ids[{index}]`: {error}");
-                return Err(ResponseError::from_msg(msg, Code::NotFoundDocumentId));
+                continue;
             };
             candidates.insert(docid);
         }

--- a/crates/meilisearch/tests/common/index.rs
+++ b/crates/meilisearch/tests/common/index.rs
@@ -411,7 +411,7 @@ impl<State> Index<'_, State> {
         self.service.get(url).await
     }
 
-    pub async fn get_document_by_filter(&self, payload: Value) -> (Value, StatusCode) {
+    pub async fn fetch_documents(&self, payload: Value) -> (Value, StatusCode) {
         let url = format!("/indexes/{}/documents/fetch", urlencode(self.uid.as_ref()));
         self.service.post(url, payload).await
     }

--- a/crates/meilisearch/tests/documents/errors.rs
+++ b/crates/meilisearch/tests/documents/errors.rs
@@ -667,7 +667,7 @@ async fn fetch_document_by_filter() {
         .await;
     index.wait_task(task.uid()).await.succeeded();
 
-    let (response, code) = index.get_document_by_filter(json!(null)).await;
+    let (response, code) = index.fetch_documents(json!(null)).await;
     snapshot!(code, @"400 Bad Request");
     snapshot!(response, @r###"
     {
@@ -678,7 +678,7 @@ async fn fetch_document_by_filter() {
     }
     "###);
 
-    let (response, code) = index.get_document_by_filter(json!({ "offset": "doggo" })).await;
+    let (response, code) = index.fetch_documents(json!({ "offset": "doggo" })).await;
     snapshot!(code, @"400 Bad Request");
     snapshot!(response, @r###"
     {
@@ -689,7 +689,7 @@ async fn fetch_document_by_filter() {
     }
     "###);
 
-    let (response, code) = index.get_document_by_filter(json!({ "limit": "doggo" })).await;
+    let (response, code) = index.fetch_documents(json!({ "limit": "doggo" })).await;
     snapshot!(code, @"400 Bad Request");
     snapshot!(response, @r###"
     {
@@ -700,7 +700,7 @@ async fn fetch_document_by_filter() {
     }
     "###);
 
-    let (response, code) = index.get_document_by_filter(json!({ "fields": "doggo" })).await;
+    let (response, code) = index.fetch_documents(json!({ "fields": "doggo" })).await;
     snapshot!(code, @"400 Bad Request");
     snapshot!(response, @r###"
     {
@@ -711,7 +711,7 @@ async fn fetch_document_by_filter() {
     }
     "###);
 
-    let (response, code) = index.get_document_by_filter(json!({ "filter": true })).await;
+    let (response, code) = index.fetch_documents(json!({ "filter": true })).await;
     snapshot!(code, @"400 Bad Request");
     snapshot!(response, @r###"
     {
@@ -722,7 +722,7 @@ async fn fetch_document_by_filter() {
     }
     "###);
 
-    let (response, code) = index.get_document_by_filter(json!({ "filter": "cool doggo" })).await;
+    let (response, code) = index.fetch_documents(json!({ "filter": "cool doggo" })).await;
     snapshot!(code, @"400 Bad Request");
     snapshot!(response, @r###"
     {
@@ -733,8 +733,7 @@ async fn fetch_document_by_filter() {
     }
     "###);
 
-    let (response, code) =
-        index.get_document_by_filter(json!({ "filter": "doggo = bernese" })).await;
+    let (response, code) = index.fetch_documents(json!({ "filter": "doggo = bernese" })).await;
     snapshot!(code, @"400 Bad Request");
     snapshot!(response, @r###"
     {
@@ -762,8 +761,7 @@ async fn retrieve_vectors() {
     "###);
 
     // FETCH ALL DOCUMENTS BY POST
-    let (response, _code) =
-        index.get_document_by_filter(json!({ "retrieveVectors": "tamo" })).await;
+    let (response, _code) = index.fetch_documents(json!({ "retrieveVectors": "tamo" })).await;
     snapshot!(response, @r###"
     {
       "message": "Invalid value type at `.retrieveVectors`: expected a boolean, but found a string: `\"tamo\"`",

--- a/crates/meilisearch/tests/documents/get_documents.rs
+++ b/crates/meilisearch/tests/documents/get_documents.rs
@@ -687,13 +687,23 @@ async fn get_document_not_found_ids() {
 
     let (response, code) = index.fetch_documents(json!({"ids": ["0", 3, 42] })).await;
     let (response2, code2) = index.get_all_documents_raw("?ids=0,3,42").await;
-    snapshot!(code, @"400 Bad Request");
+    // the document with id 42 is not in the results since it doesn't exist
+    // however, no error is raised
+    snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".enqueuedAt" => "[date]" }), @r###"
     {
-      "message": "In `.ids[2]`: Document `42` not found.",
-      "code": "not_found_document_id",
-      "type": "invalid_request",
-      "link": "https://docs.meilisearch.com/errors#not_found_document_id"
+      "results": [
+        {
+          "id": 0,
+          "color": "red"
+        },
+        {
+          "id": 3
+        }
+      ],
+      "offset": 0,
+      "limit": 20,
+      "total": 2
     }
     "###);
     assert_eq!(code, code2);

--- a/crates/meilisearch/tests/documents/get_documents.rs
+++ b/crates/meilisearch/tests/documents/get_documents.rs
@@ -658,7 +658,7 @@ async fn get_document_invalid_ids() {
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response, { ".enqueuedAt" => "[date]" }), @r###"
     {
-      "message": "In `.ids[1]`:Document identifier `\"illegal/docid\"` is invalid. A document identifier can be of type integer or string, only composed of alphanumeric characters (a-z A-Z 0-9), hyphens (-) and underscores (_), and can not be more than 511 bytes.",
+      "message": "In `.ids[1]`: Document identifier `\"illegal/docid\"` is invalid. A document identifier can be of type integer or string, only composed of alphanumeric characters (a-z A-Z 0-9), hyphens (-) and underscores (_), and can not be more than 511 bytes.",
       "code": "invalid_document_ids",
       "type": "invalid_request",
       "link": "https://docs.meilisearch.com/errors#invalid_document_ids"

--- a/crates/meilisearch/tests/documents/get_documents.rs
+++ b/crates/meilisearch/tests/documents/get_documents.rs
@@ -371,7 +371,7 @@ async fn get_document_by_filter() {
         .await;
     index.wait_task(task.uid()).await.succeeded();
 
-    let (response, code) = index.get_document_by_filter(json!({})).await;
+    let (response, code) = index.fetch_documents(json!({})).await;
     let (response2, code2) = index.get_all_documents_raw("").await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".enqueuedAt" => "[date]" }), @r###"
@@ -401,7 +401,7 @@ async fn get_document_by_filter() {
     assert_eq!(code, code2);
     assert_eq!(response, response2);
 
-    let (response, code) = index.get_document_by_filter(json!({ "filter": "color = blue" })).await;
+    let (response, code) = index.fetch_documents(json!({ "filter": "color = blue" })).await;
     let (response2, code2) = index.get_all_documents_raw("?filter=color=blue").await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".enqueuedAt" => "[date]" }), @r###"
@@ -424,9 +424,8 @@ async fn get_document_by_filter() {
     assert_eq!(code, code2);
     assert_eq!(response, response2);
 
-    let (response, code) = index
-        .get_document_by_filter(json!({ "offset": 1, "limit": 1, "filter": "color != blue" }))
-        .await;
+    let (response, code) =
+        index.fetch_documents(json!({ "offset": 1, "limit": 1, "filter": "color != blue" })).await;
     let (response2, code2) =
         index.get_all_documents_raw("?filter=color!=blue&offset=1&limit=1").await;
     snapshot!(code, @"200 OK");
@@ -446,9 +445,7 @@ async fn get_document_by_filter() {
     assert_eq!(response, response2);
 
     let (response, code) = index
-        .get_document_by_filter(
-            json!({ "limit": 1, "filter": "color != blue", "fields": ["color"] }),
-        )
+        .fetch_documents(json!({ "limit": 1, "filter": "color != blue", "fields": ["color"] }))
         .await;
     let (response2, code2) =
         index.get_all_documents_raw("?limit=1&filter=color!=blue&fields=color").await;
@@ -471,7 +468,7 @@ async fn get_document_by_filter() {
     // Now testing more complex filter that the get route can't represent
 
     let (response, code) =
-        index.get_document_by_filter(json!({ "filter": [["color = blue", "color = red"]] })).await;
+        index.fetch_documents(json!({ "filter": [["color = blue", "color = red"]] })).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".enqueuedAt" => "[date]" }), @r###"
     {

--- a/crates/meilisearch/tests/documents/get_documents.rs
+++ b/crates/meilisearch/tests/documents/get_documents.rs
@@ -492,9 +492,8 @@ async fn get_document_by_filter() {
     }
     "###);
 
-    let (response, code) = index
-        .get_document_by_filter(json!({ "filter": [["color != blue"], "color EXISTS"] }))
-        .await;
+    let (response, code) =
+        index.fetch_documents(json!({ "filter": [["color != blue"], "color EXISTS"] })).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".enqueuedAt" => "[date]" }), @r###"
     {
@@ -507,6 +506,316 @@ async fn get_document_by_filter() {
       "offset": 0,
       "limit": 20,
       "total": 1
+    }
+    "###);
+}
+
+#[actix_rt::test]
+async fn get_document_by_ids() {
+    let server = Server::new_shared();
+    let index = server.unique_index();
+    let (task, _code) = index
+        .add_documents(
+            json!([
+                { "id": 0, "color": "red" },
+                { "id": 1, "color": "blue" },
+                { "id": 2, "color": "blue" },
+                { "id": 3 },
+            ]),
+            Some("id"),
+        )
+        .await;
+    index.wait_task(task.uid()).await.succeeded();
+
+    let (response, code) = index
+        .fetch_documents(json!({
+          "ids": ["0", 1, 2, 3]
+        }))
+        .await;
+    let (response2, code2) = index.get_all_documents_raw("?ids=0,1,2,3").await;
+    snapshot!(code, @"200 OK");
+    snapshot!(json_string!(response, { ".enqueuedAt" => "[date]" }), @r###"
+    {
+      "results": [
+        {
+          "id": 0,
+          "color": "red"
+        },
+        {
+          "id": 1,
+          "color": "blue"
+        },
+        {
+          "id": 2,
+          "color": "blue"
+        },
+        {
+          "id": 3
+        }
+      ],
+      "offset": 0,
+      "limit": 20,
+      "total": 4
+    }
+    "###);
+    assert_eq!(code, code2);
+    assert_eq!(response, response2);
+
+    let (response, code) = index.fetch_documents(json!({ "ids": [2, "1"] })).await;
+    let (response2, code2) = index.get_all_documents_raw("?ids=2,1").await;
+    snapshot!(code, @"200 OK");
+    snapshot!(json_string!(response, { ".enqueuedAt" => "[date]" }), @r###"
+    {
+      "results": [
+        {
+          "id": 1,
+          "color": "blue"
+        },
+        {
+          "id": 2,
+          "color": "blue"
+        }
+      ],
+      "offset": 0,
+      "limit": 20,
+      "total": 2
+    }
+    "###);
+    assert_eq!(code, code2);
+    assert_eq!(response, response2);
+
+    let (response, code) =
+        index.fetch_documents(json!({ "offset": 1, "limit": 1, "ids": ["0", 0, 3] })).await;
+    let (response2, code2) = index.get_all_documents_raw("?ids=3,0&offset=1&limit=1").await;
+    snapshot!(code, @"200 OK");
+    snapshot!(json_string!(response, { ".enqueuedAt" => "[date]" }), @r###"
+    {
+      "results": [
+        {
+          "id": 3
+        }
+      ],
+      "offset": 1,
+      "limit": 1,
+      "total": 2
+    }
+    "###);
+    assert_eq!(code, code2);
+    assert_eq!(response, response2);
+
+    let (response, code) =
+        index.fetch_documents(json!({ "limit": 1, "ids": [0, 3], "fields": ["color"] })).await;
+    let (response2, code2) = index.get_all_documents_raw("?limit=1&ids=0,3&fields=color").await;
+    snapshot!(code, @"200 OK");
+    snapshot!(json_string!(response, { ".enqueuedAt" => "[date]" }), @r###"
+    {
+      "results": [
+        {
+          "color": "red"
+        }
+      ],
+      "offset": 0,
+      "limit": 1,
+      "total": 2
+    }
+    "###);
+    assert_eq!(code, code2);
+    assert_eq!(response, response2);
+
+    // Now testing more complex requests that the get route can't represent
+
+    let (response, code) = index.fetch_documents(json!({ "ids": [] })).await;
+    snapshot!(code, @"200 OK");
+    snapshot!(json_string!(response, { ".enqueuedAt" => "[date]" }), @r###"
+    {
+      "results": [],
+      "offset": 0,
+      "limit": 20,
+      "total": 0
+    }
+    "###);
+}
+
+#[actix_rt::test]
+async fn get_document_invalid_ids() {
+    let server = Server::new_shared();
+    let index = server.unique_index();
+    let (task, _code) = index
+        .add_documents(
+            json!([
+                { "id": 0, "color": "red" },
+                { "id": 1, "color": "blue" },
+                { "id": 2, "color": "blue" },
+                { "id": 3 },
+            ]),
+            Some("id"),
+        )
+        .await;
+    index.wait_task(task.uid()).await.succeeded();
+
+    let (response, code) = index.fetch_documents(json!({"ids": ["0", "illegal/docid"] })).await;
+    let (response2, code2) = index.get_all_documents_raw("?ids=0,illegal/docid").await;
+    snapshot!(code, @"400 Bad Request");
+    snapshot!(json_string!(response, { ".enqueuedAt" => "[date]" }), @r###"
+    {
+      "message": "In `.ids[1]`:Document identifier `\"illegal/docid\"` is invalid. A document identifier can be of type integer or string, only composed of alphanumeric characters (a-z A-Z 0-9), hyphens (-) and underscores (_), and can not be more than 511 bytes.",
+      "code": "invalid_document_ids",
+      "type": "invalid_request",
+      "link": "https://docs.meilisearch.com/errors#invalid_document_ids"
+    }
+    "###);
+    assert_eq!(code, code2);
+    assert_eq!(response, response2);
+}
+
+#[actix_rt::test]
+async fn get_document_not_found_ids() {
+    let server = Server::new_shared();
+    let index = server.unique_index();
+    let (task, _code) = index
+        .add_documents(
+            json!([
+                { "id": 0, "color": "red" },
+                { "id": 1, "color": "blue" },
+                { "id": 2, "color": "blue" },
+                { "id": 3 },
+            ]),
+            Some("id"),
+        )
+        .await;
+    index.wait_task(task.uid()).await.succeeded();
+
+    let (response, code) = index.fetch_documents(json!({"ids": ["0", 3, 42] })).await;
+    let (response2, code2) = index.get_all_documents_raw("?ids=0,3,42").await;
+    snapshot!(code, @"400 Bad Request");
+    snapshot!(json_string!(response, { ".enqueuedAt" => "[date]" }), @r###"
+    {
+      "message": "In `.ids[2]`: Document `42` not found.",
+      "code": "not_found_document_id",
+      "type": "invalid_request",
+      "link": "https://docs.meilisearch.com/errors#not_found_document_id"
+    }
+    "###);
+    assert_eq!(code, code2);
+    assert_eq!(response, response2);
+}
+
+#[actix_rt::test]
+async fn get_document_by_ids_and_filter() {
+    let server = Server::new_shared();
+    let index = server.unique_index();
+    index.update_settings_filterable_attributes(json!(["color"])).await;
+    let (task, _code) = index
+        .add_documents(
+            json!([
+                { "id": 0, "color": "red" },
+                { "id": 1, "color": "blue" },
+                { "id": 2, "color": "blue" },
+                { "id": 3 },
+            ]),
+            Some("id"),
+        )
+        .await;
+    index.wait_task(task.uid()).await.succeeded();
+
+    let (response, code) =
+        index.fetch_documents(json!({"ids": [2], "filter": "color = blue" })).await;
+    let (response2, code2) = index.get_all_documents_raw("?ids=2&filter=color=blue").await;
+    snapshot!(code, @"200 OK");
+    snapshot!(json_string!(response, { ".enqueuedAt" => "[date]" }), @r###"
+    {
+      "results": [
+        {
+          "id": 2,
+          "color": "blue"
+        }
+      ],
+      "offset": 0,
+      "limit": 20,
+      "total": 1
+    }
+    "###);
+    assert_eq!(code, code2);
+    assert_eq!(response, response2);
+
+    let (response, code) = index
+        .fetch_documents(
+            json!({ "offset": 1, "limit": 1, "ids": [0, 1, 2, 3], "filter": "color != blue" }),
+        )
+        .await;
+    let (response2, code2) =
+        index.get_all_documents_raw("?ids=0,1,2,3&filter=color!=blue&offset=1&limit=1").await;
+    snapshot!(code, @"200 OK");
+    snapshot!(json_string!(response, { ".enqueuedAt" => "[date]" }), @r###"
+    {
+      "results": [
+        {
+          "id": 3
+        }
+      ],
+      "offset": 1,
+      "limit": 1,
+      "total": 2
+    }
+    "###);
+    assert_eq!(code, code2);
+    assert_eq!(response, response2);
+
+    let (response, code) = index
+        .fetch_documents(json!({ "limit": 1, "ids": [0, 1, 2,3], "filter": "color != blue", "fields": ["color"] }))
+        .await;
+    let (response2, code2) =
+        index.get_all_documents_raw("?ids=0,1,2,3&limit=1&filter=color!=blue&fields=color").await;
+    snapshot!(code, @"200 OK");
+    snapshot!(json_string!(response, { ".enqueuedAt" => "[date]" }), @r###"
+    {
+      "results": [
+        {
+          "color": "red"
+        }
+      ],
+      "offset": 0,
+      "limit": 1,
+      "total": 2
+    }
+    "###);
+    assert_eq!(code, code2);
+    assert_eq!(response, response2);
+
+    // Now testing more complex filter that the get route can't represent
+
+    let (response, code) = index
+        .fetch_documents(json!({ "ids": [0, "2"], "filter": [["color = blue", "color = red"]] }))
+        .await;
+    snapshot!(code, @"200 OK");
+    snapshot!(json_string!(response, { ".enqueuedAt" => "[date]" }), @r###"
+    {
+      "results": [
+        {
+          "id": 0,
+          "color": "red"
+        },
+        {
+          "id": 2,
+          "color": "blue"
+        }
+      ],
+      "offset": 0,
+      "limit": 20,
+      "total": 2
+    }
+    "###);
+
+    let (response, code) = index
+        .fetch_documents(json!({ "filter": [["color != blue"], "color EXISTS"], "ids": [1, 2, 3] }))
+        .await;
+    snapshot!(code, @"200 OK");
+    snapshot!(json_string!(response, { ".enqueuedAt" => "[date]" }), @r###"
+    {
+      "results": [],
+      "offset": 0,
+      "limit": 20,
+      "total": 0
     }
     "###);
 }

--- a/crates/meilisearch/tests/similar/errors.rs
+++ b/crates/meilisearch/tests/similar/errors.rs
@@ -55,11 +55,11 @@ async fn similar_bad_id() {
     snapshot!(code, @"202 Accepted");
     server.wait_task(response.uid()).await;
 
-    let (response, code) = index.similar_post(json!({"id": ["doggo"]})).await;
+    let (response, code) = index.similar_post(json!({"id": ["doggo"], "embedder": "manual"})).await;
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
-      "message": "Invalid value at `.id`: the value of `id` is invalid. A document identifier can be of type integer or string, only composed of alphanumeric characters (a-z A-Z 0-9), hyphens (-) and underscores (_), and can not be more than 511 bytes.",
+      "message": "Invalid value at `.id`: Document identifier `[\"doggo\"]` is invalid. A document identifier can be of type integer or string, only composed of alphanumeric characters (a-z A-Z 0-9), hyphens (-) and underscores (_), and can not be more than 511 bytes.",
       "code": "invalid_similar_id",
       "type": "invalid_request",
       "link": "https://docs.meilisearch.com/errors#invalid_similar_id"
@@ -145,11 +145,12 @@ async fn similar_invalid_id() {
     snapshot!(code, @"202 Accepted");
     server.wait_task(response.uid()).await;
 
-    let (response, code) = index.similar_post(json!({"id": "http://invalid-docid/"})).await;
+    let (response, code) =
+        index.similar_post(json!({"id": "http://invalid-docid/", "embedder": "manual"})).await;
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
-      "message": "Invalid value at `.id`: the value of `id` is invalid. A document identifier can be of type integer or string, only composed of alphanumeric characters (a-z A-Z 0-9), hyphens (-) and underscores (_), and can not be more than 511 bytes.",
+      "message": "Invalid value at `.id`: Document identifier `\"http://invalid-docid/\"` is invalid. A document identifier can be of type integer or string, only composed of alphanumeric characters (a-z A-Z 0-9), hyphens (-) and underscores (_), and can not be more than 511 bytes.",
       "code": "invalid_similar_id",
       "type": "invalid_request",
       "link": "https://docs.meilisearch.com/errors#invalid_similar_id"


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #5345 

## What does this PR do?
- Implements [public usage](https://www.notion.so/meilisearch/Get-documents-by-ID-1994b06b651f805ba273e1c6b75ce4d8)
- Slightly refactor error messages for the `/similar` route