### PR TITLE
Only intern in case of single-typo when looking for single typoes

### DIFF
--- a/crates/milli/src/search/new/query_term/compute_derivations.rs
+++ b/crates/milli/src/search/new/query_term/compute_derivations.rs
@@ -92,12 +92,12 @@ fn find_one_typo_derivations(
     let mut stream = fst.search_with_state(Intersection(starts, &dfa)).into_stream();
 
     while let Some((derived_word, state)) = stream.next() {
-        let derived_word = std::str::from_utf8(derived_word)?;
-        let derived_word = ctx.word_interner.insert(derived_word.to_owned());
         let d = dfa.distance(state.1);
         match d.to_u8() {
             0 => (),
             1 => {
+                let derived_word = std::str::from_utf8(derived_word)?;
+                let derived_word = ctx.word_interner.insert(derived_word.to_owned());
                 let cf = visit(derived_word)?;
                 if cf.is_break() {
                     break;


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #5547 

## What does this PR do?
- When looking for single typoes, do not intern strings before knowing for sure that they correspond to a single-typo.
- Without this check, it was possible to build an index and a search query such that an arbitrary number of strings would be interned, causing a crash.
- Add test failing on v1.14.0, but not after this PR.

### Test output before this PR

```
thread 'tokio-runtime-worker' panicked at crates/milli/src/search/new/interner.rs:60:13:
assertion failed: self.stable_store.len() < u16::MAX as usize
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread 'search::bug_5547' panicked at crates/meilisearch/tests/search/mod.rs:131:5:
assertion `left == right` failed
  left: 500
 right: 200
```
