### PR TITLE
tests: Use Server::wait_task() instead of Index::wait_task()

### DIFF
--- a/crates/meilisearch/tests/auth/authorization.rs
+++ b/crates/meilisearch/tests/auth/authorization.rs
@@ -304,7 +304,7 @@ async fn access_authorized_stats_restricted_index() {
     let (response, code) = index.create(Some("product_id")).await;
     assert_eq!(202, code, "{:?}", &response);
     let task_id = response["taskUid"].as_u64().unwrap();
-    index.wait_task(task_id).await;
+    server.wait_task(task_id).await;
 
     // create key with access on `products` index only.
     let content = json!({
@@ -344,7 +344,7 @@ async fn access_authorized_stats_no_index_restriction() {
     let (response, code) = index.create(Some("product_id")).await;
     assert_eq!(202, code, "{:?}", &response);
     let task_id = response["taskUid"].as_u64().unwrap();
-    index.wait_task(task_id).await;
+    server.wait_task(task_id).await;
 
     // create key with access on all indexes.
     let content = json!({
@@ -384,7 +384,7 @@ async fn list_authorized_indexes_restricted_index() {
     let (response, code) = index.create(Some("product_id")).await;
     assert_eq!(202, code, "{:?}", &response);
     let task_id = response["taskUid"].as_u64().unwrap();
-    index.wait_task(task_id).await;
+    server.wait_task(task_id).await;
 
     // create key with access on `products` index only.
     let content = json!({
@@ -425,7 +425,7 @@ async fn list_authorized_indexes_no_index_restriction() {
     let (response, code) = index.create(Some("product_id")).await;
     assert_eq!(202, code, "{:?}", &response);
     let task_id = response["taskUid"].as_u64().unwrap();
-    index.wait_task(task_id).await;
+    server.wait_task(task_id).await;
 
     // create key with access on all indexes.
     let content = json!({
@@ -589,8 +589,8 @@ async fn raise_error_non_authorized_index_patterns() {
     // refer to products_2 with modified api key.
     let product_2_index = server.index("products_2");
 
-    product_1_index.wait_task(task1_id).await;
-    product_2_index.wait_task(task2_id).await;
+    product_1_server.wait_task(task1_id).await;
+    product_2_server.wait_task(task2_id).await;
 
     let (response, code) = product_1_index.get_task(task1_id).await;
     assert_eq!(200, code, "{:?}", &response);
@@ -650,7 +650,7 @@ async fn list_authorized_tasks_restricted_index() {
     let (response, code) = index.create(Some("product_id")).await;
     assert_eq!(202, code, "{:?}", &response);
     let task_id = response["taskUid"].as_u64().unwrap();
-    index.wait_task(task_id).await;
+    server.wait_task(task_id).await;
 
     // create key with access on `products` index only.
     let content = json!({
@@ -690,7 +690,7 @@ async fn list_authorized_tasks_no_index_restriction() {
     let (response, code) = index.create(Some("product_id")).await;
     assert_eq!(202, code, "{:?}", &response);
     let task_id = response["taskUid"].as_u64().unwrap();
-    index.wait_task(task_id).await;
+    server.wait_task(task_id).await;
 
     // create key with access on all indexes.
     let content = json!({
@@ -757,7 +757,7 @@ async fn error_creating_index_without_action() {
     assert_eq!(202, code, "{:?}", &response);
     let task_id = response["taskUid"].as_u64().unwrap();
 
-    let response = index.wait_task(task_id).await;
+    let response = server.wait_task(task_id).await;
     assert_eq!(response["status"], "failed");
     assert_eq!(response["error"], expected_error.clone());
 
@@ -768,7 +768,7 @@ async fn error_creating_index_without_action() {
     assert_eq!(202, code, "{:?}", &response);
     let task_id = response["taskUid"].as_u64().unwrap();
 
-    let response = index.wait_task(task_id).await;
+    let response = server.wait_task(task_id).await;
 
     assert_eq!(response["status"], "failed");
     assert_eq!(response["error"], expected_error.clone());
@@ -778,7 +778,7 @@ async fn error_creating_index_without_action() {
     assert_eq!(202, code, "{:?}", &response);
     let task_id = response["taskUid"].as_u64().unwrap();
 
-    let response = index.wait_task(task_id).await;
+    let response = server.wait_task(task_id).await;
 
     assert_eq!(response["status"], "failed");
     assert_eq!(response["error"], expected_error.clone());
@@ -830,7 +830,7 @@ async fn lazy_create_index() {
         assert_eq!(202, code, "{:?}", &response);
         let task_id = response["taskUid"].as_u64().unwrap();
 
-        index.wait_task(task_id).await;
+        server.wait_task(task_id).await;
 
         let (response, code) = index.get_task(task_id).await;
         assert_eq!(200, code, "{:?}", &response);
@@ -844,7 +844,7 @@ async fn lazy_create_index() {
         assert_eq!(202, code, "{:?}", &response);
         let task_id = response["taskUid"].as_u64().unwrap();
 
-        index.wait_task(task_id).await;
+        server.wait_task(task_id).await;
 
         let (response, code) = index.get_task(task_id).await;
         assert_eq!(200, code, "{:?}", &response);
@@ -856,7 +856,7 @@ async fn lazy_create_index() {
         assert_eq!(202, code, "{:?}", &response);
         let task_id = response["taskUid"].as_u64().unwrap();
 
-        index.wait_task(task_id).await;
+        server.wait_task(task_id).await;
 
         let (response, code) = index.get_task(task_id).await;
         assert_eq!(200, code, "{:?}", &response);
@@ -911,7 +911,7 @@ async fn lazy_create_index_from_pattern() {
         assert_eq!(202, code, "{:?}", &response);
         let task_id = response["taskUid"].as_u64().unwrap();
 
-        index.wait_task(task_id).await;
+        server.wait_task(task_id).await;
 
         let (response, code) = index.get_task(task_id).await;
         assert_eq!(200, code, "{:?}", &response);
@@ -929,7 +929,7 @@ async fn lazy_create_index_from_pattern() {
         assert_eq!(202, code, "{:?}", &response);
         let task_id = response["taskUid"].as_u64().unwrap();
 
-        index.wait_task(task_id).await;
+        server.wait_task(task_id).await;
 
         let (response, code) = index.get_task(task_id).await;
         assert_eq!(200, code, "{:?}", &response);
@@ -949,7 +949,7 @@ async fn lazy_create_index_from_pattern() {
         assert_eq!(202, code, "{:?}", &response);
         let task_id = response["taskUid"].as_u64().unwrap();
 
-        index.wait_task(task_id).await;
+        server.wait_task(task_id).await;
 
         let (response, code) = index.get_task(task_id).await;
         assert_eq!(200, code, "{:?}", &response);

--- a/crates/meilisearch/tests/auth/authorization.rs
+++ b/crates/meilisearch/tests/auth/authorization.rs
@@ -507,10 +507,10 @@ async fn access_authorized_index_patterns() {
 
     server.use_api_key(MASTER_KEY);
 
-    // refer to products_1 with modified api key.
+    // refer to products_1 with a modified api key.
     let index_1 = server.index("products_1");
 
-    index_1.wait_task(task_id).await;
+    server.wait_task(task_id).await;
 
     let (response, code) = index_1.get_task(task_id).await;
     assert_eq!(200, code, "{:?}", &response);
@@ -578,19 +578,19 @@ async fn raise_error_non_authorized_index_patterns() {
     assert_eq!(202, code, "{:?}", &response);
     let task2_id = response["taskUid"].as_u64().unwrap();
 
-    // Adding document to test index. Should Fail with 403 -- invalid_api_key
+    // Adding a document to test index. Should Fail with 403 -- invalid_api_key
     let (response, code) = test_index.add_documents(documents, None).await;
     assert_eq!(403, code, "{:?}", &response);
 
     server.use_api_key(MASTER_KEY);
 
-    // refer to products_1 with modified api key.
+    // refer to products_1 with a modified api key.
     let product_1_index = server.index("products_1");
-    // refer to products_2 with modified api key.
-    let product_2_index = server.index("products_2");
+    // refer to products_2 with a modified api key.
+    // let product_2_index = server.index("products_2");
 
-    product_1_server.wait_task(task1_id).await;
-    product_2_server.wait_task(task2_id).await;
+    server.wait_task(task1_id).await;
+    server.wait_task(task2_id).await;
 
     let (response, code) = product_1_index.get_task(task1_id).await;
     assert_eq!(200, code, "{:?}", &response);
@@ -603,7 +603,7 @@ async fn raise_error_non_authorized_index_patterns() {
 
 #[actix_rt::test]
 async fn pattern_indexes() {
-    // Create server with master key
+    // Create a server with master key
     let mut server = Server::new_auth().await;
     server.use_admin_key(MASTER_KEY).await;
 

--- a/crates/meilisearch/tests/auth/tenant_token.rs
+++ b/crates/meilisearch/tests/auth/tenant_token.rs
@@ -100,11 +100,11 @@ macro_rules! compute_authorized_search {
         let index = server.index("sales");
         let documents = DOCUMENTS.clone();
         let (task1,_status_code) = index.add_documents(documents, None).await;
-        index.wait_task(task1.uid()).await.succeeded();
+        server.wait_task(task1.uid()).await.succeeded();
         let (task2,_status_code) = index
             .update_settings(json!({"filterableAttributes": ["color"]}))
             .await;
-        index.wait_task(task2.uid()).await.succeeded();
+        server.wait_task(task2.uid()).await.succeeded();
         drop(index);
 
         for key_content in ACCEPTED_KEYS.iter() {
@@ -147,7 +147,7 @@ macro_rules! compute_forbidden_search {
         let index = server.index("sales");
         let documents = DOCUMENTS.clone();
         let (task, _status_code) = index.add_documents(documents, None).await;
-        index.wait_task(task.uid()).await.succeeded();
+        server.wait_task(task.uid()).await.succeeded();
         drop(index);
 
         for key_content in $parent_keys.iter() {

--- a/crates/meilisearch/tests/auth/tenant_token_multi_search.rs
+++ b/crates/meilisearch/tests/auth/tenant_token_multi_search.rs
@@ -268,21 +268,21 @@ macro_rules! compute_authorized_single_search {
         let index = server.index("sales");
         let documents = DOCUMENTS.clone();
         let (add_task,_status_code) = index.add_documents(documents, None).await;
-        index.wait_task(add_task.uid()).await.succeeded();
+        server.wait_task(add_task.uid()).await.succeeded();
         let (update_task,_status_code) = index
             .update_settings(json!({"filterableAttributes": ["color"]}))
             .await;
-        index.wait_task(update_task.uid()).await.succeeded();
+        server.wait_task(update_task.uid()).await.succeeded();
         drop(index);
 
         let index = server.index("products");
         let documents = NESTED_DOCUMENTS.clone();
         let (add_task2,_status_code) = index.add_documents(documents, None).await;
-        index.wait_task(add_task2.uid()).await.succeeded();
+        server.wait_task(add_task2.uid()).await.succeeded();
         let (update_task2,_status_code) = index
             .update_settings(json!({"filterableAttributes": ["doggos"]}))
             .await;
-        index.wait_task(update_task2.uid()).await.succeeded();
+        server.wait_task(update_task2.uid()).await.succeeded();
         drop(index);
 
 
@@ -339,21 +339,21 @@ macro_rules! compute_authorized_multiple_search {
         let index = server.index("sales");
         let documents = DOCUMENTS.clone();
         let (task,_status_code) = index.add_documents(documents, None).await;
-        index.wait_task(task.uid()).await.succeeded();
+        server.wait_task(task.uid()).await.succeeded();
         let (task,_status_code) = index
             .update_settings(json!({"filterableAttributes": ["color"]}))
             .await;
-        index.wait_task(task.uid()).await.succeeded();
+        server.wait_task(task.uid()).await.succeeded();
         drop(index);
 
         let index = server.index("products");
         let documents = NESTED_DOCUMENTS.clone();
         let (task,_status_code) = index.add_documents(documents, None).await;
-        index.wait_task(task.uid()).await.succeeded();
+        server.wait_task(task.uid()).await.succeeded();
         let (task,_status_code) = index
             .update_settings(json!({"filterableAttributes": ["doggos"]}))
             .await;
-        index.wait_task(task.uid()).await.succeeded();
+        server.wait_task(task.uid()).await.succeeded();
         drop(index);
 
 
@@ -423,21 +423,21 @@ macro_rules! compute_forbidden_single_search {
         let index = server.index("sales");
         let documents = DOCUMENTS.clone();
         let (task,_status_code) = index.add_documents(documents, None).await;
-        index.wait_task(task.uid()).await.succeeded();
+        server.wait_task(task.uid()).await.succeeded();
         let (task,_status_code) = index
             .update_settings(json!({"filterableAttributes": ["color"]}))
             .await;
-        index.wait_task(task.uid()).await.succeeded();
+        server.wait_task(task.uid()).await.succeeded();
         drop(index);
 
         let index = server.index("products");
         let documents = NESTED_DOCUMENTS.clone();
         let (task,_status_code) = index.add_documents(documents, None).await;
-        index.wait_task(task.uid()).await.succeeded();
+        server.wait_task(task.uid()).await.succeeded();
         let (task,_status_code) = index
             .update_settings(json!({"filterableAttributes": ["doggos"]}))
             .await;
-        index.wait_task(task.uid()).await.succeeded();
+        server.wait_task(task.uid()).await.succeeded();
         drop(index);
 
         assert_eq!($parent_keys.len(), $failed_query_indexes.len(), "keys != query_indexes");
@@ -499,21 +499,21 @@ macro_rules! compute_forbidden_multiple_search {
         let index = server.index("sales");
         let documents = DOCUMENTS.clone();
         let (task,_status_code) = index.add_documents(documents, None).await;
-        index.wait_task(task.uid()).await.succeeded();
+        server.wait_task(task.uid()).await.succeeded();
         let (task,_status_code) = index
             .update_settings(json!({"filterableAttributes": ["color"]}))
             .await;
-        index.wait_task(task.uid()).await.succeeded();
+        server.wait_task(task.uid()).await.succeeded();
         drop(index);
 
         let index = server.index("products");
         let documents = NESTED_DOCUMENTS.clone();
         let (task,_status_code) = index.add_documents(documents, None).await;
-        index.wait_task(task.uid()).await.succeeded();
+        server.wait_task(task.uid()).await.succeeded();
         let (task,_status_code) = index
             .update_settings(json!({"filterableAttributes": ["doggos"]}))
             .await;
-        index.wait_task(task.uid()).await.succeeded();
+        server.wait_task(task.uid()).await.succeeded();
         drop(index);
 
         assert_eq!($parent_keys.len(), $failed_query_indexes.len(), "keys != query_indexes");

--- a/crates/meilisearch/tests/batches/mod.rs
+++ b/crates/meilisearch/tests/batches/mod.rs
@@ -11,7 +11,7 @@ async fn error_get_unexisting_batch_status() {
     let server = Server::new().await;
     let index = server.index("test");
     let (task, _coder) = index.create(None).await;
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
     let (response, code) = index.get_batch(1).await;
 
     let expected_response = json!({
@@ -30,7 +30,7 @@ async fn get_batch_status() {
     let server = Server::new().await;
     let index = server.index("test");
     let (task, _status_code) = index.create(None).await;
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
     let (_response, code) = index.get_batch(0).await;
     assert_eq!(code, 200);
 }
@@ -40,9 +40,9 @@ async fn list_batches() {
     let server = Server::new().await;
     let index = server.index("test");
     let (task, _status_code) = index.create(None).await;
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
     let (task, _status_code) = index.create(None).await;
-    index.wait_task(task.uid()).await.failed();
+    server.wait_task(task.uid()).await.failed();
     let (response, code) = index.list_batches().await;
     assert_eq!(code, 200);
     assert_eq!(
@@ -96,10 +96,10 @@ async fn list_batches_with_star_filters() {
     let server = Server::new().await;
     let index = server.index("test");
     let (task, _code) = index.create(None).await;
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
     let index = server.index("test");
     let (task, _code) = index.create(None).await;
-    index.wait_task(task.uid()).await.failed();
+    server.wait_task(task.uid()).await.failed();
 
     let (response, code) = index.service.get("/batches?indexUids=test").await;
     assert_eq!(code, 200);
@@ -142,9 +142,9 @@ async fn list_batches_status_filtered() {
     let server = Server::new().await;
     let index = server.index("test");
     let (task, _status_code) = index.create(None).await;
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
     let (task, _status_code) = index.create(None).await;
-    index.wait_task(task.uid()).await.failed();
+    server.wait_task(task.uid()).await.failed();
 
     let (response, code) = index.filtered_batches(&[], &["succeeded"], &[]).await;
     assert_eq!(code, 200, "{}", response);
@@ -164,9 +164,9 @@ async fn list_batches_type_filtered() {
     let server = Server::new().await;
     let index = server.index("test");
     let (task, _) = index.create(None).await;
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
     let (task, _) = index.delete().await;
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
     let (response, code) = index.filtered_batches(&["indexCreation"], &[], &[]).await;
     assert_eq!(code, 200, "{}", response);
     assert_eq!(response["results"].as_array().unwrap().len(), 1);
@@ -186,7 +186,7 @@ async fn list_batches_invalid_canceled_by_filter() {
     let server = Server::new().await;
     let index = server.index("test");
     let (task, _status_code) = index.create(None).await;
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = index.filtered_batches(&[], &[], &["0"]).await;
     assert_eq!(code, 200, "{}", response);
@@ -198,9 +198,9 @@ async fn list_batches_status_and_type_filtered() {
     let server = Server::new().await;
     let index = server.index("test");
     let (task, _status_code) = index.create(None).await;
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
     let (task, _status_code) = index.update(Some("id")).await;
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = index.filtered_batches(&["indexCreation"], &["failed"], &[]).await;
     assert_eq!(code, 200, "{}", response);
@@ -272,7 +272,7 @@ async fn test_summarized_document_addition_or_update() {
     let index = server.index("test");
     let (task, _status_code) =
         index.add_documents(json!({ "id": 42, "content": "doggos & fluff" }), None).await;
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
     let (batch, _) = index.get_batch(0).await;
     assert_json_snapshot!(batch,
         {
@@ -316,7 +316,7 @@ async fn test_summarized_document_addition_or_update() {
 
     let (task, _status_code) =
         index.add_documents(json!({ "id": 42, "content": "doggos & fluff" }), Some("id")).await;
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
     let (batch, _) = index.get_batch(1).await;
     assert_json_snapshot!(batch,
         {
@@ -363,7 +363,7 @@ async fn test_summarized_delete_documents_by_batch() {
     let server = Server::new().await;
     let index = server.index("test");
     let (task, _status_code) = index.delete_batch(vec![1, 2, 3]).await;
-    index.wait_task(task.uid()).await.failed();
+    server.wait_task(task.uid()).await.failed();
     let (batch, _) = index.get_batch(0).await;
     assert_json_snapshot!(batch,
         {
@@ -404,7 +404,7 @@ async fn test_summarized_delete_documents_by_batch() {
 
     index.create(None).await;
     let (task, _status_code) = index.delete_batch(vec![42]).await;
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
     let (batch, _) = index.get_batch(2).await;
     assert_json_snapshot!(batch,
         {
@@ -452,7 +452,7 @@ async fn test_summarized_delete_documents_by_filter() {
 
     let (task, _status_code) =
         index.delete_document_by_filter(json!({ "filter": "doggo = bernese" })).await;
-    index.wait_task(task.uid()).await.failed();
+    server.wait_task(task.uid()).await.failed();
     let (batch, _) = index.get_batch(0).await;
     assert_json_snapshot!(batch,
         {
@@ -495,7 +495,7 @@ async fn test_summarized_delete_documents_by_filter() {
     index.create(None).await;
     let (task, _status_code) =
         index.delete_document_by_filter(json!({ "filter": "doggo = bernese" })).await;
-    index.wait_task(task.uid()).await.failed();
+    server.wait_task(task.uid()).await.failed();
     let (batch, _) = index.get_batch(2).await;
     assert_json_snapshot!(batch,
         {
@@ -539,7 +539,7 @@ async fn test_summarized_delete_documents_by_filter() {
     index.update_settings(json!({ "filterableAttributes": ["doggo"] })).await;
     let (task, _status_code) =
         index.delete_document_by_filter(json!({ "filter": "doggo = bernese" })).await;
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
     let (batch, _) = index.get_batch(4).await;
     assert_json_snapshot!(batch,
         {
@@ -586,7 +586,7 @@ async fn test_summarized_delete_document_by_id() {
     let server = Server::new().await;
     let index = server.index("test");
     let (task, _status_code) = index.delete_document(1).await;
-    index.wait_task(task.uid()).await.failed();
+    server.wait_task(task.uid()).await.failed();
     let (batch, _) = index.get_batch(0).await;
     assert_json_snapshot!(batch,
         {
@@ -628,7 +628,7 @@ async fn test_summarized_delete_document_by_id() {
 
     index.create(None).await;
     let (task, _status_code) = index.delete_document(42).await;
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
     let (batch, _) = index.get_batch(2).await;
     assert_json_snapshot!(batch,
         {
@@ -686,7 +686,7 @@ async fn test_summarized_settings_update() {
     "###);
 
     let (task,_status_code) = index.update_settings(json!({ "displayedAttributes": ["doggos", "name"], "filterableAttributes": ["age", "nb_paw_pads"], "sortableAttributes": ["iq"] })).await;
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
     let (batch, _) = index.get_batch(0).await;
     assert_json_snapshot!(batch,
         {
@@ -741,7 +741,7 @@ async fn test_summarized_index_creation() {
     let server = Server::new().await;
     let index = server.index("test");
     let (task, _status_code) = index.create(None).await;
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
     let (batch, _) = index.get_batch(0).await;
     assert_json_snapshot!(batch,
         {
@@ -778,7 +778,7 @@ async fn test_summarized_index_creation() {
     "###);
 
     let (task, _status_code) = index.create(Some("doggos")).await;
-    index.wait_task(task.uid()).await.failed();
+    server.wait_task(task.uid()).await.failed();
     let (batch, _) = index.get_batch(1).await;
     assert_json_snapshot!(batch,
         {
@@ -822,7 +822,7 @@ async fn test_summarized_index_deletion() {
     let server = Server::new().await;
     let index = server.index("test");
     let (ret, _code) = index.delete().await;
-    let batch = index.wait_task(ret.uid()).await.failed();
+    let batch = server.wait_task(ret.uid()).await.failed();
     snapshot!(batch,
         @r###"
     {
@@ -853,7 +853,7 @@ async fn test_summarized_index_deletion() {
     // both batches may get autobatched and the deleted documents count will be wrong.
     let (ret, _code) =
         index.add_documents(json!({ "id": 42, "content": "doggos & fluff" }), Some("id")).await;
-    let batch = index.wait_task(ret.uid()).await.succeeded();
+    let batch = server.wait_task(ret.uid()).await.succeeded();
     snapshot!(batch,
         @r###"
     {
@@ -876,7 +876,7 @@ async fn test_summarized_index_deletion() {
     "###);
 
     let (ret, _code) = index.delete().await;
-    let batch = index.wait_task(ret.uid()).await.succeeded();
+    let batch = server.wait_task(ret.uid()).await.succeeded();
     snapshot!(batch,
         @r###"
     {
@@ -899,7 +899,7 @@ async fn test_summarized_index_deletion() {
 
     // What happens when you delete an index that doesn't exists.
     let (ret, _code) = index.delete().await;
-    let batch = index.wait_task(ret.uid()).await.failed();
+    let batch = server.wait_task(ret.uid()).await.failed();
     snapshot!(batch,
         @r###"
     {
@@ -932,7 +932,7 @@ async fn test_summarized_index_update() {
     let index = server.index("test");
     // If the index doesn't exist yet, we should get errors with or without the primary key.
     let (task, _status_code) = index.update(None).await;
-    index.wait_task(task.uid()).await.failed();
+    server.wait_task(task.uid()).await.failed();
     let (batch, _) = index.get_batch(0).await;
     assert_json_snapshot!(batch,
         {
@@ -969,7 +969,7 @@ async fn test_summarized_index_update() {
     "###);
 
     let (task, _status_code) = index.update(Some("bones")).await;
-    index.wait_task(task.uid()).await.failed();
+    server.wait_task(task.uid()).await.failed();
     let (batch, _) = index.get_batch(1).await;
     assert_json_snapshot!(batch,
         {
@@ -1011,7 +1011,7 @@ async fn test_summarized_index_update() {
     index.create(None).await;
 
     let (task, _status_code) = index.update(None).await;
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
     let (batch, _) = index.get_batch(3).await;
     assert_json_snapshot!(batch,
         {
@@ -1048,7 +1048,7 @@ async fn test_summarized_index_update() {
     "###);
 
     let (task, _status_code) = index.update(Some("bones")).await;
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
     let (batch, _) = index.get_batch(4).await;
     assert_json_snapshot!(batch,
         {
@@ -1188,9 +1188,9 @@ async fn test_summarized_batch_cancelation() {
     let index = server.index("doggos");
     // to avoid being flaky we're only going to cancel an already finished batch :(
     let (task, _status_code) = index.create(None).await;
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
     let (task, _status_code) = server.cancel_tasks("uids=0").await;
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
     let (batch, _) = index.get_batch(1).await;
     assert_json_snapshot!(batch,
         {
@@ -1235,9 +1235,9 @@ async fn test_summarized_batch_deletion() {
     let index = server.index("doggos");
     // to avoid being flaky we're only going to delete an already finished batch :(
     let (task, _status_code) = index.create(None).await;
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
     let (task, _status_code) = server.delete_tasks("uids=0").await;
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
     let (batch, _) = index.get_batch(1).await;
     assert_json_snapshot!(batch,
         {

--- a/crates/meilisearch/tests/common/index.rs
+++ b/crates/meilisearch/tests/common/index.rs
@@ -265,7 +265,11 @@ impl Index<'_, Shared> {
     /// You cannot modify the content of a shared index, thus the delete_document_by_filter call
     /// must fail. If the task successfully enqueue itself, we'll wait for the task to finishes,
     /// and if it succeed the function will panic.
-    pub async fn delete_document_by_filter_fail<State>(&self, body: Value, waiter: &Server<State>) -> (Value, StatusCode) {
+    pub async fn delete_document_by_filter_fail<State>(
+        &self,
+        body: Value,
+        waiter: &Server<State>,
+    ) -> (Value, StatusCode) {
         let (mut task, code) = self._delete_document_by_filter(body).await;
         if code.is_success() {
             task = waiter.wait_task(task.uid()).await;
@@ -293,7 +297,11 @@ impl Index<'_, Shared> {
         (task, code)
     }
 
-    pub async fn update_index_fail<State>(&self, primary_key: Option<&str>, waiter: &Server<State>) -> (Value, StatusCode) {
+    pub async fn update_index_fail<State>(
+        &self,
+        primary_key: Option<&str>,
+        waiter: &Server<State>,
+    ) -> (Value, StatusCode) {
         let (mut task, code) = self._update(primary_key).await;
         if code.is_success() {
             task = waiter.wait_task(task.uid()).await;

--- a/crates/meilisearch/tests/common/mod.rs
+++ b/crates/meilisearch/tests/common/mod.rs
@@ -181,7 +181,7 @@ pub async fn shared_empty_index() -> &'static Index<'static, Shared> {
             let server = Server::new_shared();
             let index = server._index("EMPTY_INDEX").to_shared();
             let (response, _code) = index._create(None).await;
-            index.wait_task(response.uid()).await.succeeded();
+            server.wait_task(response.uid()).await.succeeded();
             index
         })
         .await
@@ -229,13 +229,13 @@ pub async fn shared_index_with_documents() -> &'static Index<'static, Shared> {
         let index = server._index("SHARED_DOCUMENTS").to_shared();
         let documents = DOCUMENTS.clone();
         let (response, _code) = index._add_documents(documents, None).await;
-        index.wait_task(response.uid()).await.succeeded();
+        server.wait_task(response.uid()).await.succeeded();
         let (response, _code) = index
             ._update_settings(
                 json!({"filterableAttributes": ["id", "title"], "sortableAttributes": ["id", "title"]}),
             )
             .await;
-        index.wait_task(response.uid()).await.succeeded();
+        server.wait_task(response.uid()).await.succeeded();
         index
     }).await
 }
@@ -272,13 +272,13 @@ pub async fn shared_index_with_score_documents() -> &'static Index<'static, Shar
         let index = server._index("SHARED_SCORE_DOCUMENTS").to_shared();
         let documents = SCORE_DOCUMENTS.clone();
         let (response, _code) = index._add_documents(documents, None).await;
-        index.wait_task(response.uid()).await.succeeded();
+        server.wait_task(response.uid()).await.succeeded();
         let (response, _code) = index
             ._update_settings(
                 json!({"filterableAttributes": ["id", "title"], "sortableAttributes": ["id", "title"]}),
             )
             .await;
-        index.wait_task(response.uid()).await.succeeded();
+        server.wait_task(response.uid()).await.succeeded();
         index
     }).await
 }
@@ -349,13 +349,13 @@ pub async fn shared_index_with_nested_documents() -> &'static Index<'static, Sha
         let index = server._index("SHARED_NESTED_DOCUMENTS").to_shared();
         let documents = NESTED_DOCUMENTS.clone();
         let (response, _code) = index._add_documents(documents, None).await;
-        index.wait_task(response.uid()).await.succeeded();
+        server.wait_task(response.uid()).await.succeeded();
         let (response, _code) = index
             ._update_settings(
                 json!({"filterableAttributes": ["father", "doggos", "cattos"], "sortableAttributes": ["doggos"]}),
             )
             .await;
-        index.wait_task(response.uid()).await.succeeded();
+        server.wait_task(response.uid()).await.succeeded();
         index
     }).await
 }
@@ -449,7 +449,7 @@ pub async fn shared_index_with_test_set() -> &'static Index<'static, Shared> {
                 )
                 .await;
             assert_eq!(code, 202);
-            index.wait_task(response.uid()).await.succeeded();
+            server.wait_task(response.uid()).await.succeeded();
             index
         })
         .await
@@ -496,14 +496,14 @@ pub async fn shared_index_with_geo_documents() -> &'static Index<'static, Shared
             let server = Server::new_shared();
             let index = server._index("SHARED_GEO_DOCUMENTS").to_shared();
             let (response, _code) = index._add_documents(GEO_DOCUMENTS.clone(), None).await;
-            index.wait_task(response.uid()).await.succeeded();
+            server.wait_task(response.uid()).await.succeeded();
 
             let (response, _code) = index
                 ._update_settings(
                     json!({"filterableAttributes": ["_geo"], "sortableAttributes": ["_geo"]}),
                 )
                 .await;
-            index.wait_task(response.uid()).await.succeeded();
+            server.wait_task(response.uid()).await.succeeded();
             index
         })
         .await

--- a/crates/meilisearch/tests/common/server.rs
+++ b/crates/meilisearch/tests/common/server.rs
@@ -407,13 +407,20 @@ impl<State> Server<State> {
     }
 
     pub async fn wait_task(&self, update_id: u64) -> Value {
+        Server::<Shared>::_wait_task(async |url| self.service.get(url).await, update_id).await
+    }
+
+    pub(super) async fn _wait_task<F>(request_fn: F, update_id: u64) -> Value
+    where
+        F: AsyncFnOnce(String) -> (Value, StatusCode) + Copy,
+    {
         // try several times to get status, or panic to not wait forever
-        let url = format!("/tasks/{}", update_id);
-        let max_attempts = 400; // 200 seconds total, 0.5s per attempt
+        let url = format!("/tasks/{update_id}");
+        let max_attempts = 400; // 200 seconds in total, 0.5secs per attempt
 
         for i in 0..max_attempts {
-            let (response, status_code) = self.service.get(&url).await;
-            assert_eq!(200, status_code, "response: {}", response);
+            let (response, status_code) = request_fn(url.clone()).await;
+            assert_eq!(200, status_code, "response: {response}");
 
             if response["status"] == "succeeded" || response["status"] == "failed" {
                 return response;

--- a/crates/meilisearch/tests/documents/add_documents.rs
+++ b/crates/meilisearch/tests/documents/add_documents.rs
@@ -1318,7 +1318,7 @@ async fn add_no_documents() {
 async fn add_larger_dataset() {
     let server = Server::new_shared();
     let index = server.unique_index();
-    let update_id = index.load_test_set().await;
+    let update_id = index.load_test_set(server).await;
     let (response, code) = index.get_task(update_id).await;
     assert_eq!(code, 200);
     assert_eq!(response["status"], "succeeded");
@@ -1333,7 +1333,7 @@ async fn add_larger_dataset() {
 
     // x-ndjson add large test
     let index = server.unique_index();
-    let update_id = index.load_test_set_ndjson().await;
+    let update_id = index.load_test_set_ndjson(server).await;
     let (response, code) = index.get_task(update_id).await;
     assert_eq!(code, 200);
     assert_eq!(response["status"], "succeeded");

--- a/crates/meilisearch/tests/documents/delete_documents.rs
+++ b/crates/meilisearch/tests/documents/delete_documents.rs
@@ -7,7 +7,7 @@ use crate::json;
 async fn delete_one_document_unexisting_index() {
     let server = Server::new_shared();
     let index = shared_does_not_exists_index().await;
-    let (task, code) = index.delete_document_by_filter_fail(json!({"filter": "a = b"})).await;
+    let (task, code) = index.delete_document_by_filter_fail(json!({"filter": "a = b"}), server).await;
     assert_eq!(code, 202);
 
     server.wait_task(task.uid()).await.failed();

--- a/crates/meilisearch/tests/documents/delete_documents.rs
+++ b/crates/meilisearch/tests/documents/delete_documents.rs
@@ -7,7 +7,8 @@ use crate::json;
 async fn delete_one_document_unexisting_index() {
     let server = Server::new_shared();
     let index = shared_does_not_exists_index().await;
-    let (task, code) = index.delete_document_by_filter_fail(json!({"filter": "a = b"}), server).await;
+    let (task, code) =
+        index.delete_document_by_filter_fail(json!({"filter": "a = b"}), server).await;
     assert_eq!(code, 202);
 
     server.wait_task(task.uid()).await.failed();

--- a/crates/meilisearch/tests/documents/errors.rs
+++ b/crates/meilisearch/tests/documents/errors.rs
@@ -559,7 +559,7 @@ async fn delete_document_by_filter() {
     let index = shared_does_not_exists_index().await;
     // index does not exists
     let (response, _code) =
-        index.delete_document_by_filter_fail(json!({ "filter": "doggo = bernese"})).await;
+        index.delete_document_by_filter_fail(json!({ "filter": "doggo = bernese"}), server).await;
     snapshot!(response, @r###"
     {
       "uid": "[uid]",
@@ -589,7 +589,7 @@ async fn delete_document_by_filter() {
     // no filterable are set
     let index = shared_empty_index().await;
     let (response, _code) =
-        index.delete_document_by_filter_fail(json!({ "filter": "doggo = bernese"})).await;
+        index.delete_document_by_filter_fail(json!({ "filter": "doggo = bernese"}), server).await;
     snapshot!(response, @r###"
     {
       "uid": "[uid]",
@@ -619,7 +619,7 @@ async fn delete_document_by_filter() {
     // not filterable while there is a filterable attribute
     let index = shared_index_with_documents().await;
     let (response, code) =
-        index.delete_document_by_filter_fail(json!({ "filter": "catto = jorts"})).await;
+        index.delete_document_by_filter_fail(json!({ "filter": "catto = jorts"}), server).await;
     snapshot!(code, @"202 Accepted");
     let response = server.wait_task(response.uid()).await.failed();
     snapshot!(response, @r###"

--- a/crates/meilisearch/tests/documents/get_documents.rs
+++ b/crates/meilisearch/tests/documents/get_documents.rs
@@ -334,7 +334,7 @@ async fn get_document_s_nested_attributes_to_retrieve() {
 async fn get_documents_displayed_attributes_is_ignored() {
     let server = Server::new_shared();
     let index = server.unique_index();
-    index.load_test_set().await;
+    index.load_test_set(server).await;
     index.update_settings(json!({"displayedAttributes": ["gender"]})).await;
 
     let (response, code) = index.get_all_documents(GetAllDocumentsOptions::default()).await;

--- a/crates/meilisearch/tests/dumps/mod.rs
+++ b/crates/meilisearch/tests/dumps/mod.rs
@@ -2366,7 +2366,7 @@ async fn generate_and_import_dump_containing_vectors() {
         ))
         .await;
     snapshot!(code, @"202 Accepted");
-    let response = index.wait_task(response.uid()).await;
+    let response = server.wait_task(response.uid()).await;
     snapshot!(response);
     let (response, code) = index
         .add_documents(
@@ -2381,12 +2381,12 @@ async fn generate_and_import_dump_containing_vectors() {
         )
         .await;
     snapshot!(code, @"202 Accepted");
-    let response = index.wait_task(response.uid()).await;
+    let response = server.wait_task(response.uid()).await;
     snapshot!(response);
 
     let (response, code) = server.create_dump().await;
     snapshot!(code, @"202 Accepted");
-    let response = index.wait_task(response.uid()).await;
+    let response = server.wait_task(response.uid()).await;
     snapshot!(response["status"], @r###""succeeded""###);
 
     // ========= We made a dump, now we should clear the DB and try to import our dump

--- a/crates/meilisearch/tests/index/create_index.rs
+++ b/crates/meilisearch/tests/index/create_index.rs
@@ -161,9 +161,9 @@ async fn test_create_multiple_indexes() {
     let (task2, _) = index2.create(None).await;
     let (task3, _) = index3.create(None).await;
 
-    index1.wait_task(task1.uid()).await.succeeded();
-    index2.wait_task(task2.uid()).await.succeeded();
-    index3.wait_task(task3.uid()).await.succeeded();
+    server.wait_task(task1.uid()).await.succeeded();
+    server.wait_task(task2.uid()).await.succeeded();
+    server.wait_task(task3.uid()).await.succeeded();
 
     assert_eq!(index1.get().await.1, 200);
     assert_eq!(index2.get().await.1, 200);

--- a/crates/meilisearch/tests/index/delete_index.rs
+++ b/crates/meilisearch/tests/index/delete_index.rs
@@ -26,7 +26,7 @@ async fn create_and_delete_index() {
 async fn error_delete_unexisting_index() {
     let server = Server::new_shared();
     let index = shared_does_not_exists_index().await;
-    let (task, code) = index.delete_index_fail().await;
+    let (task, code) = index.delete_index_fail(server).await;
 
     assert_eq!(code, 202);
     server.wait_task(task.uid()).await.failed();

--- a/crates/meilisearch/tests/index/get_index.rs
+++ b/crates/meilisearch/tests/index/get_index.rs
@@ -60,8 +60,8 @@ async fn list_multiple_indexes() {
     let index_with_key = server.unique_index();
     let (response_with_key, _status_code) = index_with_key.create(Some("key")).await;
 
-    index_without_key.wait_task(response_without_key.uid()).await.succeeded();
-    index_with_key.wait_task(response_with_key.uid()).await.succeeded();
+    server.wait_task(response_without_key.uid()).await.succeeded();
+    server.wait_task(response_with_key.uid()).await.succeeded();
 
     let (response, code) = server.list_indexes(None, Some(1000)).await;
     assert_eq!(code, 200);
@@ -81,8 +81,9 @@ async fn get_and_paginate_indexes() {
     let server = Server::new().await;
     const NB_INDEXES: usize = 50;
     for i in 0..NB_INDEXES {
-        server.index(format!("test_{i:02}")).create(None).await;
-        server.index(format!("test_{i:02}")).wait_task(i as u64).await;
+        let (task, code) = server.index(format!("test_{i:02}")).create(None).await;
+        assert_eq!(code, 202);
+        server.wait_task(task.uid()).await;
     }
 
     // basic

--- a/crates/meilisearch/tests/index/update_index.rs
+++ b/crates/meilisearch/tests/index/update_index.rs
@@ -72,7 +72,7 @@ async fn error_update_existing_primary_key() {
     let server = Server::new_shared();
     let index = shared_index_with_documents().await;
 
-    let (update_task, code) = index.update_index_fail(Some("primary")).await;
+    let (update_task, code) = index.update_index_fail(Some("primary"), server).await;
 
     assert_eq!(code, 202);
     let response = server.wait_task(update_task.uid()).await.failed();
@@ -91,7 +91,7 @@ async fn error_update_existing_primary_key() {
 async fn error_update_unexisting_index() {
     let server = Server::new_shared();
     let index = shared_does_not_exists_index().await;
-    let (task, code) = index.update_index_fail(Some("my-primary-key")).await;
+    let (task, code) = index.update_index_fail(Some("my-primary-key"), server).await;
 
     assert_eq!(code, 202);
 

--- a/crates/meilisearch/tests/search/multi/proxy.rs
+++ b/crates/meilisearch/tests/search/multi/proxy.rs
@@ -158,11 +158,11 @@ async fn remote_sharding() {
     let index1 = ms1.index("test");
     let index2 = ms2.index("test");
     let (task, _status_code) = index0.add_documents(json!(documents[0..2]), None).await;
-    index0.wait_task(task.uid()).await.succeeded();
+    ms0.wait_task(task.uid()).await.succeeded();
     let (task, _status_code) = index1.add_documents(json!(documents[2..3]), None).await;
-    index1.wait_task(task.uid()).await.succeeded();
+    ms1.wait_task(task.uid()).await.succeeded();
     let (task, _status_code) = index2.add_documents(json!(documents[3..5]), None).await;
-    index2.wait_task(task.uid()).await.succeeded();
+    ms2.wait_task(task.uid()).await.succeeded();
 
     // wrap servers
     let ms0 = Arc::new(ms0);
@@ -454,9 +454,9 @@ async fn error_unregistered_remote() {
     let index0 = ms0.index("test");
     let index1 = ms1.index("test");
     let (task, _status_code) = index0.add_documents(json!(documents[0..2]), None).await;
-    index0.wait_task(task.uid()).await.succeeded();
+    ms0.wait_task(task.uid()).await.succeeded();
     let (task, _status_code) = index1.add_documents(json!(documents[2..3]), None).await;
-    index1.wait_task(task.uid()).await.succeeded();
+    ms1.wait_task(task.uid()).await.succeeded();
 
     // wrap servers
     let ms0 = Arc::new(ms0);
@@ -572,9 +572,9 @@ async fn error_no_weighted_score() {
     let index0 = ms0.index("test");
     let index1 = ms1.index("test");
     let (task, _status_code) = index0.add_documents(json!(documents[0..2]), None).await;
-    index0.wait_task(task.uid()).await.succeeded();
+    ms0.wait_task(task.uid()).await.succeeded();
     let (task, _status_code) = index1.add_documents(json!(documents[2..3]), None).await;
-    index1.wait_task(task.uid()).await.succeeded();
+    ms1.wait_task(task.uid()).await.succeeded();
 
     // wrap servers
     let ms0 = Arc::new(ms0);
@@ -705,9 +705,9 @@ async fn error_bad_response() {
     let index0 = ms0.index("test");
     let index1 = ms1.index("test");
     let (task, _status_code) = index0.add_documents(json!(documents[0..2]), None).await;
-    index0.wait_task(task.uid()).await.succeeded();
+    ms0.wait_task(task.uid()).await.succeeded();
     let (task, _status_code) = index1.add_documents(json!(documents[2..3]), None).await;
-    index1.wait_task(task.uid()).await.succeeded();
+    ms1.wait_task(task.uid()).await.succeeded();
 
     // wrap servers
     let ms0 = Arc::new(ms0);
@@ -842,9 +842,9 @@ async fn error_bad_request() {
     let index0 = ms0.index("test");
     let index1 = ms1.index("test");
     let (task, _status_code) = index0.add_documents(json!(documents[0..2]), None).await;
-    index0.wait_task(task.uid()).await.succeeded();
+    ms0.wait_task(task.uid()).await.succeeded();
     let (task, _status_code) = index1.add_documents(json!(documents[2..3]), None).await;
-    index1.wait_task(task.uid()).await.succeeded();
+    ms1.wait_task(task.uid()).await.succeeded();
 
     // wrap servers
     let ms0 = Arc::new(ms0);
@@ -972,10 +972,10 @@ async fn error_bad_request_facets_by_index() {
     let index0 = ms0.index("test0");
     let index1 = ms1.index("test1");
     let (task, _status_code) = index0.add_documents(json!(documents[0..2]), None).await;
-    index0.wait_task(task.uid()).await.succeeded();
+    ms0.wait_task(task.uid()).await.succeeded();
 
     let (task, _status_code) = index1.add_documents(json!(documents[2..3]), None).await;
-    index1.wait_task(task.uid()).await.succeeded();
+    ms1.wait_task(task.uid()).await.succeeded();
 
     // wrap servers
     let ms0 = Arc::new(ms0);
@@ -1113,13 +1113,13 @@ async fn error_bad_request_facets_by_index_facet() {
     let index0 = ms0.index("test");
     let index1 = ms1.index("test");
     let (task, _status_code) = index0.add_documents(json!(documents[0..2]), None).await;
-    index0.wait_task(task.uid()).await.succeeded();
+    ms0.wait_task(task.uid()).await.succeeded();
 
     let (task, _status_code) = index0.update_settings_filterable_attributes(json!(["id"])).await;
-    index0.wait_task(task.uid()).await.succeeded();
+    ms0.wait_task(task.uid()).await.succeeded();
 
     let (task, _status_code) = index1.add_documents(json!(documents[2..3]), None).await;
-    index1.wait_task(task.uid()).await.succeeded();
+    ms1.wait_task(task.uid()).await.succeeded();
 
     // wrap servers
     let ms0 = Arc::new(ms0);
@@ -1263,9 +1263,9 @@ async fn error_remote_does_not_answer() {
     let index0 = ms0.index("test");
     let index1 = ms1.index("test");
     let (task, _status_code) = index0.add_documents(json!(documents[0..2]), None).await;
-    index0.wait_task(task.uid()).await.succeeded();
+    ms0.wait_task(task.uid()).await.succeeded();
     let (task, _status_code) = index1.add_documents(json!(documents[2..3]), None).await;
-    index1.wait_task(task.uid()).await.succeeded();
+    ms1.wait_task(task.uid()).await.succeeded();
 
     // wrap servers
     let ms0 = Arc::new(ms0);
@@ -1464,9 +1464,9 @@ async fn error_remote_404() {
     let index0 = ms0.index("test");
     let index1 = ms1.index("test");
     let (task, _status_code) = index0.add_documents(json!(documents[0..2]), None).await;
-    index0.wait_task(task.uid()).await.succeeded();
+    ms0.wait_task(task.uid()).await.succeeded();
     let (task, _status_code) = index1.add_documents(json!(documents[2..3]), None).await;
-    index1.wait_task(task.uid()).await.succeeded();
+    ms1.wait_task(task.uid()).await.succeeded();
 
     // wrap servers
     let ms0 = Arc::new(ms0);
@@ -1659,9 +1659,9 @@ async fn error_remote_sharding_auth() {
     let index0 = ms0.index("test");
     let index1 = ms1.index("test");
     let (task, _status_code) = index0.add_documents(json!(documents[0..2]), None).await;
-    index0.wait_task(task.uid()).await.succeeded();
+    ms0.wait_task(task.uid()).await.succeeded();
     let (task, _status_code) = index1.add_documents(json!(documents[2..3]), None).await;
-    index1.wait_task(task.uid()).await.succeeded();
+    ms1.wait_task(task.uid()).await.succeeded();
 
     // wrap servers
     ms1.clear_api_key();
@@ -1819,9 +1819,9 @@ async fn remote_sharding_auth() {
     let index0 = ms0.index("test");
     let index1 = ms1.index("test");
     let (task, _status_code) = index0.add_documents(json!(documents[0..2]), None).await;
-    index0.wait_task(task.uid()).await.succeeded();
+    ms0.wait_task(task.uid()).await.succeeded();
     let (task, _status_code) = index1.add_documents(json!(documents[2..3]), None).await;
-    index1.wait_task(task.uid()).await.succeeded();
+    ms1.wait_task(task.uid()).await.succeeded();
 
     // wrap servers
     ms1.clear_api_key();
@@ -1974,9 +1974,9 @@ async fn error_remote_500() {
     let index0 = ms0.index("test");
     let index1 = ms1.index("test");
     let (task, _status_code) = index0.add_documents(json!(documents[0..2]), None).await;
-    index0.wait_task(task.uid()).await.succeeded();
+    ms0.wait_task(task.uid()).await.succeeded();
     let (task, _status_code) = index1.add_documents(json!(documents[2..3]), None).await;
-    index1.wait_task(task.uid()).await.succeeded();
+    ms1.wait_task(task.uid()).await.succeeded();
 
     // wrap servers
     let ms0 = Arc::new(ms0);
@@ -2153,9 +2153,9 @@ async fn error_remote_500_once() {
     let index0 = ms0.index("test");
     let index1 = ms1.index("test");
     let (task, _status_code) = index0.add_documents(json!(documents[0..2]), None).await;
-    index0.wait_task(task.uid()).await.succeeded();
+    ms0.wait_task(task.uid()).await.succeeded();
     let (task, _status_code) = index1.add_documents(json!(documents[2..3]), None).await;
-    index1.wait_task(task.uid()).await.succeeded();
+    ms1.wait_task(task.uid()).await.succeeded();
 
     // wrap servers
     let ms0 = Arc::new(ms0);
@@ -2336,9 +2336,9 @@ async fn error_remote_timeout() {
     let index0 = ms0.index("test");
     let index1 = ms1.index("test");
     let (task, _status_code) = index0.add_documents(json!(documents[0..2]), None).await;
-    index0.wait_task(task.uid()).await.succeeded();
+    ms0.wait_task(task.uid()).await.succeeded();
     let (task, _status_code) = index1.add_documents(json!(documents[2..3]), None).await;
-    index1.wait_task(task.uid()).await.succeeded();
+    ms1.wait_task(task.uid()).await.succeeded();
 
     // wrap servers
     let ms0 = Arc::new(ms0);

--- a/crates/meilisearch/tests/similar/errors.rs
+++ b/crates/meilisearch/tests/similar/errors.rs
@@ -298,7 +298,7 @@ async fn similar_bad_filter() {
     let documents = DOCUMENTS.clone();
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(value.uid()).await.succeeded();
+    server.wait_task(value.uid()).await.succeeded();
 
     let (response, code) =
         index.similar_post(json!({ "id": 287947, "filter": true, "embedder": "manual" })).await;
@@ -335,7 +335,7 @@ async fn filter_invalid_syntax_object() {
     let documents = DOCUMENTS.clone();
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(value.uid()).await.succeeded();
+    server.wait_task(value.uid()).await.succeeded();
 
     index
         .similar(json!({"id": 287947, "filter": "title & Glass", "embedder": "manual"}), |response, code| {
@@ -373,7 +373,7 @@ async fn filter_invalid_syntax_array() {
     let documents = DOCUMENTS.clone();
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(value.uid()).await.succeeded();
+    server.wait_task(value.uid()).await.succeeded();
 
     index
         .similar(json!({"id": 287947, "filter": ["title & Glass"], "embedder": "manual"}), |response, code| {
@@ -411,7 +411,7 @@ async fn filter_invalid_syntax_string() {
     let documents = DOCUMENTS.clone();
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(value.uid()).await.succeeded();
+    server.wait_task(value.uid()).await.succeeded();
 
     let expected_response = json!({
         "message": "Found unexpected characters at the end of the filter: `XOR title = Glass`. You probably forgot an `OR` or an `AND` rule.\n15:32 title = Glass XOR title = Glass",
@@ -451,7 +451,7 @@ async fn filter_invalid_attribute_array() {
     let documents = DOCUMENTS.clone();
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(value.uid()).await.succeeded();
+    server.wait_task(value.uid()).await.succeeded();
 
     index
         .similar(
@@ -492,7 +492,7 @@ async fn filter_invalid_attribute_string() {
     let documents = DOCUMENTS.clone();
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(value.uid()).await.succeeded();
+    server.wait_task(value.uid()).await.succeeded();
 
     index
         .similar(
@@ -533,7 +533,7 @@ async fn filter_reserved_geo_attribute_array() {
     let documents = DOCUMENTS.clone();
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(value.uid()).await.succeeded();
+    server.wait_task(value.uid()).await.succeeded();
 
     let expected_response = json!({
         "message": "`_geo` is a reserved keyword and thus can't be used as a filter expression. Use the `_geoRadius(latitude, longitude, distance)` or `_geoBoundingBox([latitude, longitude], [latitude, longitude])` built-in rules to filter on `_geo` coordinates.\n1:13 _geo = Glass",
@@ -573,7 +573,7 @@ async fn filter_reserved_geo_attribute_string() {
     let documents = DOCUMENTS.clone();
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(value.uid()).await.succeeded();
+    server.wait_task(value.uid()).await.succeeded();
 
     let expected_response = json!({
         "message": "`_geo` is a reserved keyword and thus can't be used as a filter expression. Use the `_geoRadius(latitude, longitude, distance)` or `_geoBoundingBox([latitude, longitude], [latitude, longitude])` built-in rules to filter on `_geo` coordinates.\n1:13 _geo = Glass",
@@ -613,7 +613,7 @@ async fn filter_reserved_attribute_array() {
     let documents = DOCUMENTS.clone();
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(value.uid()).await.succeeded();
+    server.wait_task(value.uid()).await.succeeded();
 
     let expected_response = json!({
         "message": "`_geoDistance` is a reserved keyword and thus can't be used as a filter expression. Use the `_geoRadius(latitude, longitude, distance)` or `_geoBoundingBox([latitude, longitude], [latitude, longitude])` built-in rules to filter on `_geo` coordinates.\n1:21 _geoDistance = Glass",
@@ -653,7 +653,7 @@ async fn filter_reserved_attribute_string() {
     let documents = DOCUMENTS.clone();
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(value.uid()).await.succeeded();
+    server.wait_task(value.uid()).await.succeeded();
 
     let expected_response = json!({
        "message": "`_geoDistance` is a reserved keyword and thus can't be used as a filter expression. Use the `_geoRadius(latitude, longitude, distance)` or `_geoBoundingBox([latitude, longitude], [latitude, longitude])` built-in rules to filter on `_geo` coordinates.\n1:21 _geoDistance = Glass",
@@ -693,7 +693,7 @@ async fn filter_reserved_geo_point_array() {
     let documents = DOCUMENTS.clone();
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(value.uid()).await.succeeded();
+    server.wait_task(value.uid()).await.succeeded();
 
     let expected_response = json!({
         "message": "`_geoPoint` is a reserved keyword and thus can't be used as a filter expression. Use the `_geoRadius(latitude, longitude, distance)` or `_geoBoundingBox([latitude, longitude], [latitude, longitude])` built-in rules to filter on `_geo` coordinates.\n1:18 _geoPoint = Glass",
@@ -733,7 +733,7 @@ async fn filter_reserved_geo_point_string() {
     let documents = DOCUMENTS.clone();
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(value.uid()).await.succeeded();
+    server.wait_task(value.uid()).await.succeeded();
 
     let expected_response = json!({
        "message": "`_geoPoint` is a reserved keyword and thus can't be used as a filter expression. Use the `_geoRadius(latitude, longitude, distance)` or `_geoBoundingBox([latitude, longitude], [latitude, longitude])` built-in rules to filter on `_geo` coordinates.\n1:18 _geoPoint = Glass",
@@ -825,7 +825,7 @@ async fn similar_bad_embedder() {
     let documents = DOCUMENTS.clone();
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(value.uid()).await;
+    server.wait_task(value.uid()).await;
 
     let expected_response = json!({
     "message": "Cannot find embedder with name `auto`.",

--- a/crates/meilisearch/tests/snapshot/mod.rs
+++ b/crates/meilisearch/tests/snapshot/mod.rs
@@ -51,7 +51,7 @@ async fn perform_snapshot() {
         }))
         .await;
 
-    index.load_test_set().await;
+    index.load_test_set(&server).await;
 
     let (task, code) = server.index("test1").create(Some("prim")).await;
     meili_snap::snapshot!(code, @"202 Accepted");
@@ -128,7 +128,7 @@ async fn perform_on_demand_snapshot() {
         }))
         .await;
 
-    index.load_test_set().await;
+    index.load_test_set(&server).await;
 
     let (task, _status_code) = server.index("doggo").create(Some("bone")).await;
     server.wait_task(task.uid()).await.succeeded();

--- a/crates/meilisearch/tests/snapshot/mod.rs
+++ b/crates/meilisearch/tests/snapshot/mod.rs
@@ -56,7 +56,7 @@ async fn perform_snapshot() {
     let (task, code) = server.index("test1").create(Some("prim")).await;
     meili_snap::snapshot!(code, @"202 Accepted");
 
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
 
     // wait for the _next task_ to process, aka the snapshot that should be enqueued at some point
 
@@ -131,10 +131,10 @@ async fn perform_on_demand_snapshot() {
     index.load_test_set().await;
 
     let (task, _status_code) = server.index("doggo").create(Some("bone")).await;
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
 
     let (task, _status_code) = server.index("doggo").create(Some("bone")).await;
-    index.wait_task(task.uid()).await.failed();
+    server.wait_task(task.uid()).await.failed();
 
     let (task, code) = server.create_snapshot().await;
     snapshot!(code, @"202 Accepted");
@@ -147,7 +147,7 @@ async fn perform_on_demand_snapshot() {
       "enqueuedAt": "[date]"
     }
     "###);
-    let task = index.wait_task(task.uid()).await;
+    let task = server.wait_task(task.uid()).await;
     snapshot!(json_string!(task, { ".enqueuedAt" => "[date]", ".startedAt" => "[date]", ".finishedAt" => "[date]", ".duration" => "[duration]" }), @r###"
     {
       "uid": 4,

--- a/crates/meilisearch/tests/stats/mod.rs
+++ b/crates/meilisearch/tests/stats/mod.rs
@@ -32,7 +32,7 @@ async fn stats() {
     let (task, code) = index.create(Some("id")).await;
 
     assert_eq!(code, 202);
-    index.wait_task(task.uid()).await.succeeded();
+    server.wait_task(task.uid()).await.succeeded();
 
     let (response, code) = server.stats().await;
 
@@ -58,7 +58,7 @@ async fn stats() {
     assert_eq!(code, 202, "{response}");
     assert_eq!(response["taskUid"], 1);
 
-    index.wait_task(response.uid()).await.succeeded();
+    server.wait_task(response.uid()).await.succeeded();
 
     let timestamp = OffsetDateTime::now_utc();
     let (response, code) = server.stats().await;
@@ -107,7 +107,7 @@ async fn add_remove_embeddings() {
 
     let (response, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(response.uid()).await.succeeded();
+    server.wait_task(response.uid()).await.succeeded();
 
     let (stats, _code) = index.stats().await;
     snapshot!(json_string!(stats, {
@@ -135,7 +135,7 @@ async fn add_remove_embeddings() {
 
     let (response, code) = index.update_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(response.uid()).await.succeeded();
+    server.wait_task(response.uid()).await.succeeded();
 
     let (stats, _code) = index.stats().await;
     snapshot!(json_string!(stats, {
@@ -163,7 +163,7 @@ async fn add_remove_embeddings() {
 
     let (response, code) = index.update_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(response.uid()).await.succeeded();
+    server.wait_task(response.uid()).await.succeeded();
 
     let (stats, _code) = index.stats().await;
     snapshot!(json_string!(stats, {
@@ -192,7 +192,7 @@ async fn add_remove_embeddings() {
 
     let (response, code) = index.update_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(response.uid()).await.succeeded();
+    server.wait_task(response.uid()).await.succeeded();
 
     let (stats, _code) = index.stats().await;
     snapshot!(json_string!(stats, {
@@ -245,7 +245,7 @@ async fn add_remove_embedded_documents() {
 
     let (response, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(response.uid()).await.succeeded();
+    server.wait_task(response.uid()).await.succeeded();
 
     let (stats, _code) = index.stats().await;
     snapshot!(json_string!(stats, {
@@ -269,7 +269,7 @@ async fn add_remove_embedded_documents() {
     // delete one embedded document, remaining 1 embedded documents for 3 embeddings in total
     let (response, code) = index.delete_document(0).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(response.uid()).await.succeeded();
+    server.wait_task(response.uid()).await.succeeded();
 
     let (stats, _code) = index.stats().await;
     snapshot!(json_string!(stats, {
@@ -305,7 +305,7 @@ async fn update_embedder_settings() {
 
     let (response, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(response.uid()).await.succeeded();
+    server.wait_task(response.uid()).await.succeeded();
 
     let (stats, _code) = index.stats().await;
     snapshot!(json_string!(stats, {

--- a/crates/meilisearch/tests/vector/binary_quantized.rs
+++ b/crates/meilisearch/tests/vector/binary_quantized.rs
@@ -88,7 +88,7 @@ async fn binary_quantize_before_sending_documents() {
     ]);
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(value.uid()).await.succeeded();
+    server.wait_task(value.uid()).await.succeeded();
 
     // Make sure the documents are binary quantized
     let (documents, _code) = index
@@ -161,7 +161,7 @@ async fn binary_quantize_after_sending_documents() {
     ]);
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(value.uid()).await.succeeded();
+    server.wait_task(value.uid()).await.succeeded();
 
     let (response, code) = index
         .update_settings(json!({
@@ -305,7 +305,7 @@ async fn binary_quantize_clear_documents() {
     server.wait_task(response.uid()).await.succeeded();
 
     let (value, _code) = index.clear_all_documents().await;
-    index.wait_task(value.uid()).await.succeeded();
+    server.wait_task(value.uid()).await.succeeded();
 
     // Make sure the documents DB has been cleared
     let (documents, _code) = index

--- a/crates/meilisearch/tests/vector/mod.rs
+++ b/crates/meilisearch/tests/vector/mod.rs
@@ -42,7 +42,7 @@ async fn add_remove_user_provided() {
     ]);
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(value.uid()).await.succeeded();
+    server.wait_task(value.uid()).await.succeeded();
 
     let (documents, _code) = index
         .get_all_documents(GetAllDocumentsOptions { retrieve_vectors: true, ..Default::default() })
@@ -95,7 +95,7 @@ async fn add_remove_user_provided() {
     ]);
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(value.uid()).await.succeeded();
+    server.wait_task(value.uid()).await.succeeded();
 
     let (documents, _code) = index
         .get_all_documents(GetAllDocumentsOptions { retrieve_vectors: true, ..Default::default() })
@@ -138,7 +138,7 @@ async fn add_remove_user_provided() {
 
     let (value, code) = index.delete_document(0).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(value.uid()).await.succeeded();
+    server.wait_task(value.uid()).await.succeeded();
 
     let (documents, _code) = index
         .get_all_documents(GetAllDocumentsOptions { retrieve_vectors: true, ..Default::default() })
@@ -187,7 +187,7 @@ async fn user_provide_mismatched_embedding_dimension() {
     ]);
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    let task = index.wait_task(value.uid()).await;
+    let task = server.wait_task(value.uid()).await;
     snapshot!(task, @r###"
     {
       "uid": "[uid]",
@@ -218,7 +218,7 @@ async fn user_provide_mismatched_embedding_dimension() {
     ]);
     let (response, code) = index.add_documents(new_document, None).await;
     snapshot!(code, @"202 Accepted");
-    let task = index.wait_task(response.uid()).await;
+    let task = server.wait_task(response.uid()).await;
     snapshot!(task, @r###"
     {
       "uid": "[uid]",
@@ -270,7 +270,7 @@ async fn generate_default_user_provided_documents(server: &Server) -> Index {
     ]);
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    index.wait_task(value.uid()).await.succeeded();
+    server.wait_task(value.uid()).await.succeeded();
 
     index
 }
@@ -285,7 +285,7 @@ async fn user_provided_embeddings_error() {
         json!({"id": 0, "name": "kefir", "_vectors": { "manual": { "embeddings": [0, 0, 0] }}});
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    let task = index.wait_task(value.uid()).await;
+    let task = server.wait_task(value.uid()).await;
     snapshot!(task, @r###"
     {
       "uid": "[uid]",
@@ -315,7 +315,7 @@ async fn user_provided_embeddings_error() {
     let documents = json!({"id": 0, "name": "kefir", "_vectors": { "manual": {}}});
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    let task = index.wait_task(value.uid()).await;
+    let task = server.wait_task(value.uid()).await;
     snapshot!(task, @r###"
     {
       "uid": "[uid]",
@@ -346,7 +346,7 @@ async fn user_provided_embeddings_error() {
         json!({"id": 0, "name": "kefir", "_vectors": { "manual": { "regenerate": "yes please" }}});
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    let task = index.wait_task(value.uid()).await;
+    let task = server.wait_task(value.uid()).await;
     snapshot!(task, @r###"
     {
       "uid": "[uid]",
@@ -375,7 +375,7 @@ async fn user_provided_embeddings_error() {
     let documents = json!({"id": 0, "name": "kefir", "_vectors": { "manual": { "embeddings": true, "regenerate": true }}});
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    let task = index.wait_task(value.uid()).await;
+    let task = server.wait_task(value.uid()).await;
     snapshot!(task, @r###"
     {
       "uid": "[uid]",
@@ -404,7 +404,7 @@ async fn user_provided_embeddings_error() {
     let documents = json!({"id": 0, "name": "kefir", "_vectors": { "manual": { "embeddings": [true], "regenerate": true }}});
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    let task = index.wait_task(value.uid()).await;
+    let task = server.wait_task(value.uid()).await;
     snapshot!(task, @r###"
     {
       "uid": "[uid]",
@@ -433,7 +433,7 @@ async fn user_provided_embeddings_error() {
     let documents = json!({"id": 0, "name": "kefir", "_vectors": { "manual": { "embeddings": [[true]], "regenerate": false }}});
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    let task = index.wait_task(value.uid()).await;
+    let task = server.wait_task(value.uid()).await;
     snapshot!(task, @r###"
     {
       "uid": "[uid]",
@@ -462,20 +462,20 @@ async fn user_provided_embeddings_error() {
     let documents = json!({"id": 0, "name": "kefir", "_vectors": { "manual": { "embeddings": [23, 0.1, -12], "regenerate": true }}});
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    let task = index.wait_task(value.uid()).await;
+    let task = server.wait_task(value.uid()).await;
     snapshot!(task["status"], @r###""succeeded""###);
 
     let documents =
         json!({"id": 0, "name": "kefir", "_vectors": { "manual": { "regenerate": false }}});
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    let task = index.wait_task(value.uid()).await;
+    let task = server.wait_task(value.uid()).await;
     snapshot!(task["status"], @r###""succeeded""###);
 
     let documents = json!({"id": 0, "name": "kefir", "_vectors": { "manual": { "regenerate": false, "embeddings": [0.1, [0.2, 0.3]] }}});
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    let task = index.wait_task(value.uid()).await;
+    let task = server.wait_task(value.uid()).await;
     snapshot!(task, @r###"
     {
       "uid": "[uid]",
@@ -504,7 +504,7 @@ async fn user_provided_embeddings_error() {
     let documents = json!({"id": 0, "name": "kefir", "_vectors": { "manual": { "regenerate": false, "embeddings": [[0.1, 0.2], 0.3] }}});
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    let task = index.wait_task(value.uid()).await;
+    let task = server.wait_task(value.uid()).await;
     snapshot!(task, @r###"
     {
       "uid": "[uid]",
@@ -533,7 +533,7 @@ async fn user_provided_embeddings_error() {
     let documents = json!({"id": 0, "name": "kefir", "_vectors": { "manual": { "regenerate": false, "embeddings": [[0.1, true], 0.3] }}});
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    let task = index.wait_task(value.uid()).await;
+    let task = server.wait_task(value.uid()).await;
     snapshot!(task, @r###"
     {
       "uid": "[uid]",
@@ -574,7 +574,7 @@ async fn user_provided_vectors_error() {
     let documents = json!([{"id": 40, "name": "kefir"}, {"id": 41, "name": "intel"}, {"id": 42, "name": "max"}, {"id": 43, "name": "venus"}, {"id": 44, "name": "eva"}]);
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    let task = index.wait_task(value.uid()).await;
+    let task = server.wait_task(value.uid()).await;
     snapshot!(task, @r###"
     {
       "uid": "[uid]",
@@ -604,7 +604,7 @@ async fn user_provided_vectors_error() {
     let documents = json!({"id": 42, "name": "kefir", "_vector": { "manaul": [0, 0, 0] }});
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    let task = index.wait_task(value.uid()).await;
+    let task = server.wait_task(value.uid()).await;
     snapshot!(task, @r###"
     {
       "uid": "[uid]",
@@ -634,7 +634,7 @@ async fn user_provided_vectors_error() {
     let documents = json!({"id": 42, "name": "kefir", "_vectors": { "manaul": [0, 0, 0] }});
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    let task = index.wait_task(value.uid()).await;
+    let task = server.wait_task(value.uid()).await;
     snapshot!(task, @r###"
     {
       "uid": "[uid]",
@@ -667,7 +667,7 @@ async fn clear_documents() {
     let index = generate_default_user_provided_documents(&server).await;
 
     let (value, _code) = index.clear_all_documents().await;
-    index.wait_task(value.uid()).await.succeeded();
+    server.wait_task(value.uid()).await.succeeded();
 
     // Make sure the documents DB has been cleared
     let (documents, _code) = index
@@ -723,7 +723,7 @@ async fn add_remove_one_vector_4588() {
     ]);
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    let task = index.wait_task(value.uid()).await;
+    let task = server.wait_task(value.uid()).await;
     snapshot!(task, name: "document-added");
 
     let documents = json!([
@@ -731,7 +731,7 @@ async fn add_remove_one_vector_4588() {
     ]);
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    let task = index.wait_task(value.uid()).await;
+    let task = server.wait_task(value.uid()).await;
     snapshot!(task, name: "document-deleted");
 
     let (documents, _code) = index

--- a/crates/meilisearch/tests/vector/ollama.rs
+++ b/crates/meilisearch/tests/vector/ollama.rs
@@ -117,7 +117,7 @@ async fn test_both_apis() {
     ]);
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    let task = index.wait_task(value.uid()).await;
+    let task = server.wait_task(value.uid()).await;
     snapshot!(task, @r###"
     {
       "uid": "[uid]",

--- a/crates/meilisearch/tests/vector/openai.rs
+++ b/crates/meilisearch/tests/vector/openai.rs
@@ -370,7 +370,7 @@ async fn it_works() {
     ]);
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    let task = index.wait_task(value.uid()).await;
+    let task = server.wait_task(value.uid()).await;
     snapshot!(task, @r###"
     {
       "uid": "[uid]",
@@ -601,7 +601,7 @@ async fn tokenize_long_text() {
     ]);
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    let task = index.wait_task(value.uid()).await;
+    let task = server.wait_task(value.uid()).await;
     snapshot!(task, @r###"
     {
       "uid": "[uid]",
@@ -657,7 +657,7 @@ async fn bad_api_key() {
     ]);
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    let task = index.wait_task(value.uid()).await;
+    let task = server.wait_task(value.uid()).await;
 
     snapshot!(task, @r###"
     {
@@ -805,7 +805,7 @@ async fn bad_model() {
     ]);
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    let task = index.wait_task(value.uid()).await;
+    let task = server.wait_task(value.uid()).await;
 
     snapshot!(task, @r###"
     {
@@ -883,7 +883,7 @@ async fn bad_dimensions() {
     ]);
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    let task = index.wait_task(value.uid()).await;
+    let task = server.wait_task(value.uid()).await;
 
     snapshot!(task, @r###"
     {
@@ -992,7 +992,7 @@ async fn smaller_dimensions() {
     ]);
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    let task = index.wait_task(value.uid()).await;
+    let task = server.wait_task(value.uid()).await;
     snapshot!(task, @r###"
     {
       "uid": "[uid]",
@@ -1224,7 +1224,7 @@ async fn small_embedding_model() {
     ]);
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    let task = index.wait_task(value.uid()).await;
+    let task = server.wait_task(value.uid()).await;
     snapshot!(task, @r###"
     {
       "uid": "[uid]",
@@ -1455,7 +1455,7 @@ async fn legacy_embedding_model() {
     ]);
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    let task = index.wait_task(value.uid()).await;
+    let task = server.wait_task(value.uid()).await;
     snapshot!(task, @r###"
     {
       "uid": "[uid]",
@@ -1687,7 +1687,7 @@ async fn it_still_works() {
     ]);
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    let task = index.wait_task(value.uid()).await;
+    let task = server.wait_task(value.uid()).await;
     snapshot!(task, @r###"
     {
       "uid": "[uid]",
@@ -1916,7 +1916,7 @@ async fn timeout() {
     ]);
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    let task = index.wait_task(value.uid()).await;
+    let task = server.wait_task(value.uid()).await;
     snapshot!(task, @r###"
     {
       "uid": "[uid]",

--- a/crates/meilisearch/tests/vector/rest.rs
+++ b/crates/meilisearch/tests/vector/rest.rs
@@ -1099,7 +1099,7 @@ async fn add_vector_and_user_provided() {
     ]);
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    let task = index.wait_task(value.uid()).await;
+    let task = server.wait_task(value.uid()).await;
     snapshot!(task, @r###"
     {
       "uid": "[uid]",
@@ -1616,7 +1616,7 @@ async fn server_returns_multiple() {
     ]);
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    let task = index.wait_task(value.uid()).await;
+    let task = server.wait_task(value.uid()).await;
     snapshot!(task, @r###"
     {
       "uid": "[uid]",
@@ -1722,7 +1722,7 @@ async fn server_single_input_returns_in_array() {
     ]);
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    let task = index.wait_task(value.uid()).await;
+    let task = server.wait_task(value.uid()).await;
     snapshot!(task, @r###"
     {
       "uid": "[uid]",
@@ -1828,7 +1828,7 @@ async fn server_raw() {
     ]);
     let (value, code) = index.add_documents(documents, None).await;
     snapshot!(code, @"202 Accepted");
-    let task = index.wait_task(value.uid()).await;
+    let task = server.wait_task(value.uid()).await;
     snapshot!(task, @r###"
     {
       "uid": "[uid]",


### PR DESCRIPTION
# Pull Request

## Related issue
#4840 

## What does this PR do?
- The code is mostly duplicated. Server::wait_task() has better handling for errors and more retries.
