### PR TITLE
ignore flaky test

### DIFF
--- a/crates/meilisearch/tests/search/multi/proxy.rs
+++ b/crates/meilisearch/tests/search/multi/proxy.rs
@@ -2296,6 +2296,7 @@ async fn error_remote_500_once() {
 }
 
 #[actix_rt::test]
+#[ignore]
 async fn error_remote_timeout() {
     let ms0 = Server::new().await;
     let ms1 = Server::new().await;


### PR DESCRIPTION
`error_remote_timeout` has been flaky for a while now. Ignoring as it is not a very important test