### PR TITLE
chore: Fix clippy errors in the nightly channel

### DIFF
--- a/crates/benchmarks/benches/search_songs.rs
+++ b/crates/benchmarks/benches/search_songs.rs
@@ -60,7 +60,7 @@ fn bench_songs(c: &mut criterion::Criterion) {
         .queries
         .iter()
         .map(|s| {
-            s.trim().split(' ').map(|s| format!(r#""{}""#, s)).collect::<Vec<String>>().join(" ")
+            s.trim().split(' ').map(|s| format!(r#""{s}""#)).collect::<Vec<String>>().join(" ")
         })
         .collect();
     let basic_with_quote: &[&str] =

--- a/crates/benchmarks/benches/search_wiki.rs
+++ b/crates/benchmarks/benches/search_wiki.rs
@@ -39,7 +39,7 @@ fn bench_songs(c: &mut criterion::Criterion) {
         .queries
         .iter()
         .map(|s| {
-            s.trim().split(' ').map(|s| format!(r#""{}""#, s)).collect::<Vec<String>>().join(" ")
+            s.trim().split(' ').map(|s| format!(r#""{s}""#)).collect::<Vec<String>>().join(" ")
         })
         .collect();
     let basic_with_quote: &[&str] =

--- a/crates/benchmarks/build.rs
+++ b/crates/benchmarks/build.rs
@@ -78,10 +78,10 @@ fn main() -> anyhow::Result<()> {
             );
             continue;
         }
-        let url = format!("{}/{}.{}.gz", BASE_URL, dataset, extension);
-        eprintln!("downloading: {}", url);
+        let url = format!("{BASE_URL}/{dataset}.{extension}.gz");
+        eprintln!("downloading: {url}");
         let bytes = retry(|| download_dataset(url.clone()), 10)?;
-        eprintln!("{} downloaded successfully", url);
+        eprintln!("{url} downloaded successfully");
         eprintln!("uncompressing in {}", out_file.display());
         uncompress_in_file(bytes, &out_file)?;
     }

--- a/crates/build-info/build.rs
+++ b/crates/build-info/build.rs
@@ -1,6 +1,6 @@
 fn main() {
     if let Err(err) = emit_git_variables() {
-        println!("cargo:warning=vergen: {}", err);
+        println!("cargo:warning=vergen: {err}");
     }
 }
 

--- a/crates/dump/src/reader/v2/mod.rs
+++ b/crates/dump/src/reader/v2/mod.rs
@@ -127,7 +127,7 @@ impl V2Reader {
                         .path()
                         .join("updates")
                         .join("update_files")
-                        .join(format!("update_{}", uuid));
+                        .join(format!("update_{uuid}"));
                     Ok((task, Some(UpdateFile::new(&update_file_path)?)))
                 } else {
                     Ok((task, None))

--- a/crates/dump/src/reader/v2/settings.rs
+++ b/crates/dump/src/reader/v2/settings.rs
@@ -262,8 +262,8 @@ impl fmt::Display for Criterion {
             Attribute => f.write_str("attribute"),
             Sort => f.write_str("sort"),
             Exactness => f.write_str("exactness"),
-            Asc(attr) => write!(f, "{}:asc", attr),
-            Desc(attr) => write!(f, "{}:desc", attr),
+            Asc(attr) => write!(f, "{attr}:asc"),
+            Desc(attr) => write!(f, "{attr}:desc"),
         }
     }
 }

--- a/crates/dump/src/reader/v4/meta.rs
+++ b/crates/dump/src/reader/v4/meta.rs
@@ -127,7 +127,7 @@ where
                     "*" => Ok(StarOr::Star),
                     v => {
                         let other = FromStr::from_str(v).map_err(|e: T::Err| {
-                            SE::custom(format!("Invalid `other` value: {}", e))
+                            SE::custom(format!("Invalid `other` value: {e}"))
                         })?;
                         Ok(StarOr::Other(other))
                     }

--- a/crates/dump/src/reader/v5/meta.rs
+++ b/crates/dump/src/reader/v5/meta.rs
@@ -127,7 +127,7 @@ where
                     "*" => Ok(StarOr::Star),
                     v => {
                         let other = FromStr::from_str(v).map_err(|e: T::Err| {
-                            SE::custom(format!("Invalid `other` value: {}", e))
+                            SE::custom(format!("Invalid `other` value: {e}"))
                         })?;
                         Ok(StarOr::Other(other))
                     }

--- a/crates/dump/src/reader/v5/tasks.rs
+++ b/crates/dump/src/reader/v5/tasks.rs
@@ -428,7 +428,7 @@ fn serialize_duration<S: serde::Serializer>(
             write!(&mut res, "P").unwrap();
 
             if hasdate {
-                write!(&mut res, "{}D", days).unwrap();
+                write!(&mut res, "{days}D").unwrap();
             }
 
             const NANOS_PER_MILLI: i32 = Duration::MILLISECOND.subsec_nanoseconds();
@@ -436,13 +436,13 @@ fn serialize_duration<S: serde::Serializer>(
 
             if hastime {
                 if nanos == 0 {
-                    write!(&mut res, "T{}S", secs).unwrap();
+                    write!(&mut res, "T{secs}S").unwrap();
                 } else if nanos % NANOS_PER_MILLI == 0 {
                     write!(&mut res, "T{}.{:03}S", secs, nanos / NANOS_PER_MILLI).unwrap();
                 } else if nanos % NANOS_PER_MICRO == 0 {
                     write!(&mut res, "T{}.{:06}S", secs, nanos / NANOS_PER_MICRO).unwrap();
                 } else {
-                    write!(&mut res, "T{}.{:09}S", secs, nanos).unwrap();
+                    write!(&mut res, "T{secs}.{nanos:09}S").unwrap();
                 }
             }
 

--- a/crates/filter-parser/src/error.rs
+++ b/crates/filter-parser/src/error.rs
@@ -98,7 +98,7 @@ impl<'a> Error<'a> {
     pub fn char(self) -> char {
         match self.kind {
             ErrorKind::Char(c) => c,
-            error => panic!("Internal filter parser error: {:?}", error),
+            error => panic!("Internal filter parser error: {error:?}"),
         }
     }
 }
@@ -136,23 +136,23 @@ impl Display for Error<'_> {
                 writeln!(f, "Was expecting a value but instead got `{escaped_input}`, which is a reserved keyword. To use `{escaped_input}` as a field name or a value, surround it by quotes.")?
             }
             ErrorKind::ExpectedValue(ExpectedValueKind::Other) => {
-                writeln!(f, "Was expecting a value but instead got `{}`.", escaped_input)?
+                writeln!(f, "Was expecting a value but instead got `{escaped_input}`.")?
             }
             ErrorKind::MalformedValue => {
-                writeln!(f, "Malformed value: `{}`.", escaped_input)?
+                writeln!(f, "Malformed value: `{escaped_input}`.")?
             }
             ErrorKind::MissingClosingDelimiter(c) => {
-                writeln!(f, "Expression `{}` is missing the following closing delimiter: `{}`.", escaped_input, c)?
+                writeln!(f, "Expression `{escaped_input}` is missing the following closing delimiter: `{c}`.")?
             }
             ErrorKind::InvalidPrimary => {
-                let text = if input.trim().is_empty() { "but instead got nothing.".to_string() } else { format!("at `{}`.", escaped_input) };
-                writeln!(f, "Was expecting an operation `=`, `!=`, `>=`, `>`, `<=`, `<`, `IN`, `NOT IN`, `TO`, `EXISTS`, `NOT EXISTS`, `IS NULL`, `IS NOT NULL`, `IS EMPTY`, `IS NOT EMPTY`, `CONTAINS`, `NOT CONTAINS`, `STARTS WITH`, `NOT STARTS WITH`, `_geoRadius`, or `_geoBoundingBox` {}", text)?
+                let text = if input.trim().is_empty() { "but instead got nothing.".to_string() } else { format!("at `{escaped_input}`.") };
+                writeln!(f, "Was expecting an operation `=`, `!=`, `>=`, `>`, `<=`, `<`, `IN`, `NOT IN`, `TO`, `EXISTS`, `NOT EXISTS`, `IS NULL`, `IS NOT NULL`, `IS EMPTY`, `IS NOT EMPTY`, `CONTAINS`, `NOT CONTAINS`, `STARTS WITH`, `NOT STARTS WITH`, `_geoRadius`, or `_geoBoundingBox` {text}")?
             }
             ErrorKind::InvalidEscapedNumber => {
-                writeln!(f, "Found an invalid escaped sequence number: `{}`.", escaped_input)?
+                writeln!(f, "Found an invalid escaped sequence number: `{escaped_input}`.")?
             }
             ErrorKind::ExpectedEof => {
-                writeln!(f, "Found unexpected characters at the end of the filter: `{}`. You probably forgot an `OR` or an `AND` rule.", escaped_input)?
+                writeln!(f, "Found unexpected characters at the end of the filter: `{escaped_input}`. You probably forgot an `OR` or an `AND` rule.")?
             }
             ErrorKind::GeoRadius => {
                 writeln!(f, "The `_geoRadius` filter expects three arguments: `_geoRadius(latitude, longitude, radius)`.")?
@@ -188,7 +188,7 @@ impl Display for Error<'_> {
                 writeln!(f, "Expected only comma-separated field names inside `IN[..]` but instead found `{escaped_input}`.")?
             }
             ErrorKind::Char(c) => {
-                panic!("Tried to display a char error with `{}`", c)
+                panic!("Tried to display a char error with `{c}`")
             }
             ErrorKind::DepthLimitReached => writeln!(
                 f,
@@ -196,9 +196,9 @@ impl Display for Error<'_> {
             )?,
             ErrorKind::InternalError(kind) => writeln!(
                 f,
-                "Encountered an internal `{:?}` error while parsing your filter. Please fill an issue", kind
+                "Encountered an internal `{kind:?}` error while parsing your filter. Please fill an issue"
             )?,
-            ErrorKind::External(ref error) => writeln!(f, "{}", error)?,
+            ErrorKind::External(ref error) => writeln!(f, "{error}")?,
         }
         let base_column = self.context.get_utf8_column();
         let size = self.context.fragment().chars().count();

--- a/crates/filter-parser/src/lib.rs
+++ b/crates/filter-parser/src/lib.rs
@@ -611,7 +611,7 @@ pub mod tests {
     /// Create a raw [Token]. You must specify the string that appear BEFORE your element followed by your element
     pub fn rtok<'a>(before: &'a str, value: &'a str) -> Token<'a> {
         // if the string is empty we still need to return 1 for the line number
-        let lines = before.is_empty().then_some(1).unwrap_or_else(|| before.lines().count());
+        let lines = if before.is_empty() { 1 } else { before.lines().count() };
         let offset = before.chars().count();
         // the extra field is not checked in the tests so we can set it to nothing
         unsafe { Span::new_from_raw_offset(offset, lines as u32, value, "") }.into()

--- a/crates/filter-parser/src/main.rs
+++ b/crates/filter-parser/src/main.rs
@@ -1,16 +1,16 @@
 fn main() {
     let input = std::env::args().nth(1).expect("You must provide a filter to test");
 
-    println!("Trying to execute the following filter:\n{}\n", input);
+    println!("Trying to execute the following filter:\n{input}\n");
 
     match filter_parser::FilterCondition::parse(&input) {
         Ok(filter) => {
             println!("✅ Valid filter");
-            println!("{:#?}", filter);
+            println!("{filter:#?}");
         }
         Err(e) => {
             println!("❎ Invalid filter");
-            println!("{}", e);
+            println!("{e}");
         }
     }
 }

--- a/crates/filter-parser/src/value.rs
+++ b/crates/filter-parser/src/value.rs
@@ -14,7 +14,7 @@ use crate::{
 /// This function goes through all characters in the [Span] if it finds any escaped character (`\`).
 /// It generates a new string with all `\` removed from the [Span].
 fn unescape(buf: Span, char_to_escape: char) -> String {
-    let to_escape = format!("\\{}", char_to_escape);
+    let to_escape = format!("\\{char_to_escape}");
     buf.replace(&to_escape, &char_to_escape.to_string())
 }
 
@@ -262,7 +262,7 @@ pub mod test {
                 result.unwrap_err()
             );
             let token = result.unwrap().1;
-            assert_eq!(token, expected, "Filter `{}` failed.", input);
+            assert_eq!(token, expected, "Filter `{input}` failed.");
         }
     }
 
@@ -367,8 +367,7 @@ pub mod test {
             assert_eq!(
                 token.value.is_some(),
                 escaped,
-                "Filter `{}` was not supposed to be escaped",
-                input
+                "Filter `{input}` was not supposed to be escaped"
             );
             assert_eq!(
                 token.value(),
@@ -403,7 +402,7 @@ pub mod test {
             );
             // get the inner string referenced in the error
             let value = *result.finish().unwrap_err().context().fragment();
-            assert_eq!(value, expected, "Filter `{}` was supposed to fail with the following value: `{}`, but it failed with: `{}`.", input, expected, value);
+            assert_eq!(value, expected, "Filter `{input}` was supposed to fail with the following value: `{expected}`, but it failed with: `{value}`.");
         }
     }
 }

--- a/crates/fuzzers/src/bin/fuzz-indexing.rs
+++ b/crates/fuzzers/src/bin/fuzz-indexing.rs
@@ -78,7 +78,7 @@ fn main() {
                     let mut data = Unstructured::new(&v);
                     let batches = <[Batch; 5]>::arbitrary(&mut data).unwrap();
                     // will be used to display the error once a thread crashes
-                    let dbg_input = format!("{:#?}", batches);
+                    let dbg_input = format!("{batches:#?}");
 
                     let handle = s.spawn(|| {
                         let mut wtxn = index.write_txn().unwrap();

--- a/crates/index-scheduler/src/error.rs
+++ b/crates/index-scheduler/src/error.rs
@@ -62,7 +62,7 @@ pub enum Error {
     SwapDuplicateIndexFound(String),
     #[error(
         "Indexes must be declared only once during a swap. {} were specified several times.",
-        .0.iter().map(|s| format!("`{}`", s)).collect::<Vec<_>>().join(", ")
+        .0.iter().map(|s| format!("`{s}`")).collect::<Vec<_>>().join(", ")
     )]
     SwapDuplicateIndexesFound(Vec<String>),
     #[error("Index `{0}` not found.")]
@@ -71,7 +71,7 @@ pub enum Error {
     NoSpaceLeftInTaskQueue,
     #[error(
         "Indexes {} not found.",
-        .0.iter().map(|s| format!("`{}`", s)).collect::<Vec<_>>().join(", ")
+        .0.iter().map(|s| format!("`{s}`")).collect::<Vec<_>>().join(", ")
     )]
     SwapIndexesNotFound(Vec<String>),
     #[error("Corrupted dump.")]
@@ -126,7 +126,7 @@ pub enum Error {
     #[error(transparent)]
     Heed(#[from] heed::Error),
     #[error("{}", match .index_uid {
-        Some(uid) if !uid.is_empty() => format!("Index `{}`: {error}", uid),
+        Some(uid) if !uid.is_empty() => format!("Index `{uid}`: {error}"),
         _ => format!("{error}")
     })]
     Milli { error: milli::Error, index_uid: Option<String> },

--- a/crates/index-scheduler/src/lib.rs
+++ b/crates/index-scheduler/src/lib.rs
@@ -721,10 +721,9 @@ impl IndexScheduler {
                                     .queue
                                     .tasks
                                     .get_task(self.rtxn, task_id)
-                                    .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?
+                                    .map_err(io::Error::other)?
                                     .ok_or_else(|| {
-                                        io::Error::new(
-                                            io::ErrorKind::Other,
+                                        io::Error::other(
                                             Error::CorruptedTaskQueue,
                                         )
                                     })?;

--- a/crates/index-scheduler/src/lib.rs
+++ b/crates/index-scheduler/src/lib.rs
@@ -722,11 +722,7 @@ impl IndexScheduler {
                                     .tasks
                                     .get_task(self.rtxn, task_id)
                                     .map_err(io::Error::other)?
-                                    .ok_or_else(|| {
-                                        io::Error::other(
-                                            Error::CorruptedTaskQueue,
-                                        )
-                                    })?;
+                                    .ok_or_else(|| io::Error::other(Error::CorruptedTaskQueue))?;
 
                                 serde_json::to_writer(
                                     &mut self.buffer,

--- a/crates/index-scheduler/src/queue/mod.rs
+++ b/crates/index-scheduler/src/queue/mod.rs
@@ -325,7 +325,7 @@ impl Queue {
         );
 
         // it's safe to unwrap here because we checked the len above
-        let newest_task_id = to_delete.iter().last().unwrap();
+        let newest_task_id = to_delete.iter().next_back().unwrap();
         let last_task_to_delete =
             self.tasks.get_task(wtxn, newest_task_id)?.ok_or(Error::CorruptedTaskQueue)?;
 

--- a/crates/index-scheduler/src/scheduler/process_dump_creation.rs
+++ b/crates/index-scheduler/src/scheduler/process_dump_creation.rs
@@ -266,7 +266,7 @@ impl IndexScheduler {
             return Err(Error::AbortedTask);
         }
         progress.update_progress(DumpCreationProgress::CompressTheDump);
-        let path = self.scheduler.dumps_path.join(format!("{}.dump", dump_uid));
+        let path = self.scheduler.dumps_path.join(format!("{dump_uid}.dump"));
         let file = File::create(path)?;
         dump.persist_to(BufWriter::new(file))?;
 

--- a/crates/index-scheduler/src/scheduler/process_snapshot_creation.rs
+++ b/crates/index-scheduler/src/scheduler/process_snapshot_creation.rs
@@ -101,7 +101,7 @@ impl IndexScheduler {
         let db_name = base_path.file_name().and_then(OsStr::to_str).unwrap_or("data.ms");
 
         // 5.2 Tarball the content of the snapshot in a tempfile with a .snapshot extension
-        let snapshot_path = self.scheduler.snapshots_path.join(format!("{}.snapshot", db_name));
+        let snapshot_path = self.scheduler.snapshots_path.join(format!("{db_name}.snapshot"));
         let temp_snapshot_file = tempfile::NamedTempFile::new_in(&self.scheduler.snapshots_path)?;
         compression::to_tar_gz(temp_snapshot_dir.path(), temp_snapshot_file.path())?;
         let file = temp_snapshot_file.persist(snapshot_path)?;

--- a/crates/index-scheduler/src/scheduler/test_document_addition.rs
+++ b/crates/index-scheduler/src/scheduler/test_document_addition.rs
@@ -167,10 +167,9 @@ fn test_document_replace() {
     for i in 0..10 {
         let content = format!(
             r#"{{
-                    "id": {},
-                    "doggo": "bob {}"
-                }}"#,
-            i, i
+                    "id": {i},
+                    "doggo": "bob {i}"
+                }}"#
         );
 
         let (uuid, mut file) = index_scheduler.queue.create_update_file_with_uuid(i).unwrap();
@@ -218,10 +217,9 @@ fn test_document_update() {
     for i in 0..10 {
         let content = format!(
             r#"{{
-                    "id": {},
-                    "doggo": "bob {}"
-                }}"#,
-            i, i
+                    "id": {i},
+                    "doggo": "bob {i}"
+                }}"#
         );
 
         let (uuid, mut file) = index_scheduler.queue.create_update_file_with_uuid(i).unwrap();
@@ -271,10 +269,9 @@ fn test_mixed_document_addition() {
 
         let content = format!(
             r#"{{
-                    "id": {},
-                    "doggo": "bob {}"
-                }}"#,
-            i, i
+                    "id": {i},
+                    "doggo": "bob {i}"
+                }}"#
         );
 
         let (uuid, mut file) = index_scheduler.queue.create_update_file_with_uuid(i).unwrap();
@@ -322,10 +319,9 @@ fn test_document_replace_without_autobatching() {
     for i in 0..10 {
         let content = format!(
             r#"{{
-                    "id": {},
-                    "doggo": "bob {}"
-                }}"#,
-            i, i
+                    "id": {i},
+                    "doggo": "bob {i}"
+                }}"#
         );
 
         let (uuid, mut file) = index_scheduler.queue.create_update_file_with_uuid(i).unwrap();
@@ -377,10 +373,9 @@ fn test_document_update_without_autobatching() {
     for i in 0..10 {
         let content = format!(
             r#"{{
-                    "id": {},
-                    "doggo": "bob {}"
-                }}"#,
-            i, i
+                    "id": {i},
+                    "doggo": "bob {i}"
+                }}"#
         );
 
         let (uuid, mut file) = index_scheduler.queue.create_update_file_with_uuid(i).unwrap();
@@ -436,10 +431,9 @@ fn test_document_addition_cant_create_index_without_index() {
     for i in 0..10 {
         let content = format!(
             r#"{{
-                    "id": {},
-                    "doggo": "bob {}"
-                }}"#,
-            i, i
+                    "id": {i},
+                    "doggo": "bob {i}"
+                }}"#
         );
 
         let (uuid, mut file) = index_scheduler.queue.create_update_file_with_uuid(i).unwrap();
@@ -488,10 +482,9 @@ fn test_document_addition_cant_create_index_without_index_without_autobatching()
     for i in 0..10 {
         let content = format!(
             r#"{{
-                    "id": {},
-                    "doggo": "bob {}"
-                }}"#,
-            i, i
+                    "id": {i},
+                    "doggo": "bob {i}"
+                }}"#
         );
 
         let (uuid, mut file) = index_scheduler.queue.create_update_file_with_uuid(i).unwrap();
@@ -550,10 +543,9 @@ fn test_document_addition_cant_create_index_with_index() {
     for i in 0..10 {
         let content = format!(
             r#"{{
-                    "id": {},
-                    "doggo": "bob {}"
-                }}"#,
-            i, i
+                    "id": {i},
+                    "doggo": "bob {i}"
+                }}"#
         );
 
         let (uuid, mut file) = index_scheduler.queue.create_update_file_with_uuid(i).unwrap();
@@ -617,10 +609,9 @@ fn test_document_addition_cant_create_index_with_index_without_autobatching() {
     for i in 0..10 {
         let content = format!(
             r#"{{
-                    "id": {},
-                    "doggo": "bob {}"
-                }}"#,
-            i, i
+                    "id": {i},
+                    "doggo": "bob {i}"
+                }}"#
         );
 
         let (uuid, mut file) = index_scheduler.queue.create_update_file_with_uuid(i).unwrap();
@@ -688,10 +679,9 @@ fn test_document_addition_mixed_rights_with_index() {
     for i in 0..10 {
         let content = format!(
             r#"{{
-                    "id": {},
-                    "doggo": "bob {}"
-                }}"#,
-            i, i
+                    "id": {i},
+                    "doggo": "bob {i}"
+                }}"#
         );
         let allow_index_creation = i % 2 != 0;
 
@@ -745,10 +735,9 @@ fn test_document_addition_mixed_right_without_index_starts_with_cant_create() {
     for i in 0..10 {
         let content = format!(
             r#"{{
-                    "id": {},
-                    "doggo": "bob {}"
-                }}"#,
-            i, i
+                    "id": {i},
+                    "doggo": "bob {i}"
+                }}"#
         );
         let allow_index_creation = i % 2 != 0;
 

--- a/crates/index-scheduler/src/test_utils.rs
+++ b/crates/index-scheduler/src/test_utils.rs
@@ -382,7 +382,7 @@ impl IndexSchedulerHandle {
                         while self.advance() != Start {}
                         panic!("The batch failed.\n{}", snapshot_index_scheduler(&self.index_scheduler))
                     },
-                    breakpoint => panic!("Encountered an impossible breakpoint `{:?}`, this is probably an issue with the test suite.", breakpoint),
+                    breakpoint => panic!("Encountered an impossible breakpoint `{breakpoint:?}`, this is probably an issue with the test suite."),
                 }
         }
 
@@ -402,7 +402,7 @@ impl IndexSchedulerHandle {
                     ProcessBatchFailed => break,
                     ProcessBatchSucceeded => panic!("The batch succeeded. (and it wasn't supposed to sorry)\n{}", snapshot_index_scheduler(&self.index_scheduler)),
                     AbortedIndexation => panic!("The batch was aborted.\n{}", snapshot_index_scheduler(&self.index_scheduler)),
-                    breakpoint => panic!("Encountered an impossible breakpoint `{:?}`, this is probably an issue with the test suite.", breakpoint),
+                    breakpoint => panic!("Encountered an impossible breakpoint `{breakpoint:?}`, this is probably an issue with the test suite."),
                 }
         }
         self.advance_till([AfterProcessing]);

--- a/crates/index-scheduler/src/utils.rs
+++ b/crates/index-scheduler/src/utils.rs
@@ -460,7 +460,7 @@ impl crate::IndexScheduler {
                                 match status {
                                     Status::Succeeded => assert!(indexed_documents <= received_documents),
                                     Status::Failed | Status::Canceled => assert_eq!(indexed_documents, 0),
-                                    status => panic!("DocumentAddition can't have an indexed_documents set if it's {}", status),
+                                    status => panic!("DocumentAddition can't have an indexed_documents set if it's {status}"),
                                 }
                             }
                             None => {
@@ -479,7 +479,7 @@ impl crate::IndexScheduler {
                                 match status {
                                     Status::Succeeded => (),
                                     Status::Failed | Status::Canceled => assert_eq!(edited_documents, 0),
-                                    status => panic!("DocumentEdition can't have an edited_documents set if it's {}", status),
+                                    status => panic!("DocumentEdition can't have an edited_documents set if it's {status}"),
                                 }
                             }
                             None => {

--- a/crates/meilisearch-types/src/deserr/mod.rs
+++ b/crates/meilisearch-types/src/deserr/mod.rs
@@ -122,7 +122,7 @@ pub fn immutable_field_error(field: &str, accepted: &[&str], code: Code) -> Dese
         "Immutable field `{field}`: expected one of {}",
         accepted
             .iter()
-            .map(|accepted| format!("`{}`", accepted))
+            .map(|accepted| format!("`{accepted}`"))
             .collect::<Vec<String>>()
             .join(", ")
     );

--- a/crates/meilisearch-types/src/deserr/mod.rs
+++ b/crates/meilisearch-types/src/deserr/mod.rs
@@ -120,11 +120,7 @@ impl<C: Default + ErrorCode> DeserializeError for DeserrQueryParamError<C> {
 pub fn immutable_field_error(field: &str, accepted: &[&str], code: Code) -> DeserrJsonError {
     let msg = format!(
         "Immutable field `{field}`: expected one of {}",
-        accepted
-            .iter()
-            .map(|accepted| format!("`{accepted}`"))
-            .collect::<Vec<String>>()
-            .join(", ")
+        accepted.iter().map(|accepted| format!("`{accepted}`")).collect::<Vec<String>>().join(", ")
     );
 
     DeserrJsonError::new(msg, code)

--- a/crates/meilisearch-types/src/document_formats.rs
+++ b/crates/meilisearch-types/src/document_formats.rs
@@ -72,11 +72,10 @@ impl Display for DocumentFormatError {
 
                     write!(
                         f,
-                        "The `{}` payload provided is malformed. `Couldn't serialize document value: {}`.",
-                        b, message
+                        "The `{b}` payload provided is malformed. `Couldn't serialize document value: {message}`."
                     )
                 }
-                _ => write!(f, "The `{}` payload provided is malformed: `{}`.", b, me),
+                _ => write!(f, "The `{b}` payload provided is malformed: `{me}`."),
             },
         }
     }

--- a/crates/meilisearch-types/src/star_or.rs
+++ b/crates/meilisearch-types/src/star_or.rs
@@ -85,7 +85,7 @@ where
                     "*" => Ok(StarOr::Star),
                     v => {
                         let other = FromStr::from_str(v).map_err(|e: T::Err| {
-                            SE::custom(format!("Invalid `other` value: {}", e))
+                            SE::custom(format!("Invalid `other` value: {e}"))
                         })?;
                         Ok(StarOr::Other(other))
                     }

--- a/crates/meilisearch-types/src/tasks.rs
+++ b/crates/meilisearch-types/src/tasks.rs
@@ -843,7 +843,7 @@ pub fn serialize_duration<S: Serializer>(
             write!(&mut res, "P").unwrap();
 
             if hasdate {
-                write!(&mut res, "{}D", days).unwrap();
+                write!(&mut res, "{days}D").unwrap();
             }
 
             const NANOS_PER_MILLI: i32 = Duration::MILLISECOND.subsec_nanoseconds();
@@ -851,13 +851,13 @@ pub fn serialize_duration<S: Serializer>(
 
             if hastime {
                 if nanos == 0 {
-                    write!(&mut res, "T{}S", secs).unwrap();
+                    write!(&mut res, "T{secs}S").unwrap();
                 } else if nanos % NANOS_PER_MILLI == 0 {
                     write!(&mut res, "T{}.{:03}S", secs, nanos / NANOS_PER_MILLI).unwrap();
                 } else if nanos % NANOS_PER_MICRO == 0 {
                     write!(&mut res, "T{}.{:06}S", secs, nanos / NANOS_PER_MICRO).unwrap();
                 } else {
-                    write!(&mut res, "T{}.{:09}S", secs, nanos).unwrap();
+                    write!(&mut res, "T{secs}.{nanos:09}S").unwrap();
                 }
             }
 

--- a/crates/meilisearch-types/src/versioning.rs
+++ b/crates/meilisearch-types/src/versioning.rs
@@ -24,7 +24,7 @@ pub fn create_version_file(
     let version_path = db_path.join(VERSION_FILE_NAME);
     // In order to persist the file later we must create it in the `data.ms` and not in `/tmp`
     let mut file = NamedTempFile::new_in(db_path)?;
-    file.write_all(format!("{}.{}.{}", major, minor, patch).as_bytes())?;
+    file.write_all(format!("{major}.{minor}.{patch}").as_bytes())?;
     file.flush()?;
     file.persist(version_path)?;
     Ok(())

--- a/crates/meilisearch/src/error.rs
+++ b/crates/meilisearch/src/error.rs
@@ -12,7 +12,7 @@ use tokio::task::JoinError;
 #[derive(Debug, thiserror::Error)]
 pub enum MeilisearchHttpError {
     #[error("A Content-Type header is missing. Accepted values for the Content-Type header are: {}",
-            .0.iter().map(|s| format!("`{}`", s)).collect::<Vec<_>>().join(", "))]
+            .0.iter().map(|s| format!("`{s}`")).collect::<Vec<_>>().join(", "))]
     MissingContentType(Vec<String>),
     #[error("The `/logs/stream` route is currently in use by someone else.")]
     AlreadyUsedLogRoute,
@@ -20,7 +20,7 @@ pub enum MeilisearchHttpError {
     CsvDelimiterWithWrongContentType(String),
     #[error(
         "The Content-Type `{}` is invalid. Accepted values for the Content-Type header are: {}",
-        .0, .1.iter().map(|s| format!("`{}`", s)).collect::<Vec<_>>().join(", ")
+        .0, .1.iter().map(|s| format!("`{s}`")).collect::<Vec<_>>().join(", ")
     )]
     InvalidContentType(String, Vec<String>),
     #[error("Document `{0}` not found.")]
@@ -64,7 +64,7 @@ pub enum MeilisearchHttpError {
     #[error(transparent)]
     IndexScheduler(#[from] index_scheduler::Error),
     #[error("{}", match .index_name {
-        Some(name) if !name.is_empty() => format!("Index `{}`: {error}", name),
+        Some(name) if !name.is_empty() => format!("Index `{name}`: {error}"),
         _ => format!("{error}")
     })]
     Milli { error: milli::Error, index_name: Option<String> },

--- a/crates/meilisearch/src/main.rs
+++ b/crates/meilisearch/src/main.rs
@@ -202,7 +202,7 @@ pub fn print_launch_resume(opt: &Opt, analytics: Analytics, config_read_from: Op
 888       888  "Y8888  888 888 888  88888P'  "Y8888  "Y888888 888     "Y8888P 888  888
 "#;
 
-    eprintln!("{}", ascii_name);
+    eprintln!("{ascii_name}");
 
     eprintln!(
         "Config file path:\t{:?}",
@@ -225,7 +225,7 @@ pub fn print_launch_resume(opt: &Opt, analytics: Analytics, config_read_from: Op
     );
     eprintln!("Package version:\t{:?}", env!("CARGO_PKG_VERSION").to_string());
     if let Some(prototype) = build_info.describe.and_then(|describe| describe.as_prototype()) {
-        eprintln!("Prototype:\t\t{:?}", prototype);
+        eprintln!("Prototype:\t\t{prototype:?}");
     }
 
     {
@@ -244,7 +244,7 @@ Anonymous telemetry:\t\"Enabled\""
     }
 
     if let Some(instance_uid) = analytics.instance_uid() {
-        eprintln!("Instance UID:\t\t\"{}\"", instance_uid);
+        eprintln!("Instance UID:\t\t\"{instance_uid}\"");
     }
 
     eprintln!();

--- a/crates/meilisearch/src/option.rs
+++ b/crates/meilisearch/src/option.rs
@@ -847,7 +847,7 @@ impl FromStr for MaxThreads {
 impl fmt::Display for MaxThreads {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.0 {
-            Some(threads) => write!(f, "{}", threads),
+            Some(threads) => write!(f, "{threads}"),
             None => write!(f, "unlimited"),
         }
     }
@@ -1016,7 +1016,7 @@ impl Display for ScheduleSnapshot {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ScheduleSnapshot::Disabled => write!(f, ""),
-            ScheduleSnapshot::Enabled(value) => write!(f, "{}", value),
+            ScheduleSnapshot::Enabled(value) => write!(f, "{value}"),
         }
     }
 }

--- a/crates/meilisearch/src/option_test.rs
+++ b/crates/meilisearch/src/option_test.rs
@@ -29,7 +29,7 @@ fn test_meilli_config_file_path_invalid() {
         let error_message = Opt::try_build().unwrap_err().to_string();
         assert!(
             possible_error_messages.contains(&error_message.as_str()),
-            "Expected onf of {possible_error_messages:?}, got {error_message:?}."
+            "Expected one of {possible_error_messages:?}, got {error_message:?}."
         );
     });
 }

--- a/crates/meilisearch/src/option_test.rs
+++ b/crates/meilisearch/src/option_test.rs
@@ -29,9 +29,7 @@ fn test_meilli_config_file_path_invalid() {
         let error_message = Opt::try_build().unwrap_err().to_string();
         assert!(
             possible_error_messages.contains(&error_message.as_str()),
-            "Expected onf of {:?}, got {:?}.",
-            possible_error_messages,
-            error_message
+            "Expected onf of {possible_error_messages:?}, got {error_message:?}."
         );
     });
 }

--- a/crates/meilisearch/src/routes/indexes/documents.rs
+++ b/crates/meilisearch/src/routes/indexes/documents.rs
@@ -673,7 +673,7 @@ fn from_char_csv_delimiter(
         Ok(Some(c as u8))
     } else {
         Err(DeserrQueryParamError::new(
-            format!("csv delimiter must be an ascii character. Found: `{}`", c),
+            format!("csv delimiter must be an ascii character. Found: `{c}`"),
             Code::InvalidDocumentCsvDelimiter,
         ))
     }
@@ -950,7 +950,7 @@ async fn document_addition(
         }
         (Some((type_, subtype)), _) => {
             return Err(MeilisearchHttpError::InvalidContentType(
-                format!("{}/{}", type_, subtype),
+                format!("{type_}/{subtype}"),
                 ACCEPTED_CONTENT_TYPE.clone(),
             ))
         }

--- a/crates/meilisearch/src/routes/indexes/facet_search.rs
+++ b/crates/meilisearch/src/routes/indexes/facet_search.rs
@@ -163,7 +163,7 @@ impl Aggregate for FacetSearchAggregator {
 
         serde_json::json!({
             "requests": {
-                "99th_response_time":  time_spent.map(|t| format!("{:.2}", t)),
+                "99th_response_time":  time_spent.map(|t| format!("{t:.2}")),
                 "total_succeeded": total_succeeded,
                 "total_failed": total_received.saturating_sub(total_succeeded), // just to be sure we never panics
                 "total_received": total_received,

--- a/crates/meilisearch/src/routes/indexes/search_analytics.rs
+++ b/crates/meilisearch/src/routes/indexes/search_analytics.rs
@@ -188,7 +188,7 @@ impl<Method: AggregateMethod> SearchAggregator<Method> {
             ret.finite_pagination = 0;
         }
 
-        ret.matching_strategy.insert(format!("{:?}", matching_strategy), 1);
+        ret.matching_strategy.insert(format!("{matching_strategy:?}"), 1);
 
         if let Some(locales) = locales {
             ret.locales = locales.iter().copied().collect();
@@ -419,7 +419,7 @@ impl<Method: AggregateMethod> Aggregate for SearchAggregator<Method> {
 
         json!({
             "requests": {
-                "99th_response_time": time_spent.map(|t| format!("{:.2}", t)),
+                "99th_response_time": time_spent.map(|t| format!("{t:.2}")),
                 "total_succeeded": total_succeeded,
                 "total_failed": total_received.saturating_sub(total_succeeded), // just to be sure we never panics
                 "total_received": total_received,

--- a/crates/meilisearch/src/routes/indexes/similar_analytics.rs
+++ b/crates/meilisearch/src/routes/indexes/similar_analytics.rs
@@ -202,7 +202,7 @@ impl<Method: AggregateMethod> Aggregate for SimilarAggregator<Method> {
 
         json!({
             "requests": {
-                "99th_response_time": time_spent.map(|t| format!("{:.2}", t)),
+                "99th_response_time": time_spent.map(|t| format!("{t:.2}")),
                 "total_succeeded": total_succeeded,
                 "total_failed": total_received.saturating_sub(total_succeeded), // just to be sure we never panics
                 "total_received": total_received,

--- a/crates/meilisearch/src/search/federated/proxy.rs
+++ b/crates/meilisearch/src/search/federated/proxy.rs
@@ -76,7 +76,7 @@ mod error {
     fn response_from_remote(response: &Result<String, ReqwestErrorWithoutUrl>) -> String {
         match response {
             Ok(response) => {
-                format!(":\n  - response from remote: {}", response)
+                format!(":\n  - response from remote: {response}")
             }
             Err(error) => {
                 format!(":\n  - additionally, could not retrieve response from remote: {error}")

--- a/crates/meilisearch/tests/auth/authorization.rs
+++ b/crates/meilisearch/tests/auth/authorization.rs
@@ -124,7 +124,7 @@ async fn error_access_expired_key() {
         let (mut response, code) = server.dummy_request(method, route).await;
         response["message"] = serde_json::json!(null);
 
-        assert_eq!(response, INVALID_RESPONSE.clone(), "on route: {:?} - {:?}", method, route);
+        assert_eq!(response, INVALID_RESPONSE.clone(), "on route: {method:?} - {route:?}");
         assert_eq!(403, code, "{:?}", &response);
     }
 }
@@ -155,7 +155,7 @@ async fn error_access_unauthorized_index() {
         let (mut response, code) = server.dummy_request(method, route).await;
         response["message"] = serde_json::json!(null);
 
-        assert_eq!(response, INVALID_RESPONSE.clone(), "on route: {:?} - {:?}", method, route);
+        assert_eq!(response, INVALID_RESPONSE.clone(), "on route: {method:?} - {route:?}");
         assert_eq!(403, code, "{:?}", &response);
     }
 }
@@ -183,7 +183,7 @@ async fn error_access_unauthorized_action() {
         let (mut response, code) = server.dummy_request(method, route).await;
         response["message"] = serde_json::json!(null);
 
-        assert_eq!(response, INVALID_RESPONSE.clone(), "on route: {:?} - {:?}", method, route);
+        assert_eq!(response, INVALID_RESPONSE.clone(), "on route: {method:?} - {route:?}");
         assert_eq!(403, code, "{:?}", &response);
     }
 }
@@ -197,7 +197,7 @@ async fn access_authorized_master_key() {
     for ((method, route), _) in AUTHORIZATIONS.iter() {
         let (response, code) = server.dummy_request(method, route).await;
 
-        assert_ne!(response, INVALID_RESPONSE.clone(), "on route: {:?} - {:?}", method, route);
+        assert_ne!(response, INVALID_RESPONSE.clone(), "on route: {method:?} - {route:?}");
         assert_ne!(code, 403);
     }
 }
@@ -232,20 +232,14 @@ async fn access_authorized_restricted_index() {
                 assert_eq!(
                     response,
                     INVALID_METRICS_RESPONSE.clone(),
-                    "on route: {:?} - {:?} with action: {:?}",
-                    method,
-                    route,
-                    action
+                    "on route: {method:?} - {route:?} with action: {action:?}"
                 );
                 assert_eq!(code, 403);
             } else {
                 assert_ne!(
                     response,
                     INVALID_RESPONSE.clone(),
-                    "on route: {:?} - {:?} with action: {:?}",
-                    method,
-                    route,
-                    action
+                    "on route: {method:?} - {route:?} with action: {action:?}"
                 );
                 assert_ne!(code, 403);
             }
@@ -280,12 +274,9 @@ async fn access_authorized_no_index_restriction() {
             assert_ne!(
                 response,
                 INVALID_RESPONSE.clone(),
-                "on route: {:?} - {:?} with action: {:?}",
-                method,
-                route,
-                action
+                "on route: {method:?} - {route:?} with action: {action:?}"
             );
-            assert_ne!(code, 403, "on route: {:?} - {:?} with action: {:?}", method, route, action);
+            assert_ne!(code, 403, "on route: {method:?} - {route:?} with action: {action:?}");
         }
     }
 }

--- a/crates/meilisearch/tests/auth/tenant_token_multi_search.rs
+++ b/crates/meilisearch/tests/auth/tenant_token_multi_search.rs
@@ -1040,7 +1040,7 @@ async fn error_single_search_forbidden_token() {
     ];
 
     let failed_query_indexes: Vec<_> =
-        std::iter::repeat(Some(0)).take(5).chain(std::iter::repeat(None).take(6)).collect();
+        std::iter::repeat_n(Some(0), 5).chain(std::iter::repeat_n(None, 6)).collect();
 
     let failed_query_indexes = vec![failed_query_indexes; ACCEPTED_KEYS_SINGLE.len()];
 
@@ -1118,10 +1118,9 @@ async fn error_multi_search_forbidden_token() {
         },
     ];
 
-    let failed_query_indexes: Vec<_> = std::iter::repeat(Some(0))
-        .take(5)
-        .chain(std::iter::repeat(Some(1)).take(5))
-        .chain(std::iter::repeat(None).take(6))
+    let failed_query_indexes: Vec<_> = std::iter::repeat_n(Some(0), 5)
+        .chain(std::iter::repeat_n(Some(1), 5))
+        .chain(std::iter::repeat_n(None, 6))
         .collect();
 
     let failed_query_indexes = vec![failed_query_indexes; ACCEPTED_KEYS_BOTH.len()];

--- a/crates/meilisearch/tests/batches/mod.rs
+++ b/crates/meilisearch/tests/batches/mod.rs
@@ -119,21 +119,21 @@ async fn list_batches_with_star_filters() {
 
     let (response, code) =
         index.service.get("/batches?types=*,documentAdditionOrUpdate&statuses=*").await;
-    assert_eq!(code, 200, "{:?}", response);
+    assert_eq!(code, 200, "{response:?}");
     assert_eq!(response["results"].as_array().unwrap().len(), 2);
 
     let (response, code) = index
         .service
         .get("/batches?types=*,documentAdditionOrUpdate&statuses=*,failed&indexUids=test")
         .await;
-    assert_eq!(code, 200, "{:?}", response);
+    assert_eq!(code, 200, "{response:?}");
     assert_eq!(response["results"].as_array().unwrap().len(), 2);
 
     let (response, code) = index
         .service
         .get("/batches?types=*,documentAdditionOrUpdate&statuses=*,failed&indexUids=test,*")
         .await;
-    assert_eq!(code, 200, "{:?}", response);
+    assert_eq!(code, 200, "{response:?}");
     assert_eq!(response["results"].as_array().unwrap().len(), 2);
 }
 
@@ -147,15 +147,15 @@ async fn list_batches_status_filtered() {
     index.wait_task(task.uid()).await.failed();
 
     let (response, code) = index.filtered_batches(&[], &["succeeded"], &[]).await;
-    assert_eq!(code, 200, "{}", response);
+    assert_eq!(code, 200, "{response}");
     assert_eq!(response["results"].as_array().unwrap().len(), 1);
 
     let (response, code) = index.filtered_batches(&[], &["succeeded"], &[]).await;
-    assert_eq!(code, 200, "{}", response);
+    assert_eq!(code, 200, "{response}");
     assert_eq!(response["results"].as_array().unwrap().len(), 1);
 
     let (response, code) = index.filtered_batches(&[], &["succeeded", "failed"], &[]).await;
-    assert_eq!(code, 200, "{}", response);
+    assert_eq!(code, 200, "{response}");
     assert_eq!(response["results"].as_array().unwrap().len(), 2);
 }
 
@@ -168,16 +168,16 @@ async fn list_batches_type_filtered() {
     let (task, _) = index.delete().await;
     index.wait_task(task.uid()).await.succeeded();
     let (response, code) = index.filtered_batches(&["indexCreation"], &[], &[]).await;
-    assert_eq!(code, 200, "{}", response);
+    assert_eq!(code, 200, "{response}");
     assert_eq!(response["results"].as_array().unwrap().len(), 1);
 
     let (response, code) =
         index.filtered_batches(&["indexCreation", "IndexDeletion"], &[], &[]).await;
-    assert_eq!(code, 200, "{}", response);
+    assert_eq!(code, 200, "{response}");
     assert_eq!(response["results"].as_array().unwrap().len(), 2);
 
     let (response, code) = index.filtered_batches(&["indexCreation"], &[], &[]).await;
-    assert_eq!(code, 200, "{}", response);
+    assert_eq!(code, 200, "{response}");
     assert_eq!(response["results"].as_array().unwrap().len(), 1);
 }
 
@@ -189,7 +189,7 @@ async fn list_batches_invalid_canceled_by_filter() {
     index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = index.filtered_batches(&[], &[], &["0"]).await;
-    assert_eq!(code, 200, "{}", response);
+    assert_eq!(code, 200, "{response}");
     assert_eq!(response["results"].as_array().unwrap().len(), 0);
 }
 
@@ -203,7 +203,7 @@ async fn list_batches_status_and_type_filtered() {
     index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = index.filtered_batches(&["indexCreation"], &["failed"], &[]).await;
-    assert_eq!(code, 200, "{}", response);
+    assert_eq!(code, 200, "{response}");
     assert_eq!(response["results"].as_array().unwrap().len(), 0);
 
     let (response, code) = index
@@ -213,7 +213,7 @@ async fn list_batches_status_and_type_filtered() {
             &[],
         )
         .await;
-    assert_eq!(code, 200, "{}", response);
+    assert_eq!(code, 200, "{response}");
     assert_eq!(response["results"].as_array().unwrap().len(), 2);
 }
 
@@ -222,7 +222,7 @@ async fn list_batch_filter_error() {
     let server = Server::new().await;
 
     let (response, code) = server.batches_filter("lol=pied").await;
-    assert_eq!(code, 400, "{}", response);
+    assert_eq!(code, 400, "{response}");
     meili_snap::snapshot!(meili_snap::json_string!(response), @r#"
     {
       "message": "Unknown parameter `lol`: expected one of `limit`, `from`, `reverse`, `batchUids`, `uids`, `canceledBy`, `types`, `statuses`, `indexUids`, `afterEnqueuedAt`, `beforeEnqueuedAt`, `afterStartedAt`, `beforeStartedAt`, `afterFinishedAt`, `beforeFinishedAt`",
@@ -233,7 +233,7 @@ async fn list_batch_filter_error() {
     "#);
 
     let (response, code) = server.batches_filter("uids=pied").await;
-    assert_eq!(code, 400, "{}", response);
+    assert_eq!(code, 400, "{response}");
     meili_snap::snapshot!(meili_snap::json_string!(response), @r#"
     {
       "message": "Invalid value in parameter `uids`: could not parse `pied` as a positive integer",
@@ -244,7 +244,7 @@ async fn list_batch_filter_error() {
     "#);
 
     let (response, code) = server.batches_filter("from=pied").await;
-    assert_eq!(code, 400, "{}", response);
+    assert_eq!(code, 400, "{response}");
     meili_snap::snapshot!(meili_snap::json_string!(response), @r#"
     {
       "message": "Invalid value in parameter `from`: could not parse `pied` as a positive integer",
@@ -255,7 +255,7 @@ async fn list_batch_filter_error() {
     "#);
 
     let (response, code) = server.batches_filter("beforeStartedAt=pied").await;
-    assert_eq!(code, 400, "{}", response);
+    assert_eq!(code, 400, "{response}");
     meili_snap::snapshot!(meili_snap::json_string!(response), @r#"
     {
       "message": "Invalid value in parameter `beforeStartedAt`: `pied` is an invalid date-time. It should follow the YYYY-MM-DD or RFC 3339 date-time format.",

--- a/crates/meilisearch/tests/common/index.rs
+++ b/crates/meilisearch/tests/common/index.rs
@@ -366,10 +366,10 @@ impl<State> Index<'_, State> {
 
     pub async fn wait_task(&self, update_id: u64) -> Value {
         // try several times to get status, or panic to not wait forever
-        let url = format!("/tasks/{}", update_id);
+        let url = format!("/tasks/{update_id}");
         for _ in 0..100 {
             let (response, status_code) = self.service.get(&url).await;
-            assert_eq!(200, status_code, "response: {}", response);
+            assert_eq!(200, status_code, "response: {response}");
 
             if response["status"] == "succeeded" || response["status"] == "failed" {
                 return response;
@@ -382,7 +382,7 @@ impl<State> Index<'_, State> {
     }
 
     pub async fn get_task(&self, update_id: u64) -> (Value, StatusCode) {
-        let url = format!("/tasks/{}", update_id);
+        let url = format!("/tasks/{update_id}");
         self.service.get(url).await
     }
 
@@ -406,7 +406,7 @@ impl<State> Index<'_, State> {
     }
 
     pub async fn get_batch(&self, batch_id: u32) -> (Value, StatusCode) {
-        let url = format!("/batches/{}", batch_id);
+        let url = format!("/batches/{batch_id}");
         self.service.get(url).await
     }
 

--- a/crates/meilisearch/tests/common/server.rs
+++ b/crates/meilisearch/tests/common/server.rs
@@ -96,7 +96,7 @@ impl Server<Owned> {
     pub async fn use_admin_key(&mut self, master_key: impl AsRef<str>) {
         self.use_api_key(master_key);
         let (response, code) = self.list_api_keys("").await;
-        assert_eq!(200, code, "{:?}", response);
+        assert_eq!(200, code, "{response:?}");
         let admin_key = &response["results"][1]["key"];
         self.use_api_key(admin_key.as_str().unwrap());
     }
@@ -365,11 +365,11 @@ impl<State> Server<State> {
     }
 
     pub async fn tasks_filter(&self, filter: &str) -> (Value, StatusCode) {
-        self.service.get(format!("/tasks?{}", filter)).await
+        self.service.get(format!("/tasks?{filter}")).await
     }
 
     pub async fn batches_filter(&self, filter: &str) -> (Value, StatusCode) {
-        self.service.get(format!("/batches?{}", filter)).await
+        self.service.get(format!("/batches?{filter}")).await
     }
 
     pub async fn version(&self) -> (Value, StatusCode) {
@@ -389,16 +389,16 @@ impl<State> Server<State> {
     }
 
     pub async fn cancel_tasks(&self, value: &str) -> (Value, StatusCode) {
-        self.service.post(format!("/tasks/cancel?{}", value), json!(null)).await
+        self.service.post(format!("/tasks/cancel?{value}"), json!(null)).await
     }
 
     pub async fn delete_tasks(&self, value: &str) -> (Value, StatusCode) {
-        self.service.delete(format!("/tasks?{}", value)).await
+        self.service.delete(format!("/tasks?{value}")).await
     }
 
     pub async fn wait_task(&self, update_id: u64) -> Value {
         // try several times to get status, or panic to not wait forever
-        let url = format!("/tasks/{}", update_id);
+        let url = format!("/tasks/{update_id}");
         // Increase timeout for vector-related tests
         let max_attempts = if url.contains("/tasks/") {
             if update_id > 1000 {
@@ -412,7 +412,7 @@ impl<State> Server<State> {
 
         for _ in 0..max_attempts {
             let (response, status_code) = self.service.get(&url).await;
-            assert_eq!(200, status_code, "response: {}", response);
+            assert_eq!(200, status_code, "response: {response}");
 
             if response["status"] == "succeeded" || response["status"] == "failed" {
                 return response;
@@ -425,12 +425,12 @@ impl<State> Server<State> {
     }
 
     pub async fn get_task(&self, update_id: u64) -> (Value, StatusCode) {
-        let url = format!("/tasks/{}", update_id);
+        let url = format!("/tasks/{update_id}");
         self.service.get(url).await
     }
 
     pub async fn get_batch(&self, batch_id: u32) -> (Value, StatusCode) {
-        let url = format!("/batches/{}", batch_id);
+        let url = format!("/batches/{batch_id}");
         self.service.get(url).await
     }
 

--- a/crates/meilisearch/tests/content_type.rs
+++ b/crates/meilisearch/tests/content_type.rs
@@ -73,7 +73,7 @@ async fn error_json_bad_content_type() {
         let res = test::call_service(&app, req).await;
         let status_code = res.status();
         assert_ne!(status_code, 415,
-        "calling the route `{}` with a content-type of json isn't supposed to throw a bad media type error", route);
+        "calling the route `{route}` with a content-type of json isn't supposed to throw a bad media type error");
 
         // No content-type.
         let req = verb.test_request().uri(route).set_payload(document).to_request();
@@ -90,8 +90,7 @@ async fn error_json_bad_content_type() {
                     "type": "invalid_request",
                     "link": "https://docs.meilisearch.com/errors#missing_content_type",
             }),
-            "when calling the route `{}` with no content-type",
-            route,
+            "when calling the route `{route}` with no content-type",
         );
 
         for bad_content_type in bad_content_types {
@@ -108,8 +107,7 @@ async fn error_json_bad_content_type() {
             let response: Value = serde_json::from_slice(&body).unwrap_or_default();
             assert_eq!(status_code, 415);
             let expected_error_message = format!(
-                r#"The Content-Type `{}` is invalid. Accepted values for the Content-Type header are: `application/json`"#,
-                bad_content_type
+                r#"The Content-Type `{bad_content_type}` is invalid. Accepted values for the Content-Type header are: `application/json`"#
             );
             assert_eq!(
                 response,
@@ -119,9 +117,7 @@ async fn error_json_bad_content_type() {
                         "type": "invalid_request",
                         "link": "https://docs.meilisearch.com/errors#invalid_content_type",
                 }),
-                "when calling the route `{}` with a content-type of `{}`",
-                route,
-                bad_content_type,
+                "when calling the route `{route}` with a content-type of `{bad_content_type}`",
             );
         }
     }
@@ -144,7 +140,7 @@ async fn extract_actual_content_type() {
     let res = test::call_service(&app, req).await;
     let status_code = res.status();
     assert_ne!(status_code, 415,
-    "calling the route `{}` with a content-type of json isn't supposed to throw a bad media type error", route);
+    "calling the route `{route}` with a content-type of json isn't supposed to throw a bad media type error");
 
     let req = test::TestRequest::put()
         .uri(route)
@@ -154,5 +150,5 @@ async fn extract_actual_content_type() {
     let res = test::call_service(&app, req).await;
     let status_code = res.status();
     assert_ne!(status_code, 415,
-    "calling the route `{}` with a content-type of json isn't supposed to throw a bad media type error", route);
+    "calling the route `{route}` with a content-type of json isn't supposed to throw a bad media type error");
 }

--- a/crates/meilisearch/tests/documents/add_documents.rs
+++ b/crates/meilisearch/tests/documents/add_documents.rs
@@ -730,7 +730,7 @@ async fn error_add_malformed_json_documents() {
     // length = 100
     let long = "0123456789".repeat(10);
 
-    let document = format!("\"{}\"", long);
+    let document = format!("\"{long}\"");
     let req = test::TestRequest::put()
         .uri(format!("/indexes/{index_name}/documents").as_str())
         .set_payload(document)
@@ -751,7 +751,7 @@ async fn error_add_malformed_json_documents() {
     "###);
 
     // add one more char to the long string to test if the truncating works.
-    let document = format!("\"{}m\"", long);
+    let document = format!("\"{long}m\"");
     let req = test::TestRequest::put()
         .uri(format!("/indexes/{index_name}/documents").as_str())
         .set_payload(document)
@@ -1343,7 +1343,7 @@ async fn add_larger_dataset() {
     let (response, code) = index
         .get_all_documents(GetAllDocumentsOptions { limit: Some(1000), ..Default::default() })
         .await;
-    assert_eq!(code, 200, "failed with `{}`", response);
+    assert_eq!(code, 200, "failed with `{response}`");
     assert_eq!(response["results"].as_array().unwrap().len(), 77);
 }
 
@@ -2949,7 +2949,7 @@ async fn batch_several_documents_addition() {
     let (response, code) = index
         .get_all_documents(GetAllDocumentsOptions { limit: Some(200), ..Default::default() })
         .await;
-    assert_eq!(code, 200, "failed with `{}`", response);
+    assert_eq!(code, 200, "failed with `{response}`");
     assert_eq!(response["results"].as_array().unwrap().len(), 120);
 }
 

--- a/crates/meilisearch/tests/documents/update_documents.rs
+++ b/crates/meilisearch/tests/documents/update_documents.rs
@@ -74,7 +74,7 @@ async fn update_document() {
     ]);
 
     let (response, code) = index.update_documents(documents, None).await;
-    assert_eq!(code, 202, "response: {}", response);
+    assert_eq!(code, 202, "response: {response}");
 
     index.wait_task(response.uid()).await.succeeded();
 
@@ -118,7 +118,7 @@ async fn update_document_gzip_encoded() {
     ]);
 
     let (response, code) = index.update_documents(documents, None).await;
-    assert_eq!(code, 202, "response: {}", response);
+    assert_eq!(code, 202, "response: {response}");
 
     index.wait_task(response.uid()).await.succeeded();
 
@@ -219,7 +219,7 @@ async fn update_faceted_document() {
             "rankingRules": ["facet:asc"],
         }))
         .await;
-    assert_eq!("202", code.as_str(), "{:?}", response);
+    assert_eq!("202", code.as_str(), "{response:?}");
     index.wait_task(response.uid()).await.succeeded();
 
     let documents: Vec<_> = (0..1000)
@@ -244,7 +244,7 @@ async fn update_faceted_document() {
     ]);
 
     let (response, code) = index.update_documents(documents, None).await;
-    assert_eq!(code, 202, "response: {}", response);
+    assert_eq!(code, 202, "response: {response}");
 
     index.wait_task(response.uid()).await.succeeded();
 

--- a/crates/meilisearch/tests/index/delete_index.rs
+++ b/crates/meilisearch/tests/index/delete_index.rs
@@ -51,14 +51,14 @@ async fn loop_delete_add_documents() {
     for _ in 0..50 {
         let (response, code) = index.add_documents(documents.clone(), None).await;
         tasks.push(response["taskUid"].as_u64().unwrap());
-        assert_eq!(code, 202, "{}", response);
+        assert_eq!(code, 202, "{response}");
         let (response, code) = index.delete().await;
         tasks.push(response["taskUid"].as_u64().unwrap());
-        assert_eq!(code, 202, "{}", response);
+        assert_eq!(code, 202, "{response}");
     }
 
     for task in tasks {
         let response = index.wait_task(task).await.succeeded();
-        assert_eq!(response["status"], "succeeded", "{}", response);
+        assert_eq!(response["status"], "succeeded", "{response}");
     }
 }

--- a/crates/meilisearch/tests/search/errors.rs
+++ b/crates/meilisearch/tests/search/errors.rs
@@ -30,7 +30,7 @@ async fn search_unexisting_parameter() {
 
     index
         .search(json!({"marin": "hello"}), |response, code| {
-            assert_eq!(code, 400, "{}", response);
+            assert_eq!(code, 400, "{response}");
             assert_eq!(response["code"], "bad_request");
         })
         .await;

--- a/crates/meilisearch/tests/search/facet_search.rs
+++ b/crates/meilisearch/tests/search/facet_search.rs
@@ -49,11 +49,11 @@ async fn test_settings_documents_indexing_swapping_and_facet_search(
     let index = server.index("test");
 
     let (task, code) = index.add_documents(documents.clone(), None).await;
-    assert_eq!(code, 202, "{}", task);
+    assert_eq!(code, 202, "{task}");
     index.wait_task(task.uid()).await.succeeded();
 
     let (task, code) = index.update_settings(settings.clone()).await;
-    assert_eq!(code, 202, "{}", task);
+    assert_eq!(code, 202, "{task}");
     index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = index.facet_search(query.clone()).await;
@@ -62,18 +62,18 @@ async fn test_settings_documents_indexing_swapping_and_facet_search(
     }
 
     let (task, code) = server.delete_index("test").await;
-    assert_eq!(code, 202, "{}", task);
+    assert_eq!(code, 202, "{task}");
     server.wait_task(task.uid()).await.succeeded();
 
     eprintln!("Settings -> Documents -> test");
     let index = server.index("test");
 
     let (task, code) = index.update_settings(settings.clone()).await;
-    assert_eq!(code, 202, "{}", task);
+    assert_eq!(code, 202, "{task}");
     index.wait_task(task.uid()).await.succeeded();
 
     let (task, code) = index.add_documents(documents.clone(), None).await;
-    assert_eq!(code, 202, "{}", task);
+    assert_eq!(code, 202, "{task}");
     index.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = index.facet_search(query.clone()).await;
@@ -82,7 +82,7 @@ async fn test_settings_documents_indexing_swapping_and_facet_search(
     }
 
     let (task, code) = server.delete_index("test").await;
-    assert_eq!(code, 202, "{}", task);
+    assert_eq!(code, 202, "{task}");
     server.wait_task(task.uid()).await.succeeded();
 }
 

--- a/crates/meilisearch/tests/search/filters.rs
+++ b/crates/meilisearch/tests/search/filters.rs
@@ -28,7 +28,7 @@ async fn search_with_filter_string_notation() {
                 "filter": "title = Gläss"
             }),
             |response, code| {
-                assert_eq!(code, 200, "{}", response);
+                assert_eq!(code, 200, "{response}");
                 assert_eq!(response["hits"].as_array().unwrap().len(), 1);
             },
         )
@@ -52,7 +52,7 @@ async fn search_with_filter_string_notation() {
                 "filter": "cattos = pésti"
             }),
             |response, code| {
-                assert_eq!(code, 200, "{}", response);
+                assert_eq!(code, 200, "{response}");
                 assert_eq!(response["hits"].as_array().unwrap().len(), 1);
                 assert_eq!(response["hits"][0]["id"], json!(852));
             },
@@ -65,7 +65,7 @@ async fn search_with_filter_string_notation() {
                 "filter": "doggos.age > 5"
             }),
             |response, code| {
-                assert_eq!(code, 200, "{}", response);
+                assert_eq!(code, 200, "{response}");
                 assert_eq!(response["hits"].as_array().unwrap().len(), 2);
                 assert_eq!(response["hits"][0]["id"], json!(654));
                 assert_eq!(response["hits"][1]["id"], json!(951));
@@ -82,7 +82,7 @@ async fn search_with_filter_array_notation() {
             "filter": ["title = Gläss"]
         }))
         .await;
-    assert_eq!(code, 200, "{}", response);
+    assert_eq!(code, 200, "{response}");
     assert_eq!(response["hits"].as_array().unwrap().len(), 1);
 
     let (response, code) = index
@@ -90,7 +90,7 @@ async fn search_with_filter_array_notation() {
             "filter": [["title = Gläss", "title = \"Shazam!\"", "title = \"Escape Room\""]]
         }))
         .await;
-    assert_eq!(code, 200, "{}", response);
+    assert_eq!(code, 200, "{response}");
     assert_eq!(response["hits"].as_array().unwrap().len(), 3);
 }
 
@@ -116,7 +116,7 @@ async fn search_with_contains_filter() {
             "filter": "title CONTAINS cap"
         }))
         .await;
-    assert_eq!(code, 200, "{}", response);
+    assert_eq!(code, 200, "{response}");
     assert_eq!(response["hits"].as_array().unwrap().len(), 2);
 }
 
@@ -276,7 +276,7 @@ async fn search_with_pattern_filter_settings_scenario_1() {
     let index = server.index("test");
 
     let (task, code) = index.add_documents(NESTED_DOCUMENTS.clone(), None).await;
-    assert_eq!(code, 202, "{}", task);
+    assert_eq!(code, 202, "{task}");
     let response = index.wait_task(task.uid()).await;
     snapshot!(response["status"], @r###""succeeded""###);
 
@@ -289,7 +289,7 @@ async fn search_with_pattern_filter_settings_scenario_1() {
             }
         }]}))
         .await;
-    assert_eq!(code, 202, "{}", task);
+    assert_eq!(code, 202, "{task}");
     let response = index.wait_task(task.uid()).await;
     snapshot!(response["status"], @r###""succeeded""###);
 
@@ -355,7 +355,7 @@ async fn search_with_pattern_filter_settings_scenario_1() {
             }
         }]}))
         .await;
-    assert_eq!(code, 202, "{}", task);
+    assert_eq!(code, 202, "{task}");
     let response = index.wait_task(task.uid()).await;
     snapshot!(response["status"], @r###""succeeded""###);
 
@@ -467,7 +467,7 @@ async fn search_with_pattern_filter_settings_scenario_1() {
             }
         }]}))
         .await;
-    assert_eq!(code, 202, "{}", task);
+    assert_eq!(code, 202, "{task}");
     let response = index.wait_task(task.uid()).await;
     snapshot!(response["status"], @r###""succeeded""###);
 
@@ -567,7 +567,7 @@ async fn search_with_pattern_filter_settings_scenario_1() {
             }
         }]}))
         .await;
-    assert_eq!(code, 202, "{}", task);
+    assert_eq!(code, 202, "{task}");
     let response = index.wait_task(task.uid()).await;
     snapshot!(response["status"], @r###""succeeded""###);
 

--- a/crates/meilisearch/tests/search/formatted.rs
+++ b/crates/meilisearch/tests/search/formatted.rs
@@ -38,7 +38,7 @@ async fn search_formatted_from_sdk() {
               "attributesToRetrieve": ["title"]
             }),
             |response, code| {
-                assert_eq!(code, 200, "{}", response);
+                assert_eq!(code, 200, "{response}");
                 allow_duplicates! {
                   assert_json_snapshot!(response["hits"][0],
                         { "._rankingScore" => "[score]" },
@@ -70,7 +70,7 @@ async fn formatted_contain_wildcard() {
     index.search(json!({ "q": "pésti", "attributesToRetrieve": ["father", "mother"], "attributesToHighlight": ["father", "mother", "*"], "attributesToCrop": ["doggos"], "showMatchesPosition": true }),
         |response, code|
         {
-            assert_eq!(code, 200, "{}", response);
+            assert_eq!(code, 200, "{response}");
             allow_duplicates! {
               assert_json_snapshot!(response["hits"][0],
                     { "._rankingScore" => "[score]" },
@@ -97,7 +97,7 @@ async fn formatted_contain_wildcard() {
 
     index
         .search(json!({ "q": "pésti", "attributesToRetrieve": ["*"] }), |response, code| {
-            assert_eq!(code, 200, "{}", response);
+            assert_eq!(code, 200, "{response}");
             allow_duplicates! {
                 assert_json_snapshot!(response["hits"][0],
                 { "._rankingScore" => "[score]" },
@@ -115,7 +115,7 @@ async fn formatted_contain_wildcard() {
         .search(
             json!({ "q": "pésti", "attributesToRetrieve": ["*"], "attributesToHighlight": ["id"], "showMatchesPosition": true }),
             |response, code| {
-                assert_eq!(code, 200, "{}", response);
+                assert_eq!(code, 200, "{response}");
                 allow_duplicates! {
                   assert_json_snapshot!(response["hits"][0],
                  { "._rankingScore" => "[score]" },
@@ -145,7 +145,7 @@ async fn formatted_contain_wildcard() {
         .search(
             json!({ "q": "pésti", "attributesToRetrieve": ["*"], "attributesToCrop": ["*"] }),
             |response, code| {
-                assert_eq!(code, 200, "{}", response);
+                assert_eq!(code, 200, "{response}");
                 allow_duplicates! {
                     assert_json_snapshot!(response["hits"][0],
                     { "._rankingScore" => "[score]" },
@@ -166,7 +166,7 @@ async fn formatted_contain_wildcard() {
 
     index
         .search(json!({ "q": "pésti", "attributesToCrop": ["*"] }), |response, code| {
-            assert_eq!(code, 200, "{}", response);
+            assert_eq!(code, 200, "{response}");
             allow_duplicates! {
                 assert_json_snapshot!(response["hits"][0],
                 { "._rankingScore" => "[score]" },
@@ -191,7 +191,7 @@ async fn format_nested() {
 
     index
         .search(json!({ "q": "pésti", "attributesToRetrieve": ["doggos"] }), |response, code| {
-            assert_eq!(code, 200, "{}", response);
+            assert_eq!(code, 200, "{response}");
             allow_duplicates! {
                 assert_json_snapshot!(response["hits"][0],
                 { "._rankingScore" => "[score]" },
@@ -217,7 +217,7 @@ async fn format_nested() {
         .search(
             json!({ "q": "pésti", "attributesToRetrieve": ["doggos.name"] }),
             |response, code| {
-                assert_eq!(code, 200, "{}", response);
+                assert_eq!(code, 200, "{response}");
                 allow_duplicates! {
                     assert_json_snapshot!(response["hits"][0],
                     { "._rankingScore" => "[score]" },
@@ -242,7 +242,7 @@ async fn format_nested() {
         .search(
             json!({ "q": "bobby", "attributesToRetrieve": ["doggos.name"], "showMatchesPosition": true }),
             |response, code| {
-                assert_eq!(code, 200, "{}", response);
+                assert_eq!(code, 200, "{response}");
                 allow_duplicates! {
                     assert_json_snapshot!(response["hits"][0],
                     { "._rankingScore" => "[score]" },
@@ -277,7 +277,7 @@ async fn format_nested() {
     index
         .search(json!({ "q": "pésti", "attributesToRetrieve": [], "attributesToHighlight": ["doggos.name"] }),
         |response, code| {
-            assert_eq!(code, 200, "{}", response);
+            assert_eq!(code, 200, "{response}");
             allow_duplicates! {
                 assert_json_snapshot!(response["hits"][0],
                 { "._rankingScore" => "[score]" },
@@ -302,7 +302,7 @@ async fn format_nested() {
     index
         .search(json!({ "q": "pésti", "attributesToRetrieve": [], "attributesToCrop": ["doggos.name"] }),
         |response, code| {
-            assert_eq!(code, 200, "{}", response);
+            assert_eq!(code, 200, "{response}");
             allow_duplicates! {
                 assert_json_snapshot!(response["hits"][0],
                 { "._rankingScore" => "[score]" },
@@ -327,7 +327,7 @@ async fn format_nested() {
     index
         .search(json!({ "q": "pésti", "attributesToRetrieve": ["doggos.name"], "attributesToHighlight": ["doggos.age"] }),
         |response, code| {
-    assert_eq!(code, 200, "{}", response);
+    assert_eq!(code, 200, "{response}");
     allow_duplicates! {
         assert_json_snapshot!(response["hits"][0],
         { "._rankingScore" => "[score]" },
@@ -362,7 +362,7 @@ async fn format_nested() {
     index
         .search(json!({ "q": "pésti", "attributesToRetrieve": [], "attributesToHighlight": ["doggos.age"], "attributesToCrop": ["doggos.name"] }),
         |response, code| {
-                assert_eq!(code, 200, "{}", response);
+                assert_eq!(code, 200, "{response}");
                 allow_duplicates! {
                     assert_json_snapshot!(response["hits"][0],
                     { "._rankingScore" => "[score]" },
@@ -403,7 +403,7 @@ async fn displayedattr_2_smol() {
     index
         .search(json!({ "attributesToRetrieve": ["father", "id"], "attributesToHighlight": ["mother"], "attributesToCrop": ["cattos"] }),
         |response, code| {
-    assert_eq!(code, 200, "{}", response);
+    assert_eq!(code, 200, "{response}");
     allow_duplicates! {
         assert_json_snapshot!(response["hits"][0],
         { "._rankingScore" => "[score]" },
@@ -418,7 +418,7 @@ async fn displayedattr_2_smol() {
 
     index
         .search(json!({ "attributesToRetrieve": ["id"] }), |response, code| {
-            assert_eq!(code, 200, "{}", response);
+            assert_eq!(code, 200, "{response}");
             allow_duplicates! {
                 assert_json_snapshot!(response["hits"][0],
                 { "._rankingScore" => "[score]" },
@@ -433,7 +433,7 @@ async fn displayedattr_2_smol() {
 
     index
         .search(json!({ "attributesToHighlight": ["id"] }), |response, code| {
-            assert_eq!(code, 200, "{}", response);
+            assert_eq!(code, 200, "{response}");
             allow_duplicates! {
                 assert_json_snapshot!(response["hits"][0],
                 { "._rankingScore" => "[score]" },
@@ -451,7 +451,7 @@ async fn displayedattr_2_smol() {
 
     index
         .search(json!({ "attributesToCrop": ["id"] }), |response, code| {
-            assert_eq!(code, 200, "{}", response);
+            assert_eq!(code, 200, "{response}");
             allow_duplicates! {
                 assert_json_snapshot!(response["hits"][0],
                 { "._rankingScore" => "[score]" },
@@ -471,7 +471,7 @@ async fn displayedattr_2_smol() {
         .search(
             json!({ "attributesToHighlight": ["id"], "attributesToCrop": ["id"] }),
             |response, code| {
-                assert_eq!(code, 200, "{}", response);
+                assert_eq!(code, 200, "{response}");
                 allow_duplicates! {
                     assert_json_snapshot!(response["hits"][0],
                     { "._rankingScore" => "[score]" },
@@ -490,7 +490,7 @@ async fn displayedattr_2_smol() {
 
     index
         .search(json!({ "attributesToHighlight": ["cattos"] }), |response, code| {
-            assert_eq!(code, 200, "{}", response);
+            assert_eq!(code, 200, "{response}");
             allow_duplicates! {
                 assert_json_snapshot!(response["hits"][0],
                 { "._rankingScore" => "[score]" },
@@ -505,7 +505,7 @@ async fn displayedattr_2_smol() {
 
     index
         .search(json!({ "attributesToCrop": ["cattos"] }), |response, code| {
-            assert_eq!(code, 200, "{}", response);
+            assert_eq!(code, 200, "{response}");
             allow_duplicates! {
                 assert_json_snapshot!(response["hits"][0],
                 { "._rankingScore" => "[score]" },
@@ -520,7 +520,7 @@ async fn displayedattr_2_smol() {
 
     index
         .search(json!({ "attributesToRetrieve": ["cattos"] }), |response, code| {
-            assert_eq!(code, 200, "{}", response);
+            assert_eq!(code, 200, "{response}");
             allow_duplicates! {
                 assert_json_snapshot!(response["hits"][0],
                 { "._rankingScore" => "[score]" },
@@ -533,7 +533,7 @@ async fn displayedattr_2_smol() {
         .search(
             json!({ "attributesToRetrieve": ["cattos"], "attributesToHighlight": ["cattos"], "attributesToCrop": ["cattos"] }),
             |response, code| {
-    assert_eq!(code, 200, "{}", response);
+    assert_eq!(code, 200, "{response}");
     allow_duplicates! {
         assert_json_snapshot!(response["hits"][0],
         { "._rankingScore" => "[score]" },
@@ -548,7 +548,7 @@ async fn displayedattr_2_smol() {
         .search(
             json!({ "attributesToRetrieve": ["cattos"], "attributesToHighlight": ["id"] }),
             |response, code| {
-                assert_eq!(code, 200, "{}", response);
+                assert_eq!(code, 200, "{response}");
                 allow_duplicates! {
                     assert_json_snapshot!(response["hits"][0],
                     { "._rankingScore" => "[score]" },
@@ -568,7 +568,7 @@ async fn displayedattr_2_smol() {
         .search(
             json!({ "attributesToRetrieve": ["cattos"], "attributesToCrop": ["id"] }),
             |response, code| {
-                assert_eq!(code, 200, "{}", response);
+                assert_eq!(code, 200, "{response}");
                 allow_duplicates! {
                     assert_json_snapshot!(response["hits"][0],
                     { "._rankingScore" => "[score]" },
@@ -600,7 +600,7 @@ async fn test_cjk_highlight() {
 
     index
         .search(json!({"q": "で", "attributesToHighlight": ["title"]}), |response, code| {
-            assert_eq!(code, 200, "{}", response);
+            assert_eq!(code, 200, "{response}");
             assert_eq!(
                 response["hits"][0]["_formatted"]["title"],
                 json!("この度、クーポン<em>で</em>無料<em>で</em>頂きました。")
@@ -610,7 +610,7 @@ async fn test_cjk_highlight() {
 
     index
         .search(json!({"q": "大卫", "attributesToHighlight": ["title"]}), |response, code| {
-            assert_eq!(code, 200, "{}", response);
+            assert_eq!(code, 200, "{response}");
             assert_eq!(
                 response["hits"][0]["_formatted"]["title"],
                 json!("<em>大卫</em>到了扫罗那里")

--- a/crates/meilisearch/tests/search/hybrid.rs
+++ b/crates/meilisearch/tests/search/hybrid.rs
@@ -542,7 +542,7 @@ async fn distinct_is_applied() {
     let index = index_with_documents_user_provided(server, &TEST_DISTINCT_DOCUMENTS).await;
 
     let (response, code) = index.update_settings(json!({ "distinctAttribute": "distinct" } )).await;
-    assert_eq!(202, code, "{:?}", response);
+    assert_eq!(202, code, "{response:?}");
     index.wait_task(response.uid()).await.succeeded();
 
     // pure keyword

--- a/crates/meilisearch/tests/search/mod.rs
+++ b/crates/meilisearch/tests/search/mod.rs
@@ -1922,7 +1922,7 @@ async fn change_facet_casing() {
             "filterableAttributes": ["dog"],
         }))
         .await;
-    assert_eq!("202", code.as_str(), "{:?}", response);
+    assert_eq!("202", code.as_str(), "{response:?}");
     index.wait_task(response.uid()).await.succeeded();
 
     let (response, _code) = index

--- a/crates/meilisearch/tests/settings/prefix_search_settings.rs
+++ b/crates/meilisearch/tests/settings/prefix_search_settings.rs
@@ -38,7 +38,7 @@ async fn add_docs_and_disable() {
             "rankingRules": ["words", "typo", "proximity"],
         }))
         .await;
-    assert_eq!("202", code.as_str(), "{:?}", response);
+    assert_eq!("202", code.as_str(), "{response:?}");
     index.wait_task(response.uid()).await;
 
     // only 1 document should match
@@ -95,7 +95,7 @@ async fn disable_and_add_docs() {
             "rankingRules": ["words", "typo", "proximity"],
         }))
         .await;
-    assert_eq!("202", code.as_str(), "{:?}", response);
+    assert_eq!("202", code.as_str(), "{response:?}");
     index.wait_task(response.uid()).await;
 
     let (response, _code) = index.add_documents(DOCUMENTS.clone(), None).await;
@@ -154,7 +154,7 @@ async fn disable_add_docs_and_enable() {
             "rankingRules": ["words", "typo", "proximity"],
         }))
         .await;
-    assert_eq!("202", code.as_str(), "{:?}", response);
+    assert_eq!("202", code.as_str(), "{response:?}");
     index.wait_task(response.uid()).await;
 
     let (response, _code) = index.add_documents(DOCUMENTS.clone(), None).await;
@@ -166,7 +166,7 @@ async fn disable_add_docs_and_enable() {
             "rankingRules": ["words", "typo", "proximity"],
         }))
         .await;
-    assert_eq!("202", code.as_str(), "{:?}", response);
+    assert_eq!("202", code.as_str(), "{response:?}");
     index.wait_task(2).await;
 
     // all documents should match
@@ -262,7 +262,7 @@ async fn disable_add_docs_and_reset() {
             "rankingRules": ["words", "typo", "proximity"],
         }))
         .await;
-    assert_eq!("202", code.as_str(), "{:?}", response);
+    assert_eq!("202", code.as_str(), "{response:?}");
     index.wait_task(response.uid()).await;
 
     let (response, _code) = index.add_documents(DOCUMENTS.clone(), None).await;
@@ -274,7 +274,7 @@ async fn disable_add_docs_and_reset() {
             "rankingRules": ["words", "typo", "proximity"],
         }))
         .await;
-    assert_eq!("202", code.as_str(), "{:?}", response);
+    assert_eq!("202", code.as_str(), "{response:?}");
     index.wait_task(2).await;
 
     // all documents should match
@@ -369,7 +369,7 @@ async fn default_behavior() {
             "rankingRules": ["words", "typo", "proximity"],
         }))
         .await;
-    assert_eq!("202", code.as_str(), "{:?}", response);
+    assert_eq!("202", code.as_str(), "{response:?}");
     index.wait_task(response.uid()).await;
 
     let (response, _code) = index.add_documents(DOCUMENTS.clone(), None).await;

--- a/crates/meilisearch/tests/settings/vectors.rs
+++ b/crates/meilisearch/tests/settings/vectors.rs
@@ -318,6 +318,6 @@ fn valid_parameter(source: &'static str, parameter: &'static str) -> Value {
         ("rest", "response") => crate::json!({ "test": "test" }),
         ("rest", "headers") => crate::json!({ "test": "test" }),
         ("rest", "distribution") => crate::json!("normal"),
-        _ => panic!("Invalid parameter {} for source {}", parameter, source),
+        _ => panic!("Invalid parameter {parameter} for source {source}"),
     }
 }

--- a/crates/meilisearch/tests/stats/mod.rs
+++ b/crates/meilisearch/tests/stats/mod.rs
@@ -55,7 +55,7 @@ async fn stats() {
     ]);
 
     let (response, code) = index.add_documents(documents, None).await;
-    assert_eq!(code, 202, "{}", response);
+    assert_eq!(code, 202, "{response}");
     assert_eq!(response["taskUid"], 1);
 
     index.wait_task(response.uid()).await.succeeded();

--- a/crates/meilitool/src/main.rs
+++ b/crates/meilitool/src/main.rs
@@ -340,11 +340,11 @@ fn export_a_dump(
                     eprintln!("Dumping the enqueued tasks reading them in obkv format...");
                     let reader =
                         DocumentsBatchReader::from_reader(content_file).with_context(|| {
-                            format!("While reading content file {:?}", content_file_uuid)
+                            format!("While reading content file {content_file_uuid:?}")
                         })?;
                     let (mut cursor, documents_batch_index) = reader.into_cursor_and_fields_index();
                     while let Some(doc) = cursor.next_document().with_context(|| {
-                        format!("While iterating on content file {:?}", content_file_uuid)
+                        format!("While iterating on content file {content_file_uuid:?}")
                     })? {
                         dump_content_file
                             .push_document(&obkv_to_object(doc, &documents_batch_index)?)?;
@@ -355,7 +355,7 @@ fn export_a_dump(
                         serde_json::de::Deserializer::from_reader(content_file).into_iter()
                     {
                         let document = document.with_context(|| {
-                            format!("While reading content file {:?}", content_file_uuid)
+                            format!("While reading content file {content_file_uuid:?}")
                         })?;
                         dump_content_file.push_document(&document)?;
                     }
@@ -433,7 +433,7 @@ fn export_a_dump(
         "[year repr:full][month repr:numerical][day padding:zero]-[hour padding:zero][minute padding:zero][second padding:zero][subsecond digits:3]"
     )).unwrap();
 
-    let path = dump_dir.join(format!("{}.dump", dump_uid));
+    let path = dump_dir.join(format!("{dump_uid}.dump"));
     let file = File::create(&path)?;
     dump.persist_to(BufWriter::new(file))?;
 

--- a/crates/milli/src/asc_desc.rs
+++ b/crates/milli/src/asc_desc.rs
@@ -97,7 +97,7 @@ impl fmt::Display for Member {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Member::Field(name) => f.write_str(name),
-            Member::Geo([lat, lng]) => write!(f, "_geoPoint({}, {})", lat, lng),
+            Member::Geo([lat, lng]) => write!(f, "_geoPoint({lat}, {lng})"),
         }
     }
 }
@@ -229,10 +229,7 @@ mod tests {
             let res = req.parse::<AscDesc>();
             assert!(
                 res.is_ok(),
-                "Failed to parse `{}`, was expecting `{:?}` but instead got `{:?}`",
-                req,
-                expected,
-                res
+                "Failed to parse `{req}`, was expecting `{expected:?}` but instead got `{res:?}`"
             );
             assert_eq!(res.unwrap(), expected);
         }
@@ -281,18 +278,13 @@ mod tests {
             let res = req.parse::<AscDesc>();
             assert!(
                 res.is_err(),
-                "Should no be able to parse `{}`, was expecting an error but instead got: `{:?}`",
-                req,
-                res,
+                "Should no be able to parse `{req}`, was expecting an error but instead got: `{res:?}`",
             );
             let res = res.unwrap_err();
             assert_eq!(
                 res.to_string(),
                 expected_error.to_string(),
-                "Bad error for input {}: got `{:?}` instead of `{:?}`",
-                req,
-                res,
-                expected_error
+                "Bad error for input {req}: got `{res:?}` instead of `{expected_error:?}`"
             );
         }
     }

--- a/crates/milli/src/criterion.rs
+++ b/crates/milli/src/criterion.rs
@@ -101,8 +101,8 @@ impl fmt::Display for Criterion {
             Attribute => f.write_str("attribute"),
             Sort => f.write_str("sort"),
             Exactness => f.write_str("exactness"),
-            Asc(attr) => write!(f, "{}:asc", attr),
-            Desc(attr) => write!(f, "{}:desc", attr),
+            Asc(attr) => write!(f, "{attr}:asc"),
+            Desc(attr) => write!(f, "{attr}:desc"),
         }
     }
 }
@@ -136,10 +136,7 @@ mod tests {
             let res = input.parse::<Criterion>();
             assert!(
                 res.is_ok(),
-                "Failed to parse `{}`, was expecting `{:?}` but instead got `{:?}`",
-                input,
-                expected,
-                res
+                "Failed to parse `{input}`, was expecting `{expected:?}` but instead got `{res:?}`"
             );
             assert_eq!(res.unwrap(), expected);
         }
@@ -171,18 +168,13 @@ mod tests {
             let res = input.parse::<Criterion>();
             assert!(
                 res.is_err(),
-                "Should no be able to parse `{}`, was expecting an error but instead got: `{:?}`",
-                input,
-                res
+                "Should no be able to parse `{input}`, was expecting an error but instead got: `{res:?}`"
             );
             let res = res.unwrap_err();
             assert_eq!(
                 res.to_string(),
                 expected.to_string(),
-                "Bad error for input {}: got `{:?}` instead of `{:?}`",
-                input,
-                res,
-                expected
+                "Bad error for input {input}: got `{res:?}` instead of `{expected:?}`"
             );
         }
     }

--- a/crates/milli/src/documents/mod.rs
+++ b/crates/milli/src/documents/mod.rs
@@ -135,14 +135,14 @@ pub fn objects_from_json_value(json: serde_json::Value) -> Vec<crate::Object> {
         object @ serde_json::Value::Object(_) => vec![object],
         serde_json::Value::Array(objects) => objects,
         invalid => {
-            panic!("an array of objects must be specified, {:#?} is not an array", invalid)
+            panic!("an array of objects must be specified, {invalid:#?} is not an array")
         }
     };
     let mut objects = vec![];
     for document in documents {
         let object = match document {
             serde_json::Value::Object(object) => object,
-            invalid => panic!("an object must be specified, {:#?} is not an object", invalid),
+            invalid => panic!("an object must be specified, {invalid:#?} is not an object"),
         };
         objects.push(object);
     }

--- a/crates/milli/src/documents/primary_key.rs
+++ b/crates/milli/src/documents/primary_key.rs
@@ -256,7 +256,7 @@ fn fetch_matching_values_in_object(
         let base_key = if base_key.is_empty() {
             key.to_string()
         } else {
-            format!("{}{}{}", base_key, PRIMARY_KEY_SPLIT_SYMBOL, key)
+            format!("{base_key}{PRIMARY_KEY_SPLIT_SYMBOL}{key}")
         };
 
         if starts_with(selector, &base_key) {

--- a/crates/milli/src/error.rs
+++ b/crates/milli/src/error.rs
@@ -125,10 +125,9 @@ and can not be more than 511 bytes.", .document_id.to_string()
         if .invalid_facets_name.len() == 1 {
             let field = .invalid_facets_name.iter().next().unwrap();
             match .matching_rule_indices.get(field) {
-                Some(rule_index) => format!("Attribute `{}` matched rule #{} in filterableAttributes, but this rule does not enable filtering.\nHint: enable filtering in rule #{} by modifying the features.filter object\nHint: prepend another rule matching `{}` with appropriate filter features before rule #{}",
-                    field, rule_index, rule_index, field, rule_index),
+                Some(rule_index) => format!("Attribute `{field}` matched rule #{rule_index} in filterableAttributes, but this rule does not enable filtering.\nHint: enable filtering in rule #{rule_index} by modifying the features.filter object\nHint: prepend another rule matching `{field}` with appropriate filter features before rule #{rule_index}"),
                 None => match .valid_patterns.is_empty() {
-                    true => format!("Attribute `{}` is not filterable. This index does not have configured filterable attributes.", field),
+                    true => format!("Attribute `{field}` is not filterable. This index does not have configured filterable attributes."),
                     false => format!("Attribute `{}` is not filterable. Available filterable attributes patterns are: `{}`.",
                         field,
                         .valid_patterns.iter().map(AsRef::as_ref).collect::<Vec<&str>>().join(", ")),
@@ -309,7 +308,7 @@ and can not be more than 511 bytes.", .document_id.to_string()
                 field.name(),
                 allowed_sources_for_field
                 .iter()
-                .map(|accepted| format!("`{}`", accepted))
+                .map(|accepted| format!("`{accepted}`"))
                 .collect::<Vec<String>>()
                 .join(", "),
             )
@@ -319,7 +318,7 @@ and can not be more than 511 bytes.", .document_id.to_string()
             let allowed_fields_for_source = EmbeddingSettings::allowed_fields_for_source(*source_, *context);
             format!("\n  - note: available fields for source `{source_}`{}: {}",context.in_context(), allowed_fields_for_source
             .iter()
-            .map(|accepted| format!("`{}`", accepted))
+            .map(|accepted| format!("`{accepted}`"))
             .collect::<Vec<String>>()
             .join(", "),)
         },
@@ -579,7 +578,7 @@ impl From<HeedError> for Error {
             // TODO use the encoding
             HeedError::Encoding(_) => InternalError(Serialization(Encoding { db_name: None })),
             HeedError::Decoding(_) => InternalError(Serialization(Decoding { db_name: None })),
-            HeedError::EnvAlreadyOpened { .. } => UserError(EnvAlreadyOpened),
+            HeedError::EnvAlreadyOpened => UserError(EnvAlreadyOpened),
         }
     }
 }
@@ -619,6 +618,6 @@ fn conditionally_lookup_for_error_message() {
             hidden_fields: false,
         };
 
-        assert_eq!(err.to_string(), format!("{} {}", prefix, suffix));
+        assert_eq!(err.to_string(), format!("{prefix} {suffix}"));
     }
 }

--- a/crates/milli/src/facet/value_encoding.rs
+++ b/crates/milli/src/facet/value_encoding.rs
@@ -44,6 +44,6 @@ mod tests {
         let e = 43.0;
 
         let vec: Vec<_> = [a, b, c, d, e].iter().cloned().map(f64_into_bytes).collect();
-        assert!(is_sorted(&vec), "{:?}", vec);
+        assert!(is_sorted(&vec), "{vec:?}");
     }
 }

--- a/crates/milli/src/heed_codec/roaring_bitmap_length/roaring_bitmap_len_codec.rs
+++ b/crates/milli/src/heed_codec/roaring_bitmap_length/roaring_bitmap_len_codec.rs
@@ -19,14 +19,14 @@ impl RoaringBitmapLenCodec {
             if cookie == SERIAL_COOKIE_NO_RUNCONTAINER {
                 (bytes.read_u32::<LittleEndian>()? as usize, true)
             } else if (cookie as u16) == SERIAL_COOKIE {
-                return Err(io::Error::new(io::ErrorKind::Other, "run containers are unsupported"));
+                return Err(io::Error::other("run containers are unsupported"));
             } else {
-                return Err(io::Error::new(io::ErrorKind::Other, "unknown cookie value"));
+                return Err(io::Error::other("unknown cookie value"));
             }
         };
 
         if size > u16::MAX as usize + 1 {
-            return Err(io::Error::new(io::ErrorKind::Other, "size is greater than supported"));
+            return Err(io::Error::other("size is greater than supported"));
         }
 
         let mut description_bytes = vec![0u8; size * 4];

--- a/crates/milli/src/lib.rs
+++ b/crates/milli/src/lib.rs
@@ -258,9 +258,9 @@ pub fn json_to_string(value: &Value) -> Option<String> {
         use std::fmt::Write;
         match value {
             Value::Null => false,
-            Value::Bool(boolean) => write!(output, "{}", boolean).is_ok(),
-            Value::Number(number) => write!(output, "{}", number).is_ok(),
-            Value::String(string) => write!(output, "{}", string).is_ok(),
+            Value::Bool(boolean) => write!(output, "{boolean}").is_ok(),
+            Value::Number(number) => write!(output, "{number}").is_ok(),
+            Value::String(string) => write!(output, "{string}").is_ok(),
             Value::Array(array) => {
                 let mut count = 0;
                 for value in array {
@@ -277,7 +277,7 @@ pub fn json_to_string(value: &Value) -> Option<String> {
                 let mut count = 0;
                 for (key, value) in object {
                     buffer.clear();
-                    let _ = write!(&mut buffer, "{}: ", key);
+                    let _ = write!(&mut buffer, "{key}: ");
                     if inner(value, &mut buffer) {
                         buffer.push_str(". ");
                         // We write the "key: value. " pair only when

--- a/crates/milli/src/search/facet/facet_distribution_iter.rs
+++ b/crates/milli/src/search/facet/facet_distribution_iter.rs
@@ -38,11 +38,9 @@ where
     let highest_level = get_highest_level(rtxn, db, field_id)?;
 
     if let Some(first_bound) = get_first_facet_value::<BytesRefCodec, _>(rtxn, db, field_id)? {
-        fd.iterate(candidates, highest_level, first_bound, usize::MAX)?;
-        Ok(())
-    } else {
-        Ok(())
+        let _ = fd.iterate(candidates, highest_level, first_bound, usize::MAX)?;
     }
+    Ok(())
 }
 
 pub fn count_iterate_over_facet_distribution<'t, CB>(

--- a/crates/milli/src/search/facet/filter.rs
+++ b/crates/milli/src/search/facet/filter.rs
@@ -49,13 +49,11 @@ impl Display for BadGeoError {
             }
             Self::Lat(lat) => write!(
                 f,
-                "Bad latitude `{}`. Latitude must be contained between -90 and 90 degrees. ",
-                lat
+                "Bad latitude `{lat}`. Latitude must be contained between -90 and 90 degrees. "
             ),
             Self::Lng(lng) => write!(
                 f,
-                "Bad longitude `{}`. Longitude must be contained between -180 and 180 degrees. ",
-                lng
+                "Bad longitude `{lng}`. Longitude must be contained between -180 and 180 degrees. "
             ),
         }
     }
@@ -98,10 +96,9 @@ impl Display for FilterError<'_> {
             }
             Self::TooDeep => write!(
                 f,
-                "Too many filter conditions, can't process more than {} filters.",
-                MAX_FILTER_DEPTH
+                "Too many filter conditions, can't process more than {MAX_FILTER_DEPTH} filters."
             ),
-            Self::ParseGeoError(error) => write!(f, "{}", error),
+            Self::ParseGeoError(error) => write!(f, "{error}"),
         }
     }
 }
@@ -1236,7 +1233,7 @@ mod tests {
         let tipic_filter = "account_ids=14361 OR ";
         let mut filter_string = String::with_capacity(tipic_filter.len() * 14360);
         for i in 1..=14361 {
-            let _ = write!(&mut filter_string, "account_ids={}", i);
+            let _ = write!(&mut filter_string, "account_ids={i}");
             if i != 14361 {
                 let _ = write!(&mut filter_string, " OR ");
             }

--- a/crates/milli/src/search/new/bucket_sort.rs
+++ b/crates/milli/src/search/new/bucket_sort.rs
@@ -353,8 +353,7 @@ fn maybe_add_to_results<'ctx, Q: RankingRuleQueryTrait>(
         let candidates = candidates.iter().take(length - valid_docids.len()).collect::<Vec<u32>>();
         logger.add_to_results(&candidates);
         valid_docids.extend_from_slice(&candidates);
-        valid_scores
-            .extend(std::iter::repeat_n(ranking_rule_scores.to_owned(), candidates.len()));
+        valid_scores.extend(std::iter::repeat_n(ranking_rule_scores.to_owned(), candidates.len()));
     }
 
     *cur_offset += candidates.len() as usize;

--- a/crates/milli/src/search/new/bucket_sort.rs
+++ b/crates/milli/src/search/new/bucket_sort.rs
@@ -346,7 +346,7 @@ fn maybe_add_to_results<'ctx, Q: RankingRuleQueryTrait>(
             logger.add_to_results(&candidates);
             valid_docids.extend_from_slice(&candidates);
             valid_scores
-                .extend(std::iter::repeat(ranking_rule_scores.to_owned()).take(candidates.len()));
+                .extend(std::iter::repeat_n(ranking_rule_scores.to_owned(), candidates.len()));
         }
     } else {
         // if we have passed the offset already, add some of the documents (up to the limit)
@@ -354,7 +354,7 @@ fn maybe_add_to_results<'ctx, Q: RankingRuleQueryTrait>(
         logger.add_to_results(&candidates);
         valid_docids.extend_from_slice(&candidates);
         valid_scores
-            .extend(std::iter::repeat(ranking_rule_scores.to_owned()).take(candidates.len()));
+            .extend(std::iter::repeat_n(ranking_rule_scores.to_owned(), candidates.len()));
     }
 
     *cur_offset += candidates.len() as usize;

--- a/crates/milli/src/search/new/ranking_rule_graph/cheapest_paths.rs
+++ b/crates/milli/src/search/new/ranking_rule_graph/cheapest_paths.rs
@@ -195,9 +195,7 @@ impl<G: RankingRuleGraphTrait> VisitorState<G> {
     ) -> Result<ControlFlow<(), bool>> {
         if !ctx
             .all_costs_from_node
-            .get(dest_node)
-            .iter()
-            .any(|next_cost| *next_cost == self.remaining_cost)
+            .get(dest_node).contains(&self.remaining_cost)
         {
             return Ok(ControlFlow::Continue(false));
         }
@@ -245,9 +243,7 @@ impl<G: RankingRuleGraphTrait> VisitorState<G> {
         // one cost that we can visit that corresponds to our remaining budget.
         if !ctx
             .all_costs_from_node
-            .get(dest_node)
-            .iter()
-            .any(|next_cost| *next_cost == self.remaining_cost)
+            .get(dest_node).contains(&self.remaining_cost)
         {
             return Ok(ControlFlow::Continue(false));
         }

--- a/crates/milli/src/search/new/ranking_rule_graph/cheapest_paths.rs
+++ b/crates/milli/src/search/new/ranking_rule_graph/cheapest_paths.rs
@@ -193,10 +193,7 @@ impl<G: RankingRuleGraphTrait> VisitorState<G> {
         visit: VisitFn<'_, G>,
         ctx: &mut VisitorContext<'_, G>,
     ) -> Result<ControlFlow<(), bool>> {
-        if !ctx
-            .all_costs_from_node
-            .get(dest_node).contains(&self.remaining_cost)
-        {
+        if !ctx.all_costs_from_node.get(dest_node).contains(&self.remaining_cost) {
             return Ok(ControlFlow::Continue(false));
         }
         // We've reached the END node!
@@ -241,10 +238,7 @@ impl<G: RankingRuleGraphTrait> VisitorState<G> {
 
         // Checking that from the destination node, there is at least
         // one cost that we can visit that corresponds to our remaining budget.
-        if !ctx
-            .all_costs_from_node
-            .get(dest_node).contains(&self.remaining_cost)
-        {
+        if !ctx.all_costs_from_node.get(dest_node).contains(&self.remaining_cost) {
             return Ok(ControlFlow::Continue(false));
         }
 

--- a/crates/milli/src/search/new/small_bitmap.rs
+++ b/crates/milli/src/search/new/small_bitmap.rs
@@ -220,8 +220,7 @@ impl SmallBitmapInternal {
             SmallBitmapInternal::Tiny(set) => {
                 assert!(
                     x < 64,
-                    "index out of bounds: the universe length is 64 but the index is {}",
-                    x
+                    "index out of bounds: the universe length is 64 but the index is {x}"
                 );
                 (*set, x)
             }
@@ -243,8 +242,7 @@ impl SmallBitmapInternal {
             SmallBitmapInternal::Tiny(set) => {
                 assert!(
                     x < 64,
-                    "index out of bounds: the universe length is 64 but the index is {}",
-                    x
+                    "index out of bounds: the universe length is 64 but the index is {x}"
                 );
                 (set, x)
             }

--- a/crates/milli/src/search/new/sort.rs
+++ b/crates/milli/src/search/new/sort.rs
@@ -79,7 +79,7 @@ impl<'ctx, Query> Sort<'ctx, Query> {
             return Ok(false);
         };
 
-        Ok(!displayed_fields.iter().any(|&field| field == field_name))
+        Ok(!displayed_fields.contains(&field_name))
     }
 }
 

--- a/crates/milli/src/snapshot_tests.rs
+++ b/crates/milli/src/snapshot_tests.rs
@@ -356,7 +356,7 @@ pub fn snap_words_fst(index: &Index) -> String {
     let bytes = words_fst.into_fst().as_bytes().to_owned();
     let mut snap = String::new();
     for byte in bytes {
-        write!(&mut snap, "{:x}", byte).unwrap();
+        write!(&mut snap, "{byte:x}").unwrap();
     }
     snap
 }
@@ -366,7 +366,7 @@ pub fn snap_words_prefixes_fst(index: &Index) -> String {
     let bytes = words_prefixes_fst.into_fst().as_bytes().to_owned();
     let mut snap = String::new();
     for byte in bytes {
-        write!(&mut snap, "{:x}", byte).unwrap();
+        write!(&mut snap, "{byte:x}").unwrap();
     }
     snap
 }

--- a/crates/milli/src/update/index_documents/enrich.rs
+++ b/crates/milli/src/update/index_documents/enrich.rs
@@ -180,7 +180,7 @@ pub enum DocumentId {
 
 impl DocumentId {
     fn debug(&self) -> String {
-        format!("{:?}", self)
+        format!("{self:?}")
     }
 
     pub fn is_generated(&self) -> bool {
@@ -198,9 +198,9 @@ impl DocumentId {
 impl fmt::Debug for DocumentId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            DocumentId::Retrieved { value } => write!(f, "{:?}", value),
+            DocumentId::Retrieved { value } => write!(f, "{value:?}"),
             DocumentId::Generated { value, document_nth } => {
-                write!(f, "{{{:?}}} of the {}nth document", value, document_nth)
+                write!(f, "{{{value:?}}} of the {document_nth}nth document")
             }
         }
     }

--- a/crates/milli/src/update/index_documents/extract/extract_docid_word_positions.rs
+++ b/crates/milli/src/update/index_documents/extract/extract_docid_word_positions.rs
@@ -260,9 +260,9 @@ fn json_to_string<'a>(value: &'a Value, buffer: &'a mut String) -> Option<&'a st
         use std::fmt::Write;
         match value {
             Value::Null | Value::Object(_) => false,
-            Value::Bool(boolean) => write!(output, "{}", boolean).is_ok(),
-            Value::Number(number) => write!(output, "{}", number).is_ok(),
-            Value::String(string) => write!(output, "{}", string).is_ok(),
+            Value::Bool(boolean) => write!(output, "{boolean}").is_ok(),
+            Value::Number(number) => write!(output, "{number}").is_ok(),
+            Value::String(string) => write!(output, "{string}").is_ok(),
             Value::Array(array) => {
                 let mut count = 0;
                 for value in array {

--- a/crates/milli/src/update/index_documents/mod.rs
+++ b/crates/milli/src/update/index_documents/mod.rs
@@ -3214,8 +3214,7 @@ mod tests {
         for id in results.documents_ids.iter() {
             assert!(
                 !deleted_internal_ids.contains(id),
-                "The document {} was supposed to be deleted",
-                id
+                "The document {id} was supposed to be deleted"
             );
         }
 
@@ -3271,8 +3270,7 @@ mod tests {
         for id in results.documents_ids.iter() {
             assert!(
                 !deleted_internal_ids.contains(id),
-                "The document {} was supposed to be deleted",
-                id
+                "The document {id} was supposed to be deleted"
             );
         }
     }
@@ -3329,8 +3327,7 @@ mod tests {
         for id in results.documents_ids.iter() {
             assert!(
                 !deleted_internal_ids.contains(id),
-                "The document {} was supposed to be deleted",
-                id
+                "The document {id} was supposed to be deleted"
             );
         }
 
@@ -3395,8 +3392,7 @@ mod tests {
             let (id, _) = result.unwrap();
             assert!(
                 !deleted_internal_ids.contains(&id),
-                "The document {} was supposed to be deleted",
-                id
+                "The document {id} was supposed to be deleted"
             );
         }
 
@@ -3405,8 +3401,7 @@ mod tests {
         for id in results {
             assert!(
                 !deleted_internal_ids.contains(&id),
-                "The document {} was supposed to be deleted",
-                id
+                "The document {id} was supposed to be deleted"
             );
         }
 
@@ -3415,8 +3410,7 @@ mod tests {
         for id in deleted_external_ids {
             assert!(
                 results.get(&rtxn, id).unwrap().is_none(),
-                "The document {} was supposed to be deleted",
-                id
+                "The document {id} was supposed to be deleted"
             );
         }
         drop(rtxn);

--- a/crates/milli/src/update/new/extract/mod.rs
+++ b/crates/milli/src/update/new/extract/mod.rs
@@ -63,7 +63,7 @@ pub mod perm_json_p {
             let base_key = if base_key.is_empty() {
                 key.to_string()
             } else {
-                format!("{}{}{}", base_key, SPLIT_SYMBOL, key)
+                format!("{base_key}{SPLIT_SYMBOL}{key}")
             };
 
             let selection = seeker(&base_key, Depth::OnBaseKey, value)?;

--- a/crates/milli/src/update/test_settings.rs
+++ b/crates/milli/src/update/test_settings.rs
@@ -232,7 +232,7 @@ fn set_filterable_fields() {
         let document = document.unwrap();
         let json =
             crate::obkv_to_json(&fidmap.ids().collect::<Vec<_>>(), &fidmap, document.1).unwrap();
-        println!("json: {:?}", json);
+        println!("json: {json:?}");
     }
     let count = index
         .facet_id_f64_docids

--- a/crates/milli/src/vector/json_template.rs
+++ b/crates/milli/src/vector/json_template.rs
@@ -273,7 +273,7 @@ fn expected_component(component: Option<&PathComponent>) -> String {
             format!(r#"an array with at least {} item(s)"#, index.saturating_add(1))
         }
         Some(PathComponent::MapKey(key)) => {
-            format!("an object with key `{}`", key)
+            format!("an object with key `{key}`")
         }
         None => "unknown".to_string(),
     }

--- a/crates/permissive-json-pointer/src/lib.rs
+++ b/crates/permissive-json-pointer/src/lib.rs
@@ -83,7 +83,7 @@ pub fn map_leaf_values_in_object(
         let base_key = if base_key.is_empty() {
             key.to_string()
         } else {
-            format!("{}{}{}", base_key, SPLIT_SYMBOL, key)
+            format!("{base_key}{SPLIT_SYMBOL}{key}")
         };
 
         // here if the user only specified `doggo` we need to iterate in all the fields of `doggo`

--- a/crates/tracing-trace/src/main.rs
+++ b/crates/tracing-trace/src/main.rs
@@ -113,7 +113,7 @@ fn print_extracted_spantraces(error: &(dyn std::error::Error + 'static)) {
         if let Some(spantrace) = err.span_trace() {
             eprintln!("found a spantrace:\n{}", color_spantrace::colorize(spantrace));
         } else {
-            eprintln!("{:>4}: {}", ind, err);
+            eprintln!("{ind:>4}: {err}");
         }
 
         error = err.source();

--- a/crates/xtask/src/bench/assets.rs
+++ b/crates/xtask/src/bench/assets.rs
@@ -99,7 +99,7 @@ pub async fn fetch_assets(
         }
 
         // checking asset store
-        let store_filename = format!("{}/{}", asset_folder, name);
+        let store_filename = format!("{asset_folder}/{name}");
 
         match std::fs::File::open(&store_filename) {
             Ok(file) => {
@@ -148,7 +148,7 @@ fn check_sha256(name: &str, asset: &Asset, mut file: std::fs::File) -> anyhow::R
     let mut file_hash = sha2::Sha256::new();
     file_hash.update(&bytes);
     let file_hash = file_hash.finalize();
-    let file_hash = format!("{:x}", file_hash);
+    let file_hash = format!("{file_hash:x}");
     tracing::debug!(hash = file_hash, "hashed local file");
 
     Ok(match &asset.sha256 {

--- a/crates/xtask/src/bench/client.rs
+++ b/crates/xtask/src/bench/client.rs
@@ -33,7 +33,7 @@ impl Client {
             if route.is_empty() {
                 self.client.request(method, base_url)
             } else {
-                self.client.request(method, format!("{}/{}", base_url, route))
+                self.client.request(method, format!("{base_url}/{route}"))
             }
         } else {
             self.client.request(method, route)

--- a/crates/xtask/src/bench/command.rs
+++ b/crates/xtask/src/bench/command.rs
@@ -124,7 +124,7 @@ async fn wait_for_tasks(client: &Client) -> anyhow::Result<()> {
         match response.get("total") {
             Some(serde_json::Value::Number(number)) => {
                 let number = number.as_u64().with_context(|| {
-                    format!("waiting for tasks: could not parse 'total' as integer, got {}", number)
+                    format!("waiting for tasks: could not parse 'total' as integer, got {number}")
                 })?;
                 if number == 0 {
                     break;
@@ -169,7 +169,7 @@ pub async fn run(
     };
 
     let response =
-        request.send().await.with_context(|| format!("error sending command: {}", command))?;
+        request.send().await.with_context(|| format!("error sending command: {command}"))?;
 
     let code = response.status();
     if code.is_client_error() {


### PR DESCRIPTION
# Pull Request

The PR touches many files but it is mostly about inlining of format!() arguments.
It is produced by running: `cargo +nightly clippy --fix`

There are some more warnings about too big enums (due to too big variant) but those are not addressed!

## Related issue
N/A

## What does this PR do?
- applies suggestions by Clippy from the nightly channel
