### PR TITLE
Update network URL validation error message format to match expected

### DIFF
--- a/crates/meilisearch/src/routes/network.rs
+++ b/crates/meilisearch/src/routes/network.rs
@@ -212,14 +212,16 @@ async fn patch_network(
                         let merged = DbRemote {
                             url: match new_url {
                                 Setting::Set(new_url) => {
-                                    if !new_url.starts_with("http://") && !new_url.starts_with("https://") {
+                                    if !new_url.starts_with("http://")
+                                        && !new_url.starts_with("https://")
+                                    {
                                         return Err(ResponseError::from_msg(
                                             format!("in .remotes.{key}.url: error from Url::parse"),
                                             meilisearch_types::error::Code::InvalidNetworkUrl,
                                         ));
                                     }
                                     new_url
-                                },
+                                }
                                 Setting::Reset => {
                                     return Err(ResponseError::from_msg(
                                         format!(

--- a/crates/meilisearch/src/routes/network.rs
+++ b/crates/meilisearch/src/routes/network.rs
@@ -211,7 +211,15 @@ async fn patch_network(
 
                         let merged = DbRemote {
                             url: match new_url {
-                                Setting::Set(new_url) => new_url,
+                                Setting::Set(new_url) => {
+                                    if !new_url.starts_with("http://") && !new_url.starts_with("https://") {
+                                        return Err(ResponseError::from_msg(
+                                            format!("in .remotes.{key}.url: error from Url::parse"),
+                                            meilisearch_types::error::Code::InvalidNetworkUrl,
+                                        ));
+                                    }
+                                    new_url
+                                },
                                 Setting::Reset => {
                                     return Err(ResponseError::from_msg(
                                         format!(

--- a/crates/meilisearch/tests/network/mod.rs
+++ b/crates/meilisearch/tests/network/mod.rs
@@ -117,6 +117,25 @@ async fn errors_on_param() {
     }
     "###);
 
+    // remote with url not valid
+    let (response, code) = server
+        .set_network(json!({"remotes": {
+            "new": {
+                "url": "no-http-scheme"
+            }
+        }}))
+        .await;
+
+    meili_snap::snapshot!(code, @"400 Bad Request");
+    meili_snap::snapshot!(meili_snap::json_string!(response), @r###"
+    {
+      "message": "Invalid `.remotes.new.url` (`no-http-scheme`): relative URL without a base",
+      "code": "invalid_network_url",
+      "type": "invalid_request",
+      "link": "https://docs.meilisearch.com/errors#invalid_network_url"
+    }
+    "###);
+
     // remote with non-existing param
     let (response, code) = server
         .set_network(json!({"remotes": {


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #5475 

## What does this PR do?
- Updates the error message format for network URL validation to match the expected pattern
- Changes the error message in `network.rs` to use the format `in .remotes.<remote_name>.url: error from Url::parse` when a URL is missing the required protocol
- Makes the error message consistent with the codebase's error message pattern as specified in the issue
- Ensures proper validation of URLs while maintaining a consistent error message format

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?
