### PR TITLE
tests: Faster document::errors IT tests

### DIFF
--- a/crates/meilisearch/tests/documents/errors.rs
+++ b/crates/meilisearch/tests/documents/errors.rs
@@ -621,7 +621,7 @@ async fn delete_document_by_filter() {
     let (response, code) =
         index.delete_document_by_filter_fail(json!({ "filter": "catto = jorts"})).await;
     snapshot!(code, @"202 Accepted");
-    let response = server.wait_task(response.uid()).await;
+    let response = server.wait_task(response.uid()).await.failed();
     snapshot!(response, @r###"
     {
       "uid": "[uid]",
@@ -665,7 +665,7 @@ async fn fetch_document_by_filter() {
             Some("id"),
         )
         .await;
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = index.fetch_documents(json!(null)).await;
     snapshot!(code, @"400 Bad Request");


### PR DESCRIPTION
# Pull Request

## Related issue
#4840

## What does this PR do?
* Add a call to .failed() for an awaited task
* Use Server::wait_task() instead of Index::wait_task() - it has better error checking

The tests already use the shared server!