### PR TITLE
Remove old dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3744,7 +3744,6 @@ dependencies = [
  "actix-web-lab",
  "anyhow",
  "async-openai",
- "async-trait",
  "brotli",
  "bstr",
  "build-info",
@@ -3969,7 +3968,6 @@ dependencies = [
  "ordered-float 5.0.0",
  "rand 0.8.5",
  "rayon",
- "rayon-par-bridge",
  "rhai",
  "roaring",
  "rstar",
@@ -3987,7 +3985,6 @@ dependencies = [
  "time",
  "tokenizers",
  "tracing",
- "uell",
  "ureq",
  "url",
  "utoipa",
@@ -5000,15 +4997,6 @@ checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
-]
-
-[[package]]
-name = "rayon-par-bridge"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6a14d8f65834aca6b0fe4cbbd7a27e639cd3efb1f2a32de9942368f1991de8"
-dependencies = [
- "rayon",
 ]
 
 [[package]]
@@ -6456,15 +6444,6 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
-
-[[package]]
-name = "uell"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40de5982e28612e20330e77d81f1559b74f66caf3c7fc10b19ada4843f4b4fd7"
-dependencies = [
- "bumpalo",
-]
 
 [[package]]
 name = "ug"

--- a/crates/meilisearch/Cargo.toml
+++ b/crates/meilisearch/Cargo.toml
@@ -28,7 +28,6 @@ actix-web = { version = "4.11.0", default-features = false, features = [
     "rustls-0_23",
 ] }
 anyhow = { version = "1.0.98", features = ["backtrace"] }
-async-trait = "0.1.88"
 bstr = "1.12.0"
 byte-unit = { version = "5.1.6", features = ["serde"] }
 bytes = "1.10.1"

--- a/crates/milli/Cargo.toml
+++ b/crates/milli/Cargo.toml
@@ -92,14 +92,12 @@ rand = "0.8.5"
 tracing = "0.1.41"
 ureq = { version = "2.12.1", features = ["json"] }
 url = "2.5.4"
-rayon-par-bridge = "0.1.0"
 hashbrown = "0.15.4"
 bumpalo = "3.18.1"
 bumparaw-collections = "0.1.4"
 thread_local = "1.1.9"
 allocator-api2 = "0.3.0"
 rustc-hash = "2.1.1"
-uell = "0.1.0"
 enum-iterator = "2.1.0"
 bbqueue = { git = "https://github.com/meilisearch/bbqueue" }
 flume = { version = "0.11.1", default-features = false }


### PR DESCRIPTION
# Pull Request

I think I have found at least 3 unnecessary dependencies among the crates of this repository.

- uell
- rayon-par-bridge
- async-trait

I also found a number of seemingly unnecessary dependencies. However, I am less certain that they are useless as they are also depended on indirectly anyway. Since specifying their versions might have been intentional and I don't want to break anything on my first day, I did not include them in this PR. All tests pass without them though, so here is the list for reference: 

dump:
- anyhow

fuzzers:
- serde

index-scheduler:
- bincode
- bumparaw-collections
- csv
- derive_builder

meilisearch-auth:
- roaring

meilisearch-types:
- either
- tokio

xtask:
- futures-core

milli:
- allocator-api2

meilisearch:
- actix-utils
- fst
- ordered-float
- parking_lot
- rayon
- rustls-pki-types
- sha2
- siphasher
- slice-group-by
- tar

## Related issue
N/A

## What does this PR do?
- ...

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
