### PR TITLE
Fix _matchesPosition length calculate

### DIFF
--- a/crates/meilisearch/tests/search/formatted.rs
+++ b/crates/meilisearch/tests/search/formatted.rs
@@ -74,7 +74,7 @@ async fn formatted_contain_wildcard() {
             allow_duplicates! {
               assert_json_snapshot!(response["hits"][0],
                     { "._rankingScore" => "[score]" },
-                    @r###"
+                    @r#"
               {
                 "_formatted": {
                   "id": "852",
@@ -84,12 +84,12 @@ async fn formatted_contain_wildcard() {
                   "cattos": [
                     {
                       "start": 0,
-                      "length": 5
+                      "length": 6
                     }
                   ]
                 }
               }
-              "###);
+              "#);
             }
     }
     )
@@ -119,7 +119,7 @@ async fn formatted_contain_wildcard() {
                 allow_duplicates! {
                   assert_json_snapshot!(response["hits"][0],
                  { "._rankingScore" => "[score]" },
-                 @r###"
+                 @r#"
                   {
                     "id": 852,
                     "cattos": "pésti",
@@ -131,12 +131,12 @@ async fn formatted_contain_wildcard() {
                       "cattos": [
                         {
                           "start": 0,
-                          "length": 5
+                          "length": 6
                         }
                       ]
                     }
                   }
-                  "###)
+                  "#)
              }
         })
         .await;

--- a/crates/milli/src/search/new/matches/mod.rs
+++ b/crates/milli/src/search/new/matches/mod.rs
@@ -229,8 +229,12 @@ impl<'t, 'tokenizer> Matcher<'t, 'tokenizer, '_, '_> {
                 .iter()
                 .map(|m| MatchBounds {
                     start: tokens[m.get_first_token_pos()].byte_start,
-                    // TODO: Why is this in chars, while start is in bytes?
-                    length: m.char_count,
+                    length: (m.get_first_token_pos()..m.get_last_token_pos() + 1)
+                        .map(|i| tokens[i].clone())
+                        .flat_map(|token| token.char_map.clone().unwrap_or(vec![(1, 1); token.char_end - token.char_start] /* Some token doesn't have a char map, here we treat them as single byte chars. */))
+                        .map(|(original, _)| original as usize)
+                        .take(m.char_count)
+                        .sum(),
                     indices: if array_indices.is_empty() {
                         None
                     } else {

--- a/crates/milli/src/search/new/matches/mod.rs
+++ b/crates/milli/src/search/new/matches/mod.rs
@@ -230,7 +230,7 @@ impl<'t, 'tokenizer> Matcher<'t, 'tokenizer, '_, '_> {
                 .iter()
                 .map(|m| MatchBounds {
                     start: tokens[m.get_first_token_pos()].byte_start,
-                    length: self.calc_byte_length(&tokens, m),
+                    length: self.calc_byte_length(tokens, m),
                     indices: if array_indices.is_empty() {
                         None
                     } else {
@@ -241,7 +241,7 @@ impl<'t, 'tokenizer> Matcher<'t, 'tokenizer, '_, '_> {
         }
     }
 
-    fn calc_byte_length(&self, tokens: &Vec<Token<'t>>, m: &Match) -> usize {
+    fn calc_byte_length(&self, tokens: &[Token<'t>], m: &Match) -> usize {
         (m.get_first_token_pos()..=m.get_last_token_pos())
             .flat_map(|i| match &tokens[i].char_map {
                 Some(char_map) => {


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #5429 

## What does this PR do?
- It fixed #5429, which incorrectly using char length instead of byte length as result of `_matchesPosition`

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
