### PR TITLE
Prompt for Email

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ LABEL   org.opencontainers.image.source="https://github.com/meilisearch/meilisea
 
 ENV     MEILI_HTTP_ADDR 0.0.0.0:7700
 ENV     MEILI_SERVER_PROVIDER docker
-ENV     MEILI_CONTACT_EMAIL
+ENV     MEILI_CONTACT_EMAIL ""
 
 RUN     apk add -q --no-cache libgcc tini curl
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ LABEL   org.opencontainers.image.source="https://github.com/meilisearch/meilisea
 
 ENV     MEILI_HTTP_ADDR 0.0.0.0:7700
 ENV     MEILI_SERVER_PROVIDER docker
+ENV     MEILI_CONTACT_EMAIL
 
 RUN     apk add -q --no-cache libgcc tini curl
 

--- a/crates/meilisearch/src/analytics/mod.rs
+++ b/crates/meilisearch/src/analytics/mod.rs
@@ -45,7 +45,7 @@ macro_rules! empty_analytics {
 /// `~/.config/Meilisearch` on *NIX or *BSD.
 /// `~/Library/ApplicationSupport` on macOS.
 /// `%APPDATA` (= `C:\Users%USERNAME%\AppData\Roaming`) on windows.
-static MEILISEARCH_CONFIG_PATH: Lazy<Option<PathBuf>> =
+pub static MEILISEARCH_CONFIG_PATH: Lazy<Option<PathBuf>> =
     Lazy::new(|| AppDirs::new(Some("Meilisearch"), false).map(|appdir| appdir.config_dir));
 
 fn config_user_id_path(db_path: &Path) -> Option<PathBuf> {

--- a/crates/meilisearch/src/analytics/segment_analytics.rs
+++ b/crates/meilisearch/src/analytics/segment_analytics.rs
@@ -277,6 +277,7 @@ impl Infos {
             log_level,
             indexer_options,
             config_file_path,
+            contact_email: _,
             no_analytics: _,
         } = options;
 

--- a/crates/meilisearch/src/main.rs
+++ b/crates/meilisearch/src/main.rs
@@ -155,16 +155,21 @@ async fn prompt_for_contact_email() -> anyhow::Result<Option<String>> {
         return Ok(None);
     }
 
-    println!("Would you mind providing your contact email for support and news?");
-    println!("We will use it to contact you with news only.");
+    println!("Would you mind providing your contact email for support and news? We will use it to contact you with news only.");
+    println!("Press enter to skip.");
     print!("contact email> ");
     std::io::stdout().flush()?;
 
     let mut email = String::new();
     let mut stdin = BufReader::new(stdin);
     let _ = stdin.read_line(&mut email).await?;
+    let email = email.trim();
 
-    Ok(Some(email.trim().to_string()))
+    if email.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(email.to_string()))
+    }
 }
 
 async fn run_http(

--- a/crates/meilisearch/src/main.rs
+++ b/crates/meilisearch/src/main.rs
@@ -132,13 +132,12 @@ async fn try_main() -> anyhow::Result<()> {
     let (index_scheduler, auth_controller) = setup_meilisearch(&opt)?;
 
     // We ask users their emails just after the data.ms is created
-    let skip_email_path = MEILISEARCH_CONFIG_PATH.as_ref().map(|conf| conf.join(SKIP_EMAIL_FILENAME));
+    let skip_email_path =
+        MEILISEARCH_CONFIG_PATH.as_ref().map(|conf| conf.join(SKIP_EMAIL_FILENAME));
     // If the config path does not exist, it means the user don't have a home directory
-    let skip_email = skip_email_path.as_ref().map_or(true, |path| path.exists());
+    let skip_email = skip_email_path.as_ref().is_none_or(|path| path.exists());
     opt.contact_email = match opt.contact_email.as_ref().map(|email| email.as_deref()) {
-        Some(Some("false")) | None if !skip_email => {
-            prompt_for_contact_email().await.map(Some)?
-        }
+        Some(Some("false")) | None if !skip_email => prompt_for_contact_email().await.map(Some)?,
         Some(Some(email)) if !skip_email => Some(Some(email.to_string())),
         _otherwise => None,
     };
@@ -147,7 +146,7 @@ async fn try_main() -> anyhow::Result<()> {
         let email = email.clone();
         // We spawn a task to register the email and create the skip email
         // file to avoid blocking the Meilisearch launch further.
-        let _ = tokio::spawn(async move {
+        let handle = tokio::spawn(async move {
             if let Some(skip_email_path) = skip_email_path {
                 // If the analytics are disabled the directory might not exist at all
                 if let Err(e) = tokio::fs::create_dir_all(skip_email_path.parent().unwrap()).await {
@@ -161,6 +160,7 @@ async fn try_main() -> anyhow::Result<()> {
                 eprintln!("Failed to register email: {}", err);
             }
         });
+        drop(handle);
     }
 
     let analytics =

--- a/crates/meilisearch/src/main.rs
+++ b/crates/meilisearch/src/main.rs
@@ -187,8 +187,8 @@ async fn prompt_for_contact_email() -> anyhow::Result<Option<String>> {
         return Ok(None);
     }
 
-    println!("Stay up to date! Get monthly updates about new features and tips to get the most out of Meilisearch.");
-    println!("You can use the `--contact-email` parameter to disable this prompt.");
+    println!("Get monthly updates about new features and tips to get the most out of Meilisearch.");
+    println!("Use the --contact-email option to disable this prompt.");
     print!("Enter your email or leave blank to skip> ");
     std::io::stdout().flush()?;
 

--- a/crates/meilisearch/src/main.rs
+++ b/crates/meilisearch/src/main.rs
@@ -179,9 +179,9 @@ async fn prompt_for_contact_email() -> anyhow::Result<Option<String>> {
         return Ok(None);
     }
 
-    println!("Enter your email to receive occasional updates and tips about Meilisearch.");
-    println!("Leave blank to skip.");
-    print!("contact email> ");
+    println!("Stay up to date! Get monthly updates about new features and tips to get the most out of Meilisearch.");
+    println!("You can use the `--contact-email` parameter to disable this prompt.");
+    print!("Enter your email or leave blank to skip> ");
     std::io::stdout().flush()?;
 
     let mut email = String::new();

--- a/crates/meilisearch/src/main.rs
+++ b/crates/meilisearch/src/main.rs
@@ -170,8 +170,8 @@ async fn prompt_for_contact_email() -> anyhow::Result<Option<String>> {
         return Ok(None);
     }
 
-    println!("Would you mind providing your contact email for support and news? We will use it to contact you with news only.");
-    println!("Press enter to skip.");
+    println!("Enter your email to receive occasional updates and tips about Meilisearch.");
+    println!("Leave blank to skip.");
     print!("contact email> ");
     std::io::stdout().flush()?;
 

--- a/crates/meilisearch/src/option.rs
+++ b/crates/meilisearch/src/option.rs
@@ -66,6 +66,7 @@ const MEILI_EXPERIMENTAL_LIMIT_BATCHED_TASKS_TOTAL_SIZE: &str =
 const MEILI_EXPERIMENTAL_EMBEDDING_CACHE_ENTRIES: &str =
     "MEILI_EXPERIMENTAL_EMBEDDING_CACHE_ENTRIES";
 const MEILI_EXPERIMENTAL_NO_SNAPSHOT_COMPACTION: &str = "MEILI_EXPERIMENTAL_NO_SNAPSHOT_COMPACTION";
+const MEILI_CONTACT_EMAIL: &str = "MEILI_CONTACT_EMAIL";
 const DEFAULT_CONFIG_FILE_PATH: &str = "./config.toml";
 const DEFAULT_DB_PATH: &str = "./data.ms";
 const DEFAULT_HTTP_ADDR: &str = "localhost:7700";
@@ -347,6 +348,10 @@ pub struct Opt {
     #[serde(default)]
     pub log_level: LogLevel,
 
+    /// Sets the email address to contact for support and news.
+    #[clap(long, env = MEILI_CONTACT_EMAIL)]
+    pub contact_email: Option<Option<String>>,
+
     /// Experimental contains filter feature. For more information,
     /// see: <https://github.com/orgs/meilisearch/discussions/763>
     ///
@@ -556,6 +561,7 @@ impl Opt {
             ignore_dump_if_db_exists: _,
             config_file_path: _,
             no_analytics,
+            contact_email,
             experimental_contains_filter,
             experimental_enable_metrics,
             experimental_search_queue_size,
@@ -588,6 +594,10 @@ impl Opt {
         }
 
         export_to_env_if_not_present(MEILI_NO_ANALYTICS, no_analytics.to_string());
+        export_to_env_if_not_present(
+            MEILI_CONTACT_EMAIL,
+            contact_email.flatten().unwrap_or_else(|| "false".to_string()),
+        );
         export_to_env_if_not_present(
             MEILI_HTTP_PAYLOAD_SIZE_LIMIT,
             http_payload_size_limit.to_string(),

--- a/crates/meilisearch/src/option.rs
+++ b/crates/meilisearch/src/option.rs
@@ -349,6 +349,9 @@ pub struct Opt {
     pub log_level: LogLevel,
 
     /// Sets the email address to contact for support and news.
+    ///
+    /// Use this option to disable contact email prompting. Leave
+    /// blank or without value to disable contact email prompting.
     #[clap(long, env = MEILI_CONTACT_EMAIL)]
     pub contact_email: Option<Option<String>>,
 


### PR DESCRIPTION
This PR prompts for a contact email for support and to subscribe to the newsletter. It doesn't prompt if [the TTY is not a terminal](https://en.wikipedia.org/wiki/Tty_(Unix)). It can be disabled by specifying an email via this prompt, via the `contact-email` flag, or by leaving the parameter empty.

### Database Changes (db changes)

This feature creates a `skip-email` file in [global config directory](https://github.com/meilisearch/MeiliSearch/blob/main/crates/meilisearch/src/analytics/mod.rs#L44-L50) if an email (or a text) has been specified via the `--contact-email` parameter or the email prompt. This way, the user does not see the prompt when they start Meilisearch again. The file is not kept between dumps or snapshots, so Meilisearch instances starting from those will display the prompt again.