### PR TITLE
Decouple geo facet extraction from rest of document

### DIFF
--- a/crates/meilisearch/tests/documents/add_documents.rs
+++ b/crates/meilisearch/tests/documents/add_documents.rs
@@ -2040,6 +2040,14 @@ async fn update_documents_with_geo_field() {
     {
       "hits": [
         {
+          "id": "4",
+          "_geo": {
+            "lat": "4",
+            "lng": "0"
+          },
+          "_geoDistance": 667170
+        },
+        {
           "id": "3",
           "_geo": {
             "lat": 5,
@@ -2047,14 +2055,6 @@ async fn update_documents_with_geo_field() {
           },
           "doggo": "kefir",
           "_geoDistance": 555975
-        },
-        {
-          "id": "4",
-          "_geo": {
-            "lat": "4",
-            "lng": "0"
-          },
-          "_geoDistance": 667170
         },
         {
           "id": "1"

--- a/crates/meilisearch/tests/documents/add_documents.rs
+++ b/crates/meilisearch/tests/documents/add_documents.rs
@@ -2040,14 +2040,6 @@ async fn update_documents_with_geo_field() {
     {
       "hits": [
         {
-          "id": "4",
-          "_geo": {
-            "lat": "4",
-            "lng": "0"
-          },
-          "_geoDistance": 667170
-        },
-        {
           "id": "3",
           "_geo": {
             "lat": 5,
@@ -2055,6 +2047,14 @@ async fn update_documents_with_geo_field() {
           },
           "doggo": "kefir",
           "_geoDistance": 555975
+        },
+        {
+          "id": "4",
+          "_geo": {
+            "lat": "4",
+            "lng": "0"
+          },
+          "_geoDistance": 667170
         },
         {
           "id": "1"

--- a/crates/milli/src/update/new/extract/faceted/extract_facets.rs
+++ b/crates/milli/src/update/new/extract/faceted/extract_facets.rs
@@ -153,7 +153,7 @@ impl FacetedDocidsExtractor {
                 }
             }
             DocumentChange::Update(inner) => {
-                let has_changed = inner.has_changed_for_fields(
+                let has_changed_for_facets = inner.has_changed_for_fields(
                     &mut |field_name| {
                         match_faceted_field(
                             field_name,
@@ -171,7 +171,7 @@ impl FacetedDocidsExtractor {
                     inner.has_changed_for_geo_fields(rtxn, index, context.db_fields_ids_map)?;
 
                 // 1. Maybe update doc
-                if has_changed {
+                if has_changed_for_facets {
                     extract_document_facets(
                         inner.current(rtxn, index, context.db_fields_ids_map)?,
                         new_fields_ids_map.deref_mut(),

--- a/crates/milli/src/update/new/extract/faceted/extract_facets.rs
+++ b/crates/milli/src/update/new/extract/faceted/extract_facets.rs
@@ -91,8 +91,8 @@ impl FacetedDocidsExtractor {
         let mut del_add_facet_value = DelAddFacetValue::new(&context.doc_alloc);
         let docid = document_change.docid();
 
-        // Macro expanding to an insertion/deletion facet fn,
-        // using a macro avoid to borrow the parameters as mutable in both closures at the same time by postponing their creation 
+        // Using a macro avoid borrowing the parameters as mutable in both closures at
+        // the same time by postponing their creation
         macro_rules! facet_fn {
             (del) => {
                 |fid: FieldId, meta: Metadata, depth: perm_json_p::Depth, value: &Value| {
@@ -168,8 +168,6 @@ impl FacetedDocidsExtractor {
                     index,
                     context.db_fields_ids_map,
                 )?;
-                let has_changed_for_geo_fields =
-                    inner.has_changed_for_geo_fields(rtxn, index, context.db_fields_ids_map)?;
 
                 // 1. Maybe update doc
                 if has_changed_for_facets {
@@ -195,7 +193,9 @@ impl FacetedDocidsExtractor {
                 }
 
                 // 2. Maybe update geo
-                if is_geo_enabled && inner.has_changed_for_geo_fields(rtxn, index, context.db_fields_ids_map)? {
+                if is_geo_enabled
+                    && inner.has_changed_for_geo_fields(rtxn, index, context.db_fields_ids_map)?
+                {
                     extract_geo_document(
                         inner.current(rtxn, index, context.db_fields_ids_map)?,
                         inner.external_document_id(),

--- a/crates/milli/src/update/new/extract/faceted/extract_facets.rs
+++ b/crates/milli/src/update/new/extract/faceted/extract_facets.rs
@@ -135,7 +135,6 @@ impl FacetedDocidsExtractor {
 
                 extract_document_facets(
                     inner.current(rtxn, index, context.db_fields_ids_map)?,
-                    inner.external_document_id(),
                     new_fields_ids_map.deref_mut(),
                     filterable_attributes,
                     sortable_fields,
@@ -177,7 +176,6 @@ impl FacetedDocidsExtractor {
 
                     extract_document_facets(
                         inner.current(rtxn, index, context.db_fields_ids_map)?,
-                        inner.external_document_id(),
                         new_fields_ids_map.deref_mut(),
                         filterable_attributes,
                         sortable_fields,
@@ -200,7 +198,6 @@ impl FacetedDocidsExtractor {
 
                     extract_document_facets(
                         inner.merged(rtxn, index, context.db_fields_ids_map)?,
-                        inner.external_document_id(),
                         new_fields_ids_map.deref_mut(),
                         filterable_attributes,
                         sortable_fields,
@@ -224,7 +221,6 @@ impl FacetedDocidsExtractor {
 
                 extract_document_facets(
                     inner.inserted(),
-                    inner.external_document_id(),
                     new_fields_ids_map.deref_mut(),
                     filterable_attributes,
                     sortable_fields,
@@ -232,6 +228,7 @@ impl FacetedDocidsExtractor {
                     distinct_field,
                     &mut add,
                 )?;
+
                 if is_geo_enabled {
                     extract_geo_document(
                         inner.inserted(),

--- a/crates/milli/src/update/new/extract/faceted/extract_facets.rs
+++ b/crates/milli/src/update/new/extract/faceted/extract_facets.rs
@@ -194,7 +194,7 @@ impl FacetedDocidsExtractor {
                 }
 
                 // 2. Maybe update geo
-                if is_geo_enabled && has_changed_for_geo_fields {
+                if is_geo_enabled && inner.has_changed_for_geo_fields(rtxn, index, context.db_fields_ids_map)? {
                     extract_geo_document(
                         inner.current(rtxn, index, context.db_fields_ids_map)?,
                         inner.external_document_id(),

--- a/crates/milli/src/update/new/extract/faceted/extract_facets.rs
+++ b/crates/milli/src/update/new/extract/faceted/extract_facets.rs
@@ -91,7 +91,8 @@ impl FacetedDocidsExtractor {
         let mut del_add_facet_value = DelAddFacetValue::new(&context.doc_alloc);
         let docid = document_change.docid();
 
-        // Macro expanding to an insertion/deletion facet fn
+        // Macro expanding to an insertion/deletion facet fn,
+        // using a macro avoid to borrow the parameters as mutable in both closures at the same time by postponing their creation 
         macro_rules! facet_fn {
             (del) => {
                 |fid: FieldId, meta: Metadata, depth: perm_json_p::Depth, value: &Value| {

--- a/crates/milli/src/update/new/extract/faceted/facet_document.rs
+++ b/crates/milli/src/update/new/extract/faceted/facet_document.rs
@@ -108,7 +108,6 @@ pub fn extract_geo_document<'doc>(
     document: impl Document<'doc>,
     external_document_id: &str,
     field_id_map: &mut GlobalFieldsIdsMap,
-    asc_desc_fields: &HashSet<String>,
     facet_fn: &mut impl FnMut(FieldId, Metadata, perm_json_p::Depth, &Value) -> Result<()>,
 ) -> Result<()> {
     if let Some(geo_value) = document.geo_field()? {

--- a/crates/milli/src/update/new/extract/faceted/facet_document.rs
+++ b/crates/milli/src/update/new/extract/faceted/facet_document.rs
@@ -22,7 +22,6 @@ pub fn extract_document_facets<'doc>(
     sortable_fields: &HashSet<String>,
     asc_desc_fields: &HashSet<String>,
     distinct_field: &Option<String>,
-    is_geo_enabled: bool,
     facet_fn: &mut impl FnMut(FieldId, Metadata, perm_json_p::Depth, &Value) -> Result<()>,
 ) -> Result<()> {
     // return the match result for the given field name.
@@ -102,17 +101,25 @@ pub fn extract_document_facets<'doc>(
         }
     }
 
-    if is_geo_enabled {
-        if let Some(geo_value) = document.geo_field()? {
-            if let Some([lat, lng]) = extract_geo_coordinates(external_document_id, geo_value)? {
-                let ((lat_fid, lat_meta), (lng_fid, lng_meta)) = field_id_map
-                    .id_with_metadata_or_insert("_geo.lat")
-                    .zip(field_id_map.id_with_metadata_or_insert("_geo.lng"))
-                    .ok_or(UserError::AttributeLimitReached)?;
+    Ok(())
+}
 
-                facet_fn(lat_fid, lat_meta, perm_json_p::Depth::OnBaseKey, &lat.into())?;
-                facet_fn(lng_fid, lng_meta, perm_json_p::Depth::OnBaseKey, &lng.into())?;
-            }
+pub fn extract_geo_document<'doc>(
+    document: impl Document<'doc>,
+    external_document_id: &str,
+    field_id_map: &mut GlobalFieldsIdsMap,
+    asc_desc_fields: &HashSet<String>,
+    facet_fn: &mut impl FnMut(FieldId, Metadata, perm_json_p::Depth, &Value) -> Result<()>,
+) -> Result<()> {
+    if let Some(geo_value) = document.geo_field()? {
+        if let Some([lat, lng]) = extract_geo_coordinates(external_document_id, geo_value)? {
+            let ((lat_fid, lat_meta), (lng_fid, lng_meta)) = field_id_map
+                .id_with_metadata_or_insert("_geo.lat")
+                .zip(field_id_map.id_with_metadata_or_insert("_geo.lng"))
+                .ok_or(UserError::AttributeLimitReached)?;
+
+            facet_fn(lat_fid, lat_meta, perm_json_p::Depth::OnBaseKey, &lat.into())?;
+            facet_fn(lng_fid, lng_meta, perm_json_p::Depth::OnBaseKey, &lng.into())?;
         }
     }
 

--- a/crates/milli/src/update/new/extract/faceted/facet_document.rs
+++ b/crates/milli/src/update/new/extract/faceted/facet_document.rs
@@ -16,7 +16,6 @@ use crate::filterable_attributes_rules::match_faceted_field;
 #[allow(clippy::too_many_arguments)]
 pub fn extract_document_facets<'doc>(
     document: impl Document<'doc>,
-    external_document_id: &str,
     field_id_map: &mut GlobalFieldsIdsMap,
     filterable_attributes: &[FilterableAttributesRule],
     sortable_fields: &HashSet<String>,


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #5440 

## What does this PR do?
- introduces new function `extract_geo_document` for _geo facet extraction & removes that logic from `extract_document_facets` 
- adds a new `macro_rules!` macro to generate `add` and `del` facet functions, limiting code duplication 

Note: Since each variant of the macro uses a &mut ref, we can't just define top level helpers to use throughout the match block. Ideally a factory function would be used in place of this macro but since closures have anonymous types we run into issues defining the signature of the factory, unless we wanna toss in `Box<dyn ...>`. I think the macro is a nice trade-off here

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
