### PR TITLE
Searchable fields aren't indexed when I add and remove them out of filterableAttributes

### DIFF
--- a/crates/milli/src/update/index_documents/extract/extract_docid_word_positions.rs
+++ b/crates/milli/src/update/index_documents/extract/extract_docid_word_positions.rs
@@ -29,7 +29,6 @@ pub fn extract_docid_word_positions<R: io::Read + io::Seek>(
     let max_positions_per_attributes = max_positions_per_attributes
         .map_or(MAX_POSITION_PER_ATTRIBUTE, |max| max.min(MAX_POSITION_PER_ATTRIBUTE));
     let max_memory = indexer.max_memory_by_thread();
-    let force_reindexing = settings_diff.reindex_searchable();
 
     // initialize destination values.
     let mut documents_ids = RoaringBitmap::new();
@@ -42,6 +41,12 @@ pub fn extract_docid_word_positions<R: io::Read + io::Seek>(
         max_memory,
         true,
     );
+
+    let force_reindexing = settings_diff.reindex_searchable();
+    let skip_indexing = !force_reindexing && settings_diff.settings_update_only();
+    if skip_indexing {
+        return sorter_into_reader(docid_word_positions_sorter, indexer);
+    }
 
     // initialize buffers.
     let mut del_buffers = Buffers::default();


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #5650

## What does this PR do?
- add a test reproducing the bug
- Skip indexing on settings update when possible,

> when removing a field from the filterable settings,
this will trigger a reindexing of the negative version of the document,
which removes the document from the searchable as well because the field was considered removed.