### PR TITLE
tests: Faster search::facet_search IT tests

### DIFF
--- a/crates/meilisearch/tests/search/facet_search.rs
+++ b/crates/meilisearch/tests/search/facet_search.rs
@@ -50,13 +50,11 @@ async fn test_settings_documents_indexing_swapping_and_facet_search(
 
     let (task, code) = index.add_documents(documents.clone(), None).await;
     assert_eq!(code, 202, "{}", task);
-    let response = index.wait_task(task.uid()).await.succeeded();
-    assert!(response.is_success(), "{response:?}");
+    index.wait_task(task.uid()).await.succeeded();
 
     let (task, code) = index.update_settings(settings.clone()).await;
     assert_eq!(code, 202, "{}", task);
-    let response = index.wait_task(task.uid()).await.succeeded();
-    assert!(response.is_success(), "{response:?}");
+    index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = index.facet_search(query.clone()).await;
     insta::allow_duplicates! {
@@ -65,21 +63,18 @@ async fn test_settings_documents_indexing_swapping_and_facet_search(
 
     let (task, code) = server.delete_index("test").await;
     assert_eq!(code, 202, "{}", task);
-    let response = server.wait_task(task.uid()).await.succeeded();
-    assert!(response.is_success(), "{response:?}");
+    server.wait_task(task.uid()).await.succeeded();
 
     eprintln!("Settings -> Documents -> test");
     let index = server.index("test");
 
     let (task, code) = index.update_settings(settings.clone()).await;
     assert_eq!(code, 202, "{}", task);
-    let response = index.wait_task(task.uid()).await.succeeded();
-    assert!(response.is_success(), "{response:?}");
+    index.wait_task(task.uid()).await.succeeded();
 
     let (task, code) = index.add_documents(documents.clone(), None).await;
     assert_eq!(code, 202, "{}", task);
-    let response = index.wait_task(task.uid()).await.succeeded();
-    assert!(response.is_success(), "{response:?}");
+    index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = index.facet_search(query.clone()).await;
     insta::allow_duplicates! {
@@ -88,8 +83,7 @@ async fn test_settings_documents_indexing_swapping_and_facet_search(
 
     let (task, code) = server.delete_index("test").await;
     assert_eq!(code, 202, "{}", task);
-    let response = server.wait_task(task.uid()).await.succeeded();
-    assert!(response.is_success(), "{response:?}");
+    server.wait_task(task.uid()).await.succeeded();
 }
 
 #[actix_rt::test]


### PR DESCRIPTION

# Pull Request

## Related issue
#4840

## What does this PR do?
- Use shared server + unique indices where possible. 
- Assert .succeeded() for the waited tasks.
- Drop usage of dbg!() in the assertions. It caused noise in the logs
