### PR TITLE
fix(milli/search): Cyrillic has different typo tolerance due to byte counting bug

### DIFF
--- a/crates/meilisearch/tests/search/locales.rs
+++ b/crates/meilisearch/tests/search/locales.rs
@@ -147,23 +147,20 @@ async fn simple_search() {
         .search(
             json!({"q": "進撃", "locales": ["jpn"], "attributesToRetrieve": ["id"]}),
             |response, code| {
-                snapshot!(response, @r###"
+                snapshot!(response, @r#"
                 {
                   "hits": [
                     {
                       "id": 852
-                    },
-                    {
-                      "id": 853
                     }
                   ],
                   "query": "進撃",
                   "processingTimeMs": "[duration]",
                   "limit": 20,
                   "offset": 0,
-                  "estimatedTotalHits": 2
+                  "estimatedTotalHits": 1
                 }
-                "###);
+                "#);
                 snapshot!(code, @"200 OK");
             },
         )

--- a/crates/meilisearch/tests/search/locales.rs
+++ b/crates/meilisearch/tests/search/locales.rs
@@ -169,23 +169,20 @@ async fn simple_search() {
     // chinese
     index
         .search(json!({"q": "进击", "attributesToRetrieve": ["id"]}), |response, code| {
-            snapshot!(response, @r###"
+            snapshot!(response, @r#"
             {
               "hits": [
                 {
                   "id": 853
-                },
-                {
-                  "id": 852
                 }
               ],
               "query": "进击",
               "processingTimeMs": "[duration]",
               "limit": 20,
               "offset": 0,
-              "estimatedTotalHits": 2
+              "estimatedTotalHits": 1
             }
-            "###);
+            "#);
             snapshot!(code, @"200 OK");
         })
         .await;

--- a/crates/milli/src/search/new/query_term/parse_query.rs
+++ b/crates/milli/src/search/new/query_term/parse_query.rs
@@ -386,51 +386,56 @@ mod tests {
         let temp_index = temp_index_with_documents();
         let rtxn = temp_index.read_txn()?;
         let ctx = SearchContext::new(&temp_index, &rtxn)?;
-        
+
         let nbr_typos = number_of_typos_allowed(&ctx)?;
-        
+
         // ASCII word "doggy" (5 chars, 5 bytes)
         let ascii_word = "doggy";
         let ascii_typos = nbr_typos(ascii_word);
-        
-        // Cyrillic word "собак" (5 chars, 10 bytes)  
+
+        // Cyrillic word "собак" (5 chars, 10 bytes)
         let cyrillic_word = "собак";
         let cyrillic_typos = nbr_typos(cyrillic_word);
-        
+
         // Both words have 5 characters, so they should have the same typo tolerance
-        assert_eq!(ascii_typos, cyrillic_typos,
-            "Words with same character count should get same typo tolerance");
-        
+        assert_eq!(
+            ascii_typos, cyrillic_typos,
+            "Words with same character count should get same typo tolerance"
+        );
+
         // With default settings (oneTypo=5, twoTypos=9), 5-char words should get 1 typo
         assert_eq!(ascii_typos, 1, "5-character word should get 1 typo tolerance");
         assert_eq!(cyrillic_typos, 1, "5-character word should get 1 typo tolerance");
-        
+
         Ok(())
     }
 
-    #[test] 
+    #[test]
     fn test_various_unicode_scripts() -> Result<()> {
         let temp_index = temp_index_with_documents();
         let rtxn = temp_index.read_txn()?;
         let ctx = SearchContext::new(&temp_index, &rtxn)?;
-        
+
         let nbr_typos = number_of_typos_allowed(&ctx)?;
-        
+
         // Let's use 5-character words for consistent testing
         let five_char_words = vec![
-            ("doggy", "ASCII"),           // 5 chars, 5 bytes
-            ("café!", "Accented"),        // 5 chars, 7 bytes
-            ("собак", "Cyrillic"),        // 5 chars, 10 bytes 
+            ("doggy", "ASCII"),    // 5 chars, 5 bytes
+            ("café!", "Accented"), // 5 chars, 7 bytes
+            ("собак", "Cyrillic"), // 5 chars, 10 bytes
         ];
-        
+
         let expected_typos = 1; // With default settings, 5-char words get 1 typo
-        
+
         for (word, script) in five_char_words {
             let typos = nbr_typos(word);
-            assert_eq!(typos, expected_typos,
-                "{} word '{}' should get {} typo(s)", script, word, expected_typos);
+            assert_eq!(
+                typos, expected_typos,
+                "{} word '{}' should get {} typo(s)",
+                script, word, expected_typos
+            );
         }
-        
+
         Ok(())
     }
 }

--- a/crates/milli/src/search/new/query_term/parse_query.rs
+++ b/crates/milli/src/search/new/query_term/parse_query.rs
@@ -380,7 +380,6 @@ mod tests {
 
         Ok(())
     }
-}
 
     #[test]
     fn test_unicode_typo_tolerance_fixed() -> Result<()> {
@@ -397,11 +396,6 @@ mod tests {
         // Cyrillic word "собак" (5 chars, 10 bytes)  
         let cyrillic_word = "собак";
         let cyrillic_typos = nbr_typos(cyrillic_word);
-        
-        eprintln!("ASCII '{}': char_count={}, typos={}", 
-                  ascii_word, ascii_word.chars().count(), ascii_typos);
-        eprintln!("Cyrillic '{}': char_count={}, typos={}", 
-                  cyrillic_word, cyrillic_word.chars().count(), cyrillic_typos);
         
         // Both words have 5 characters, so they should have the same typo tolerance
         assert_eq!(ascii_typos, cyrillic_typos,
@@ -433,11 +427,10 @@ mod tests {
         
         for (word, script) in five_char_words {
             let typos = nbr_typos(word);
-            eprintln!("{} '{}': chars={}, bytes={}, typos={}", 
-                      script, word, word.chars().count(), word.chars().count(), typos);
             assert_eq!(typos, expected_typos,
                 "{} word '{}' should get {} typo(s)", script, word, expected_typos);
         }
         
         Ok(())
     }
+}

--- a/crates/milli/src/search/new/query_term/parse_query.rs
+++ b/crates/milli/src/search/new/query_term/parse_query.rs
@@ -202,11 +202,11 @@ pub fn number_of_typos_allowed<'ctx>(
 
     Ok(Box::new(move |word: &str| {
         if !authorize_typos
-            || word.len() < min_len_one_typo as usize
+            || word.chars().count() < min_len_one_typo as usize
             || exact_words.as_ref().is_some_and(|fst| fst.contains(word))
         {
             0
-        } else if word.len() < min_len_two_typos as usize {
+        } else if word.chars().count() < min_len_two_typos as usize {
             1
         } else {
             2
@@ -381,3 +381,63 @@ mod tests {
         Ok(())
     }
 }
+
+    #[test]
+    fn test_unicode_typo_tolerance_fixed() -> Result<()> {
+        let temp_index = temp_index_with_documents();
+        let rtxn = temp_index.read_txn()?;
+        let ctx = SearchContext::new(&temp_index, &rtxn)?;
+        
+        let nbr_typos = number_of_typos_allowed(&ctx)?;
+        
+        // ASCII word "doggy" (5 chars, 5 bytes)
+        let ascii_word = "doggy";
+        let ascii_typos = nbr_typos(ascii_word);
+        
+        // Cyrillic word "собак" (5 chars, 10 bytes)  
+        let cyrillic_word = "собак";
+        let cyrillic_typos = nbr_typos(cyrillic_word);
+        
+        eprintln!("ASCII '{}': char_count={}, typos={}", 
+                  ascii_word, ascii_word.chars().count(), ascii_typos);
+        eprintln!("Cyrillic '{}': char_count={}, typos={}", 
+                  cyrillic_word, cyrillic_word.chars().count(), cyrillic_typos);
+        
+        // Both words have 5 characters, so they should have the same typo tolerance
+        assert_eq!(ascii_typos, cyrillic_typos,
+            "Words with same character count should get same typo tolerance");
+        
+        // With default settings (oneTypo=5, twoTypos=9), 5-char words should get 1 typo
+        assert_eq!(ascii_typos, 1, "5-character word should get 1 typo tolerance");
+        assert_eq!(cyrillic_typos, 1, "5-character word should get 1 typo tolerance");
+        
+        Ok(())
+    }
+
+    #[test] 
+    fn test_various_unicode_scripts() -> Result<()> {
+        let temp_index = temp_index_with_documents();
+        let rtxn = temp_index.read_txn()?;
+        let ctx = SearchContext::new(&temp_index, &rtxn)?;
+        
+        let nbr_typos = number_of_typos_allowed(&ctx)?;
+        
+        // Let's use 5-character words for consistent testing
+        let five_char_words = vec![
+            ("doggy", "ASCII"),           // 5 chars, 5 bytes
+            ("café!", "Accented"),        // 5 chars, 7 bytes
+            ("собак", "Cyrillic"),        // 5 chars, 10 bytes 
+        ];
+        
+        let expected_typos = 1; // With default settings, 5-char words get 1 typo
+        
+        for (word, script) in five_char_words {
+            let typos = nbr_typos(word);
+            eprintln!("{} '{}': chars={}, bytes={}, typos={}", 
+                      script, word, word.chars().count(), word.chars().count(), typos);
+            assert_eq!(typos, expected_typos,
+                "{} word '{}' should get {} typo(s)", script, word, expected_typos);
+        }
+        
+        Ok(())
+    }


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes https://github.com/meilisearch/meilisearch/issues/5594

## What does this PR do?

Fixes the Unicode character typo tolerance bug in the Meilisearch `milli` crate that was causing incorrect typo tolerance for multi-byte Unicode characters including Cyrillic, Arabic, Hebrew, Chinese, Japanese, Korean, and other non-ASCII text. The fix ensures that typo tolerance is determined by logical character count rather than UTF-8 byte representation, providing consistent behavior across all languages and writing systems.

### Root Cause

The bug was located in the `number_of_typos_allowed` function in `./crates/milli/src/search/new/query_term/parse_query.rs` at lines 205 and 209, where the code was using `word.len()` (byte count) instead of `word.chars().count()` (character count) to determine typo tolerance.

### The Problem

- ASCII characters: Each character = 1 byte, so `"doggy".len()` = 5 bytes = 5 characters
- Cyrillic characters: Each character = 2-3 bytes in UTF-8, so `"собак".len()` = 10 bytes ≠ 5 characters

This caused words with the same character count to receive different typo tolerance based on their byte representation.

### What Was Not Changed
The `ngram_str.len() > MAX_WORD_LENGTH` check at line 249 was intentionally left unchanged because `MAX_WORD_LENGTH` represents a byte-based limit for LMDB database storage, not a character-based limit.

### Impact of the Fix
- **Before**: Words with same character count but different byte lengths got different typo tolerance
  - "doggy" (5 chars, 5 bytes) → 1 typo tolerance
  - "собак" (5 chars, 10 bytes) → 2 typos tolerance (incorrect)
- **After**: Words with same character count get same typo tolerance regardless of byte length
  - "doggy" (5 chars, 5 bytes) → 1 typo tolerance  
  - "собак" (5 chars, 10 bytes) → 1 typo tolerance (correct)

### Tests

```sh
cargo test --package milli --lib -- search::new::query_term::parse_query::tests --show-output 

    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.16s
     Running unittests src/lib.rs (target/debug/deps/milli-a43628d37620dffa)

running 3 tests
test search::new::query_term::parse_query::tests::test_unicode_typo_tolerance_fixed ... ok
test search::new::query_term::parse_query::tests::start_with_hard_separator ... ok
test search::new::query_term::parse_query::tests::test_various_unicode_scripts ... ok

successes:

successes:
    search::new::query_term::parse_query::tests::start_with_hard_separator
    search::new::query_term::parse_query::tests::test_unicode_typo_tolerance_fixed
    search::new::query_term::parse_query::tests::test_various_unicode_scripts

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 267 filtered out; finished in 0.30s
```

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
