### PR TITLE
[Experiment] Reduce prefix db computation

### DIFF
--- a/crates/milli/src/update/new/words_prefix_docids.rs
+++ b/crates/milli/src/update/new/words_prefix_docids.rs
@@ -291,6 +291,9 @@ impl<'a, 'rtxn> FrozenPrefixIntegerBitmaps<'a, 'rtxn> {
                 let (_word, pos) = StrBEU16Codec::bytes_decode(key).map_err(Error::Decoding)?;
                 positions.entry(pos).or_insert_with(Vec::new).push(bytes);
             }
+
+            // We remove all the positions that have less than 100 bitmaps.
+            positions.retain(|_, bitmaps| bitmaps.len() > 100);
             assert!(prefixes_bitmaps.insert(prefix.as_str(), positions).is_none());
         }
 


### PR DESCRIPTION
Experiment a prefix database optimizations.

This PR adds an indexing threshold in the `prefix_postion_docids` and `prefix_fids_docids` databases in order to index the keys containing at least 100 roaring bitmaps unions.

This is only a POC, stabilizing this optimization is a bit more complex (see the TODOs in the code)