### PR TITLE
tests: Use Server::wait_task() instead of Index::wait_task() in settings::

### DIFF
--- a/crates/meilisearch/tests/settings/distinct.rs
+++ b/crates/meilisearch/tests/settings/distinct.rs
@@ -7,7 +7,7 @@ async fn set_and_reset_distinct_attribute() {
     let index = server.unique_index();
 
     let (task1, _code) = index.update_settings(json!({ "distinctAttribute": "test"})).await;
-    index.wait_task(task1.uid()).await.succeeded();
+    server.wait_task(task1.uid()).await.succeeded();
 
     let (response, _) = index.settings().await;
 
@@ -15,7 +15,7 @@ async fn set_and_reset_distinct_attribute() {
 
     let (task2, _status_code) = index.update_settings(json!({ "distinctAttribute": null })).await;
 
-    index.wait_task(task2.uid()).await.succeeded();
+    server.wait_task(task2.uid()).await.succeeded();
 
     let (response, _) = index.settings().await;
 
@@ -28,7 +28,7 @@ async fn set_and_reset_distinct_attribute_with_dedicated_route() {
     let index = server.unique_index();
 
     let (update_task1, _code) = index.update_distinct_attribute(json!("test")).await;
-    index.wait_task(update_task1.uid()).await.succeeded();
+    server.wait_task(update_task1.uid()).await.succeeded();
 
     let (response, _) = index.get_distinct_attribute().await;
 
@@ -36,7 +36,7 @@ async fn set_and_reset_distinct_attribute_with_dedicated_route() {
 
     let (update_task2, _status_code) = index.update_distinct_attribute(json!(null)).await;
 
-    index.wait_task(update_task2.uid()).await.succeeded();
+    server.wait_task(update_task2.uid()).await.succeeded();
 
     let (response, _) = index.get_distinct_attribute().await;
 

--- a/crates/meilisearch/tests/settings/proximity_settings.rs
+++ b/crates/meilisearch/tests/settings/proximity_settings.rs
@@ -30,7 +30,7 @@ async fn attribute_scale_search() {
     let index = server.unique_index();
 
     let (task, _status_code) = index.add_documents(DOCUMENTS.clone(), None).await;
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = index
         .update_settings(json!({
@@ -39,7 +39,7 @@ async fn attribute_scale_search() {
         }))
         .await;
     assert_eq!("202", code.as_str(), "{response:?}");
-    index.wait_task(response.uid()).await.succeeded();
+    server.wait_task(response.uid()).await.succeeded();
 
     // the expected order is [1, 3, 2] instead of [3, 1, 2]
     // because the attribute scale doesn't make the difference between 1 and 3.
@@ -103,7 +103,7 @@ async fn attribute_scale_phrase_search() {
     let index = server.unique_index();
 
     let (task, _status_code) = index.add_documents(DOCUMENTS.clone(), None).await;
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
 
     let (task, _code) = index
         .update_settings(json!({
@@ -111,7 +111,7 @@ async fn attribute_scale_phrase_search() {
             "rankingRules": ["words", "typo", "proximity"],
         }))
         .await;
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
 
     // the expected order is [1, 3] instead of [3, 1]
     // because the attribute scale doesn't make the difference between 1 and 3.
@@ -171,7 +171,7 @@ async fn word_scale_set_and_reset() {
     let index = server.unique_index();
 
     let (task, _status_code) = index.add_documents(DOCUMENTS.clone(), None).await;
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
 
     // Set and reset the setting ensuring the swap between the 2 settings is applied.
     let (update_task1, _code) = index
@@ -180,7 +180,7 @@ async fn word_scale_set_and_reset() {
             "rankingRules": ["words", "typo", "proximity"],
         }))
         .await;
-    index.wait_task(update_task1.uid()).await.succeeded();
+    server.wait_task(update_task1.uid()).await.succeeded();
 
     let (update_task2, _code) = index
         .update_settings(json!({
@@ -188,7 +188,7 @@ async fn word_scale_set_and_reset() {
             "rankingRules": ["words", "typo", "proximity"],
         }))
         .await;
-    index.wait_task(update_task2.uid()).await.succeeded();
+    server.wait_task(update_task2.uid()).await.succeeded();
 
     // [3, 1, 2]
     index
@@ -286,7 +286,7 @@ async fn attribute_scale_default_ranking_rules() {
     let index = server.unique_index();
 
     let (task, _status_code) = index.add_documents(DOCUMENTS.clone(), None).await;
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = index
         .update_settings(json!({
@@ -294,7 +294,7 @@ async fn attribute_scale_default_ranking_rules() {
         }))
         .await;
     assert_eq!("202", code.as_str(), "{response:?}");
-    index.wait_task(response.uid()).await.succeeded();
+    server.wait_task(response.uid()).await.succeeded();
 
     // the expected order is [3, 1, 2]
     index

--- a/crates/meilisearch/tests/settings/tokenizer_customization.rs
+++ b/crates/meilisearch/tests/settings/tokenizer_customization.rs
@@ -15,7 +15,7 @@ async fn set_and_reset() {
             "dictionary": ["J.R.R.", "J. R. R."],
         }))
         .await;
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
 
     let (response, _) = index.settings().await;
     snapshot!(json_string!(response["nonSeparatorTokens"]), @r###"
@@ -45,7 +45,7 @@ async fn set_and_reset() {
         }))
         .await;
 
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
 
     let (response, _) = index.settings().await;
     snapshot!(json_string!(response["nonSeparatorTokens"]), @"[]");
@@ -74,7 +74,7 @@ async fn set_and_search() {
     let index = server.unique_index();
 
     let (add_task, _status_code) = index.add_documents(documents, None).await;
-    index.wait_task(add_task.uid()).await.succeeded();
+    server.wait_task(add_task.uid()).await.succeeded();
 
     let (update_task, _code) = index
         .update_settings(json!({
@@ -83,7 +83,7 @@ async fn set_and_search() {
             "dictionary": ["#", "A#", "B#", "C#", "D#", "E#", "F#", "G#"],
         }))
         .await;
-    index.wait_task(update_task.uid()).await.succeeded();
+    server.wait_task(update_task.uid()).await.succeeded();
 
     index
         .search(json!({"q": "&", "attributesToHighlight": ["content"]}), |response, code| {
@@ -228,7 +228,7 @@ async fn advanced_synergies() {
     let index = server.unique_index();
 
     let (add_task, _status_code) = index.add_documents(documents, None).await;
-    index.wait_task(add_task.uid()).await.succeeded();
+    server.wait_task(add_task.uid()).await.succeeded();
 
     let (update_task, _code) = index
         .update_settings(json!({
@@ -243,7 +243,7 @@ async fn advanced_synergies() {
             }
         }))
         .await;
-    index.wait_task(update_task.uid()).await.succeeded();
+    server.wait_task(update_task.uid()).await.succeeded();
 
     index
         .search(json!({"q": "J.R.R.", "attributesToHighlight": ["content"]}), |response, code| {
@@ -353,7 +353,7 @@ async fn advanced_synergies() {
             "dictionary": ["J.R.R.", "J. R. R.", "J.K.", "J. K."],
         }))
         .await;
-    index.wait_task(_response.uid()).await.succeeded();
+    server.wait_task(_response.uid()).await.succeeded();
 
     index
         .search(json!({"q": "jk", "attributesToHighlight": ["content"]}), |response, code| {


### PR DESCRIPTION
# Pull Request

## Related issue
#4840

## What does this PR do?
- The code is mostly duplicated. Server::wait_task() has better handling for errors and more retries.