### PR TITLE
Setup the Milestone CI to update the Ruleset

### DIFF
--- a/.github/workflows/milestone-workflow.yml
+++ b/.github/workflows/milestone-workflow.yml
@@ -5,6 +5,7 @@ name: Milestone's workflow
 # For each Milestone created (not opened!), and if the release is NOT a patch release (only the patch changed)
 # - the roadmap issue is created, see https://github.com/meilisearch/engine-team/blob/main/issue-templates/roadmap-issue.md
 # - the changelog issue is created, see https://github.com/meilisearch/engine-team/blob/main/issue-templates/changelog-issue.md
+# - update the ruleset to add the current release version to the list of allowed versions and be able to use the merge queue.
 
 # For each Milestone closed
 # - the `release_version` label is created
@@ -21,10 +22,9 @@ env:
   GH_TOKEN: ${{ secrets.MEILI_BOT_GH_PAT }}
 
 jobs:
-
-# -----------------
-# MILESTONE CREATED
-# -----------------
+  # -----------------
+  # MILESTONE CREATED
+  # -----------------
 
   get-release-version:
     if: github.event.action == 'created'
@@ -148,9 +148,37 @@ jobs:
             --body-file $ISSUE_TEMPLATE \
             --milestone $MILESTONE_VERSION
 
-# ----------------
-# MILESTONE CLOSED
-# ----------------
+  update-ruleset:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install jq
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq
+      - name: Update ruleset
+        env:
+          # gh api repos/meilisearch/meilisearch/rulesets --jq '.[] | {name: .name, id: .id}'
+          RULESET_ID: 4253297
+          BRANCH_NAME: ${{ github.event.inputs.branch_name }}
+        run: |
+          # Get current ruleset conditions
+          CONDITIONS=$(gh api repos/meilisearch/meilisearch/rulesets/$RULESET_ID --jq '{ conditions: .conditions }')
+
+          # Update the conditions by appending the milestone version
+          UPDATED_CONDITIONS=$(echo $CONDITIONS | jq '.conditions.ref_name.include += ["refs/heads/release-'$MILESTONE_VERSION'"]')
+
+          # Update the ruleset from stdin (-)
+          echo $UPDATED_CONDITIONS |
+            gh api repos/meilisearch/meilisearch/rulesets/$RULESET_ID \
+              --method PUT \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              --input -
+
+  # ----------------
+  # MILESTONE CLOSED
+  # ----------------
 
   create-release-label:
     if: github.event.action == 'closed'


### PR DESCRIPTION
This new CI job is meant to update the new Repository Ruleset we will use to be able to use the GitHub Merge Queues and remove bors from our workflow. This CI will be triggered whenever we create a new milestone and will add its title (version of the form vx.y.z) to the ruleset `conditions.ref_name.include` field.