### PR TITLE
Fix Gemini base_url when used with OpenAI clients

### DIFF
--- a/crates/meilisearch-types/src/features.rs
+++ b/crates/meilisearch-types/src/features.rs
@@ -154,7 +154,7 @@ impl ChatCompletionSource {
         match self {
             OpenAi => Some("https://api.openai.com/v1/"),
             Mistral => Some("https://api.mistral.ai/v1/"),
-            Gemini => Some("https://generativelanguage.googleapis.com/v1beta/openai/"),
+            Gemini => Some("https://generativelanguage.googleapis.com/v1beta/openai"),
             AzureOpenAi | VLlm => None,
         }
     }


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #5684

## What does this PR do?
- Just updates the Gemini base_url that is used with OpenAI libraries.

