### PR TITLE
Deactivate numbers in typos

### DIFF
--- a/crates/dump/src/reader/compat/v5_to_v6.rs
+++ b/crates/dump/src/reader/compat/v5_to_v6.rs
@@ -373,6 +373,7 @@ impl<T> From<v5::Settings<T>> for v6::Settings<v6::Unchecked> {
                     },
                     disable_on_words: typo.disable_on_words.into(),
                     disable_on_attributes: typo.disable_on_attributes.into(),
+                    disable_on_numbers: v6::Setting::NotSet,
                 }),
                 v5::Setting::Reset => v6::Setting::Reset,
                 v5::Setting::NotSet => v6::Setting::NotSet,

--- a/crates/meilisearch-types/src/settings.rs
+++ b/crates/meilisearch-types/src/settings.rs
@@ -8,6 +8,7 @@ use std::str::FromStr;
 
 use deserr::{DeserializeError, Deserr, ErrorKind, MergeWithError, ValuePointerRef};
 use fst::IntoStreamer;
+use milli::disabled_typos_terms::DisabledTyposTerms;
 use milli::index::{IndexEmbeddingConfig, PrefixSearch};
 use milli::proximity::ProximityPrecision;
 use milli::update::Setting;
@@ -104,6 +105,10 @@ pub struct TypoSettings {
     #[deserr(default)]
     #[schema(value_type = Option<BTreeSet<String>>, example = json!(["uuid", "url"]))]
     pub disable_on_attributes: Setting<BTreeSet<String>>,
+    #[serde(default, skip_serializing_if = "Setting::is_not_set")]
+    #[deserr(default)]
+    #[schema(value_type = Option<bool>, example = json!(true))]
+    pub disable_on_numbers: Setting<bool>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq, Deserr, ToSchema)]
@@ -826,12 +831,14 @@ pub fn settings(
     };
 
     let disabled_attributes = index.exact_attributes(rtxn)?.into_iter().map(String::from).collect();
+    let DisabledTyposTerms { disable_on_numbers } = index.disabled_typos_terms(rtxn)?;
 
     let typo_tolerance = TypoSettings {
         enabled: Setting::Set(index.authorize_typos(rtxn)?),
         min_word_size_for_typos: Setting::Set(min_typo_word_len),
         disable_on_words: Setting::Set(disabled_words),
         disable_on_attributes: Setting::Set(disabled_attributes),
+        disable_on_numbers: Setting::Set(disable_on_numbers),
     };
 
     let faceting = FacetingSettings {

--- a/crates/meilisearch-types/src/settings.rs
+++ b/crates/meilisearch-types/src/settings.rs
@@ -706,6 +706,12 @@ pub fn apply_settings_to_builder(
                 Setting::Reset => builder.reset_exact_attributes(),
                 Setting::NotSet => (),
             }
+
+            match value.disable_on_numbers {
+                Setting::Set(val) => builder.set_disable_on_numbers(val),
+                Setting::Reset => builder.reset_disable_on_numbers(),
+                Setting::NotSet => (),
+            }
         }
         Setting::Reset => {
             // all typo settings need to be reset here.

--- a/crates/meilisearch/tests/dumps/mod.rs
+++ b/crates/meilisearch/tests/dumps/mod.rs
@@ -87,7 +87,8 @@ async fn import_dump_v1_movie_raw() {
           "twoTypos": 9
         },
         "disableOnWords": [],
-        "disableOnAttributes": []
+        "disableOnAttributes": [],
+        "disableOnNumbers": false
       },
       "faceting": {
         "maxValuesPerFacet": 100,
@@ -260,7 +261,8 @@ async fn import_dump_v1_movie_with_settings() {
           "twoTypos": 9
         },
         "disableOnWords": [],
-        "disableOnAttributes": []
+        "disableOnAttributes": [],
+        "disableOnNumbers": false
       },
       "faceting": {
         "maxValuesPerFacet": 100,
@@ -432,7 +434,8 @@ async fn import_dump_v1_rubygems_with_settings() {
           "twoTypos": 9
         },
         "disableOnWords": [],
-        "disableOnAttributes": []
+        "disableOnAttributes": [],
+        "disableOnNumbers": false
       },
       "faceting": {
         "maxValuesPerFacet": 100,
@@ -590,7 +593,8 @@ async fn import_dump_v2_movie_raw() {
           "twoTypos": 9
         },
         "disableOnWords": [],
-        "disableOnAttributes": []
+        "disableOnAttributes": [],
+        "disableOnNumbers": false
       },
       "faceting": {
         "maxValuesPerFacet": 100,
@@ -760,7 +764,8 @@ async fn import_dump_v2_movie_with_settings() {
           "twoTypos": 9
         },
         "disableOnWords": [],
-        "disableOnAttributes": []
+        "disableOnAttributes": [],
+        "disableOnNumbers": false
       },
       "faceting": {
         "maxValuesPerFacet": 100,
@@ -929,7 +934,8 @@ async fn import_dump_v2_rubygems_with_settings() {
           "twoTypos": 9
         },
         "disableOnWords": [],
-        "disableOnAttributes": []
+        "disableOnAttributes": [],
+        "disableOnNumbers": false
       },
       "faceting": {
         "maxValuesPerFacet": 100,
@@ -1087,7 +1093,8 @@ async fn import_dump_v3_movie_raw() {
           "twoTypos": 9
         },
         "disableOnWords": [],
-        "disableOnAttributes": []
+        "disableOnAttributes": [],
+        "disableOnNumbers": false
       },
       "faceting": {
         "maxValuesPerFacet": 100,
@@ -1257,7 +1264,8 @@ async fn import_dump_v3_movie_with_settings() {
           "twoTypos": 9
         },
         "disableOnWords": [],
-        "disableOnAttributes": []
+        "disableOnAttributes": [],
+        "disableOnNumbers": false
       },
       "faceting": {
         "maxValuesPerFacet": 100,
@@ -1426,7 +1434,8 @@ async fn import_dump_v3_rubygems_with_settings() {
           "twoTypos": 9
         },
         "disableOnWords": [],
-        "disableOnAttributes": []
+        "disableOnAttributes": [],
+        "disableOnNumbers": false
       },
       "faceting": {
         "maxValuesPerFacet": 100,
@@ -1584,7 +1593,8 @@ async fn import_dump_v4_movie_raw() {
           "twoTypos": 9
         },
         "disableOnWords": [],
-        "disableOnAttributes": []
+        "disableOnAttributes": [],
+        "disableOnNumbers": false
       },
       "faceting": {
         "maxValuesPerFacet": 100,
@@ -1754,7 +1764,8 @@ async fn import_dump_v4_movie_with_settings() {
           "twoTypos": 9
         },
         "disableOnWords": [],
-        "disableOnAttributes": []
+        "disableOnAttributes": [],
+        "disableOnNumbers": false
       },
       "faceting": {
         "maxValuesPerFacet": 100,
@@ -1923,7 +1934,8 @@ async fn import_dump_v4_rubygems_with_settings() {
           "twoTypos": 9
         },
         "disableOnWords": [],
-        "disableOnAttributes": []
+        "disableOnAttributes": [],
+        "disableOnNumbers": false
       },
       "faceting": {
         "maxValuesPerFacet": 100,
@@ -2212,7 +2224,8 @@ async fn import_dump_v6_containing_experimental_features() {
           "twoTypos": 9
         },
         "disableOnWords": [],
-        "disableOnAttributes": []
+        "disableOnAttributes": [],
+        "disableOnNumbers": false
       },
       "faceting": {
         "maxValuesPerFacet": 100,
@@ -2444,7 +2457,8 @@ async fn generate_and_import_dump_containing_vectors() {
           "twoTypos": 9
         },
         "disableOnWords": [],
-        "disableOnAttributes": []
+        "disableOnAttributes": [],
+        "disableOnNumbers": false
       },
       "faceting": {
         "maxValuesPerFacet": 100,

--- a/crates/meilisearch/tests/settings/errors.rs
+++ b/crates/meilisearch/tests/settings/errors.rs
@@ -274,7 +274,7 @@ async fn settings_bad_typo_tolerance() {
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
-      "message": "Unknown field `typoTolerance`: expected one of `enabled`, `minWordSizeForTypos`, `disableOnWords`, `disableOnAttributes`",
+      "message": "Unknown field `typoTolerance`: expected one of `enabled`, `minWordSizeForTypos`, `disableOnWords`, `disableOnAttributes`, `disableOnNumbers`",
       "code": "invalid_settings_typo_tolerance",
       "type": "invalid_request",
       "link": "https://docs.meilisearch.com/errors#invalid_settings_typo_tolerance"

--- a/crates/meilisearch/tests/settings/get_settings.rs
+++ b/crates/meilisearch/tests/settings/get_settings.rs
@@ -276,7 +276,7 @@ async fn secrets_are_hidden_in_settings() {
 
     let (response, code) = index.settings().await;
     meili_snap::snapshot!(code, @"200 OK");
-    meili_snap::snapshot!(meili_snap::json_string!(response), @r#"
+    meili_snap::snapshot!(meili_snap::json_string!(response), @r###"
     {
       "displayedAttributes": [
         "*"
@@ -308,7 +308,8 @@ async fn secrets_are_hidden_in_settings() {
           "twoTypos": 9
         },
         "disableOnWords": [],
-        "disableOnAttributes": []
+        "disableOnAttributes": [],
+        "disableOnNumbers": false
       },
       "faceting": {
         "maxValuesPerFacet": 100,
@@ -337,7 +338,7 @@ async fn secrets_are_hidden_in_settings() {
       "facetSearch": true,
       "prefixSearch": "indexingTime"
     }
-    "#);
+    "###);
 
     let (response, code) = server.get_task(settings_update_uid).await;
     meili_snap::snapshot!(code, @"200 OK");

--- a/crates/meilisearch/tests/settings/get_settings.rs
+++ b/crates/meilisearch/tests/settings/get_settings.rs
@@ -179,7 +179,7 @@ test_setting_routes!(
     {
         setting: typo_tolerance,
         update_verb: patch,
-        default_value: {"enabled": true, "minWordSizeForTypos": {"oneTypo": 5, "twoTypos": 9}, "disableOnWords": [], "disableOnAttributes": []}
+        default_value: {"enabled": true, "minWordSizeForTypos": {"oneTypo": 5, "twoTypos": 9}, "disableOnWords": [], "disableOnAttributes": [], "disableOnNumbers": false}
     },
 );
 

--- a/crates/meilisearch/tests/upgrade/v1_12/snapshots/v1_12_0.rs/check_the_index_features/kefir_settings.snap
+++ b/crates/meilisearch/tests/upgrade/v1_12/snapshots/v1_12_0.rs/check_the_index_features/kefir_settings.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/meilisearch/tests/upgrade/v1_12/v1_12_0.rs
-snapshot_kind: text
 ---
 {
   "displayedAttributes": [
@@ -49,7 +48,8 @@ snapshot_kind: text
     ],
     "disableOnAttributes": [
       "surname"
-    ]
+    ],
+    "disableOnNumbers": false
   },
   "faceting": {
     "maxValuesPerFacet": 99,

--- a/crates/milli/src/disabled_typos_terms.rs
+++ b/crates/milli/src/disabled_typos_terms.rs
@@ -28,7 +28,7 @@ impl Index {
         self.main.remap_types::<Str, SerdeJson<DisabledTyposTerms>>().put(
             txn,
             main_key::DISABLED_TYPOS_TERMS,
-            &disabled_typos_terms,
+            disabled_typos_terms,
         )?;
 
         Ok(())

--- a/crates/milli/src/disabled_typos_terms.rs
+++ b/crates/milli/src/disabled_typos_terms.rs
@@ -1,0 +1,50 @@
+use heed::{
+    types::{SerdeJson, Str},
+    RoTxn, RwTxn,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{index::main_key, Index};
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct DisabledTyposTerms {
+    pub disable_on_numbers: bool,
+}
+
+impl Index {
+    pub fn disabled_typos_terms(&self, txn: &RoTxn<'_>) -> heed::Result<DisabledTyposTerms> {
+        self.main
+            .remap_types::<Str, SerdeJson<DisabledTyposTerms>>()
+            .get(txn, main_key::DISABLED_TYPOS_TERMS)
+            .map(|option| option.unwrap_or_default())
+    }
+
+    pub(crate) fn put_disabled_typos_terms(
+        &self,
+        txn: &mut RwTxn<'_>,
+        disabled_typos_terms: &DisabledTyposTerms,
+    ) -> heed::Result<()> {
+        self.main.remap_types::<Str, SerdeJson<DisabledTyposTerms>>().put(
+            txn,
+            main_key::DISABLED_TYPOS_TERMS,
+            &disabled_typos_terms,
+        )?;
+
+        Ok(())
+    }
+
+    pub(crate) fn delete_disabled_typos_terms(&self, txn: &mut RwTxn<'_>) -> heed::Result<()> {
+        self.main
+            .remap_types::<Str, SerdeJson<DisabledTyposTerms>>()
+            .delete(txn, main_key::DISABLED_TYPOS_TERMS)?;
+        Ok(())
+    }
+}
+
+impl DisabledTyposTerms {
+    pub fn is_exact(&self, word: &str) -> bool {
+        // If disable_on_numbers is true, we disable the word if it contains only numbers or punctuation
+        self.disable_on_numbers && word.chars().all(|c| c.is_numeric() || c.is_ascii_punctuation())
+    }
+}

--- a/crates/milli/src/index.rs
+++ b/crates/milli/src/index.rs
@@ -78,6 +78,7 @@ pub mod main_key {
     pub const FACET_SEARCH: &str = "facet_search";
     pub const PREFIX_SEARCH: &str = "prefix_search";
     pub const DOCUMENTS_STATS: &str = "documents_stats";
+    pub const DISABLED_TYPOS_TERMS: &str = "disabled_typos_terms";
 }
 
 pub mod db_name {

--- a/crates/milli/src/lib.rs
+++ b/crates/milli/src/lib.rs
@@ -12,6 +12,7 @@ mod asc_desc;
 mod attribute_patterns;
 mod criterion;
 pub mod database_stats;
+pub mod disabled_typos_terms;
 mod error;
 mod external_documents_ids;
 pub mod facet;

--- a/crates/milli/src/update/index_documents/extract/extract_word_docids.rs
+++ b/crates/milli/src/update/index_documents/extract/extract_word_docids.rs
@@ -128,7 +128,7 @@ pub fn extract_word_docids<R: io::Read + io::Seek>(
         let obkv = KvReaderDelAdd::from_slice(value);
         if let Some(value) = obkv.get(DelAdd::Deletion) {
             let delete_from_exact = settings_diff.old.exact_attributes.contains(&fid)
-                || settings_diff.old.disabled_typos_terms.is_exact(&w);
+                || settings_diff.old.disabled_typos_terms.is_exact(w);
             buffer.clear();
             let mut obkv = KvWriterDelAdd::new(&mut buffer);
             obkv.insert(DelAdd::Deletion, value)?;
@@ -141,7 +141,7 @@ pub fn extract_word_docids<R: io::Read + io::Seek>(
         // merge all additions
         if let Some(value) = obkv.get(DelAdd::Addition) {
             let add_in_exact = settings_diff.new.exact_attributes.contains(&fid)
-                || settings_diff.new.disabled_typos_terms.is_exact(&w);
+                || settings_diff.new.disabled_typos_terms.is_exact(w);
             buffer.clear();
             let mut obkv = KvWriterDelAdd::new(&mut buffer);
             obkv.insert(DelAdd::Addition, value)?;

--- a/crates/milli/src/update/index_documents/extract/extract_word_docids.rs
+++ b/crates/milli/src/update/index_documents/extract/extract_word_docids.rs
@@ -127,7 +127,8 @@ pub fn extract_word_docids<R: io::Read + io::Seek>(
         // merge all deletions
         let obkv = KvReaderDelAdd::from_slice(value);
         if let Some(value) = obkv.get(DelAdd::Deletion) {
-            let delete_from_exact = settings_diff.old.exact_attributes.contains(&fid);
+            let delete_from_exact = settings_diff.old.exact_attributes.contains(&fid)
+                || settings_diff.old.disabled_typos_terms.is_exact(&w);
             buffer.clear();
             let mut obkv = KvWriterDelAdd::new(&mut buffer);
             obkv.insert(DelAdd::Deletion, value)?;
@@ -139,7 +140,8 @@ pub fn extract_word_docids<R: io::Read + io::Seek>(
         }
         // merge all additions
         if let Some(value) = obkv.get(DelAdd::Addition) {
-            let add_in_exact = settings_diff.new.exact_attributes.contains(&fid);
+            let add_in_exact = settings_diff.new.exact_attributes.contains(&fid)
+                || settings_diff.new.disabled_typos_terms.is_exact(&w);
             buffer.clear();
             let mut obkv = KvWriterDelAdd::new(&mut buffer);
             obkv.insert(DelAdd::Addition, value)?;

--- a/crates/milli/src/update/index_documents/typed_chunk.rs
+++ b/crates/milli/src/update/index_documents/typed_chunk.rs
@@ -273,14 +273,11 @@ pub(crate) fn write_typed_chunk_into_index(
                     unreachable!();
                 };
                 let clonable_word_docids = unsafe { as_cloneable_grenad(&word_docids_reader) }?;
-                let clonable_exact_word_docids =
-                    unsafe { as_cloneable_grenad(&exact_word_docids_reader) }?;
 
                 word_docids_builder.push(word_docids_reader.into_cursor()?);
                 exact_word_docids_builder.push(exact_word_docids_reader.into_cursor()?);
                 word_fid_docids_builder.push(word_fid_docids_reader.into_cursor()?);
                 fst_merger_builder.push(clonable_word_docids.into_cursor()?);
-                fst_merger_builder.push(clonable_exact_word_docids.into_cursor()?);
             }
 
             let word_docids_merger = word_docids_builder.build();

--- a/crates/milli/src/update/new/extract/searchable/extract_word_docids.rs
+++ b/crates/milli/src/update/new/extract/searchable/extract_word_docids.rs
@@ -319,8 +319,11 @@ impl WordDocidsExtractors {
         let doc_alloc = &context.doc_alloc;
 
         let exact_attributes = index.exact_attributes(rtxn)?;
-        let is_exact_attribute =
-            |fname: &str| exact_attributes.iter().any(|attr| contained_in(fname, attr));
+        let disabled_typos_terms = index.disabled_typos_terms(rtxn)?;
+        let is_exact = |fname: &str, word: &str| {
+            exact_attributes.iter().any(|attr| contained_in(fname, attr))
+                || disabled_typos_terms.is_exact(word)
+        };
         match document_change {
             DocumentChange::Deletion(inner) => {
                 let mut token_fn = |fname: &str, fid, pos, word: &str| {
@@ -328,7 +331,7 @@ impl WordDocidsExtractors {
                         fid,
                         pos,
                         word,
-                        is_exact_attribute(fname),
+                        is_exact(fname, word),
                         inner.docid(),
                         doc_alloc,
                     )
@@ -356,7 +359,7 @@ impl WordDocidsExtractors {
                         fid,
                         pos,
                         word,
-                        is_exact_attribute(fname),
+                        is_exact(fname, word),
                         inner.docid(),
                         doc_alloc,
                     )
@@ -372,7 +375,7 @@ impl WordDocidsExtractors {
                         fid,
                         pos,
                         word,
-                        is_exact_attribute(fname),
+                        is_exact(fname, word),
                         inner.docid(),
                         doc_alloc,
                     )
@@ -389,7 +392,7 @@ impl WordDocidsExtractors {
                         fid,
                         pos,
                         word,
-                        is_exact_attribute(fname),
+                        is_exact(fname, word),
                         inner.docid(),
                         doc_alloc,
                     )

--- a/crates/milli/src/update/new/indexer/mod.rs
+++ b/crates/milli/src/update/new/indexer/mod.rs
@@ -9,6 +9,7 @@ pub use document_operation::{DocumentOperation, PayloadStats};
 use hashbrown::HashMap;
 use heed::RwTxn;
 pub use partial_dump::PartialDump;
+pub use post_processing::recompute_word_fst_from_word_docids_database;
 pub use update_by_function::UpdateByFunction;
 pub use write::ChannelCongestion;
 use write::{build_vectors, update_index, write_to_db};

--- a/crates/milli/src/update/test_settings.rs
+++ b/crates/milli/src/update/test_settings.rs
@@ -896,6 +896,7 @@ fn test_correct_settings_init() {
                 localized_attributes_rules,
                 prefix_search,
                 facet_search,
+                disabled_typos_terms,
             } = settings;
             assert!(matches!(searchable_fields, Setting::NotSet));
             assert!(matches!(displayed_fields, Setting::NotSet));
@@ -923,6 +924,7 @@ fn test_correct_settings_init() {
             assert!(matches!(localized_attributes_rules, Setting::NotSet));
             assert!(matches!(prefix_search, Setting::NotSet));
             assert!(matches!(facet_search, Setting::NotSet));
+            assert!(matches!(disabled_typos_terms, Setting::NotSet));
         })
         .unwrap();
 }

--- a/crates/milli/src/update/test_settings.rs
+++ b/crates/milli/src/update/test_settings.rs
@@ -896,7 +896,7 @@ fn test_correct_settings_init() {
                 localized_attributes_rules,
                 prefix_search,
                 facet_search,
-                disabled_typos_terms,
+                disable_on_numbers,
             } = settings;
             assert!(matches!(searchable_fields, Setting::NotSet));
             assert!(matches!(displayed_fields, Setting::NotSet));
@@ -924,7 +924,7 @@ fn test_correct_settings_init() {
             assert!(matches!(localized_attributes_rules, Setting::NotSet));
             assert!(matches!(prefix_search, Setting::NotSet));
             assert!(matches!(facet_search, Setting::NotSet));
-            assert!(matches!(disabled_typos_terms, Setting::NotSet));
+            assert!(matches!(disable_on_numbers, Setting::NotSet));
         })
         .unwrap();
 }

--- a/crates/milli/src/update/upgrade/mod.rs
+++ b/crates/milli/src/update/upgrade/mod.rs
@@ -1,11 +1,12 @@
 mod v1_12;
 mod v1_13;
 mod v1_14;
-
+mod v1_15;
 use heed::RwTxn;
 use v1_12::{V1_12_3_To_V1_13_0, V1_12_To_V1_12_3};
 use v1_13::{V1_13_0_To_V1_13_1, V1_13_1_To_Latest_V1_13};
 use v1_14::Latest_V1_13_To_Latest_V1_14;
+use v1_15::Latest_V1_14_To_Latest_V1_15;
 
 use crate::progress::{Progress, VariableNameStep};
 use crate::{Index, InternalError, Result};
@@ -36,6 +37,7 @@ pub fn upgrade(
         &V1_13_0_To_V1_13_1 {},
         &V1_13_1_To_Latest_V1_13 {},
         &Latest_V1_13_To_Latest_V1_14 {},
+        &Latest_V1_14_To_Latest_V1_15 {},
     ];
 
     let start = match from {
@@ -43,8 +45,9 @@ pub fn upgrade(
         (1, 12, 3..) => 1,
         (1, 13, 0) => 2,
         (1, 13, _) => 4,
+        (1, 14, _) => 5,
         // We must handle the current version in the match because in case of a failure some index may have been upgraded but not other.
-        (1, 14, _) => 4,
+        (1, 15, _) => 5,
         (major, minor, patch) => {
             return Err(InternalError::CannotUpgradeToVersion(major, minor, patch).into())
         }

--- a/crates/milli/src/update/upgrade/v1_15.rs
+++ b/crates/milli/src/update/upgrade/v1_15.rs
@@ -1,0 +1,35 @@
+use heed::RwTxn;
+
+use super::UpgradeIndex;
+use crate::progress::Progress;
+use crate::update::new::indexer::recompute_word_fst_from_word_docids_database;
+use crate::{make_enum_progress, Index, Result};
+
+#[allow(non_camel_case_types)]
+pub(super) struct Latest_V1_14_To_Latest_V1_15();
+
+impl UpgradeIndex for Latest_V1_14_To_Latest_V1_15 {
+    fn upgrade(
+        &self,
+        wtxn: &mut RwTxn,
+        index: &Index,
+        _original: (u32, u32, u32),
+        progress: Progress,
+    ) -> Result<bool> {
+        // Recompute the word FST from the word docids database.
+        make_enum_progress! {
+            enum TypoTolerance {
+                RecomputeWordFst,
+            }
+        };
+
+        progress.update_progress(TypoTolerance::RecomputeWordFst);
+        recompute_word_fst_from_word_docids_database(index, wtxn)?;
+
+        Ok(false)
+    }
+
+    fn target_version(&self) -> (u32, u32, u32) {
+        (1, 15, 0)
+    }
+}


### PR DESCRIPTION
# Pull Request

Public usage link: [Usage page link](https://meilisearch.notion.site/Deactivate-typo-tolerance-on-specific-kinds-of-terms-1a44b06b651f809d9cb7db67b322a4b8?pvs=4)

## Related issue
Fixes #5344

## What does this PR do?
- Add tests
- Extends the typo API, allowing the user to deactivate typos on numbers

## This PR makes forward-compatible changes

This PR adds a new typo sub-setting `disableOnNumbers` that is forward compatible because the missing setting will be automatically replaced by the default value corresponding to the previous version's behavior.

## This PR makes breaking changes

The FST does not contain the `exact_word_docids` words and should be recomputed; the upgrade will recompute the FST based on the `word_docids` database, only the content changes, the format doesn't.

- dumpless upgrade in milli
    - [x] the upgrade function should be written and called [here](https://github.com/meilisearch/meilisearch/blob/3fd86e8d76d7d468b0095d679adb09211ca3b6c0/crates/milli/src/update/upgrade/mod.rs#L24-L47)
