### PR TITLE
fixed misleading error message for max_fields_limit_exceeded

### DIFF
--- a/crates/milli/src/error.rs
+++ b/crates/milli/src/error.rs
@@ -108,7 +108,7 @@ pub enum FieldIdMapMissingEntry {
 
 #[derive(Error, Debug)]
 pub enum UserError {
-    #[error("A document cannot contain more than 65,535 fields.")]
+    #[error("A single index cannot have more than 65,535 unique fields across all documents.")]
     AttributeLimitReached,
     #[error(transparent)]
     CriterionError(#[from] CriterionError),


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #5508 

## What does this PR do?
Fixes misleading error message for `max_fields_limit_exceeded` 

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
