### PR TITLE
tests: Use Server::wait_task() instead of Index::wait_task() in documents::

### DIFF
--- a/crates/meilisearch/tests/documents/add_documents.rs
+++ b/crates/meilisearch/tests/documents/add_documents.rs
@@ -293,7 +293,7 @@ async fn add_csv_document() {
       "enqueuedAt": "[date]"
     }
     "#);
-    let response = index.wait_task(response.uid()).await.succeeded();
+    let response = server.wait_task(response.uid()).await.succeeded();
     snapshot!(json_string!(response, { ".uid" => "[uid]", ".batchUid" => "[batch_uid]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]", ".duration" => "[duration]" }), @r###"
     {
       "uid": "[uid]",
@@ -358,7 +358,7 @@ async fn add_csv_document_with_types() {
       "enqueuedAt": "[date]"
     }
     "#);
-    let response = index.wait_task(response.uid()).await.succeeded();
+    let response = server.wait_task(response.uid()).await.succeeded();
     snapshot!(json_string!(response, { ".uid" => "[uid]", ".batchUid" => "[batch_uid]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]", ".duration" => "[duration]" }), @r###"
     {
       "uid": "[uid]",
@@ -434,7 +434,7 @@ async fn add_csv_document_with_custom_delimiter() {
       "enqueuedAt": "[date]"
     }
     "#);
-    let response = index.wait_task(response.uid()).await.succeeded();
+    let response = server.wait_task(response.uid()).await.succeeded();
     snapshot!(json_string!(response, { ".uid" => "[uid]", ".batchUid" => "[batch_uid]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]", ".duration" => "[duration]" }), @r###"
     {
       "uid": "[uid]",
@@ -991,7 +991,7 @@ async fn add_documents_no_index_creation() {
     let (response, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
 
-    let response = index.wait_task(response.uid()).await.succeeded();
+    let response = server.wait_task(response.uid()).await.succeeded();
     snapshot!(code, @"202 Accepted");
     snapshot!(response,
         @r###"
@@ -1068,7 +1068,7 @@ async fn document_addition_with_primary_key() {
     }
     "#);
 
-    index.wait_task(response.uid()).await.succeeded();
+    server.wait_task(response.uid()).await.succeeded();
 
     let (response, code) = index.get_task(response.uid()).await;
     snapshot!(code, @"200 OK");
@@ -1120,7 +1120,7 @@ async fn document_addition_with_huge_int_primary_key() {
     let (response, code) = index.add_documents(documents, Some("primary")).await;
     snapshot!(code, @"202 Accepted");
 
-    let response = index.wait_task(response.uid()).await.succeeded();
+    let response = server.wait_task(response.uid()).await.succeeded();
     snapshot!(response,
         @r###"
     {
@@ -1178,7 +1178,7 @@ async fn replace_document() {
     }
     "#);
 
-    index.wait_task(response.uid()).await.succeeded();
+    server.wait_task(response.uid()).await.succeeded();
 
     let documents = json!([
         {
@@ -1190,7 +1190,7 @@ async fn replace_document() {
     let (task, code) = index.add_documents(documents, None).await;
     snapshot!(code,@"202 Accepted");
 
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
@@ -1362,7 +1362,7 @@ async fn error_add_documents_bad_document_id() {
         }
     ]);
     let (task, _status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await.failed();
+    server.wait_task(task.uid()).await.failed();
     let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".uid" => "[uid]", ".batchUid" => "[batch_uid]", ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
@@ -1399,7 +1399,7 @@ async fn error_add_documents_bad_document_id() {
         }
     ]);
     let (value, _code) = index.add_documents(documents, None).await;
-    index.wait_task(value.uid()).await.failed();
+    server.wait_task(value.uid()).await.failed();
     let (response, code) = index.get_task(value.uid()).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".uid" => "[uid]", ".batchUid" => "[batch_uid]", ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
@@ -1436,7 +1436,7 @@ async fn error_add_documents_bad_document_id() {
         }
     ]);
     let (value, _code) = index.add_documents(documents, None).await;
-    index.wait_task(value.uid()).await.failed();
+    server.wait_task(value.uid()).await.failed();
     let (response, code) = index.get_task(value.uid()).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".uid" => "[uid]", ".batchUid" => "[batch_uid]", ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
@@ -1478,7 +1478,7 @@ async fn error_add_documents_missing_document_id() {
         }
     ]);
     let (task, _status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await.failed();
+    server.wait_task(task.uid()).await.failed();
     let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".uid" => "[uid]", ".batchUid" => "[batch_uid]", ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
@@ -1527,7 +1527,7 @@ async fn error_document_field_limit_reached_in_one_document() {
     let (response, code) = index.update_documents(documents, Some("id")).await;
     snapshot!(code, @"202 Accepted");
 
-    let response = index.wait_task(response.uid()).await.failed();
+    let response = server.wait_task(response.uid()).await.failed();
     snapshot!(code, @"202 Accepted");
     // Documents without a primary key are not accepted.
     snapshot!(response,
@@ -1576,7 +1576,7 @@ async fn error_document_field_limit_reached_over_multiple_documents() {
     let (response, code) = index.update_documents(documents, Some("id")).await;
     snapshot!(code, @"202 Accepted");
 
-    let response = index.wait_task(response.uid()).await.succeeded();
+    let response = server.wait_task(response.uid()).await.succeeded();
     snapshot!(code, @"202 Accepted");
     snapshot!(response,
         @r###"
@@ -1611,7 +1611,7 @@ async fn error_document_field_limit_reached_over_multiple_documents() {
     let (response, code) = index.update_documents(documents, Some("id")).await;
     snapshot!(code, @"202 Accepted");
 
-    let response = index.wait_task(response.uid()).await.failed();
+    let response = server.wait_task(response.uid()).await.failed();
     snapshot!(code, @"202 Accepted");
     snapshot!(response,
         @r###"
@@ -1660,7 +1660,7 @@ async fn error_document_field_limit_reached_in_one_nested_document() {
     let (response, code) = index.update_documents(documents, Some("id")).await;
     snapshot!(code, @"202 Accepted");
 
-    let response = index.wait_task(response.uid()).await.succeeded();
+    let response = server.wait_task(response.uid()).await.succeeded();
     snapshot!(code, @"202 Accepted");
     // Documents without a primary key are not accepted.
     snapshot!(response,
@@ -1705,7 +1705,7 @@ async fn error_document_field_limit_reached_over_multiple_documents_with_nested_
     let (response, code) = index.update_documents(documents, Some("id")).await;
     snapshot!(code, @"202 Accepted");
 
-    let response = index.wait_task(response.uid()).await.succeeded();
+    let response = server.wait_task(response.uid()).await.succeeded();
     snapshot!(code, @"202 Accepted");
     snapshot!(response,
         @r###"
@@ -1741,7 +1741,7 @@ async fn error_document_field_limit_reached_over_multiple_documents_with_nested_
     let (response, code) = index.update_documents(documents, Some("id")).await;
     snapshot!(code, @"202 Accepted");
 
-    let response = index.wait_task(response.uid()).await.succeeded();
+    let response = server.wait_task(response.uid()).await.succeeded();
     snapshot!(code, @"202 Accepted");
     snapshot!(response,
         @r###"
@@ -1790,7 +1790,7 @@ async fn add_documents_with_geo_field() {
     ]);
 
     let (task, _status_code) = index.add_documents(documents, None).await;
-    let response = index.wait_task(task.uid()).await.succeeded();
+    let response = server.wait_task(task.uid()).await.succeeded();
     snapshot!(json_string!(response, { ".uid" => "[uid]", ".batchUid" => "[batch_uid]", ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
         @r#"
     {
@@ -1914,7 +1914,7 @@ async fn update_documents_with_geo_field() {
     ]);
 
     let (task, _status_code) = index.add_documents(documents, None).await;
-    let response = index.wait_task(task.uid()).await.succeeded();
+    let response = server.wait_task(task.uid()).await.succeeded();
     snapshot!(json_string!(response, { ".uid" => "[uid]", ".batchUid" => "[batch_uid]", ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
         @r#"
     {
@@ -1983,7 +1983,7 @@ async fn update_documents_with_geo_field() {
         }
     ]);
     let (task, _status_code) = index.update_documents(updated_documents, None).await;
-    let response = index.wait_task(task.uid()).await.succeeded();
+    let response = server.wait_task(task.uid()).await.succeeded();
     snapshot!(json_string!(response, { ".uid" => "[uid]", ".batchUid" => "[batch_uid]", ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
         @r###"
     {
@@ -2097,7 +2097,7 @@ async fn add_documents_invalid_geo_field() {
     ]);
 
     let (task, _status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await.failed();
+    server.wait_task(task.uid()).await.failed();
     let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".uid" => "[uid]", ".batchUid" => "[batch_uid]", ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]", ".indexUid" => "[uuid]" }),
@@ -2135,7 +2135,7 @@ async fn add_documents_invalid_geo_field() {
     ]);
 
     let (task, _status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await.failed();
+    server.wait_task(task.uid()).await.failed();
     let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".uid" => "[uid]", ".batchUid" => "[batch_uid]", ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
@@ -2173,7 +2173,7 @@ async fn add_documents_invalid_geo_field() {
     ]);
 
     let (task, _status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await.failed();
+    server.wait_task(task.uid()).await.failed();
     let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".uid" => "[uid]", ".batchUid" => "[batch_uid]", ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
@@ -2211,7 +2211,7 @@ async fn add_documents_invalid_geo_field() {
     ]);
 
     let (task, _status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await.failed();
+    server.wait_task(task.uid()).await.failed();
     let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".uid" => "[uid]", ".batchUid" => "[batch_uid]", ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
@@ -2249,7 +2249,7 @@ async fn add_documents_invalid_geo_field() {
     ]);
 
     let (task, _status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await.failed();
+    server.wait_task(task.uid()).await.failed();
     let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".uid" => "[uid]", ".batchUid" => "[batch_uid]", ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
@@ -2287,7 +2287,7 @@ async fn add_documents_invalid_geo_field() {
     ]);
 
     let (task, _status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await.failed();
+    server.wait_task(task.uid()).await.failed();
     let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".uid" => "[uid]", ".batchUid" => "[batch_uid]", ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
@@ -2325,7 +2325,7 @@ async fn add_documents_invalid_geo_field() {
     ]);
 
     let (task, _status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await.failed();
+    server.wait_task(task.uid()).await.failed();
     let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".uid" => "[uid]", ".batchUid" => "[batch_uid]", ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
@@ -2363,7 +2363,7 @@ async fn add_documents_invalid_geo_field() {
     ]);
 
     let (task, _status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await.failed();
+    server.wait_task(task.uid()).await.failed();
     let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".uid" => "[uid]", ".batchUid" => "[batch_uid]", ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
@@ -2401,7 +2401,7 @@ async fn add_documents_invalid_geo_field() {
     ]);
 
     let (task, _status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await.failed();
+    server.wait_task(task.uid()).await.failed();
     let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".uid" => "[uid]", ".batchUid" => "[batch_uid]", ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
@@ -2439,7 +2439,7 @@ async fn add_documents_invalid_geo_field() {
     ]);
 
     let (task, _status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await.failed();
+    server.wait_task(task.uid()).await.failed();
     let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".uid" => "[uid]", ".batchUid" => "[batch_uid]", ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
@@ -2477,7 +2477,7 @@ async fn add_documents_invalid_geo_field() {
     ]);
 
     let (task, _status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await.failed();
+    server.wait_task(task.uid()).await.failed();
     let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".uid" => "[uid]", ".batchUid" => "[batch_uid]", ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
@@ -2515,7 +2515,7 @@ async fn add_documents_invalid_geo_field() {
     ]);
 
     let (task, _status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await.failed();
+    server.wait_task(task.uid()).await.failed();
     let (response, code) = index.get_task(task.uid()).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".uid" => "[uid]", ".batchUid" => "[batch_uid]", ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
@@ -2556,7 +2556,7 @@ async fn add_documents_invalid_geo_field() {
 
     let (response, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    let response = index.wait_task(response.uid()).await.failed();
+    let response = server.wait_task(response.uid()).await.failed();
     snapshot!(json_string!(response, { ".uid" => "[uid]", ".batchUid" => "[batch_uid]", ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
         @r###"
     {
@@ -2593,7 +2593,7 @@ async fn add_documents_invalid_geo_field() {
 
     let (response, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    let response = index.wait_task(response.uid()).await.failed();
+    let response = server.wait_task(response.uid()).await.failed();
     snapshot!(json_string!(response, { ".uid" => "[uid]", ".batchUid" => "[batch_uid]", ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
         @r###"
     {
@@ -2630,7 +2630,7 @@ async fn add_documents_invalid_geo_field() {
 
     let (response, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    let response = index.wait_task(response.uid()).await.failed();
+    let response = server.wait_task(response.uid()).await.failed();
     snapshot!(json_string!(response, { ".uid" => "[uid]", ".batchUid" => "[batch_uid]", ".duration" => "[duration]", ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]" }),
         @r###"
     {
@@ -2674,7 +2674,7 @@ async fn add_invalid_geo_and_then_settings() {
     ]);
     let (ret, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    let ret = index.wait_task(ret.uid()).await.succeeded();
+    let ret = server.wait_task(ret.uid()).await.succeeded();
     snapshot!(ret, @r###"
     {
       "uid": "[uid]",
@@ -2697,7 +2697,7 @@ async fn add_invalid_geo_and_then_settings() {
 
     let (ret, code) = index.update_settings(json!({ "sortableAttributes": ["_geo"] })).await;
     snapshot!(code, @"202 Accepted");
-    let ret = index.wait_task(ret.uid()).await.failed();
+    let ret = server.wait_task(ret.uid()).await.failed();
     snapshot!(ret, @r###"
     {
       "uid": "[uid]",
@@ -2765,7 +2765,7 @@ async fn error_primary_key_inference() {
     ]);
 
     let (task, _status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await.failed();
+    server.wait_task(task.uid()).await.failed();
     let (response, code) = index.get_task(task.uid()).await;
     assert_eq!(code, 200);
 
@@ -2806,7 +2806,7 @@ async fn error_primary_key_inference() {
     ]);
 
     let (task, _status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await.failed();
+    server.wait_task(task.uid()).await.failed();
     let (response, code) = index.get_task(task.uid()).await;
     assert_eq!(code, 200);
 
@@ -2845,7 +2845,7 @@ async fn error_primary_key_inference() {
     ]);
 
     let (task, _status_code) = index.add_documents(documents, None).await;
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
     let (response, code) = index.get_task(task.uid()).await;
     assert_eq!(code, 200);
 
@@ -2884,12 +2884,12 @@ async fn add_documents_with_primary_key_twice() {
     ]);
 
     let (task, _status_code) = index.add_documents(documents.clone(), Some("title")).await;
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
     let (response, _code) = index.get_task(task.uid()).await;
     assert_eq!(response["status"], "succeeded");
 
     let (task, _status_code) = index.add_documents(documents, Some("title")).await;
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
     let (response, _code) = index.get_task(task.uid()).await;
     assert_eq!(response["status"], "succeeded");
 }
@@ -2922,7 +2922,7 @@ async fn batch_several_documents_addition() {
     // wait first batch of documents to finish
     let finished_tasks = futures::future::join_all(waiter).await;
     for (task, _code) in finished_tasks {
-        index.wait_task(task.uid()).await;
+        server.wait_task(task.uid()).await;
     }
 
     // run a second completely failing batch
@@ -2936,7 +2936,7 @@ async fn batch_several_documents_addition() {
     // wait second batch of documents to finish
     let finished_tasks = futures::future::join_all(waiter).await;
     for (task, _code) in finished_tasks {
-        index.wait_task(task.uid()).await;
+        server.wait_task(task.uid()).await;
     }
 
     let (response, _code) = index.filtered_tasks(&[], &["failed"], &[]).await;

--- a/crates/meilisearch/tests/documents/get_documents.rs
+++ b/crates/meilisearch/tests/documents/get_documents.rs
@@ -23,7 +23,7 @@ async fn error_get_unexisting_document() {
     let server = Server::new_shared();
     let index = server.unique_index();
     let (task, _code) = index.create(None).await;
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = index.get_document(1, None).await;
 
@@ -43,7 +43,7 @@ async fn get_document() {
     let server = Server::new_shared();
     let index = server.unique_index();
     let (task, _code) = index.create(None).await;
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
     let documents = json!([
         {
             "id": 0,
@@ -52,7 +52,7 @@ async fn get_document() {
     ]);
     let (task, code) = index.add_documents(documents, None).await;
     assert_eq!(code, 202);
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
     let (response, code) = index.get_document(0, None).await;
     assert_eq!(code, 200);
     assert_eq!(
@@ -276,7 +276,7 @@ async fn get_document_s_nested_attributes_to_retrieve() {
     let server = Server::new_shared();
     let index = server.unique_index();
     let (task, _code) = index.create(None).await;
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
 
     let documents = json!([
         {
@@ -293,7 +293,7 @@ async fn get_document_s_nested_attributes_to_retrieve() {
     ]);
     let (task, code) = index.add_documents(documents, None).await;
     assert_eq!(code, 202);
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = index.get_document(0, Some(json!({ "fields": ["content"] }))).await;
     assert_eq!(code, 200);
@@ -369,7 +369,7 @@ async fn get_document_by_filter() {
             Some("id"),
         )
         .await;
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = index.fetch_documents(json!({})).await;
     let (response2, code2) = index.get_all_documents_raw("").await;
@@ -525,7 +525,7 @@ async fn get_document_by_ids() {
             Some("id"),
         )
         .await;
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = index
         .fetch_documents(json!({
@@ -651,7 +651,7 @@ async fn get_document_invalid_ids() {
             Some("id"),
         )
         .await;
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = index.fetch_documents(json!({"ids": ["0", "illegal/docid"] })).await;
     let (response2, code2) = index.get_all_documents_raw("?ids=0,illegal/docid").await;
@@ -683,7 +683,7 @@ async fn get_document_not_found_ids() {
             Some("id"),
         )
         .await;
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = index.fetch_documents(json!({"ids": ["0", 3, 42] })).await;
     let (response2, code2) = index.get_all_documents_raw("?ids=0,3,42").await;
@@ -726,7 +726,7 @@ async fn get_document_by_ids_and_filter() {
             Some("id"),
         )
         .await;
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
 
     let (response, code) =
         index.fetch_documents(json!({"ids": [2], "filter": "color = blue" })).await;
@@ -854,7 +854,7 @@ async fn get_document_with_vectors() {
     ]);
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(value.uid()).await.succeeded();
+    server.wait_task(value.uid()).await.succeeded();
 
     // by default you shouldn't see the `_vectors` object
     let (documents, _code) = index.get_all_documents(Default::default()).await;

--- a/crates/meilisearch/tests/documents/update_documents.rs
+++ b/crates/meilisearch/tests/documents/update_documents.rs
@@ -34,7 +34,7 @@ async fn document_update_with_primary_key() {
     let (response, code) = index.update_documents(documents, Some("primary")).await;
     assert_eq!(code, 202);
 
-    index.wait_task(response.uid()).await.succeeded();
+    server.wait_task(response.uid()).await.succeeded();
 
     let (response, code) = index.get_task(response.uid()).await;
     assert_eq!(code, 200);
@@ -63,7 +63,7 @@ async fn update_document() {
     let (response, code) = index.add_documents(documents, None).await;
     assert_eq!(code, 202);
 
-    index.wait_task(response.uid()).await.succeeded();
+    server.wait_task(response.uid()).await.succeeded();
 
     let documents = json!([
         {
@@ -75,7 +75,7 @@ async fn update_document() {
     let (response, code) = index.update_documents(documents, None).await;
     assert_eq!(code, 202, "response: {}", response);
 
-    index.wait_task(response.uid()).await.succeeded();
+    server.wait_task(response.uid()).await.succeeded();
 
     let (response, code) = index.get_task(response.uid()).await;
     assert_eq!(code, 200);
@@ -107,7 +107,7 @@ async fn update_document_gzip_encoded() {
     let (response, code) = index.add_documents(documents, None).await;
     assert_eq!(code, 202);
 
-    index.wait_task(response.uid()).await.succeeded();
+    server.wait_task(response.uid()).await.succeeded();
 
     let documents = json!([
         {
@@ -119,7 +119,7 @@ async fn update_document_gzip_encoded() {
     let (response, code) = index.update_documents(documents, None).await;
     assert_eq!(code, 202, "response: {}", response);
 
-    index.wait_task(response.uid()).await.succeeded();
+    server.wait_task(response.uid()).await.succeeded();
 
     let (response, code) = index.get_task(response.uid()).await;
     assert_eq!(code, 200);
@@ -142,7 +142,7 @@ async fn update_larger_dataset() {
     let index = server.unique_index();
     let documents = serde_json::from_str(include_str!("../assets/test_set.json")).unwrap();
     let (task, _code) = index.update_documents(documents, None).await;
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
     let (response, code) = index.get_task(task.uid()).await;
     assert_eq!(code, 200);
     assert_eq!(response["type"], "documentAdditionOrUpdate");
@@ -166,7 +166,7 @@ async fn error_update_documents_bad_document_id() {
         }
     ]);
     let (task, _code) = index.update_documents(documents, None).await;
-    let response = index.wait_task(task.uid()).await;
+    let response = server.wait_task(task.uid()).await;
     assert_eq!(response["status"], json!("failed"));
     assert_eq!(
         response["error"]["message"],
@@ -194,7 +194,7 @@ async fn error_update_documents_missing_document_id() {
         }
     ]);
     let (task, _code) = index.update_documents(documents, None).await;
-    let response = index.wait_task(task.uid()).await;
+    let response = server.wait_task(task.uid()).await;
     assert_eq!(response["status"], "failed");
     assert_eq!(
         response["error"]["message"],
@@ -219,7 +219,7 @@ async fn update_faceted_document() {
         }))
         .await;
     assert_eq!("202", code.as_str(), "{:?}", response);
-    index.wait_task(response.uid()).await.succeeded();
+    server.wait_task(response.uid()).await.succeeded();
 
     let documents: Vec<_> = (0..1000)
         .map(|id| {
@@ -233,7 +233,7 @@ async fn update_faceted_document() {
     let (response, code) = index.add_documents(documents.into(), None).await;
     assert_eq!(code, 202);
 
-    index.wait_task(response.uid()).await.succeeded();
+    server.wait_task(response.uid()).await.succeeded();
 
     let documents = json!([
         {
@@ -245,7 +245,7 @@ async fn update_faceted_document() {
     let (response, code) = index.update_documents(documents, None).await;
     assert_eq!(code, 202, "response: {}", response);
 
-    index.wait_task(response.uid()).await.succeeded();
+    server.wait_task(response.uid()).await.succeeded();
 
     index
         .search(json!({"limit": 10}), |response, code| {


### PR DESCRIPTION
# Pull Request

## Related issue
#4840

## What does this PR do?
- The code is mostly duplicated. Server::wait_task() has better handling for errors and more retries.
