### PR TITLE
Added support for nested wildcards to attributes_to_search_on

### DIFF
--- a/crates/meilisearch/tests/search/restrict_searchable.rs
+++ b/crates/meilisearch/tests/search/restrict_searchable.rs
@@ -493,10 +493,22 @@ async fn nested_search_with_suffix_wildcard() {
     // It's worth noting the difference between 'details.*' and '*.title'
     index
         .search(
-            json!({"q": "Captain Marvel", "attributesToSearchOn": ["details.*"]}),
+            json!({"q": "Captain Marvel", "attributesToSearchOn": ["details.*"], "attributesToRetrieve": ["id"]}),
             |response, code| {
                 snapshot!(code, @"200 OK");
-                snapshot!(response["hits"].as_array().unwrap().len(), @"3");
+                snapshot!(json_string!(response["hits"]),
+                    @r###"
+                [
+                  {
+                    "id": "3"
+                  },
+                  {
+                    "id": "1"
+                  },
+                  {
+                    "id": "2"
+                  }
+                ]"###);
             },
         )
         .await;
@@ -504,10 +516,16 @@ async fn nested_search_with_suffix_wildcard() {
     // Should return 1 document (ids: 1)
     index
         .search(
-            json!({"q": "gold", "attributesToSearchOn": ["details.*"]}),
+            json!({"q": "gold", "attributesToSearchOn": ["details.*"], "attributesToRetrieve": ["id"]}),
             |response, code| {
                 snapshot!(code, @"200 OK");
-                snapshot!(response["hits"].as_array().unwrap().len(), @"1");
+                snapshot!(json_string!(response["hits"]),
+                    @r###"
+                [
+                  {
+                    "id": "1"
+                  }
+                ]"###);
             },
         )
         .await;
@@ -515,10 +533,19 @@ async fn nested_search_with_suffix_wildcard() {
     // Should return 2 documents (ids: 1 and 2)
     index
         .search(
-            json!({"q": "true", "attributesToSearchOn": ["details.*"]}),
+            json!({"q": "true", "attributesToSearchOn": ["details.*"], "attributesToRetrieve": ["id"]}),
             |response, code| {
                 snapshot!(code, @"200 OK");
-                snapshot!(response["hits"].as_array().unwrap().len(), @"2");
+                snapshot!(json_string!(response["hits"]),
+                    @r###"
+                [
+                  {
+                    "id": "1"
+                  },
+                  {
+                    "id": "2"
+                  }
+                ]"###);
             },
         )
         .await;
@@ -533,10 +560,19 @@ async fn nested_search_on_title_restricted_set_with_suffix_wildcard() {
 
     index
         .search(
-            json!({"q": "Captain Marvel", "attributesToSearchOn": ["details.*"]}),
+            json!({"q": "Captain Marvel", "attributesToSearchOn": ["details.*"], "attributesToRetrieve": ["id"]}),
             |response, code| {
                 snapshot!(code, @"200 OK");
-                snapshot!(response["hits"].as_array().unwrap().len(), @"2");
+                snapshot!(json_string!(response["hits"]),
+                    @r###"
+                [
+                  {
+                    "id": "3"
+                  },
+                  {
+                    "id": "2"
+                  }
+                ]"###);
             },
         )
         .await;
@@ -575,10 +611,19 @@ async fn nested_search_no_searchable_attribute_set_with_any_wildcard() {
 
     index
         .search(
-            json!({"q": "Captain Marvel", "attributesToSearchOn": ["unknown.*", "*.unknown", "*.title"]}),
+            json!({"q": "Captain Marvel", "attributesToSearchOn": ["unknown.*", "*.unknown", "*.title"], "attributesToRetrieve": ["id"]}),
             |response, code| {
                 snapshot!(code, @"200 OK");
-                snapshot!(response["hits"].as_array().unwrap().len(), @"2");
+                snapshot!(json_string!(response["hits"]),
+                    @r###"
+                [
+                  {
+                    "id": "3"
+                  },
+                  {
+                    "id": "2"
+                  }
+                ]"###);
             },
         )
         .await;
@@ -589,13 +634,22 @@ async fn nested_prefix_search_on_title_with_prefix_wildcard() {
     let server = Server::new().await;
     let index = index_with_documents(&server, &NESTED_SEARCH_DOCUMENTS).await;
 
-    // Nested prefix search with wildcard prefix should return 2 documents (ids: 2 and 3).
+    // Nested prefix search with prefix wildcard should return 2 documents (ids: 2 and 3).
     index
         .search(
-            json!({"q": "Captain Mar", "attributesToSearchOn": ["*.title"]}),
+            json!({"q": "Captain Mar", "attributesToSearchOn": ["*.title"], "attributesToRetrieve": ["id"]}),
             |response, code| {
                 snapshot!(code, @"200 OK");
-                snapshot!(response["hits"].as_array().unwrap().len(), @"2");
+                snapshot!(json_string!(response["hits"]),
+                    @r###"
+                [
+                  {
+                    "id": "3"
+                  },
+                  {
+                    "id": "2"
+                  }
+                ]"###);
             },
         )
         .await;
@@ -608,10 +662,22 @@ async fn nested_prefix_search_on_details_with_suffix_wildcard() {
 
     index
         .search(
-            json!({"q": "Captain Mar", "attributesToSearchOn": ["details.*"]}),
+            json!({"q": "Captain Mar", "attributesToSearchOn": ["details.*"], "attributesToRetrieve": ["id"]}),
             |response, code| {
                 snapshot!(code, @"200 OK");
-                snapshot!(response["hits"].as_array().unwrap().len(), @"3");
+                snapshot!(json_string!(response["hits"]),
+                    @r###"
+                [
+                  {
+                    "id": "3"
+                  },
+                  {
+                    "id": "1"
+                  },
+                  {
+                    "id": "2"
+                  }
+                ]"###);
             },
         )
         .await;
@@ -622,13 +688,22 @@ async fn nested_prefix_search_on_weaknesses_with_suffix_wildcard() {
     let server = Server::new().await;
     let index = index_with_documents(&server, &NESTED_SEARCH_DOCUMENTS).await;
 
-    // Deep wildcard search on nested weaknesses should return 2 documents (ids: 1 and 3)
+    // Wildcard search on nested weaknesses should return 2 documents (ids: 1 and 3)
     index
         .search(
-            json!({"q": "mag", "attributesToSearchOn": ["details.*"]}),
+            json!({"q": "mag", "attributesToSearchOn": ["details.*"], "attributesToRetrieve": ["id"]}),
             |response, code| {
                 snapshot!(code, @"200 OK");
-                snapshot!(response["hits"].as_array().unwrap().len(), @"2");
+                snapshot!(json_string!(response["hits"]),
+                    @r###"
+                [
+                  {
+                    "id": "1"
+                  },
+                  {
+                    "id": "3"
+                  }
+                ]"###);
             },
         )
         .await;
@@ -642,10 +717,16 @@ async fn nested_search_on_title_matching_strategy_all() {
     // Nested search matching strategy all should only return 1 document (ids: 3)
     index
         .search(
-            json!({"q": "Captain Marvel", "attributesToSearchOn": ["*.title"], "matchingStrategy": "all"}),
+            json!({"q": "Captain Marvel", "attributesToSearchOn": ["*.title"], "matchingStrategy": "all", "attributesToRetrieve": ["id"]}),
             |response, code| {
                 snapshot!(code, @"200 OK");
-                snapshot!(response["hits"].as_array().unwrap().len(), @"1");
+                snapshot!(json_string!(response["hits"]),
+                    @r###"
+                [
+                  {
+                    "id": "3"
+                  }
+                ]"###);
             },
         )
         .await;

--- a/crates/meilisearch/tests/search/restrict_searchable.rs
+++ b/crates/meilisearch/tests/search/restrict_searchable.rs
@@ -466,10 +466,19 @@ async fn nested_search_on_title_with_prefix_wildcard() {
     // Wildcard should match to 'details.' attribute
     index
         .search(
-            json!({"q": "Captain Marvel", "attributesToSearchOn": ["*.title"]}),
+            json!({"q": "Captain Marvel", "attributesToSearchOn": ["*.title"], "attributesToRetrieve": ["id"]}),
             |response, code| {
                 snapshot!(code, @"200 OK");
-                snapshot!(response["hits"].as_array().unwrap().len(), @"2");
+                snapshot!(json_string!(response["hits"]),
+                    @r###"
+                [
+                  {
+                    "id": "3"
+                  },
+                  {
+                    "id": "2"
+                  }
+                ]"###);
             },
         )
         .await;

--- a/crates/meilisearch/tests/search/restrict_searchable.rs
+++ b/crates/meilisearch/tests/search/restrict_searchable.rs
@@ -555,7 +555,8 @@ async fn nested_search_with_suffix_wildcard() {
 async fn nested_search_on_title_restricted_set_with_suffix_wildcard() {
     let server = Server::new().await;
     let index = index_with_documents(&server, &NESTED_SEARCH_DOCUMENTS).await;
-    let (task, _status_code) = index.update_settings_searchable_attributes(json!(["details.title"])).await;
+    let (task, _status_code) =
+        index.update_settings_searchable_attributes(json!(["details.title"])).await;
     index.wait_task(task.uid()).await.succeeded();
 
     index

--- a/crates/meilisearch/tests/search/restrict_searchable.rs
+++ b/crates/meilisearch/tests/search/restrict_searchable.rs
@@ -416,3 +416,323 @@ async fn phrase_search_on_title() {
         )
         .await;
 }
+
+static NESTED_SEARCH_DOCUMENTS: Lazy<Value> = Lazy::new(|| {
+    json!([
+    {
+        "details": {
+            "title": "Shazam!",
+            "desc": "a Captain Marvel ersatz",
+            "weaknesses": ["magic", "requires transformation"],
+            "outfit": {
+                "has_cape": true
+            }
+        },
+        "id": "1",
+    },
+    {
+        "details": {
+            "title": "Captain Planet",
+            "desc": "He's not part of the Marvel Cinematic Universe",
+            "blue_skin": true,
+            "outfit": {
+                "has_cape": false
+            }
+        },
+        "id": "2",
+    },
+    {
+        "details": {
+            "title": "Captain Marvel",
+            "desc": "a Shazam ersatz",
+            "weaknesses": ["magic", "power instability"],
+            "outfit": {
+                "has_cape": false
+            }
+        },
+        "id": "3",
+    }])
+});
+
+#[actix_rt::test]
+async fn nested_search_on_title_with_prefix_wildcard() {
+    let server = Server::new().await;
+    let index = index_with_documents(&server, &NESTED_SEARCH_DOCUMENTS).await;
+
+    // Wildcard should match to 'details.' attribute
+    index
+        .search(
+            json!({"q": "Captain Marvel", "attributesToSearchOn": ["*.title"]}),
+            |response, code| {
+                snapshot!(code, @"200 OK");
+                snapshot!(response["hits"].as_array().unwrap().len(), @"2");
+            },
+        )
+        .await;
+}
+
+#[actix_rt::test]
+async fn nested_search_on_title_with_suffix_wildcard() {
+    let server = Server::new().await;
+    let index = index_with_documents(&server, &NESTED_SEARCH_DOCUMENTS).await;
+
+    // Wildcard should match to any attribute inside 'details.'
+    // It's worth noting the difference between 'details.*' and '*.title'
+    index
+        .search(
+            json!({"q": "Captain Marvel", "attributesToSearchOn": ["details.*"]}),
+            |response, code| {
+                snapshot!(code, @"200 OK");
+                snapshot!(response["hits"].as_array().unwrap().len(), @"3");
+            },
+        )
+        .await;
+}
+
+#[actix_rt::test]
+async fn nested_search_all_details_with_deep_wildcard() {
+    let server = Server::new().await;
+    let index = index_with_documents(&server, &NESTED_SEARCH_DOCUMENTS).await;
+
+    // Similar to matching all attributes on simple search documents with universal wildcard
+    index
+        .search(
+            json!({"q": "Captain Marvel", "attributesToSearchOn": ["details.**"]}),
+            |response, code| {
+                snapshot!(code, @"200 OK");
+                snapshot!(response["hits"].as_array().unwrap().len(), @"3");
+            },
+        )
+        .await;
+
+    // Should return 2 documents (ids: 1 and 2)
+    index
+        .search(
+            json!({"q": "true", "attributesToSearchOn": ["details.**"]}),
+            |response, code| {
+                snapshot!(code, @"200 OK");
+                snapshot!(response["hits"].as_array().unwrap().len(), @"2");
+            },
+        )
+        .await;
+}
+
+#[actix_rt::test]
+async fn nested_search_all_details_restricted_set_with_any_wildcard() {
+    let server = Server::new().await;
+    let index = index_with_documents(&server, &NESTED_SEARCH_DOCUMENTS).await;
+    let (task, _status_code) = index.update_settings_searchable_attributes(json!(["details.title"])).await;
+    index.wait_task(task.uid()).await.succeeded();
+
+    index
+        .search(
+            json!({"q": "Captain Marvel", "attributesToSearchOn": ["details.*"]}),
+            |response, code| {
+                snapshot!(code, @"200 OK");
+                snapshot!(response["hits"].as_array().unwrap().len(), @"2");
+            },
+        )
+        .await;
+
+    index
+        .search(
+            json!({"q": "Captain Marvel", "attributesToSearchOn": ["details.**"]}),
+            |response, code| {
+                snapshot!(code, @"200 OK");
+                snapshot!(response["hits"].as_array().unwrap().len(), @"2");
+            },
+        )
+        .await;
+}
+
+#[actix_rt::test]
+async fn nested_search_no_searchable_attribute_set_with_any_wildcard() {
+    let server = Server::new().await;
+    let index = index_with_documents(&server, &NESTED_SEARCH_DOCUMENTS).await;
+
+    index
+        .search(
+            json!({"q": "Captain Marvel", "attributesToSearchOn": ["unknown.*", "*.unknown"]}),
+            |response, code| {
+                snapshot!(code, @"200 OK");
+                snapshot!(response["hits"].as_array().unwrap().len(), @"0");
+            },
+        )
+        .await;
+
+    let (task, _status_code) = index.update_settings_searchable_attributes(json!(["*"])).await;
+    index.wait_task(task.uid()).await.succeeded();
+
+    index
+        .search(
+            json!({"q": "Captain Marvel", "attributesToSearchOn": ["unknown.*", "*.unknown"]}),
+            |response, code| {
+                snapshot!(code, @"200 OK");
+                snapshot!(response["hits"].as_array().unwrap().len(), @"0");
+            },
+        )
+        .await;
+
+    index
+        .search(
+            json!({"q": "Captain Marvel", "attributesToSearchOn": ["unknown.**",]}),
+            |response, code| {
+                snapshot!(code, @"200 OK");
+                snapshot!(response["hits"].as_array().unwrap().len(), @"0");
+            },
+        )
+        .await;
+
+    let (task, _status_code) = index.update_settings_searchable_attributes(json!(["*"])).await;
+    index.wait_task(task.uid()).await.succeeded();
+
+    index
+        .search(
+            json!({"q": "Captain Marvel", "attributesToSearchOn": ["unknown.*", "*.unknown", "*.title"]}),
+            |response, code| {
+                snapshot!(code, @"200 OK");
+                snapshot!(response["hits"].as_array().unwrap().len(), @"2");
+            },
+        )
+        .await;
+
+    // We only match deep wild card at the end, otherwise we need to recursively match deep wildcards
+    index
+        .search(
+            json!({"q": "Captain Marvel", "attributesToSearchOn": ["unknown.**", "details.**"]}),
+            |response, code| {
+                snapshot!(code, @"200 OK");
+                snapshot!(response["hits"].as_array().unwrap().len(), @"3");
+            },
+        )
+        .await;
+}
+
+#[actix_rt::test]
+async fn nested_prefix_search_on_title_with_prefix_wildcard() {
+    let server = Server::new().await;
+    let index = index_with_documents(&server, &NESTED_SEARCH_DOCUMENTS).await;
+
+    // Nested prefix search with wildcard prefix should return 2 documents (ids: 2 and 3).
+    index
+        .search(
+            json!({"q": "Captain Mar", "attributesToSearchOn": ["*.title"]}),
+            |response, code| {
+                snapshot!(code, @"200 OK");
+                snapshot!(response["hits"].as_array().unwrap().len(), @"2");
+            },
+        )
+        .await;
+}
+
+#[actix_rt::test]
+async fn nested_prefix_search_on_details_with_suffix_wildcard() {
+    let server = Server::new().await;
+    let index = index_with_documents(&server, &NESTED_SEARCH_DOCUMENTS).await;
+
+    index
+        .search(
+            json!({"q": "Captain Mar", "attributesToSearchOn": ["details.*"]}),
+            |response, code| {
+                snapshot!(code, @"200 OK");
+                snapshot!(response["hits"].as_array().unwrap().len(), @"3");
+            },
+        )
+        .await;
+}
+
+#[actix_rt::test]
+async fn nested_prefix_search_on_weaknesses_with_deep_wildcard() {
+    let server = Server::new().await;
+    let index = index_with_documents(&server, &NESTED_SEARCH_DOCUMENTS).await;
+
+    // Deep wildcard search on nested weaknesses should return 2 documents (ids: 1 and 3)
+    index
+        .search(
+            json!({"q": "mag", "attributesToSearchOn": ["details.**"]}),
+            |response, code| {
+                snapshot!(code, @"200 OK");
+                snapshot!(response["hits"].as_array().unwrap().len(), @"2");
+            },
+        )
+        .await;
+}
+
+#[actix_rt::test]
+async fn nested_search_on_title_matching_strategy_all() {
+    let server = Server::new().await;
+    let index = index_with_documents(&server, &NESTED_SEARCH_DOCUMENTS).await;
+
+    // Nested search matching strategy all should only return 1 document (ids: 3)
+    index
+        .search(
+            json!({"q": "Captain Marvel", "attributesToSearchOn": ["*.title"], "matchingStrategy": "all"}),
+            |response, code| {
+                snapshot!(code, @"200 OK");
+                snapshot!(response["hits"].as_array().unwrap().len(), @"1");
+            },
+        )
+        .await;
+}
+
+#[actix_rt::test]
+async fn nested_attributes_ranking_rule_order_with_wildcard() {
+    let server = Server::new().await;
+    let index = index_with_documents(&server, &NESTED_SEARCH_DOCUMENTS).await;
+
+    // Document 3 should appear before documents 1 and 2
+    index
+        .search(
+            json!({"q": "Captain Marvel", "attributesToSearchOn": ["*.desc", "*.title"], "attributesToRetrieve": ["id"]}),
+            |response, code| {
+                snapshot!(code, @"200 OK");
+                snapshot!(json_string!(response["hits"]),
+                    @r###"
+                [
+                  {
+                    "id": "3"
+                  },
+                  {
+                    "id": "1"
+                  },
+                  {
+                    "id": "2"
+                  }
+                ]
+                "###
+                );
+            },
+        )
+        .await;
+}
+
+#[actix_rt::test]
+async fn nested_attributes_ranking_rule_order_with_deep_wildcard() {
+    let server = Server::new().await;
+    let index = index_with_documents(&server, &NESTED_SEARCH_DOCUMENTS).await;
+
+    // Document 3 should appear before documents 1 and 2
+    index
+        .search(
+            json!({"q": "Captain Marvel", "attributesToSearchOn": ["details.**"], "attributesToRetrieve": ["id"]}),
+            |response, code| {
+                snapshot!(code, @"200 OK");
+                snapshot!(json_string!(response["hits"]),
+                    @r###"
+                [
+                  {
+                    "id": "3"
+                  },
+                  {
+                    "id": "1"
+                  },
+                  {
+                    "id": "2"
+                  }
+                ]
+                "###
+                );
+            },
+        )
+        .await;
+}

--- a/crates/meilisearch/tests/search/restrict_searchable.rs
+++ b/crates/meilisearch/tests/search/restrict_searchable.rs
@@ -425,7 +425,11 @@ static NESTED_SEARCH_DOCUMENTS: Lazy<Value> = Lazy::new(|| {
             "desc": "a Captain Marvel ersatz",
             "weaknesses": ["magic", "requires transformation"],
             "outfit": {
-                "has_cape": true
+                "has_cape": true,
+                "colors": {
+                    "primary": "red",
+                    "secondary": "gold"
+                }
             }
         },
         "id": "1",
@@ -494,13 +498,13 @@ async fn nested_search_all_details_with_deep_wildcard() {
     let server = Server::new().await;
     let index = index_with_documents(&server, &NESTED_SEARCH_DOCUMENTS).await;
 
-    // Similar to matching all attributes on simple search documents with universal wildcard
+    // Deep wildcard should match deeply nested attributes
     index
         .search(
-            json!({"q": "Captain Marvel", "attributesToSearchOn": ["details.**"]}),
+            json!({"q": "gold", "attributesToSearchOn": ["details.**"]}),
             |response, code| {
                 snapshot!(code, @"200 OK");
-                snapshot!(response["hits"].as_array().unwrap().len(), @"3");
+                snapshot!(response["hits"].as_array().unwrap().len(), @"1");
             },
         )
         .await;

--- a/crates/milli/src/attribute_patterns.rs
+++ b/crates/milli/src/attribute_patterns.rs
@@ -50,7 +50,7 @@ impl AttributePatterns {
 ///
 /// * `pattern` - The pattern to match against.
 /// * `str` - The string to match against the pattern.
-fn match_pattern(pattern: &str, str: &str) -> PatternMatch {
+pub fn match_pattern(pattern: &str, str: &str) -> PatternMatch {
     // If the pattern is a wildcard, return Match
     if pattern == "*" {
         return PatternMatch::Match;

--- a/crates/milli/src/search/new/mod.rs
+++ b/crates/milli/src/search/new/mod.rs
@@ -137,9 +137,7 @@ impl<'ctx> SearchContext<'ctx> {
             if searchable_weight.is_none() && field_name.contains("*") {
                 let matching_searchable_weights: Vec<_> = searchable_fields_weights
                     .iter()
-                    .filter(|(name, _, _)| {
-                        match_pattern(field_name, name) == PatternMatch::Match
-                    })
+                    .filter(|(name, _, _)| match_pattern(field_name, name) == PatternMatch::Match)
                     .collect();
 
                 if !matching_searchable_weights.is_empty() {


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #5531
Fixes #5586

## What does this PR do?
- Allow [`attributesToSearchOn` search parameter](https://www.meilisearch.com/docs/reference/api/search#customize-attributes-to-search-on-at-search-time) to match nested suffix wildcard
- ~~Added deep wildcard~~ Added nested attribute searching with prefix wildcard 

Example doc:
```
{
  "id": 1,
  "ext": {
    "field1": "a",
    "field2": "b",
    "field3": {
      "field4": "c"
    }
  }
}
```

Example search:
```
{
  "q": "c",
  "attributesToSearchOn": ["ext.*"]
}
```

or

```
{
  "q": "c",
  "attributesToSearchOn": ["*.field4"]
}
```

Will find doc id:1
## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
