### PR TITLE
tests: Use Server::wait_task() instead of Index::wait_task() in index::

### DIFF
--- a/crates/meilisearch/tests/index/create_index.rs
+++ b/crates/meilisearch/tests/index/create_index.rs
@@ -17,7 +17,7 @@ async fn create_index_no_primary_key() {
 
     assert_eq!(response["status"], "enqueued");
 
-    let response = index.wait_task(response.uid()).await;
+    let response = server.wait_task(response.uid()).await;
 
     assert_eq!(response["status"], "succeeded");
     assert_eq!(response["type"], "indexCreation");
@@ -34,7 +34,7 @@ async fn create_index_with_gzip_encoded_request() {
 
     assert_eq!(response["status"], "enqueued");
 
-    let response = index.wait_task(response.uid()).await;
+    let response = server.wait_task(response.uid()).await;
 
     assert_eq!(response["status"], "succeeded");
     assert_eq!(response["type"], "indexCreation");
@@ -83,7 +83,7 @@ async fn create_index_with_zlib_encoded_request() {
 
     assert_eq!(response["status"], "enqueued");
 
-    let response = index.wait_task(response.uid()).await;
+    let response = server.wait_task(response.uid()).await;
 
     assert_eq!(response["status"], "succeeded");
     assert_eq!(response["type"], "indexCreation");
@@ -100,7 +100,7 @@ async fn create_index_with_brotli_encoded_request() {
 
     assert_eq!(response["status"], "enqueued");
 
-    let response = index.wait_task(response.uid()).await;
+    let response = server.wait_task(response.uid()).await;
 
     assert_eq!(response["status"], "succeeded");
     assert_eq!(response["type"], "indexCreation");
@@ -117,7 +117,7 @@ async fn create_index_with_primary_key() {
 
     assert_eq!(response["status"], "enqueued");
 
-    let response = index.wait_task(response.uid()).await.succeeded();
+    let response = server.wait_task(response.uid()).await.succeeded();
 
     assert_eq!(response["status"], "succeeded");
     assert_eq!(response["type"], "indexCreation");
@@ -132,7 +132,7 @@ async fn create_index_with_invalid_primary_key() {
     let index = server.unique_index();
     let (response, code) = index.add_documents(documents, Some("title")).await;
     assert_eq!(code, 202);
-    index.wait_task(response.uid()).await.failed();
+    server.wait_task(response.uid()).await.failed();
 
     let (response, code) = index.get().await;
     assert_eq!(code, 200);
@@ -142,7 +142,7 @@ async fn create_index_with_invalid_primary_key() {
 
     let (response, code) = index.add_documents(documents, Some("id")).await;
     assert_eq!(code, 202);
-    index.wait_task(response.uid()).await.failed();
+    server.wait_task(response.uid()).await.failed();
 
     let (response, code) = index.get().await;
     assert_eq!(code, 200);
@@ -181,7 +181,7 @@ async fn error_create_existing_index() {
 
     let (task, _) = index.create(Some("primary")).await;
 
-    let response = index.wait_task(task.uid()).await;
+    let response = server.wait_task(task.uid()).await;
     let msg = format!(
         "Index `{}` already exists.",
         task["indexUid"].as_str().expect("indexUid should exist").trim_matches('"')

--- a/crates/meilisearch/tests/index/delete_index.rs
+++ b/crates/meilisearch/tests/index/delete_index.rs
@@ -9,7 +9,7 @@ async fn create_and_delete_index() {
 
     assert_eq!(code, 202);
 
-    index.wait_task(response.uid()).await.succeeded();
+    server.wait_task(response.uid()).await.succeeded();
 
     assert_eq!(index.get().await.1, 200);
 
@@ -17,18 +17,19 @@ async fn create_and_delete_index() {
 
     assert_eq!(code, 202);
 
-    index.wait_task(response.uid()).await.succeeded();
+    server.wait_task(response.uid()).await.succeeded();
 
     assert_eq!(index.get().await.1, 404);
 }
 
 #[actix_rt::test]
 async fn error_delete_unexisting_index() {
+    let server = Server::new_shared();
     let index = shared_does_not_exists_index().await;
     let (task, code) = index.delete_index_fail().await;
 
     assert_eq!(code, 202);
-    index.wait_task(task.uid()).await.failed();
+    server.wait_task(task.uid()).await.failed();
 
     let expected_response = json!({
         "message": "Index `DOES_NOT_EXISTS` not found.",
@@ -37,7 +38,7 @@ async fn error_delete_unexisting_index() {
         "link": "https://docs.meilisearch.com/errors#index_not_found"
     });
 
-    let response = index.wait_task(task.uid()).await;
+    let response = server.wait_task(task.uid()).await;
     assert_eq!(response["status"], "failed");
     assert_eq!(response["error"], expected_response);
 }
@@ -58,7 +59,7 @@ async fn loop_delete_add_documents() {
     }
 
     for task in tasks {
-        let response = index.wait_task(task).await.succeeded();
+        let response = server.wait_task(task).await.succeeded();
         assert_eq!(response["status"], "succeeded", "{}", response);
     }
 }

--- a/crates/meilisearch/tests/index/get_index.rs
+++ b/crates/meilisearch/tests/index/get_index.rs
@@ -12,7 +12,7 @@ async fn create_and_get_index() {
 
     assert_eq!(code, 202);
 
-    index.wait_task(response.uid()).await.succeeded();
+    server.wait_task(response.uid()).await.succeeded();
 
     let (response, code) = index.get().await;
 

--- a/crates/meilisearch/tests/index/stats.rs
+++ b/crates/meilisearch/tests/index/stats.rs
@@ -10,7 +10,7 @@ async fn stats() {
 
     assert_eq!(code, 202);
 
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = index.stats().await;
 
@@ -33,7 +33,7 @@ async fn stats() {
     let (response, code) = index.add_documents(documents, None).await;
     assert_eq!(code, 202);
 
-    index.wait_task(response.uid()).await.succeeded();
+    server.wait_task(response.uid()).await.succeeded();
 
     let (response, code) = index.stats().await;
 


### PR DESCRIPTION
# Pull Request

## Related issue
#4840

## What does this PR do?
- The code is mostly duplicated. Server::wait_task() has better handling for errors and more retries.
