### PR TITLE
Add a Read-Only Admin API Key by default

### DIFF
--- a/crates/meilisearch-auth/src/lib.rs
+++ b/crates/meilisearch-auth/src/lib.rs
@@ -158,7 +158,7 @@ impl AuthController {
         self.store.delete_all_keys()
     }
 
-    /// Delete all the keys in the DB.
+    /// Insert a key directly into the store.
     pub fn raw_insert_key(&mut self, key: Key) -> Result<()> {
         self.store.put_api_key(key)?;
         Ok(())
@@ -353,6 +353,7 @@ fn generate_default_keys(store: &HeedAuthStore) -> Result<()> {
     store.put_api_key(Key::default_chat())?;
     store.put_api_key(Key::default_admin())?;
     store.put_api_key(Key::default_search())?;
+    store.put_api_key(Key::default_management())?;
 
     Ok(())
 }

--- a/crates/meilisearch-auth/src/lib.rs
+++ b/crates/meilisearch-auth/src/lib.rs
@@ -351,9 +351,9 @@ pub struct IndexSearchRules {
 
 fn generate_default_keys(store: &HeedAuthStore) -> Result<()> {
     store.put_api_key(Key::default_chat())?;
+    store.put_api_key(Key::default_management())?;
     store.put_api_key(Key::default_admin())?;
     store.put_api_key(Key::default_search())?;
-    store.put_api_key(Key::default_management())?;
 
     Ok(())
 }

--- a/crates/meilisearch-auth/src/store.rs
+++ b/crates/meilisearch-auth/src/store.rs
@@ -89,7 +89,7 @@ impl HeedAuthStore {
         for action in &key.actions {
             match action {
                 Action::All => actions.extend(enum_iterator::all::<Action>()),
-                Action::AllRead => actions.extend(enum_iterator::all::<Action>().filter(|a| a.is_read())),
+                Action::AllGet => actions.extend(enum_iterator::all::<Action>().filter(|a| a.is_read())),
                 Action::DocumentsAll => {
                     actions.extend(
                         [Action::DocumentsGet, Action::DocumentsDelete, Action::DocumentsAdd]

--- a/crates/meilisearch-auth/src/store.rs
+++ b/crates/meilisearch-auth/src/store.rs
@@ -89,6 +89,7 @@ impl HeedAuthStore {
         for action in &key.actions {
             match action {
                 Action::All => actions.extend(enum_iterator::all::<Action>()),
+                Action::AllRead => actions.extend(enum_iterator::all::<Action>().filter(|a| a.is_read())),
                 Action::DocumentsAll => {
                     actions.extend(
                         [Action::DocumentsGet, Action::DocumentsDelete, Action::DocumentsAdd]

--- a/crates/meilisearch-auth/src/store.rs
+++ b/crates/meilisearch-auth/src/store.rs
@@ -88,7 +88,10 @@ impl HeedAuthStore {
         let mut actions = HashSet::new();
         for action in &key.actions {
             match action {
-                Action::All => actions.extend(enum_iterator::all::<Action>()),
+                Action::All => {
+                    actions.extend(enum_iterator::all::<Action>());
+                    actions.remove(&Action::AllGet);
+                },
                 Action::AllGet => actions.extend(enum_iterator::all::<Action>().filter(|a| a.is_read())),
                 Action::DocumentsAll => {
                     actions.extend(

--- a/crates/meilisearch-types/src/keys.rs
+++ b/crates/meilisearch-types/src/keys.rs
@@ -131,7 +131,7 @@ pub struct Key {
 impl Key {
     pub fn default_admin() -> Self {
         let now = OffsetDateTime::now_utc();
-        let uid = Uuid::from_u128(0);
+        let uid = Uuid::new_v4();
         Self {
             name: Some("Default Admin API Key".to_string()),
             description: Some("Use it for anything that is not a search operation. Caution! Do not expose it on a public frontend".to_string()),
@@ -146,7 +146,7 @@ impl Key {
 
     pub fn default_management() -> Self {
         let now = OffsetDateTime::now_utc();
-        let uid = Uuid::from_u128(1);
+        let uid = Uuid::new_v4();
         Self {
             name: Some("Default Read-Only Admin API Key".to_string()),
             description: Some("Use it to peek into the instance in a read-only mode. Caution! Do not expose it on a public frontend. It would give access to all other keys".to_string()),
@@ -161,7 +161,7 @@ impl Key {
 
     pub fn default_search() -> Self {
         let now = OffsetDateTime::now_utc();
-        let uid = Uuid::from_u128(2);
+        let uid = Uuid::new_v4();
         Self {
             name: Some("Default Search API Key".to_string()),
             description: Some("Use it to search from the frontend".to_string()),
@@ -176,7 +176,7 @@ impl Key {
 
     pub fn default_chat() -> Self {
         let now = OffsetDateTime::now_utc();
-        let uid = Uuid::from_u128(3);
+        let uid = Uuid::new_v4();
         Self {
             name: Some("Default Chat API Key".to_string()),
             description: Some("Use it to chat and search from the frontend".to_string()),

--- a/crates/meilisearch-types/src/keys.rs
+++ b/crates/meilisearch-types/src/keys.rs
@@ -144,6 +144,21 @@ impl Key {
         }
     }
 
+    pub fn default_management() -> Self {
+        let now = OffsetDateTime::now_utc();
+        let uid = Uuid::new_v4();
+        Self {
+            name: Some("Default Management API Key".to_string()),
+            description: Some("Use it to peek into the instance in a read-only mode. Caution! Do not expose it on a public frontend".to_string()),
+            uid,
+            actions: vec![Action::AllRead],
+            indexes: vec![IndexUidPattern::all()],
+            expires_at: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
     pub fn default_search() -> Self {
         let now = OffsetDateTime::now_utc();
         let uid = Uuid::new_v4();
@@ -453,6 +468,7 @@ pub mod actions {
     use super::Action::*;
 
     pub(crate) const ALL: u8 = All.repr();
+    pub const ALL_READ: u8 = AllRead.repr();
     pub const SEARCH: u8 = Search.repr();
     pub const DOCUMENTS_ALL: u8 = DocumentsAll.repr();
     pub const DOCUMENTS_ADD: u8 = DocumentsAdd.repr();

--- a/crates/meilisearch-types/src/keys.rs
+++ b/crates/meilisearch-types/src/keys.rs
@@ -233,8 +233,8 @@ pub enum Action {
     #[serde(rename = "*")]
     #[deserr(rename = "*")]
     All = 0,
-    #[serde(rename = "*.read")]
-    #[deserr(rename = "*.read")]
+    #[serde(rename = "*.get")]
+    #[deserr(rename = "*.get")]
     AllRead,
     #[serde(rename = "search")]
     #[deserr(rename = "search")]

--- a/crates/meilisearch-types/src/keys.rs
+++ b/crates/meilisearch-types/src/keys.rs
@@ -218,6 +218,9 @@ pub enum Action {
     #[serde(rename = "*")]
     #[deserr(rename = "*")]
     All = 0,
+    #[serde(rename = "*.read")]
+    #[deserr(rename = "*.read")]
+    AllRead,
     #[serde(rename = "search")]
     #[deserr(rename = "search")]
     Search,
@@ -393,6 +396,51 @@ impl Action {
             NETWORK_GET => Some(Self::NetworkGet),
             NETWORK_UPDATE => Some(Self::NetworkUpdate),
             _otherwise => None,
+        }
+    }
+
+    /// Whether the action should be included in [Action::AllRead].
+    pub fn is_read(&self) -> bool {
+        use Action::*;
+
+        // It's using an exhaustive match to force the addition of new actions.
+        match self {
+            // Any action that expands to others must return false, as it wouldn't be able to expand recursively.
+            All | AllRead | DocumentsAll | IndexesAll | ChatsAll | TasksAll | SettingsAll
+                | StatsAll | MetricsAll | DumpsAll | SnapshotsAll | ChatsSettingsAll => false,
+
+            Search => true,
+            DocumentsAdd => false,
+            DocumentsGet => true,
+            DocumentsDelete => false,
+            IndexesAdd => false,
+            IndexesGet => true,
+            IndexesUpdate => false,
+            IndexesDelete => false,
+            IndexesSwap => false,
+            TasksCancel => false,
+            TasksDelete => false,
+            TasksGet => true,
+            SettingsGet => true,
+            SettingsUpdate => false,
+            StatsGet => true,
+            MetricsGet => true,
+            DumpsCreate => false,
+            SnapshotsCreate => false,
+            Version => true,
+            KeysAdd => false,
+            KeysGet => false, // Prevent privilege escalation by not allowing reading other keys.
+            KeysUpdate => false,
+            KeysDelete => false,
+            ExperimentalFeaturesGet => true,
+            ExperimentalFeaturesUpdate => false,
+            NetworkGet => true,
+            NetworkUpdate => false,
+            ChatCompletions => false, // Disabled because it might trigger generation of new chats.
+            ChatsGet => true,
+            ChatsDelete => false,
+            ChatsSettingsGet => true,
+            ChatsSettingsUpdate => false,
         }
     }
 

--- a/crates/meilisearch-types/src/keys.rs
+++ b/crates/meilisearch-types/src/keys.rs
@@ -148,8 +148,8 @@ impl Key {
         let now = OffsetDateTime::now_utc();
         let uid = Uuid::from_u128(1);
         Self {
-            name: Some("Read-only Admin key".to_string()),
-            description: Some("Use it to peek into the instance in a read-only mode. Caution! Do not expose it on a public frontend".to_string()),
+            name: Some("Default Read-Only Admin API Key".to_string()),
+            description: Some("Use it to peek into the instance in a read-only mode. Caution! Do not expose it on a public frontend. It would give access to all other keys".to_string()),
             uid,
             actions: vec![Action::AllRead],
             indexes: vec![IndexUidPattern::all()],
@@ -444,7 +444,7 @@ impl Action {
             SnapshotsCreate => false,
             Version => true,
             KeysAdd => false,
-            KeysGet => false, // Prevent privilege escalation by not allowing reading other keys.
+            KeysGet => true,
             KeysUpdate => false,
             KeysDelete => false,
             ExperimentalFeaturesGet => true,

--- a/crates/meilisearch-types/src/keys.rs
+++ b/crates/meilisearch-types/src/keys.rs
@@ -151,7 +151,7 @@ impl Key {
             name: Some("Default Read-Only Admin API Key".to_string()),
             description: Some("Use it to peek into the instance in a read-only mode. Caution! Do not expose it on a public frontend. It would give access to all other keys".to_string()),
             uid,
-            actions: vec![Action::AllRead],
+            actions: vec![Action::AllGet],
             indexes: vec![IndexUidPattern::all()],
             expires_at: None,
             created_at: now,
@@ -235,7 +235,7 @@ pub enum Action {
     All = 0,
     #[serde(rename = "*.get")]
     #[deserr(rename = "*.get")]
-    AllRead,
+    AllGet,
     #[serde(rename = "search")]
     #[deserr(rename = "search")]
     Search,
@@ -421,7 +421,7 @@ impl Action {
         // It's using an exhaustive match to force the addition of new actions.
         match self {
             // Any action that expands to others must return false, as it wouldn't be able to expand recursively.
-            All | AllRead | DocumentsAll | IndexesAll | ChatsAll | TasksAll | SettingsAll
+            All | AllGet | DocumentsAll | IndexesAll | ChatsAll | TasksAll | SettingsAll
                 | StatsAll | MetricsAll | DumpsAll | SnapshotsAll | ChatsSettingsAll => false,
 
             Search => true,
@@ -468,7 +468,7 @@ pub mod actions {
     use super::Action::*;
 
     pub(crate) const ALL: u8 = All.repr();
-    pub const ALL_READ: u8 = AllRead.repr();
+    pub const ALL_READ: u8 = AllGet.repr();
     pub const SEARCH: u8 = Search.repr();
     pub const DOCUMENTS_ALL: u8 = DocumentsAll.repr();
     pub const DOCUMENTS_ADD: u8 = DocumentsAdd.repr();

--- a/crates/meilisearch-types/src/keys.rs
+++ b/crates/meilisearch-types/src/keys.rs
@@ -131,7 +131,7 @@ pub struct Key {
 impl Key {
     pub fn default_admin() -> Self {
         let now = OffsetDateTime::now_utc();
-        let uid = Uuid::new_v4();
+        let uid = Uuid::from_u128(0);
         Self {
             name: Some("Default Admin API Key".to_string()),
             description: Some("Use it for anything that is not a search operation. Caution! Do not expose it on a public frontend".to_string()),
@@ -146,9 +146,9 @@ impl Key {
 
     pub fn default_management() -> Self {
         let now = OffsetDateTime::now_utc();
-        let uid = Uuid::new_v4();
+        let uid = Uuid::from_u128(1);
         Self {
-            name: Some("Default Management API Key".to_string()),
+            name: Some("Read-only Admin key".to_string()),
             description: Some("Use it to peek into the instance in a read-only mode. Caution! Do not expose it on a public frontend".to_string()),
             uid,
             actions: vec![Action::AllRead],
@@ -161,7 +161,7 @@ impl Key {
 
     pub fn default_search() -> Self {
         let now = OffsetDateTime::now_utc();
-        let uid = Uuid::new_v4();
+        let uid = Uuid::from_u128(2);
         Self {
             name: Some("Default Search API Key".to_string()),
             description: Some("Use it to search from the frontend".to_string()),
@@ -176,7 +176,7 @@ impl Key {
 
     pub fn default_chat() -> Self {
         let now = OffsetDateTime::now_utc();
-        let uid = Uuid::new_v4();
+        let uid = Uuid::from_u128(3);
         Self {
             name: Some("Default Chat API Key".to_string()),
             description: Some("Use it to chat and search from the frontend".to_string()),

--- a/crates/meilisearch/tests/auth/api_keys.rs
+++ b/crates/meilisearch/tests/auth/api_keys.rs
@@ -790,7 +790,7 @@ async fn list_api_keys() {
     meili_snap::snapshot!(code, @"201 Created");
 
     let (response, code) = server.list_api_keys("").await;
-    meili_snap::snapshot!(meili_snap::json_string!(response, { ".results[].createdAt" => "[ignored]", ".results[].updatedAt" => "[ignored]", ".results[].uid" => "[ignored]", ".results[].key" => "[ignored]" }), @r###"
+    meili_snap::snapshot!(meili_snap::json_string!(response, { ".results[].createdAt" => "[ignored]", ".results[].updatedAt" => "[ignored]", ".results[0].uid" => "[ignored]", ".results[].key" => "[ignored]" }), @r#"
     {
       "results": [
         {
@@ -824,7 +824,7 @@ async fn list_api_keys() {
           "name": "Default Search API Key",
           "description": "Use it to search from the frontend",
           "key": "[ignored]",
-          "uid": "[ignored]",
+          "uid": "00000000-0000-0000-0000-000000000002",
           "actions": [
             "search"
           ],
@@ -839,9 +839,24 @@ async fn list_api_keys() {
           "name": "Default Admin API Key",
           "description": "Use it for anything that is not a search operation. Caution! Do not expose it on a public frontend",
           "key": "[ignored]",
-          "uid": "[ignored]",
+          "uid": "00000000-0000-0000-0000-000000000000",
           "actions": [
             "*"
+          ],
+          "indexes": [
+            "*"
+          ],
+          "expiresAt": null,
+          "createdAt": "[ignored]",
+          "updatedAt": "[ignored]"
+        },
+        {
+          "name": "Default Read-Only Admin API Key",
+          "description": "Use it to peek into the instance in a read-only mode. Caution! Do not expose it on a public frontend. It would give access to all other keys",
+          "key": "[ignored]",
+          "uid": "00000000-0000-0000-0000-000000000001",
+          "actions": [
+            "*.get"
           ],
           "indexes": [
             "*"
@@ -854,7 +869,7 @@ async fn list_api_keys() {
           "name": "Default Chat API Key",
           "description": "Use it to chat and search from the frontend",
           "key": "[ignored]",
-          "uid": "[ignored]",
+          "uid": "00000000-0000-0000-0000-000000000003",
           "actions": [
             "chatCompletions",
             "search"
@@ -869,9 +884,9 @@ async fn list_api_keys() {
       ],
       "offset": 0,
       "limit": 20,
-      "total": 4
+      "total": 5
     }
-    "###);
+    "#);
     meili_snap::snapshot!(code, @"200 OK");
 }
 

--- a/crates/meilisearch/tests/auth/api_keys.rs
+++ b/crates/meilisearch/tests/auth/api_keys.rs
@@ -790,7 +790,7 @@ async fn list_api_keys() {
     meili_snap::snapshot!(code, @"201 Created");
 
     let (response, code) = server.list_api_keys("").await;
-    meili_snap::snapshot!(meili_snap::json_string!(response, { ".results[].createdAt" => "[ignored]", ".results[].updatedAt" => "[ignored]", ".results[0].uid" => "[ignored]", ".results[].key" => "[ignored]" }), @r#"
+    meili_snap::snapshot!(meili_snap::json_string!(response, { ".results[].createdAt" => "[ignored]", ".results[].updatedAt" => "[ignored]", ".results[].uid" => "[ignored]", ".results[].key" => "[ignored]" }), @r#"
     {
       "results": [
         {
@@ -824,7 +824,7 @@ async fn list_api_keys() {
           "name": "Default Search API Key",
           "description": "Use it to search from the frontend",
           "key": "[ignored]",
-          "uid": "00000000-0000-0000-0000-000000000002",
+          "uid": "[ignored]",
           "actions": [
             "search"
           ],
@@ -839,7 +839,7 @@ async fn list_api_keys() {
           "name": "Default Admin API Key",
           "description": "Use it for anything that is not a search operation. Caution! Do not expose it on a public frontend",
           "key": "[ignored]",
-          "uid": "00000000-0000-0000-0000-000000000000",
+          "uid": "[ignored]",
           "actions": [
             "*"
           ],
@@ -854,7 +854,7 @@ async fn list_api_keys() {
           "name": "Default Read-Only Admin API Key",
           "description": "Use it to peek into the instance in a read-only mode. Caution! Do not expose it on a public frontend. It would give access to all other keys",
           "key": "[ignored]",
-          "uid": "00000000-0000-0000-0000-000000000001",
+          "uid": "[ignored]",
           "actions": [
             "*.get"
           ],
@@ -869,7 +869,7 @@ async fn list_api_keys() {
           "name": "Default Chat API Key",
           "description": "Use it to chat and search from the frontend",
           "key": "[ignored]",
-          "uid": "00000000-0000-0000-0000-000000000003",
+          "uid": "[ignored]",
           "actions": [
             "chatCompletions",
             "search"

--- a/crates/meilisearch/tests/auth/api_keys.rs
+++ b/crates/meilisearch/tests/auth/api_keys.rs
@@ -419,14 +419,14 @@ async fn error_add_api_key_invalid_parameters_actions() {
     let (response, code) = server.add_api_key(content).await;
 
     meili_snap::snapshot!(code, @"400 Bad Request");
-    meili_snap::snapshot!(meili_snap::json_string!(response, { ".createdAt" => "[ignored]", ".updatedAt" => "[ignored]" }), @r###"
+    meili_snap::snapshot!(meili_snap::json_string!(response, { ".createdAt" => "[ignored]", ".updatedAt" => "[ignored]" }), @r#"
     {
-      "message": "Unknown value `doc.add` at `.actions[0]`: expected one of `*`, `search`, `documents.*`, `documents.add`, `documents.get`, `documents.delete`, `indexes.*`, `indexes.create`, `indexes.get`, `indexes.update`, `indexes.delete`, `indexes.swap`, `tasks.*`, `tasks.cancel`, `tasks.delete`, `tasks.get`, `settings.*`, `settings.get`, `settings.update`, `stats.*`, `stats.get`, `metrics.*`, `metrics.get`, `dumps.*`, `dumps.create`, `snapshots.*`, `snapshots.create`, `version`, `keys.create`, `keys.get`, `keys.update`, `keys.delete`, `experimental.get`, `experimental.update`, `network.get`, `network.update`, `chatCompletions`, `chats.*`, `chats.get`, `chats.delete`, `chatsSettings.*`, `chatsSettings.get`, `chatsSettings.update`",
+      "message": "Unknown value `doc.add` at `.actions[0]`: expected one of `*`, `*.get`, `search`, `documents.*`, `documents.add`, `documents.get`, `documents.delete`, `indexes.*`, `indexes.create`, `indexes.get`, `indexes.update`, `indexes.delete`, `indexes.swap`, `tasks.*`, `tasks.cancel`, `tasks.delete`, `tasks.get`, `settings.*`, `settings.get`, `settings.update`, `stats.*`, `stats.get`, `metrics.*`, `metrics.get`, `dumps.*`, `dumps.create`, `snapshots.*`, `snapshots.create`, `version`, `keys.create`, `keys.get`, `keys.update`, `keys.delete`, `experimental.get`, `experimental.update`, `network.get`, `network.update`, `chatCompletions`, `chats.*`, `chats.get`, `chats.delete`, `chatsSettings.*`, `chatsSettings.get`, `chatsSettings.update`",
       "code": "invalid_api_key_actions",
       "type": "invalid_request",
       "link": "https://docs.meilisearch.com/errors#invalid_api_key_actions"
     }
-    "###);
+    "#);
 }
 
 #[actix_rt::test]

--- a/crates/meilisearch/tests/auth/errors.rs
+++ b/crates/meilisearch/tests/auth/errors.rs
@@ -91,14 +91,14 @@ async fn create_api_key_bad_actions() {
     // can't parse
     let (response, code) = server.add_api_key(json!({ "actions": ["doggo"] })).await;
     snapshot!(code, @"400 Bad Request");
-    snapshot!(json_string!(response), @r###"
+    snapshot!(json_string!(response), @r#"
     {
-      "message": "Unknown value `doggo` at `.actions[0]`: expected one of `*`, `search`, `documents.*`, `documents.add`, `documents.get`, `documents.delete`, `indexes.*`, `indexes.create`, `indexes.get`, `indexes.update`, `indexes.delete`, `indexes.swap`, `tasks.*`, `tasks.cancel`, `tasks.delete`, `tasks.get`, `settings.*`, `settings.get`, `settings.update`, `stats.*`, `stats.get`, `metrics.*`, `metrics.get`, `dumps.*`, `dumps.create`, `snapshots.*`, `snapshots.create`, `version`, `keys.create`, `keys.get`, `keys.update`, `keys.delete`, `experimental.get`, `experimental.update`, `network.get`, `network.update`, `chatCompletions`, `chats.*`, `chats.get`, `chats.delete`, `chatsSettings.*`, `chatsSettings.get`, `chatsSettings.update`",
+      "message": "Unknown value `doggo` at `.actions[0]`: expected one of `*`, `*.get`, `search`, `documents.*`, `documents.add`, `documents.get`, `documents.delete`, `indexes.*`, `indexes.create`, `indexes.get`, `indexes.update`, `indexes.delete`, `indexes.swap`, `tasks.*`, `tasks.cancel`, `tasks.delete`, `tasks.get`, `settings.*`, `settings.get`, `settings.update`, `stats.*`, `stats.get`, `metrics.*`, `metrics.get`, `dumps.*`, `dumps.create`, `snapshots.*`, `snapshots.create`, `version`, `keys.create`, `keys.get`, `keys.update`, `keys.delete`, `experimental.get`, `experimental.update`, `network.get`, `network.update`, `chatCompletions`, `chats.*`, `chats.get`, `chats.delete`, `chatsSettings.*`, `chatsSettings.get`, `chatsSettings.update`",
       "code": "invalid_api_key_actions",
       "type": "invalid_request",
       "link": "https://docs.meilisearch.com/errors#invalid_api_key_actions"
     }
-    "###);
+    "#);
 }
 
 #[actix_rt::test]

--- a/crates/meilisearch/tests/common/server.rs
+++ b/crates/meilisearch/tests/common/server.rs
@@ -97,6 +97,7 @@ impl Server<Owned> {
         self.use_api_key(master_key);
         let (response, code) = self.list_api_keys("").await;
         assert_eq!(200, code, "{:?}", response);
+        // TODO: relying on the order of keys is not ideal, we should use the static uuid
         let admin_key = &response["results"][1]["key"];
         self.use_api_key(admin_key.as_str().unwrap());
     }


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes N/A

## What does this PR do?

This PR introduces a new kind of API key that will allow peeking into an instance without resorting to the master key, thus avoiding the risk of altering data.
This is a kind of "Read-Only Admin API Key."

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?
