### PR TITLE
Fix disableOnNumbers reset

### DIFF
--- a/crates/meilisearch-types/src/settings.rs
+++ b/crates/meilisearch-types/src/settings.rs
@@ -751,6 +751,7 @@ pub fn apply_settings_to_builder(
             builder.reset_min_word_len_two_typos();
             builder.reset_exact_words();
             builder.reset_exact_attributes();
+            builder.reset_disable_on_numbers();
         }
         Setting::NotSet => (),
     }


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #5688 

## What does this PR do?
- Add missing reset_disable_on_numbers to typo-tolerance reset
- Add tests

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured that resetting typo tolerance settings also resets the "disable on numbers" option to its default value.

- **Tests**
  - Expanded test coverage to verify correct behavior and default values for "typoTolerance" and "chat" settings in API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->