### PR TITLE
Add set in GitHub action to notify deployment to Swarmia

### DIFF
--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -111,7 +111,7 @@ jobs:
         run: |
           JSON_STRING=$( jq --null-input --compact-output \
           --arg version "${{ github.ref_name }}" \
-          --arg appName "" \
+          --arg appName "meilisearch" \
           --arg environment "production" \
           --arg commitSha "${{ github.sha }}" \
           --arg repositoryFullName "${{ github.repository }}" \


### PR DESCRIPTION
✅ `SWARMIA_DEPLOYMENTS_AUTHORIZATION` added

https://app.swarmia.com -> a tool to get metrics around our code deployment and PR management cycles (already used by Cloud team)

Proof I did not break the Docker CI: https://github.com/meilisearch/meilisearch/actions/runs/14913157865/job/41892271749
