### PR TITLE
Bump mini-dashboard v0.2.18

### DIFF
--- a/crates/meilisearch/Cargo.toml
+++ b/crates/meilisearch/Cargo.toml
@@ -169,5 +169,5 @@ german = ["meilisearch-types/german"]
 turkish = ["meilisearch-types/turkish"]
 
 [package.metadata.mini-dashboard]
-assets-url = "https://github.com/meilisearch/mini-dashboard/releases/download/v0.2.17/build.zip"
-sha1 = "29e92ce25f306208a9c86f013279c736bdc1e034"
+assets-url = "https://github.com/meilisearch/mini-dashboard/releases/download/v0.2.18/build.zip"
+sha1 = "b408a30dcb6e20cddb0c153c23385bcac4c8e912"


### PR DESCRIPTION
## Description

The previous build didn't have the environment variable correctly configured, so form submissions didn't work. 

We fixed the build in https://github.com/meilisearch/mini-dashboard/pull/592, and this PR uses the new mini-dashboard build.

Related to https://github.com/meilisearch/meilisearch/issues/5361.

## To-do

- [x] Update assets-url
- [x] Update sha1

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
