### PR TITLE
Skip snapshots on windows

### DIFF
--- a/crates/meilisearch/tests/snapshot/mod.rs
+++ b/crates/meilisearch/tests/snapshot/mod.rs
@@ -111,6 +111,7 @@ async fn perform_snapshot() {
 }
 
 #[actix_rt::test]
+#[cfg_attr(target_os = "windows", ignore)]
 async fn perform_on_demand_snapshot() {
     let temp = tempfile::tempdir().unwrap();
     let snapshot_dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
Reapplying https://github.com/meilisearch/meilisearch/pull/5383 in v1.13.3 because it blocks the CI.