### PR TITLE
Add last embedder error in batches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,8 @@
 ##  ... unreviewed
 *.snap.new
 
+# Database snapshot
+crates/meilisearch/db.snapshot
+
 # Fuzzcheck data for the facet indexing fuzz test
 crates/milli/fuzz/update::facet::incremental::fuzz::fuzz/

--- a/crates/benchmarks/benches/indexing.rs
+++ b/crates/benchmarks/benches/indexing.rs
@@ -65,7 +65,7 @@ fn setup_settings<'t>(
     let sortable_fields = sortable_fields.iter().map(|s| s.to_string()).collect();
     builder.set_sortable_fields(sortable_fields);
 
-    builder.execute(|_| (), || false).unwrap();
+    builder.execute(|_| (), || false, None).unwrap();
 }
 
 fn setup_index_with_settings(

--- a/crates/benchmarks/benches/indexing.rs
+++ b/crates/benchmarks/benches/indexing.rs
@@ -65,7 +65,7 @@ fn setup_settings<'t>(
     let sortable_fields = sortable_fields.iter().map(|s| s.to_string()).collect();
     builder.set_sortable_fields(sortable_fields);
 
-    builder.execute(|_| (), || false, None).unwrap();
+    builder.execute(|_| (), || false, Default::default()).unwrap();
 }
 
 fn setup_index_with_settings(
@@ -169,6 +169,7 @@ fn indexing_songs_default(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
+                    Default::default(),
                 )
                 .unwrap();
 
@@ -235,6 +236,7 @@ fn reindexing_songs_default(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
+                    Default::default(),
                 )
                 .unwrap();
 
@@ -279,6 +281,7 @@ fn reindexing_songs_default(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
+                    Default::default(),
                 )
                 .unwrap();
 
@@ -347,6 +350,7 @@ fn deleting_songs_in_batches_default(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
+                    Default::default(),
                 )
                 .unwrap();
 
@@ -423,6 +427,7 @@ fn indexing_songs_in_three_batches_default(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
+                    Default::default(),
                 )
                 .unwrap();
 
@@ -467,6 +472,7 @@ fn indexing_songs_in_three_batches_default(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
+                    Default::default(),
                 )
                 .unwrap();
 
@@ -507,6 +513,7 @@ fn indexing_songs_in_three_batches_default(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
+                    Default::default(),
                 )
                 .unwrap();
 
@@ -574,6 +581,7 @@ fn indexing_songs_without_faceted_numbers(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
+                    Default::default(),
                 )
                 .unwrap();
 
@@ -640,6 +648,7 @@ fn indexing_songs_without_faceted_fields(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
+                    Default::default(),
                 )
                 .unwrap();
 
@@ -706,6 +715,7 @@ fn indexing_wiki(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
+                    Default::default(),
                 )
                 .unwrap();
 
@@ -771,6 +781,7 @@ fn reindexing_wiki(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
+                    Default::default(),
                 )
                 .unwrap();
 
@@ -815,6 +826,7 @@ fn reindexing_wiki(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
+                    Default::default(),
                 )
                 .unwrap();
 
@@ -882,6 +894,7 @@ fn deleting_wiki_in_batches_default(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
+                    Default::default(),
                 )
                 .unwrap();
 
@@ -958,6 +971,7 @@ fn indexing_wiki_in_three_batches(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
+                    Default::default(),
                 )
                 .unwrap();
 
@@ -1003,6 +1017,7 @@ fn indexing_wiki_in_three_batches(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
+                    Default::default(),
                 )
                 .unwrap();
 
@@ -1044,6 +1059,7 @@ fn indexing_wiki_in_three_batches(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
+                    Default::default(),
                 )
                 .unwrap();
 
@@ -1110,6 +1126,7 @@ fn indexing_movies_default(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
+                    Default::default(),
                 )
                 .unwrap();
 
@@ -1175,6 +1192,7 @@ fn reindexing_movies_default(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
+                    Default::default(),
                 )
                 .unwrap();
 
@@ -1219,6 +1237,7 @@ fn reindexing_movies_default(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
+                    Default::default(),
                 )
                 .unwrap();
 
@@ -1286,6 +1305,7 @@ fn deleting_movies_in_batches_default(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
+                    Default::default(),
                 )
                 .unwrap();
 
@@ -1334,6 +1354,7 @@ fn delete_documents_from_ids(index: Index, document_ids_to_delete: Vec<RoaringBi
             EmbeddingConfigs::default(),
             &|| false,
             &Progress::default(),
+            Default::default(),
         )
         .unwrap();
 
@@ -1398,6 +1419,7 @@ fn indexing_movies_in_three_batches(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
+                    Default::default(),
                 )
                 .unwrap();
 
@@ -1442,6 +1464,7 @@ fn indexing_movies_in_three_batches(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
+                    Default::default(),
                 )
                 .unwrap();
 
@@ -1482,6 +1505,7 @@ fn indexing_movies_in_three_batches(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
+                    Default::default(),
                 )
                 .unwrap();
 
@@ -1571,6 +1595,7 @@ fn indexing_nested_movies_default(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
+                    Default::default(),
                 )
                 .unwrap();
 
@@ -1661,6 +1686,7 @@ fn deleting_nested_movies_in_batches_default(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
+                    Default::default(),
                 )
                 .unwrap();
 
@@ -1743,6 +1769,7 @@ fn indexing_nested_movies_without_faceted_fields(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
+                    Default::default(),
                 )
                 .unwrap();
 
@@ -1809,6 +1836,7 @@ fn indexing_geo(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
+                    Default::default(),
                 )
                 .unwrap();
 
@@ -1874,6 +1902,7 @@ fn reindexing_geo(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
+                    Default::default(),
                 )
                 .unwrap();
 
@@ -1918,6 +1947,7 @@ fn reindexing_geo(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
+                    Default::default(),
                 )
                 .unwrap();
 
@@ -1985,6 +2015,7 @@ fn deleting_geo_in_batches_default(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
+                    Default::default(),
                 )
                 .unwrap();
 

--- a/crates/benchmarks/benches/indexing.rs
+++ b/crates/benchmarks/benches/indexing.rs
@@ -169,7 +169,7 @@ fn indexing_songs_default(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
-                    Default::default(),
+                    &Default::default(),
                 )
                 .unwrap();
 
@@ -236,7 +236,7 @@ fn reindexing_songs_default(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
-                    Default::default(),
+                    &Default::default(),
                 )
                 .unwrap();
 
@@ -281,7 +281,7 @@ fn reindexing_songs_default(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
-                    Default::default(),
+                    &Default::default(),
                 )
                 .unwrap();
 
@@ -350,7 +350,7 @@ fn deleting_songs_in_batches_default(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
-                    Default::default(),
+                    &Default::default(),
                 )
                 .unwrap();
 
@@ -427,7 +427,7 @@ fn indexing_songs_in_three_batches_default(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
-                    Default::default(),
+                    &Default::default(),
                 )
                 .unwrap();
 
@@ -472,7 +472,7 @@ fn indexing_songs_in_three_batches_default(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
-                    Default::default(),
+                    &Default::default(),
                 )
                 .unwrap();
 
@@ -513,7 +513,7 @@ fn indexing_songs_in_three_batches_default(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
-                    Default::default(),
+                    &Default::default(),
                 )
                 .unwrap();
 
@@ -581,7 +581,7 @@ fn indexing_songs_without_faceted_numbers(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
-                    Default::default(),
+                    &Default::default(),
                 )
                 .unwrap();
 
@@ -648,7 +648,7 @@ fn indexing_songs_without_faceted_fields(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
-                    Default::default(),
+                    &Default::default(),
                 )
                 .unwrap();
 
@@ -715,7 +715,7 @@ fn indexing_wiki(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
-                    Default::default(),
+                    &Default::default(),
                 )
                 .unwrap();
 
@@ -781,7 +781,7 @@ fn reindexing_wiki(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
-                    Default::default(),
+                    &Default::default(),
                 )
                 .unwrap();
 
@@ -826,7 +826,7 @@ fn reindexing_wiki(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
-                    Default::default(),
+                    &Default::default(),
                 )
                 .unwrap();
 
@@ -894,7 +894,7 @@ fn deleting_wiki_in_batches_default(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
-                    Default::default(),
+                    &Default::default(),
                 )
                 .unwrap();
 
@@ -971,7 +971,7 @@ fn indexing_wiki_in_three_batches(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
-                    Default::default(),
+                    &Default::default(),
                 )
                 .unwrap();
 
@@ -1017,7 +1017,7 @@ fn indexing_wiki_in_three_batches(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
-                    Default::default(),
+                    &Default::default(),
                 )
                 .unwrap();
 
@@ -1059,7 +1059,7 @@ fn indexing_wiki_in_three_batches(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
-                    Default::default(),
+                    &Default::default(),
                 )
                 .unwrap();
 
@@ -1126,7 +1126,7 @@ fn indexing_movies_default(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
-                    Default::default(),
+                    &Default::default(),
                 )
                 .unwrap();
 
@@ -1192,7 +1192,7 @@ fn reindexing_movies_default(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
-                    Default::default(),
+                    &Default::default(),
                 )
                 .unwrap();
 
@@ -1237,7 +1237,7 @@ fn reindexing_movies_default(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
-                    Default::default(),
+                    &Default::default(),
                 )
                 .unwrap();
 
@@ -1305,7 +1305,7 @@ fn deleting_movies_in_batches_default(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
-                    Default::default(),
+                    &Default::default(),
                 )
                 .unwrap();
 
@@ -1354,7 +1354,7 @@ fn delete_documents_from_ids(index: Index, document_ids_to_delete: Vec<RoaringBi
             EmbeddingConfigs::default(),
             &|| false,
             &Progress::default(),
-            Default::default(),
+            &Default::default(),
         )
         .unwrap();
 
@@ -1419,7 +1419,7 @@ fn indexing_movies_in_three_batches(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
-                    Default::default(),
+                    &Default::default(),
                 )
                 .unwrap();
 
@@ -1464,7 +1464,7 @@ fn indexing_movies_in_three_batches(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
-                    Default::default(),
+                    &Default::default(),
                 )
                 .unwrap();
 
@@ -1505,7 +1505,7 @@ fn indexing_movies_in_three_batches(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
-                    Default::default(),
+                    &Default::default(),
                 )
                 .unwrap();
 
@@ -1595,7 +1595,7 @@ fn indexing_nested_movies_default(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
-                    Default::default(),
+                    &Default::default(),
                 )
                 .unwrap();
 
@@ -1686,7 +1686,7 @@ fn deleting_nested_movies_in_batches_default(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
-                    Default::default(),
+                    &Default::default(),
                 )
                 .unwrap();
 
@@ -1769,7 +1769,7 @@ fn indexing_nested_movies_without_faceted_fields(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
-                    Default::default(),
+                    &Default::default(),
                 )
                 .unwrap();
 
@@ -1836,7 +1836,7 @@ fn indexing_geo(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
-                    Default::default(),
+                    &Default::default(),
                 )
                 .unwrap();
 
@@ -1902,7 +1902,7 @@ fn reindexing_geo(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
-                    Default::default(),
+                    &Default::default(),
                 )
                 .unwrap();
 
@@ -1947,7 +1947,7 @@ fn reindexing_geo(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
-                    Default::default(),
+                    &Default::default(),
                 )
                 .unwrap();
 
@@ -2015,7 +2015,7 @@ fn deleting_geo_in_batches_default(c: &mut Criterion) {
                     EmbeddingConfigs::default(),
                     &|| false,
                     &Progress::default(),
-                    Default::default(),
+                    &Default::default(),
                 )
                 .unwrap();
 

--- a/crates/benchmarks/benches/utils.rs
+++ b/crates/benchmarks/benches/utils.rs
@@ -90,7 +90,7 @@ pub fn base_setup(conf: &Conf) -> Index {
 
     (conf.configure)(&mut builder);
 
-    builder.execute(|_| (), || false).unwrap();
+    builder.execute(|_| (), || false, None).unwrap();
     wtxn.commit().unwrap();
 
     let config = IndexerConfig::default();

--- a/crates/benchmarks/benches/utils.rs
+++ b/crates/benchmarks/benches/utils.rs
@@ -128,7 +128,7 @@ pub fn base_setup(conf: &Conf) -> Index {
         EmbeddingConfigs::default(),
         &|| false,
         &Progress::default(),
-        Default::default(),
+        &Default::default(),
     )
     .unwrap();
 

--- a/crates/benchmarks/benches/utils.rs
+++ b/crates/benchmarks/benches/utils.rs
@@ -90,7 +90,7 @@ pub fn base_setup(conf: &Conf) -> Index {
 
     (conf.configure)(&mut builder);
 
-    builder.execute(|_| (), || false, None).unwrap();
+    builder.execute(|_| (), || false, Default::default()).unwrap();
     wtxn.commit().unwrap();
 
     let config = IndexerConfig::default();
@@ -128,6 +128,7 @@ pub fn base_setup(conf: &Conf) -> Index {
         EmbeddingConfigs::default(),
         &|| false,
         &Progress::default(),
+        Default::default(),
     )
     .unwrap();
 

--- a/crates/dump/src/lib.rs
+++ b/crates/dump/src/lib.rs
@@ -328,6 +328,7 @@ pub(crate) mod test {
                 progress_trace: Default::default(),
                 write_channel_congestion: None,
                 internal_database_sizes: Default::default(),
+                embeddings: Default::default(),
             },
             enqueued_at: Some(BatchEnqueuedAt {
                 earliest: datetime!(2022-11-11 0:00 UTC),

--- a/crates/dump/src/lib.rs
+++ b/crates/dump/src/lib.rs
@@ -329,7 +329,7 @@ pub(crate) mod test {
                 write_channel_congestion: None,
                 internal_database_sizes: Default::default(),
             },
-            embedder_stats: None,
+            embedder_stats: Default::default(),
             enqueued_at: Some(BatchEnqueuedAt {
                 earliest: datetime!(2022-11-11 0:00 UTC),
                 oldest: datetime!(2022-11-11 0:00 UTC),

--- a/crates/dump/src/lib.rs
+++ b/crates/dump/src/lib.rs
@@ -328,8 +328,8 @@ pub(crate) mod test {
                 progress_trace: Default::default(),
                 write_channel_congestion: None,
                 internal_database_sizes: Default::default(),
-                embeddings: Default::default(),
             },
+            embedder_stats: None,
             enqueued_at: Some(BatchEnqueuedAt {
                 earliest: datetime!(2022-11-11 0:00 UTC),
                 oldest: datetime!(2022-11-11 0:00 UTC),

--- a/crates/fuzzers/src/bin/fuzz-indexing.rs
+++ b/crates/fuzzers/src/bin/fuzz-indexing.rs
@@ -144,7 +144,7 @@ fn main() {
                                 embedders,
                                 &|| false,
                                 &Progress::default(),
-                                Default::default(),
+                                &Default::default(),
                             )
                             .unwrap();
 

--- a/crates/fuzzers/src/bin/fuzz-indexing.rs
+++ b/crates/fuzzers/src/bin/fuzz-indexing.rs
@@ -144,6 +144,7 @@ fn main() {
                                 embedders,
                                 &|| false,
                                 &Progress::default(),
+                                Default::default(),
                             )
                             .unwrap();
 

--- a/crates/index-scheduler/src/insta_snapshot.rs
+++ b/crates/index-scheduler/src/insta_snapshot.rs
@@ -367,10 +367,12 @@ pub fn snapshot_batch(batch: &Batch) -> String {
     snap.push_str(&format!("uid: {uid}, "));
     snap.push_str(&format!("details: {}, ", serde_json::to_string(details).unwrap()));
     snap.push_str(&format!("stats: {}, ", serde_json::to_string(&stats).unwrap()));
-    snap.push_str(&format!(
-        "embedder_stats: {}, ",
-        serde_json::to_string(&embedder_stats).unwrap()
-    ));
+    if !embedder_stats.skip_serializing() {
+        snap.push_str(&format!(
+            "embedder stats: {}, ",
+            serde_json::to_string(&embedder_stats).unwrap()
+        ));
+    }
     snap.push_str(&format!("stop reason: {}, ", serde_json::to_string(&stop_reason).unwrap()));
     snap.push('}');
     snap

--- a/crates/index-scheduler/src/insta_snapshot.rs
+++ b/crates/index-scheduler/src/insta_snapshot.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 use std::fmt::Write;
 
-use meilisearch_types::batches::{Batch, EmbedderStatsView, BatchEnqueuedAt, BatchStats};
+use meilisearch_types::batches::{Batch, BatchEnqueuedAt, BatchStats};
 use meilisearch_types::heed::types::{SerdeBincode, SerdeJson, Str};
 use meilisearch_types::heed::{Database, RoTxn};
 use meilisearch_types::milli::{CboRoaringBitmapCodec, RoaringBitmapCodec, BEU32};
@@ -367,7 +367,10 @@ pub fn snapshot_batch(batch: &Batch) -> String {
     snap.push_str(&format!("uid: {uid}, "));
     snap.push_str(&format!("details: {}, ", serde_json::to_string(details).unwrap()));
     snap.push_str(&format!("stats: {}, ", serde_json::to_string(&stats).unwrap()));
-    snap.push_str(&format!("embedder_stats: {}, ", serde_json::to_string(&embedder_stats).unwrap()));
+    snap.push_str(&format!(
+        "embedder_stats: {}, ",
+        serde_json::to_string(&embedder_stats).unwrap()
+    ));
     snap.push_str(&format!("stop reason: {}, ", serde_json::to_string(&stop_reason).unwrap()));
     snap.push('}');
     snap

--- a/crates/index-scheduler/src/insta_snapshot.rs
+++ b/crates/index-scheduler/src/insta_snapshot.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 use std::fmt::Write;
 
-use meilisearch_types::batches::{Batch, BatchEmbeddingStats, BatchEnqueuedAt, BatchStats};
+use meilisearch_types::batches::{Batch, EmbedderStatsView, BatchEnqueuedAt, BatchStats};
 use meilisearch_types::heed::types::{SerdeBincode, SerdeJson, Str};
 use meilisearch_types::heed::{Database, RoTxn};
 use meilisearch_types::milli::{CboRoaringBitmapCodec, RoaringBitmapCodec, BEU32};

--- a/crates/index-scheduler/src/insta_snapshot.rs
+++ b/crates/index-scheduler/src/insta_snapshot.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 use std::fmt::Write;
 
-use meilisearch_types::batches::{Batch, BatchEnqueuedAt, BatchStats};
+use meilisearch_types::batches::{Batch, BatchEmbeddingStats, BatchEnqueuedAt, BatchStats};
 use meilisearch_types::heed::types::{SerdeBincode, SerdeJson, Str};
 use meilisearch_types::heed::{Database, RoTxn};
 use meilisearch_types::milli::{CboRoaringBitmapCodec, RoaringBitmapCodec, BEU32};
@@ -343,6 +343,7 @@ pub fn snapshot_batch(batch: &Batch) -> String {
         uid,
         details,
         stats,
+        embedder_stats,
         started_at,
         finished_at,
         progress: _,
@@ -366,6 +367,7 @@ pub fn snapshot_batch(batch: &Batch) -> String {
     snap.push_str(&format!("uid: {uid}, "));
     snap.push_str(&format!("details: {}, ", serde_json::to_string(details).unwrap()));
     snap.push_str(&format!("stats: {}, ", serde_json::to_string(&stats).unwrap()));
+    snap.push_str(&format!("embedder_stats: {}, ", serde_json::to_string(&embedder_stats).unwrap()));
     snap.push_str(&format!("stop reason: {}, ", serde_json::to_string(&stop_reason).unwrap()));
     snap.push('}');
     snap

--- a/crates/index-scheduler/src/queue/batches.rs
+++ b/crates/index-scheduler/src/queue/batches.rs
@@ -174,7 +174,7 @@ impl BatchQueue {
     pub(crate) fn write_batch(&self, wtxn: &mut RwTxn, batch: ProcessingBatch) -> Result<()> {
         let old_batch = self.all_batches.get(wtxn, &batch.uid)?;
 
-        println!("Saving batch: {}", batch.embedder_stats.is_some());
+        println!("Saving batch: {:?}", batch.embedder_stats);
 
         self.all_batches.put(
             wtxn,
@@ -184,7 +184,7 @@ impl BatchQueue {
                 progress: None,
                 details: batch.details,
                 stats: batch.stats,
-                embedder_stats: batch.embedder_stats.as_ref().map(|s| BatchEmbeddingStats::from(s.as_ref())),
+                embedder_stats: batch.embedder_stats.as_ref().into(),
                 started_at: batch.started_at,
                 finished_at: batch.finished_at,
                 enqueued_at: batch.enqueued_at,

--- a/crates/index-scheduler/src/queue/batches.rs
+++ b/crates/index-scheduler/src/queue/batches.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 use std::ops::{Bound, RangeBounds};
 
-use meilisearch_types::batches::{Batch, EmbedderStatsView, BatchId};
+use meilisearch_types::batches::{Batch, BatchId};
 use meilisearch_types::heed::types::{DecodeIgnore, SerdeBincode, SerdeJson, Str};
 use meilisearch_types::heed::{Database, Env, RoTxn, RwTxn, WithoutTls};
 use meilisearch_types::milli::{CboRoaringBitmapCodec, RoaringBitmapCodec, BEU32};

--- a/crates/index-scheduler/src/scheduler/create_batch.rs
+++ b/crates/index-scheduler/src/scheduler/create_batch.rs
@@ -437,10 +437,8 @@ impl IndexScheduler {
         #[cfg(test)]
         self.maybe_fail(crate::test_utils::FailureLocation::InsideCreateBatch)?;
 
-        println!("create next batch");
         let batch_id = self.queue.batches.next_batch_id(rtxn)?;
         let mut current_batch = ProcessingBatch::new(batch_id);
-        println!("over");
 
         let enqueued = &self.queue.tasks.get_status(rtxn, Status::Enqueued)?;
         let count_total_enqueued = enqueued.len();
@@ -456,7 +454,6 @@ impl IndexScheduler {
                 kind: Kind::TaskCancelation,
                 id: task_id,
             });
-            println!("task cancelled");
             return Ok(Some((Batch::TaskCancelation { task }, current_batch)));
         }
 
@@ -527,7 +524,7 @@ impl IndexScheduler {
         }
 
         // 5. We make a batch from the unprioritised tasks. Start by taking the next enqueued task.
-        let task_id = if let Some(task_id) = enqueued.min() { task_id } else { println!("return"); return Ok(None) };
+        let task_id = if let Some(task_id) = enqueued.min() { task_id } else { return Ok(None) };
         let mut task =
             self.queue.tasks.get_task(rtxn, task_id)?.ok_or(Error::CorruptedTaskQueue)?;
 
@@ -605,7 +602,6 @@ impl IndexScheduler {
             autobatcher::autobatch(enqueued, index_already_exists, primary_key.as_deref())
         {
             current_batch.reason(autobatch_stop_reason.unwrap_or(stop_reason));
-            println!("autobatch");
             return Ok(self
                 .create_next_batch_index(
                     rtxn,
@@ -619,7 +615,6 @@ impl IndexScheduler {
 
         // If we found no tasks then we were notified for something that got autobatched
         // somehow and there is nothing to do.
-        println!("nothing to do");
         Ok(None)
     }
 }

--- a/crates/index-scheduler/src/scheduler/process_batch.rs
+++ b/crates/index-scheduler/src/scheduler/process_batch.rs
@@ -1,11 +1,10 @@
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::atomic::Ordering;
-use std::sync::Arc;
 
 use meilisearch_types::batches::{BatchEnqueuedAt, BatchId};
 use meilisearch_types::heed::{RoTxn, RwTxn};
-use meilisearch_types::milli::progress::{EmbedderStats, Progress, VariableNameStep};
+use meilisearch_types::milli::progress::{Progress, VariableNameStep};
 use meilisearch_types::milli::{self, ChannelCongestion};
 use meilisearch_types::tasks::{Details, IndexSwap, Kind, KindWithContent, Status, Task};
 use meilisearch_types::versioning::{VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH};
@@ -163,8 +162,13 @@ impl IndexScheduler {
                     .set_currently_updating_index(Some((index_uid.clone(), index.clone())));
 
                 let pre_commit_dabases_sizes = index.database_sizes(&index_wtxn)?;
-                let (tasks, congestion) =
-                    self.apply_index_operation(&mut index_wtxn, &index, op, &progress, current_batch.embedder_stats.clone())?;
+                let (tasks, congestion) = self.apply_index_operation(
+                    &mut index_wtxn,
+                    &index,
+                    op,
+                    &progress,
+                    current_batch.embedder_stats.clone(),
+                )?;
 
                 {
                     progress.update_progress(FinalizingIndexStep::Committing);

--- a/crates/index-scheduler/src/scheduler/process_batch.rs
+++ b/crates/index-scheduler/src/scheduler/process_batch.rs
@@ -242,6 +242,7 @@ impl IndexScheduler {
                         .execute(
                             |indexing_step| tracing::debug!(update = ?indexing_step),
                             || must_stop_processing.get(),
+                            Some(progress.embedder_stats),
                         )
                         .map_err(|e| Error::from_milli(e, Some(index_uid.to_string())))?;
                     index_wtxn.commit()?;

--- a/crates/index-scheduler/src/scheduler/process_index_operation.rs
+++ b/crates/index-scheduler/src/scheduler/process_index_operation.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use bumpalo::collections::CollectIn;
 use bumpalo::Bump;
 use meilisearch_types::heed::RwTxn;
@@ -472,6 +474,7 @@ impl IndexScheduler {
                     .execute(
                         |indexing_step| tracing::debug!(update = ?indexing_step),
                         || must_stop_processing.get(),
+                        Some(Arc::clone(&progress.embedder_stats))
                     )
                     .map_err(|err| Error::from_milli(err, Some(index_uid.clone())))?;
 

--- a/crates/index-scheduler/src/scheduler/process_index_operation.rs
+++ b/crates/index-scheduler/src/scheduler/process_index_operation.rs
@@ -35,7 +35,7 @@ impl IndexScheduler {
         index: &'i Index,
         operation: IndexOperation,
         progress: &Progress,
-        embedder_stats: Arc<EmbedderStats>, // Cant change
+        embedder_stats: Arc<EmbedderStats>,
     ) -> Result<(Vec<Task>, Option<ChannelCongestion>)> {
         let indexer_alloc = Bump::new();
         let started_processing_at = std::time::Instant::now();

--- a/crates/index-scheduler/src/scheduler/process_index_operation.rs
+++ b/crates/index-scheduler/src/scheduler/process_index_operation.rs
@@ -478,7 +478,7 @@ impl IndexScheduler {
                     .execute(
                         |indexing_step| tracing::debug!(update = ?indexing_step),
                         || must_stop_processing.get(),
-                        embedder_stats.clone(),
+                        embedder_stats,
                     )
                     .map_err(|err| Error::from_milli(err, Some(index_uid.clone())))?;
 

--- a/crates/index-scheduler/src/scheduler/process_index_operation.rs
+++ b/crates/index-scheduler/src/scheduler/process_index_operation.rs
@@ -35,7 +35,7 @@ impl IndexScheduler {
         index: &'i Index,
         operation: IndexOperation,
         progress: &Progress,
-        embedder_stats: Arc<EmbedderStats>,
+        embedder_stats: Arc<EmbedderStats>, // Cant change
     ) -> Result<(Vec<Task>, Option<ChannelCongestion>)> {
         let indexer_alloc = Bump::new();
         let started_processing_at = std::time::Instant::now();
@@ -180,7 +180,7 @@ impl IndexScheduler {
                             embedders,
                             &|| must_stop_processing.get(),
                             progress,
-                            embedder_stats,
+                            &embedder_stats,
                         )
                         .map_err(|e| Error::from_milli(e, Some(index_uid.clone())))?,
                     );
@@ -292,7 +292,7 @@ impl IndexScheduler {
                             embedders,
                             &|| must_stop_processing.get(),
                             progress,
-                            embedder_stats,
+                            &embedder_stats,
                         )
                         .map_err(|err| Error::from_milli(err, Some(index_uid.clone())))?,
                     );
@@ -441,7 +441,7 @@ impl IndexScheduler {
                             embedders,
                             &|| must_stop_processing.get(),
                             progress,
-                            embedder_stats,
+                            &embedder_stats,
                         )
                         .map_err(|err| Error::from_milli(err, Some(index_uid.clone())))?,
                     );
@@ -478,7 +478,7 @@ impl IndexScheduler {
                     .execute(
                         |indexing_step| tracing::debug!(update = ?indexing_step),
                         || must_stop_processing.get(),
-                        embedder_stats,
+                        embedder_stats.clone(),
                     )
                     .map_err(|err| Error::from_milli(err, Some(index_uid.clone())))?;
 

--- a/crates/index-scheduler/src/scheduler/process_index_operation.rs
+++ b/crates/index-scheduler/src/scheduler/process_index_operation.rs
@@ -4,7 +4,7 @@ use bumpalo::collections::CollectIn;
 use bumpalo::Bump;
 use meilisearch_types::heed::RwTxn;
 use meilisearch_types::milli::documents::PrimaryKey;
-use meilisearch_types::milli::progress::Progress;
+use meilisearch_types::milli::progress::{EmbedderStats, Progress};
 use meilisearch_types::milli::update::new::indexer::{self, UpdateByFunction};
 use meilisearch_types::milli::update::DocumentAdditionResult;
 use meilisearch_types::milli::{self, ChannelCongestion, Filter};
@@ -26,7 +26,7 @@ impl IndexScheduler {
     /// The list of processed tasks.
     #[tracing::instrument(
         level = "trace",
-        skip(self, index_wtxn, index, progress),
+        skip(self, index_wtxn, index, progress, embedder_stats),
         target = "indexing::scheduler"
     )]
     pub(crate) fn apply_index_operation<'i>(
@@ -35,6 +35,7 @@ impl IndexScheduler {
         index: &'i Index,
         operation: IndexOperation,
         progress: &Progress,
+        embedder_stats: Arc<EmbedderStats>,
     ) -> Result<(Vec<Task>, Option<ChannelCongestion>)> {
         let indexer_alloc = Bump::new();
         let started_processing_at = std::time::Instant::now();
@@ -179,6 +180,7 @@ impl IndexScheduler {
                             embedders,
                             &|| must_stop_processing.get(),
                             progress,
+                            embedder_stats,
                         )
                         .map_err(|e| Error::from_milli(e, Some(index_uid.clone())))?,
                     );
@@ -290,6 +292,7 @@ impl IndexScheduler {
                             embedders,
                             &|| must_stop_processing.get(),
                             progress,
+                            embedder_stats,
                         )
                         .map_err(|err| Error::from_milli(err, Some(index_uid.clone())))?,
                     );
@@ -438,6 +441,7 @@ impl IndexScheduler {
                             embedders,
                             &|| must_stop_processing.get(),
                             progress,
+                            embedder_stats,
                         )
                         .map_err(|err| Error::from_milli(err, Some(index_uid.clone())))?,
                     );
@@ -474,7 +478,7 @@ impl IndexScheduler {
                     .execute(
                         |indexing_step| tracing::debug!(update = ?indexing_step),
                         || must_stop_processing.get(),
-                        Some(Arc::clone(&progress.embedder_stats))
+                        embedder_stats,
                     )
                     .map_err(|err| Error::from_milli(err, Some(index_uid.clone())))?;
 
@@ -494,6 +498,7 @@ impl IndexScheduler {
                         tasks: cleared_tasks,
                     },
                     progress,
+                    embedder_stats.clone(),
                 )?;
 
                 let (settings_tasks, _congestion) = self.apply_index_operation(
@@ -501,6 +506,7 @@ impl IndexScheduler {
                     index,
                     IndexOperation::Settings { index_uid, settings, tasks: settings_tasks },
                     progress,
+                    embedder_stats,
                 )?;
 
                 let mut tasks = settings_tasks;

--- a/crates/index-scheduler/src/utils.rs
+++ b/crates/index-scheduler/src/utils.rs
@@ -1,11 +1,11 @@
 //! Utility functions on the DBs. Mainly getter and setters.
 
+use crate::milli::progress::EmbedderStats;
 use std::collections::{BTreeSet, HashSet};
 use std::ops::Bound;
 use std::sync::Arc;
-use crate::milli::progress::EmbedderStats;
 
-use meilisearch_types::batches::{Batch, EmbedderStatsView, BatchEnqueuedAt, BatchId, BatchStats};
+use meilisearch_types::batches::{Batch, BatchEnqueuedAt, BatchId, BatchStats};
 use meilisearch_types::heed::{Database, RoTxn, RwTxn};
 use meilisearch_types::milli::CboRoaringBitmapCodec;
 use meilisearch_types::task_view::DetailsView;

--- a/crates/index-scheduler/src/utils.rs
+++ b/crates/index-scheduler/src/utils.rs
@@ -5,7 +5,7 @@ use std::ops::Bound;
 use std::sync::Arc;
 use crate::milli::progress::EmbedderStats;
 
-use meilisearch_types::batches::{Batch, BatchEmbeddingStats, BatchEnqueuedAt, BatchId, BatchStats};
+use meilisearch_types::batches::{Batch, EmbedderStatsView, BatchEnqueuedAt, BatchId, BatchStats};
 use meilisearch_types::heed::{Database, RoTxn, RwTxn};
 use meilisearch_types::milli::CboRoaringBitmapCodec;
 use meilisearch_types::task_view::DetailsView;
@@ -46,8 +46,6 @@ impl ProcessingBatch {
         // At the beginning, all the tasks are processing
         let mut statuses = HashSet::default();
         statuses.insert(Status::Processing);
-
-        println!("Processing batch created: {}", uid);
 
         Self {
             uid,
@@ -104,14 +102,11 @@ impl ProcessingBatch {
     }
 
     pub fn reason(&mut self, reason: BatchStopReason) {
-        println!("batch stopped: {:?}", reason);
         self.reason = reason;
     }
 
     /// Must be called once the batch has finished processing.
     pub fn finished(&mut self) {
-        println!("Batch finished: {}", self.uid);
-
         self.details = DetailsView::default();
         self.stats = BatchStats::default();
         self.finished_at = Some(OffsetDateTime::now_utc());
@@ -126,8 +121,6 @@ impl ProcessingBatch {
 
     /// Update the timestamp of the tasks and the inner structure of this structure.
     pub fn update(&mut self, task: &mut Task) {
-        println!("Updating task: {} in batch: {}", task.uid, self.uid);
-
         // We must re-set this value in case we're dealing with a task that has been added between
         // the `processing` and `finished` state
         // We must re-set this value in case we're dealing with a task that has been added between
@@ -152,7 +145,6 @@ impl ProcessingBatch {
     }
 
     pub fn to_batch(&self) -> Batch {
-        println!("Converting to batch: {:?} {:?}", self.uid, self.embedder_stats);
         Batch {
             uid: self.uid,
             progress: None,

--- a/crates/meilisearch-types/src/batch_view.rs
+++ b/crates/meilisearch-types/src/batch_view.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 use time::{Duration, OffsetDateTime};
 use utoipa::ToSchema;
 
-use crate::batches::{Batch, BatchId, BatchStats};
+use crate::batches::{Batch, BatchEmbeddingStats, BatchId, BatchStats};
 use crate::task_view::DetailsView;
 use crate::tasks::serialize_duration;
 
@@ -14,7 +14,7 @@ pub struct BatchView {
     pub uid: BatchId,
     pub progress: Option<ProgressView>,
     pub details: DetailsView,
-    pub stats: BatchStats,
+    pub stats: BatchStatsView,
     #[serde(serialize_with = "serialize_duration", default)]
     pub duration: Option<Duration>,
     #[serde(with = "time::serde::rfc3339", default)]
@@ -25,13 +25,26 @@ pub struct BatchView {
     pub batch_strategy: String,
 }
 
+#[derive(Debug, Clone, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+#[schema(rename_all = "camelCase")]
+pub struct BatchStatsView {
+    #[serde(flatten)]
+    pub stats: BatchStats,
+    #[serde(skip_serializing_if = "BatchEmbeddingStats::skip_serializing")]
+    pub embedder: Option<BatchEmbeddingStats>,
+}
+
 impl BatchView {
     pub fn from_batch(batch: &Batch) -> Self {
         Self {
             uid: batch.uid,
             progress: batch.progress.clone(),
             details: batch.details.clone(),
-            stats: batch.stats.clone(),
+            stats: BatchStatsView {
+                stats: batch.stats.clone(),
+                embedder: batch.embedder_stats.clone(),
+            },
             duration: batch.finished_at.map(|finished_at| finished_at - batch.started_at),
             started_at: batch.started_at,
             finished_at: batch.finished_at,

--- a/crates/meilisearch-types/src/batch_view.rs
+++ b/crates/meilisearch-types/src/batch_view.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 use time::{Duration, OffsetDateTime};
 use utoipa::ToSchema;
 
-use crate::batches::{Batch, BatchEmbeddingStats, BatchId, BatchStats};
+use crate::batches::{Batch, EmbedderStatsView, BatchId, BatchStats};
 use crate::task_view::DetailsView;
 use crate::tasks::serialize_duration;
 
@@ -31,8 +31,8 @@ pub struct BatchView {
 pub struct BatchStatsView {
     #[serde(flatten)]
     pub stats: BatchStats,
-    #[serde(skip_serializing_if = "BatchEmbeddingStats::skip_serializing", default)]
-    pub embedder: BatchEmbeddingStats,
+    #[serde(skip_serializing_if = "EmbedderStatsView::skip_serializing", default)]
+    pub embedder: EmbedderStatsView,
 }
 
 impl BatchView {

--- a/crates/meilisearch-types/src/batch_view.rs
+++ b/crates/meilisearch-types/src/batch_view.rs
@@ -31,8 +31,8 @@ pub struct BatchView {
 pub struct BatchStatsView {
     #[serde(flatten)]
     pub stats: BatchStats,
-    #[serde(skip_serializing_if = "BatchEmbeddingStats::skip_serializing")]
-    pub embedder: Option<BatchEmbeddingStats>,
+    #[serde(skip_serializing_if = "BatchEmbeddingStats::skip_serializing", default)]
+    pub embedder: BatchEmbeddingStats,
 }
 
 impl BatchView {

--- a/crates/meilisearch-types/src/batch_view.rs
+++ b/crates/meilisearch-types/src/batch_view.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 use time::{Duration, OffsetDateTime};
 use utoipa::ToSchema;
 
-use crate::batches::{Batch, EmbedderStatsView, BatchId, BatchStats};
+use crate::batches::{Batch, BatchId, BatchStats, EmbedderStatsView};
 use crate::task_view::DetailsView;
 use crate::tasks::serialize_duration;
 

--- a/crates/meilisearch-types/src/batch_view.rs
+++ b/crates/meilisearch-types/src/batch_view.rs
@@ -32,7 +32,7 @@ pub struct BatchStatsView {
     #[serde(flatten)]
     pub stats: BatchStats,
     #[serde(skip_serializing_if = "EmbedderStatsView::skip_serializing", default)]
-    pub embedder: EmbedderStatsView,
+    pub embedder_requests: EmbedderStatsView,
 }
 
 impl BatchView {
@@ -43,7 +43,7 @@ impl BatchView {
             details: batch.details.clone(),
             stats: BatchStatsView {
                 stats: batch.stats.clone(),
-                embedder: batch.embedder_stats.clone(),
+                embedder_requests: batch.embedder_stats.clone(),
             },
             duration: batch.finished_at.map(|finished_at| finished_at - batch.started_at),
             started_at: batch.started_at,

--- a/crates/meilisearch-types/src/batches.rs
+++ b/crates/meilisearch-types/src/batches.rs
@@ -82,4 +82,14 @@ pub struct BatchStats {
     pub write_channel_congestion: Option<serde_json::Map<String, serde_json::Value>>,
     #[serde(default, skip_serializing_if = "serde_json::Map::is_empty")]
     pub internal_database_sizes: serde_json::Map<String, serde_json::Value>,
+    pub embeddings: BatchEmbeddingStats
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+#[schema(rename_all = "camelCase")]
+pub struct BatchEmbeddingStats {
+    pub total_count: usize,
+    pub error_count: usize,
+    pub last_error: Option<String>,
 }

--- a/crates/meilisearch-types/src/batches.rs
+++ b/crates/meilisearch-types/src/batches.rs
@@ -100,7 +100,7 @@ pub struct EmbedderStatsView {
 
 impl From<&EmbedderStats> for EmbedderStatsView {
     fn from(stats: &EmbedderStats) -> Self {
-        let errors = stats.errors.read().unwrap();
+        let errors = stats.errors.read().unwrap_or_else(|p| p.into_inner());
         Self {
             total_count: stats.total_count.load(std::sync::atomic::Ordering::Relaxed),
             error_count: errors.1 as usize,

--- a/crates/meilisearch-types/src/batches.rs
+++ b/crates/meilisearch-types/src/batches.rs
@@ -20,7 +20,8 @@ pub struct Batch {
     pub progress: Option<ProgressView>,
     pub details: DetailsView,
     pub stats: BatchStats,
-    pub embedder_stats: Option<BatchEmbeddingStats>,
+    #[serde(skip_serializing_if = "BatchEmbeddingStats::skip_serializing", default)]
+    pub embedder_stats: BatchEmbeddingStats,
 
     #[serde(with = "time::serde::rfc3339")]
     pub started_at: OffsetDateTime,
@@ -110,10 +111,7 @@ impl From<&EmbedderStats> for BatchEmbeddingStats {
 }
 
 impl BatchEmbeddingStats {
-    pub fn skip_serializing(this: &Option<BatchEmbeddingStats>) -> bool {
-        match this {
-            Some(stats) => stats.total_count == 0 && stats.error_count == 0 && stats.last_error.is_none(),
-            None => true,
-        }
+    pub fn skip_serializing(&self) -> bool {
+        self.total_count == 0 && self.error_count == 0 && self.last_error.is_none()
     }
 }

--- a/crates/meilisearch-types/src/batches.rs
+++ b/crates/meilisearch-types/src/batches.rs
@@ -92,8 +92,8 @@ pub struct BatchStats {
 #[serde(rename_all = "camelCase")]
 #[schema(rename_all = "camelCase")]
 pub struct EmbedderStatsView {
-    pub total_count: usize,
-    pub error_count: usize,
+    pub total: usize,
+    pub failed: usize,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub last_error: Option<String>,
 }
@@ -102,8 +102,8 @@ impl From<&EmbedderStats> for EmbedderStatsView {
     fn from(stats: &EmbedderStats) -> Self {
         let errors = stats.errors.read().unwrap_or_else(|p| p.into_inner());
         Self {
-            total_count: stats.total_count.load(std::sync::atomic::Ordering::Relaxed),
-            error_count: errors.1 as usize,
+            total: stats.total_count.load(std::sync::atomic::Ordering::Relaxed),
+            failed: errors.1 as usize,
             last_error: errors.0.clone(),
         }
     }
@@ -111,6 +111,6 @@ impl From<&EmbedderStats> for EmbedderStatsView {
 
 impl EmbedderStatsView {
     pub fn skip_serializing(&self) -> bool {
-        self.total_count == 0 && self.error_count == 0 && self.last_error.is_none()
+        self.total == 0 && self.failed == 0 && self.last_error.is_none()
     }
 }

--- a/crates/meilisearch-types/src/batches.rs
+++ b/crates/meilisearch-types/src/batches.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeMap;
-use std::sync::Arc;
 
 use milli::progress::{EmbedderStats, ProgressView};
 use serde::{Deserialize, Serialize};

--- a/crates/meilisearch/src/lib.rs
+++ b/crates/meilisearch/src/lib.rs
@@ -543,7 +543,7 @@ fn import_dump(
         tracing::info!("Importing the settings.");
         let settings = index_reader.settings()?;
         apply_settings_to_builder(&settings, &mut builder);
-        let embedder_stats: Arc<EmbedderStats> = Default::default(); // FIXME: this isn't linked to anything
+        let embedder_stats: Arc<EmbedderStats> = Default::default();
         builder.execute(
             |indexing_step| tracing::debug!("update: {:?}", indexing_step),
             || false,

--- a/crates/meilisearch/src/lib.rs
+++ b/crates/meilisearch/src/lib.rs
@@ -543,7 +543,7 @@ fn import_dump(
         let settings = index_reader.settings()?;
         apply_settings_to_builder(&settings, &mut builder);
         builder
-            .execute(|indexing_step| tracing::debug!("update: {:?}", indexing_step), || false)?;
+            .execute(|indexing_step| tracing::debug!("update: {:?}", indexing_step), || false, None)?;
 
         // 4.3 Import the documents.
         // 4.3.1 We need to recreate the grenad+obkv format accepted by the index.
@@ -574,6 +574,7 @@ fn import_dump(
             },
             |indexing_step| tracing::trace!("update: {:?}", indexing_step),
             || false,
+            None,
         )?;
 
         let builder = builder.with_embedders(embedders);

--- a/crates/meilisearch/src/lib.rs
+++ b/crates/meilisearch/src/lib.rs
@@ -579,7 +579,7 @@ fn import_dump(
             },
             |indexing_step| tracing::trace!("update: {:?}", indexing_step),
             || false,
-            embedder_stats,
+            &embedder_stats,
         )?;
 
         let builder = builder.with_embedders(embedders);

--- a/crates/meilisearch/src/lib.rs
+++ b/crates/meilisearch/src/lib.rs
@@ -544,8 +544,11 @@ fn import_dump(
         let settings = index_reader.settings()?;
         apply_settings_to_builder(&settings, &mut builder);
         let embedder_stats: Arc<EmbedderStats> = Default::default(); // FIXME: this isn't linked to anything
-        builder
-            .execute(|indexing_step| tracing::debug!("update: {:?}", indexing_step), || false, embedder_stats.clone())?;
+        builder.execute(
+            |indexing_step| tracing::debug!("update: {:?}", indexing_step),
+            || false,
+            embedder_stats.clone(),
+        )?;
 
         // 4.3 Import the documents.
         // 4.3.1 We need to recreate the grenad+obkv format accepted by the index.

--- a/crates/meilisearch/src/lib.rs
+++ b/crates/meilisearch/src/lib.rs
@@ -37,6 +37,7 @@ use index_scheduler::{IndexScheduler, IndexSchedulerOptions};
 use meilisearch_auth::{open_auth_store_env, AuthController};
 use meilisearch_types::milli::constants::VERSION_MAJOR;
 use meilisearch_types::milli::documents::{DocumentsBatchBuilder, DocumentsBatchReader};
+use meilisearch_types::milli::progress::EmbedderStats;
 use meilisearch_types::milli::update::{
     default_thread_pool_and_threads, IndexDocumentsConfig, IndexDocumentsMethod, IndexerConfig,
 };
@@ -542,8 +543,9 @@ fn import_dump(
         tracing::info!("Importing the settings.");
         let settings = index_reader.settings()?;
         apply_settings_to_builder(&settings, &mut builder);
+        let embedder_stats: Arc<EmbedderStats> = Default::default(); // FIXME: this isn't linked to anything
         builder
-            .execute(|indexing_step| tracing::debug!("update: {:?}", indexing_step), || false, None)?;
+            .execute(|indexing_step| tracing::debug!("update: {:?}", indexing_step), || false, embedder_stats.clone())?;
 
         // 4.3 Import the documents.
         // 4.3.1 We need to recreate the grenad+obkv format accepted by the index.
@@ -574,7 +576,7 @@ fn import_dump(
             },
             |indexing_step| tracing::trace!("update: {:?}", indexing_step),
             || false,
-            None,
+            embedder_stats,
         )?;
 
         let builder = builder.with_embedders(embedders);

--- a/crates/meilisearch/tests/vector/rest.rs
+++ b/crates/meilisearch/tests/vector/rest.rs
@@ -2182,7 +2182,7 @@ async fn last_error_stats() {
     let (response, _code) = index.filtered_batches(&[], &[], &[]).await;
     snapshot!(json_string!(response["results"][0], {
         ".progress" => "[ignored]",
-        ".stats.embedder.totalCount" => "[ignored]",
+        ".stats.embedderRequests.total" => "[ignored]",
         ".startedAt" => "[ignored]"
     }), @r#"
     {
@@ -2203,9 +2203,9 @@ async fn last_error_stats() {
         "indexUids": {
           "doggo": 1
         },
-        "embedder": {
-          "totalCount": "[ignored]",
-          "errorCount": 5,
+        "embedderRequests": {
+          "total": "[ignored]",
+          "failed": 5,
           "lastError": "runtime error: received internal error HTTP 500 from embedding server\n  - server replied with `Service Unavailable`"
         }
       },

--- a/crates/meilisearch/tests/vector/rest.rs
+++ b/crates/meilisearch/tests/vector/rest.rs
@@ -2195,5 +2195,35 @@ async fn last_error_stats() {
     receiver.recv().await;
 
     let (response, _code) = index.filtered_batches(&[], &[], &[]).await;
-    snapshot!(response["results"][0], @r###""###);
+    snapshot!(json_string!(response["results"][0], { ".progress" => "[ignored]", ".stats.embedder.totalCount" => "[ignored]", ".startedAt" => "[ignored]" }), @r#"
+    {
+      "uid": 1,
+      "progress": "[ignored]",
+      "details": {
+        "receivedDocuments": 3,
+        "indexedDocuments": null
+      },
+      "stats": {
+        "totalNbTasks": 1,
+        "status": {
+          "processing": 1
+        },
+        "types": {
+          "documentAdditionOrUpdate": 1
+        },
+        "indexUids": {
+          "doggo": 1
+        },
+        "embedder": {
+          "totalCount": "[ignored]",
+          "errorCount": 5,
+          "lastError": "runtime error: received internal error HTTP 500 from embedding server\n  - server replied with `{\"error\":\"Service Unavailable\",\"text\":\"will_error\"}`"
+        }
+      },
+      "duration": null,
+      "startedAt": "[ignored]",
+      "finishedAt": null,
+      "batchStrategy": "batched all enqueued tasks"
+    }
+    "#);
 }

--- a/crates/meilisearch/tests/vector/rest.rs
+++ b/crates/meilisearch/tests/vector/rest.rs
@@ -349,7 +349,7 @@ async fn create_faulty_mock_raw(sender: mpsc::Sender<()>) -> (MockServer, Value)
             if count >= 5 {
                 let _ = sender.try_send(());
                 ResponseTemplate::new(500)
-                    .set_delay(Duration::from_secs(u64::MAX))
+                    .set_delay(Duration::from_secs(u64::MAX)) // Make the response hang forever
                     .set_body_string("Service Unavailable")
             } else {
                 ResponseTemplate::new(500).set_body_string("Service Unavailable")

--- a/crates/milli/src/progress.rs
+++ b/crates/milli/src/progress.rs
@@ -25,7 +25,7 @@ pub struct Progress {
 #[derive(Default)]
 pub struct EmbedderStats {
     pub errors: Arc<RwLock<(Option<String>, u32)>>,
-    pub total_count: AtomicUsize
+    pub total_count: AtomicUsize,
 }
 
 impl std::fmt::Debug for EmbedderStats {

--- a/crates/milli/src/progress.rs
+++ b/crates/milli/src/progress.rs
@@ -1,7 +1,7 @@
 use std::any::TypeId;
 use std::borrow::Cow;
 use std::marker::PhantomData;
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 
@@ -20,6 +20,13 @@ pub trait Step: 'static + Send + Sync {
 #[derive(Clone, Default)]
 pub struct Progress {
     steps: Arc<RwLock<InnerProgress>>,
+    pub embedder_stats: Arc<EmbedderStats>,
+}
+
+#[derive(Default)]
+pub struct EmbedderStats {
+    pub errors: Arc<RwLock<(Option<String>, u32)>>,
+    pub total_requests: AtomicUsize
 }
 
 #[derive(Default)]
@@ -65,7 +72,19 @@ impl Progress {
             });
         }
 
-        ProgressView { steps: step_view, percentage: percentage * 100.0 }
+        let embedder_view = {
+            let (last_error, error_count) = match self.embedder_stats.errors.read() {
+                Ok(guard) => (guard.0.clone(), guard.1),
+                Err(_) => (None, 0),
+            };
+            EmbedderStatsView {
+                last_error,
+                request_count: self.embedder_stats.total_requests.load(Ordering::Relaxed) as u32,
+                error_count,
+            }
+        };
+
+        ProgressView { steps: step_view, percentage: percentage * 100.0, embedder: embedder_view }
     }
 
     pub fn accumulated_durations(&self) -> IndexMap<String, String> {
@@ -209,6 +228,7 @@ make_enum_progress! {
 pub struct ProgressView {
     pub steps: Vec<ProgressStepView>,
     pub percentage: f32,
+    pub embedder: EmbedderStatsView,
 }
 
 #[derive(Debug, Serialize, Clone, ToSchema)]
@@ -218,6 +238,16 @@ pub struct ProgressStepView {
     pub current_step: Cow<'static, str>,
     pub finished: u32,
     pub total: u32,
+}
+
+#[derive(Debug, Serialize, Clone, ToSchema)]
+#[serde(rename_all = "camelCase")]
+#[schema(rename_all = "camelCase")]
+pub struct EmbedderStatsView {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
+    pub request_count: u32,
+    pub error_count: u32,
 }
 
 /// Used when the name can change but it's still the same step.

--- a/crates/milli/src/progress.rs
+++ b/crates/milli/src/progress.rs
@@ -25,15 +25,15 @@ pub struct Progress {
 #[derive(Default)]
 pub struct EmbedderStats {
     pub errors: Arc<RwLock<(Option<String>, u32)>>,
-    pub total_requests: AtomicUsize
+    pub total_count: AtomicUsize
 }
 
 impl std::fmt::Debug for EmbedderStats {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let (error, count) = self.errors.read().unwrap().clone();
         f.debug_struct("EmbedderStats")
-            .field("errors", &error)
-            .field("total_requests", &self.total_requests.load(Ordering::Relaxed))
+            .field("last_error", &error)
+            .field("total_count", &self.total_count.load(Ordering::Relaxed))
             .field("error_count", &count)
             .finish()
     }

--- a/crates/milli/src/progress.rs
+++ b/crates/milli/src/progress.rs
@@ -30,7 +30,9 @@ pub struct EmbedderStats {
 
 impl std::fmt::Debug for EmbedderStats {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let (error, count) = self.errors.read().unwrap().clone();
+        let guard = self.errors.read().unwrap_or_else(|p| p.into_inner());
+        let (error, count) = (guard.0.clone(), guard.1);
+        std::mem::drop(guard);
         f.debug_struct("EmbedderStats")
             .field("last_error", &error)
             .field("total_count", &self.total_count.load(Ordering::Relaxed))

--- a/crates/milli/src/search/new/tests/integration.rs
+++ b/crates/milli/src/search/new/tests/integration.rs
@@ -95,7 +95,7 @@ pub fn setup_search_index_with_criteria(criteria: &[Criterion]) -> Index {
         embedders,
         &|| false,
         &Progress::default(),
-            Default::default(),
+        Default::default(),
     )
     .unwrap();
 

--- a/crates/milli/src/search/new/tests/integration.rs
+++ b/crates/milli/src/search/new/tests/integration.rs
@@ -44,7 +44,7 @@ pub fn setup_search_index_with_criteria(criteria: &[Criterion]) -> Index {
         S("america") => vec![S("the united states")],
     });
     builder.set_searchable_fields(vec![S("title"), S("description")]);
-    builder.execute(|_| (), || false).unwrap();
+    builder.execute(|_| (), || false, None).unwrap();
     wtxn.commit().unwrap();
 
     // index documents

--- a/crates/milli/src/search/new/tests/integration.rs
+++ b/crates/milli/src/search/new/tests/integration.rs
@@ -44,7 +44,7 @@ pub fn setup_search_index_with_criteria(criteria: &[Criterion]) -> Index {
         S("america") => vec![S("the united states")],
     });
     builder.set_searchable_fields(vec![S("title"), S("description")]);
-    builder.execute(|_| (), || false, None).unwrap();
+    builder.execute(|_| (), || false, Default::default()).unwrap();
     wtxn.commit().unwrap();
 
     // index documents
@@ -95,6 +95,7 @@ pub fn setup_search_index_with_criteria(criteria: &[Criterion]) -> Index {
         embedders,
         &|| false,
         &Progress::default(),
+            Default::default(),
     )
     .unwrap();
 

--- a/crates/milli/src/search/new/tests/integration.rs
+++ b/crates/milli/src/search/new/tests/integration.rs
@@ -95,7 +95,7 @@ pub fn setup_search_index_with_criteria(criteria: &[Criterion]) -> Index {
         embedders,
         &|| false,
         &Progress::default(),
-        Default::default(),
+        &Default::default(),
     )
     .unwrap();
 

--- a/crates/milli/src/test_index.rs
+++ b/crates/milli/src/test_index.rs
@@ -103,6 +103,7 @@ impl TempIndex {
                 embedders,
                 &|| false,
                 &Progress::default(),
+                Default::default(),
             )
         })
         .unwrap()?;
@@ -134,7 +135,7 @@ impl TempIndex {
     ) -> Result<(), crate::error::Error> {
         let mut builder = update::Settings::new(wtxn, &self.inner, &self.indexer_config);
         update(&mut builder);
-        builder.execute(drop, || false, None)?;
+        builder.execute(drop, || false, Default::default())?;
         Ok(())
     }
 
@@ -185,6 +186,7 @@ impl TempIndex {
                 embedders,
                 &|| false,
                 &Progress::default(),
+                Default::default(),
             )
         })
         .unwrap()?;
@@ -259,6 +261,7 @@ fn aborting_indexation() {
                 embedders,
                 &|| should_abort.load(Relaxed),
                 &Progress::default(),
+                Default::default(),
             )
         })
         .unwrap()

--- a/crates/milli/src/test_index.rs
+++ b/crates/milli/src/test_index.rs
@@ -103,7 +103,7 @@ impl TempIndex {
                 embedders,
                 &|| false,
                 &Progress::default(),
-                Default::default(),
+                &Default::default(),
             )
         })
         .unwrap()?;
@@ -186,7 +186,7 @@ impl TempIndex {
                 embedders,
                 &|| false,
                 &Progress::default(),
-                Default::default(),
+                &Default::default(),
             )
         })
         .unwrap()?;
@@ -261,7 +261,7 @@ fn aborting_indexation() {
                 embedders,
                 &|| should_abort.load(Relaxed),
                 &Progress::default(),
-                Default::default(),
+                &Default::default(),
             )
         })
         .unwrap()

--- a/crates/milli/src/test_index.rs
+++ b/crates/milli/src/test_index.rs
@@ -134,7 +134,7 @@ impl TempIndex {
     ) -> Result<(), crate::error::Error> {
         let mut builder = update::Settings::new(wtxn, &self.inner, &self.indexer_config);
         update(&mut builder);
-        builder.execute(drop, || false)?;
+        builder.execute(drop, || false, None)?;
         Ok(())
     }
 

--- a/crates/milli/src/update/index_documents/extract/extract_vector_points.rs
+++ b/crates/milli/src/update/index_documents/extract/extract_vector_points.rs
@@ -684,12 +684,10 @@ pub fn extract_embeddings<R: io::Read + io::Seek>(
     embedder: Arc<Embedder>,
     embedder_name: &str,
     possible_embedding_mistakes: &PossibleEmbeddingMistakes,
-    embedder_stats: Option<Arc<EmbedderStats>>,
+    embedder_stats: Arc<EmbedderStats>,
     unused_vectors_distribution: &UnusedVectorsDistribution,
     request_threads: &ThreadPoolNoAbort,
 ) -> Result<grenad::Reader<BufReader<File>>> {
-    println!("Extract embedder stats {}:", embedder_stats.is_some());
-
     let n_chunks = embedder.chunk_count_hint(); // chunk level parallelism
     let n_vectors_per_chunk = embedder.prompt_count_in_chunk_hint(); // number of vectors in a single chunk
 
@@ -791,7 +789,7 @@ fn embed_chunks(
     text_chunks: Vec<Vec<String>>,
     embedder_name: &str,
     possible_embedding_mistakes: &PossibleEmbeddingMistakes,
-    embedder_stats: Option<Arc<EmbedderStats>>,
+    embedder_stats: Arc<EmbedderStats>,
     unused_vectors_distribution: &UnusedVectorsDistribution,
     request_threads: &ThreadPoolNoAbort,
 ) -> Result<Vec<Vec<Embedding>>> {

--- a/crates/milli/src/update/index_documents/extract/extract_vector_points.rs
+++ b/crates/milli/src/update/index_documents/extract/extract_vector_points.rs
@@ -687,6 +687,8 @@ pub fn extract_embeddings<R: io::Read + io::Seek>(
     unused_vectors_distribution: &UnusedVectorsDistribution,
     request_threads: &ThreadPoolNoAbort,
 ) -> Result<grenad::Reader<BufReader<File>>> {
+    println!("Extract embedder stats {}:", embedder_stats.is_some());
+
     let n_chunks = embedder.chunk_count_hint(); // chunk level parallelism
     let n_vectors_per_chunk = embedder.prompt_count_in_chunk_hint(); // number of vectors in a single chunk
 

--- a/crates/milli/src/update/index_documents/extract/extract_vector_points.rs
+++ b/crates/milli/src/update/index_documents/extract/extract_vector_points.rs
@@ -684,7 +684,7 @@ pub fn extract_embeddings<R: io::Read + io::Seek>(
     embedder: Arc<Embedder>,
     embedder_name: &str,
     possible_embedding_mistakes: &PossibleEmbeddingMistakes,
-    embedder_stats: Arc<EmbedderStats>,
+    embedder_stats: &EmbedderStats,
     unused_vectors_distribution: &UnusedVectorsDistribution,
     request_threads: &ThreadPoolNoAbort,
 ) -> Result<grenad::Reader<BufReader<File>>> {
@@ -727,7 +727,7 @@ pub fn extract_embeddings<R: io::Read + io::Seek>(
                 std::mem::replace(&mut chunks, Vec::with_capacity(n_chunks)),
                 embedder_name,
                 possible_embedding_mistakes,
-                embedder_stats.clone(),
+                embedder_stats,
                 unused_vectors_distribution,
                 request_threads,
             )?;
@@ -750,7 +750,7 @@ pub fn extract_embeddings<R: io::Read + io::Seek>(
             std::mem::take(&mut chunks),
             embedder_name,
             possible_embedding_mistakes,
-            embedder_stats.clone(),
+            embedder_stats,
             unused_vectors_distribution,
             request_threads,
         )?;
@@ -789,7 +789,7 @@ fn embed_chunks(
     text_chunks: Vec<Vec<String>>,
     embedder_name: &str,
     possible_embedding_mistakes: &PossibleEmbeddingMistakes,
-    embedder_stats: Arc<EmbedderStats>,
+    embedder_stats: &EmbedderStats,
     unused_vectors_distribution: &UnusedVectorsDistribution,
     request_threads: &ThreadPoolNoAbort,
 ) -> Result<Vec<Vec<Embedding>>> {

--- a/crates/milli/src/update/index_documents/extract/extract_vector_points.rs
+++ b/crates/milli/src/update/index_documents/extract/extract_vector_points.rs
@@ -17,6 +17,7 @@ use crate::constants::RESERVED_VECTORS_FIELD_NAME;
 use crate::error::FaultSource;
 use crate::fields_ids_map::metadata::FieldIdMapWithMetadata;
 use crate::index::IndexEmbeddingConfig;
+use crate::progress::EmbedderStats;
 use crate::prompt::Prompt;
 use crate::update::del_add::{DelAdd, KvReaderDelAdd, KvWriterDelAdd};
 use crate::update::settings::InnerIndexSettingsDiff;
@@ -682,6 +683,7 @@ pub fn extract_embeddings<R: io::Read + io::Seek>(
     embedder: Arc<Embedder>,
     embedder_name: &str,
     possible_embedding_mistakes: &PossibleEmbeddingMistakes,
+    embedder_stats: Option<Arc<EmbedderStats>>,
     unused_vectors_distribution: &UnusedVectorsDistribution,
     request_threads: &ThreadPoolNoAbort,
 ) -> Result<grenad::Reader<BufReader<File>>> {
@@ -724,6 +726,7 @@ pub fn extract_embeddings<R: io::Read + io::Seek>(
                 std::mem::replace(&mut chunks, Vec::with_capacity(n_chunks)),
                 embedder_name,
                 possible_embedding_mistakes,
+                embedder_stats.clone(),
                 unused_vectors_distribution,
                 request_threads,
             )?;
@@ -746,6 +749,7 @@ pub fn extract_embeddings<R: io::Read + io::Seek>(
             std::mem::take(&mut chunks),
             embedder_name,
             possible_embedding_mistakes,
+            embedder_stats.clone(),
             unused_vectors_distribution,
             request_threads,
         )?;
@@ -764,6 +768,7 @@ pub fn extract_embeddings<R: io::Read + io::Seek>(
             vec![std::mem::take(&mut current_chunk)],
             embedder_name,
             possible_embedding_mistakes,
+            embedder_stats,
             unused_vectors_distribution,
             request_threads,
         )?;
@@ -783,10 +788,11 @@ fn embed_chunks(
     text_chunks: Vec<Vec<String>>,
     embedder_name: &str,
     possible_embedding_mistakes: &PossibleEmbeddingMistakes,
+    embedder_stats: Option<Arc<EmbedderStats>>,
     unused_vectors_distribution: &UnusedVectorsDistribution,
     request_threads: &ThreadPoolNoAbort,
 ) -> Result<Vec<Vec<Embedding>>> {
-    match embedder.embed_index(text_chunks, request_threads) {
+    match embedder.embed_index(text_chunks, request_threads, embedder_stats) {
         Ok(chunks) => Ok(chunks),
         Err(error) => {
             if let FaultSource::Bug = error.fault {

--- a/crates/milli/src/update/index_documents/extract/extract_vector_points.rs
+++ b/crates/milli/src/update/index_documents/extract/extract_vector_points.rs
@@ -675,6 +675,7 @@ fn compare_vectors(a: &[f32], b: &[f32]) -> Ordering {
     a.iter().copied().map(OrderedFloat).cmp(b.iter().copied().map(OrderedFloat))
 }
 
+#[allow(clippy::too_many_arguments)]
 #[tracing::instrument(level = "trace", skip_all, target = "indexing::extract")]
 pub fn extract_embeddings<R: io::Read + io::Seek>(
     // docid, prompt

--- a/crates/milli/src/update/index_documents/extract/mod.rs
+++ b/crates/milli/src/update/index_documents/extract/mod.rs
@@ -274,7 +274,7 @@ fn send_original_documents_data(
                             embedder.clone(),
                             &embedder_name,
                             &possible_embedding_mistakes,
-                            Some(embedder_stats.clone()),
+                            embedder_stats.clone(),
                             &unused_vectors_distribution,
                             request_threads(),
                         ) {

--- a/crates/milli/src/update/index_documents/extract/mod.rs
+++ b/crates/milli/src/update/index_documents/extract/mod.rs
@@ -50,7 +50,7 @@ pub(crate) fn data_from_obkv_documents(
     settings_diff: Arc<InnerIndexSettingsDiff>,
     max_positions_per_attributes: Option<u32>,
     possible_embedding_mistakes: Arc<PossibleEmbeddingMistakes>,
-    embedder_stats: Option<Arc<EmbedderStats>>,
+    embedder_stats: Arc<EmbedderStats>,
 ) -> Result<()> {
     let (original_pipeline_result, flattened_pipeline_result): (Result<_>, Result<_>) = rayon::join(
         || {
@@ -234,7 +234,7 @@ fn send_original_documents_data(
     embedders_configs: Arc<Vec<IndexEmbeddingConfig>>,
     settings_diff: Arc<InnerIndexSettingsDiff>,
     possible_embedding_mistakes: Arc<PossibleEmbeddingMistakes>,
-    embedder_stats: Option<Arc<EmbedderStats>>,
+    embedder_stats: Arc<EmbedderStats>,
 ) -> Result<()> {
     let original_documents_chunk =
         original_documents_chunk.and_then(|c| unsafe { as_cloneable_grenad(&c) })?;
@@ -274,7 +274,7 @@ fn send_original_documents_data(
                             embedder.clone(),
                             &embedder_name,
                             &possible_embedding_mistakes,
-                            embedder_stats.clone(),
+                            Some(embedder_stats.clone()),
                             &unused_vectors_distribution,
                             request_threads(),
                         ) {

--- a/crates/milli/src/update/index_documents/extract/mod.rs
+++ b/crates/milli/src/update/index_documents/extract/mod.rs
@@ -31,6 +31,7 @@ use self::extract_word_position_docids::extract_word_position_docids;
 use super::helpers::{as_cloneable_grenad, CursorClonableMmap, GrenadParameters};
 use super::{helpers, TypedChunk};
 use crate::index::IndexEmbeddingConfig;
+use crate::progress::EmbedderStats;
 use crate::update::settings::InnerIndexSettingsDiff;
 use crate::vector::error::PossibleEmbeddingMistakes;
 use crate::{FieldId, Result, ThreadPoolNoAbort, ThreadPoolNoAbortBuilder};
@@ -49,6 +50,7 @@ pub(crate) fn data_from_obkv_documents(
     settings_diff: Arc<InnerIndexSettingsDiff>,
     max_positions_per_attributes: Option<u32>,
     possible_embedding_mistakes: Arc<PossibleEmbeddingMistakes>,
+    embedder_stats: Option<Arc<EmbedderStats>>,
 ) -> Result<()> {
     let (original_pipeline_result, flattened_pipeline_result): (Result<_>, Result<_>) = rayon::join(
         || {
@@ -62,6 +64,7 @@ pub(crate) fn data_from_obkv_documents(
                         embedders_configs.clone(),
                         settings_diff.clone(),
                         possible_embedding_mistakes.clone(),
+                        embedder_stats.clone(),
                     )
                 })
                 .collect::<Result<()>>()
@@ -231,6 +234,7 @@ fn send_original_documents_data(
     embedders_configs: Arc<Vec<IndexEmbeddingConfig>>,
     settings_diff: Arc<InnerIndexSettingsDiff>,
     possible_embedding_mistakes: Arc<PossibleEmbeddingMistakes>,
+    embedder_stats: Option<Arc<EmbedderStats>>,
 ) -> Result<()> {
     let original_documents_chunk =
         original_documents_chunk.and_then(|c| unsafe { as_cloneable_grenad(&c) })?;
@@ -270,6 +274,7 @@ fn send_original_documents_data(
                             embedder.clone(),
                             &embedder_name,
                             &possible_embedding_mistakes,
+                            embedder_stats.clone(),
                             &unused_vectors_distribution,
                             request_threads(),
                         ) {

--- a/crates/milli/src/update/index_documents/extract/mod.rs
+++ b/crates/milli/src/update/index_documents/extract/mod.rs
@@ -50,7 +50,7 @@ pub(crate) fn data_from_obkv_documents(
     settings_diff: Arc<InnerIndexSettingsDiff>,
     max_positions_per_attributes: Option<u32>,
     possible_embedding_mistakes: Arc<PossibleEmbeddingMistakes>,
-    embedder_stats: Arc<EmbedderStats>, // Cant change
+    embedder_stats: &Arc<EmbedderStats>,
 ) -> Result<()> {
     let (original_pipeline_result, flattened_pipeline_result): (Result<_>, Result<_>) = rayon::join(
         || {
@@ -234,7 +234,7 @@ fn send_original_documents_data(
     embedders_configs: Arc<Vec<IndexEmbeddingConfig>>,
     settings_diff: Arc<InnerIndexSettingsDiff>,
     possible_embedding_mistakes: Arc<PossibleEmbeddingMistakes>,
-    embedder_stats: Arc<EmbedderStats>, // Cant change
+    embedder_stats: Arc<EmbedderStats>,
 ) -> Result<()> {
     let original_documents_chunk =
         original_documents_chunk.and_then(|c| unsafe { as_cloneable_grenad(&c) })?;

--- a/crates/milli/src/update/index_documents/extract/mod.rs
+++ b/crates/milli/src/update/index_documents/extract/mod.rs
@@ -50,7 +50,7 @@ pub(crate) fn data_from_obkv_documents(
     settings_diff: Arc<InnerIndexSettingsDiff>,
     max_positions_per_attributes: Option<u32>,
     possible_embedding_mistakes: Arc<PossibleEmbeddingMistakes>,
-    embedder_stats: Arc<EmbedderStats>,
+    embedder_stats: Arc<EmbedderStats>, // Cant change
 ) -> Result<()> {
     let (original_pipeline_result, flattened_pipeline_result): (Result<_>, Result<_>) = rayon::join(
         || {
@@ -234,7 +234,7 @@ fn send_original_documents_data(
     embedders_configs: Arc<Vec<IndexEmbeddingConfig>>,
     settings_diff: Arc<InnerIndexSettingsDiff>,
     possible_embedding_mistakes: Arc<PossibleEmbeddingMistakes>,
-    embedder_stats: Arc<EmbedderStats>,
+    embedder_stats: Arc<EmbedderStats>, // Cant change
 ) -> Result<()> {
     let original_documents_chunk =
         original_documents_chunk.and_then(|c| unsafe { as_cloneable_grenad(&c) })?;
@@ -274,7 +274,7 @@ fn send_original_documents_data(
                             embedder.clone(),
                             &embedder_name,
                             &possible_embedding_mistakes,
-                            embedder_stats.clone(),
+                            &embedder_stats,
                             &unused_vectors_distribution,
                             request_threads(),
                         ) {

--- a/crates/milli/src/update/index_documents/mod.rs
+++ b/crates/milli/src/update/index_documents/mod.rs
@@ -81,7 +81,7 @@ pub struct IndexDocuments<'t, 'i, 'a, FP, FA> {
     added_documents: u64,
     deleted_documents: u64,
     embedders: EmbeddingConfigs,
-    embedder_stats: Option<Arc<EmbedderStats>>,
+    embedder_stats: Arc<EmbedderStats>,
 }
 
 #[derive(Default, Debug, Clone)]
@@ -104,7 +104,7 @@ where
         config: IndexDocumentsConfig,
         progress: FP,
         should_abort: FA,
-        embedder_stats: Option<Arc<EmbedderStats>>,
+        embedder_stats: Arc<EmbedderStats>,
     ) -> Result<IndexDocuments<'t, 'i, 'a, FP, FA>> {
         let transform = Some(Transform::new(
             wtxn,
@@ -2030,6 +2030,7 @@ mod tests {
             EmbeddingConfigs::default(),
             &|| false,
             &Progress::default(),
+            Default::default(),
         )
         .unwrap();
         wtxn.commit().unwrap();
@@ -2117,6 +2118,7 @@ mod tests {
             EmbeddingConfigs::default(),
             &|| false,
             &Progress::default(),
+            Default::default(),
         )
         .unwrap();
         wtxn.commit().unwrap();
@@ -2302,6 +2304,7 @@ mod tests {
             embedders,
             &|| false,
             &Progress::default(),
+            Default::default(),
         )
         .unwrap();
         wtxn.commit().unwrap();
@@ -2364,6 +2367,7 @@ mod tests {
             embedders,
             &|| false,
             &Progress::default(),
+            Default::default(),
         )
         .unwrap();
         wtxn.commit().unwrap();
@@ -2417,6 +2421,7 @@ mod tests {
             embedders,
             &|| false,
             &Progress::default(),
+            Default::default(),
         )
         .unwrap();
         wtxn.commit().unwrap();
@@ -2469,6 +2474,7 @@ mod tests {
             embedders,
             &|| false,
             &Progress::default(),
+            Default::default(),
         )
         .unwrap();
         wtxn.commit().unwrap();
@@ -2523,6 +2529,7 @@ mod tests {
             embedders,
             &|| false,
             &Progress::default(),
+            Default::default(),
         )
         .unwrap();
         wtxn.commit().unwrap();
@@ -2582,6 +2589,7 @@ mod tests {
             embedders,
             &|| false,
             &Progress::default(),
+            Default::default(),
         )
         .unwrap();
         wtxn.commit().unwrap();
@@ -2634,6 +2642,7 @@ mod tests {
             embedders,
             &|| false,
             &Progress::default(),
+            Default::default(),
         )
         .unwrap();
         wtxn.commit().unwrap();
@@ -2686,6 +2695,7 @@ mod tests {
             embedders,
             &|| false,
             &Progress::default(),
+            Default::default(),
         )
         .unwrap();
         wtxn.commit().unwrap();
@@ -2884,6 +2894,7 @@ mod tests {
             embedders,
             &|| false,
             &Progress::default(),
+            Default::default(),
         )
         .unwrap();
         wtxn.commit().unwrap();
@@ -2943,6 +2954,7 @@ mod tests {
             embedders,
             &|| false,
             &Progress::default(),
+            Default::default(),
         )
         .unwrap();
         wtxn.commit().unwrap();
@@ -2999,6 +3011,7 @@ mod tests {
             embedders,
             &|| false,
             &Progress::default(),
+            Default::default(),
         )
         .unwrap();
         wtxn.commit().unwrap();

--- a/crates/milli/src/update/index_documents/mod.rs
+++ b/crates/milli/src/update/index_documents/mod.rs
@@ -81,7 +81,7 @@ pub struct IndexDocuments<'t, 'i, 'a, FP, FA> {
     added_documents: u64,
     deleted_documents: u64,
     embedders: EmbeddingConfigs,
-    embedder_stats: Arc<EmbedderStats>, // Cant change
+    embedder_stats: &'t Arc<EmbedderStats>,
 }
 
 #[derive(Default, Debug, Clone)]
@@ -104,7 +104,7 @@ where
         config: IndexDocumentsConfig,
         progress: FP,
         should_abort: FA,
-        embedder_stats: Arc<EmbedderStats>, // Cant change
+        embedder_stats: &'t Arc<EmbedderStats>,
     ) -> Result<IndexDocuments<'t, 'i, 'a, FP, FA>> {
         let transform = Some(Transform::new(
             wtxn,
@@ -331,7 +331,7 @@ where
                             settings_diff_cloned,
                             max_positions_per_attributes,
                             Arc::new(possible_embedding_mistakes),
-                            embedder_stats.clone()
+                            &embedder_stats
                         )
                     });
 

--- a/crates/milli/src/update/index_documents/mod.rs
+++ b/crates/milli/src/update/index_documents/mod.rs
@@ -81,7 +81,7 @@ pub struct IndexDocuments<'t, 'i, 'a, FP, FA> {
     added_documents: u64,
     deleted_documents: u64,
     embedders: EmbeddingConfigs,
-    embedder_stats: Arc<EmbedderStats>,
+    embedder_stats: Arc<EmbedderStats>, // Cant change
 }
 
 #[derive(Default, Debug, Clone)]
@@ -104,7 +104,7 @@ where
         config: IndexDocumentsConfig,
         progress: FP,
         should_abort: FA,
-        embedder_stats: Arc<EmbedderStats>,
+        embedder_stats: Arc<EmbedderStats>, // Cant change
     ) -> Result<IndexDocuments<'t, 'i, 'a, FP, FA>> {
         let transform = Some(Transform::new(
             wtxn,
@@ -2030,7 +2030,7 @@ mod tests {
             EmbeddingConfigs::default(),
             &|| false,
             &Progress::default(),
-            Default::default(),
+            &Default::default(),
         )
         .unwrap();
         wtxn.commit().unwrap();
@@ -2118,7 +2118,7 @@ mod tests {
             EmbeddingConfigs::default(),
             &|| false,
             &Progress::default(),
-            Default::default(),
+            &Default::default(),
         )
         .unwrap();
         wtxn.commit().unwrap();
@@ -2304,7 +2304,7 @@ mod tests {
             embedders,
             &|| false,
             &Progress::default(),
-            Default::default(),
+            &Default::default(),
         )
         .unwrap();
         wtxn.commit().unwrap();
@@ -2367,7 +2367,7 @@ mod tests {
             embedders,
             &|| false,
             &Progress::default(),
-            Default::default(),
+            &Default::default(),
         )
         .unwrap();
         wtxn.commit().unwrap();
@@ -2421,7 +2421,7 @@ mod tests {
             embedders,
             &|| false,
             &Progress::default(),
-            Default::default(),
+            &Default::default(),
         )
         .unwrap();
         wtxn.commit().unwrap();
@@ -2474,7 +2474,7 @@ mod tests {
             embedders,
             &|| false,
             &Progress::default(),
-            Default::default(),
+            &Default::default(),
         )
         .unwrap();
         wtxn.commit().unwrap();
@@ -2529,7 +2529,7 @@ mod tests {
             embedders,
             &|| false,
             &Progress::default(),
-            Default::default(),
+            &Default::default(),
         )
         .unwrap();
         wtxn.commit().unwrap();
@@ -2589,7 +2589,7 @@ mod tests {
             embedders,
             &|| false,
             &Progress::default(),
-            Default::default(),
+            &Default::default(),
         )
         .unwrap();
         wtxn.commit().unwrap();
@@ -2642,7 +2642,7 @@ mod tests {
             embedders,
             &|| false,
             &Progress::default(),
-            Default::default(),
+            &Default::default(),
         )
         .unwrap();
         wtxn.commit().unwrap();
@@ -2695,7 +2695,7 @@ mod tests {
             embedders,
             &|| false,
             &Progress::default(),
-            Default::default(),
+            &Default::default(),
         )
         .unwrap();
         wtxn.commit().unwrap();
@@ -2894,7 +2894,7 @@ mod tests {
             embedders,
             &|| false,
             &Progress::default(),
-            Default::default(),
+            &Default::default(),
         )
         .unwrap();
         wtxn.commit().unwrap();
@@ -2954,7 +2954,7 @@ mod tests {
             embedders,
             &|| false,
             &Progress::default(),
-            Default::default(),
+            &Default::default(),
         )
         .unwrap();
         wtxn.commit().unwrap();
@@ -3011,7 +3011,7 @@ mod tests {
             embedders,
             &|| false,
             &Progress::default(),
-            Default::default(),
+            &Default::default(),
         )
         .unwrap();
         wtxn.commit().unwrap();

--- a/crates/milli/src/update/new/extract/vectors/mod.rs
+++ b/crates/milli/src/update/new/extract/vectors/mod.rs
@@ -23,7 +23,7 @@ pub struct EmbeddingExtractor<'a, 'b> {
     embedders: &'a EmbeddingConfigs,
     sender: EmbeddingSender<'a, 'b>,
     possible_embedding_mistakes: PossibleEmbeddingMistakes,
-    embedder_stats: Option<Arc<EmbedderStats>>,
+    embedder_stats: Arc<EmbedderStats>,
     threads: &'a ThreadPoolNoAbort,
 }
 
@@ -32,7 +32,7 @@ impl<'a, 'b> EmbeddingExtractor<'a, 'b> {
         embedders: &'a EmbeddingConfigs,
         sender: EmbeddingSender<'a, 'b>,
         field_distribution: &'a FieldDistribution,
-        embedder_stats: Option<Arc<EmbedderStats>>,
+        embedder_stats: Arc<EmbedderStats>,
         threads: &'a ThreadPoolNoAbort,
     ) -> Self {
         let possible_embedding_mistakes = PossibleEmbeddingMistakes::new(field_distribution);
@@ -311,7 +311,7 @@ struct Chunks<'a, 'b, 'extractor> {
     dimensions: usize,
     prompt: &'a Prompt,
     possible_embedding_mistakes: &'a PossibleEmbeddingMistakes,
-    embedder_stats: Option<Arc<EmbedderStats>>,
+    embedder_stats: Arc<EmbedderStats>,
     user_provided: &'a RefCell<EmbeddingExtractorData<'extractor>>,
     threads: &'a ThreadPoolNoAbort,
     sender: EmbeddingSender<'a, 'b>,
@@ -327,7 +327,7 @@ impl<'a, 'b, 'extractor> Chunks<'a, 'b, 'extractor> {
         prompt: &'a Prompt,
         user_provided: &'a RefCell<EmbeddingExtractorData<'extractor>>,
         possible_embedding_mistakes: &'a PossibleEmbeddingMistakes,
-        embedder_stats: Option<Arc<EmbedderStats>>,
+        embedder_stats: Arc<EmbedderStats>,
         threads: &'a ThreadPoolNoAbort,
         sender: EmbeddingSender<'a, 'b>,
         doc_alloc: &'a Bump,
@@ -416,7 +416,7 @@ impl<'a, 'b, 'extractor> Chunks<'a, 'b, 'extractor> {
         embedder_id: u8,
         embedder_name: &str,
         possible_embedding_mistakes: &PossibleEmbeddingMistakes,
-        embedder_stats: Option<Arc<EmbedderStats>>,
+        embedder_stats: Arc<EmbedderStats>,
         unused_vectors_distribution: &UnusedVectorsDistributionBump,
         threads: &ThreadPoolNoAbort,
         sender: EmbeddingSender<'a, 'b>,

--- a/crates/milli/src/update/new/extract/vectors/mod.rs
+++ b/crates/milli/src/update/new/extract/vectors/mod.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, sync::Arc};
+use std::cell::RefCell;
 
 use bumpalo::collections::Vec as BVec;
 use bumpalo::Bump;
@@ -23,7 +23,7 @@ pub struct EmbeddingExtractor<'a, 'b> {
     embedders: &'a EmbeddingConfigs,
     sender: EmbeddingSender<'a, 'b>,
     possible_embedding_mistakes: PossibleEmbeddingMistakes,
-    embedder_stats: Arc<EmbedderStats>,
+    embedder_stats: &'a EmbedderStats,
     threads: &'a ThreadPoolNoAbort,
 }
 
@@ -32,7 +32,7 @@ impl<'a, 'b> EmbeddingExtractor<'a, 'b> {
         embedders: &'a EmbeddingConfigs,
         sender: EmbeddingSender<'a, 'b>,
         field_distribution: &'a FieldDistribution,
-        embedder_stats: Arc<EmbedderStats>,
+        embedder_stats: &'a EmbedderStats,
         threads: &'a ThreadPoolNoAbort,
     ) -> Self {
         let possible_embedding_mistakes = PossibleEmbeddingMistakes::new(field_distribution);
@@ -78,7 +78,7 @@ impl<'extractor> Extractor<'extractor> for EmbeddingExtractor<'_, '_> {
                 prompt,
                 context.data,
                 &self.possible_embedding_mistakes,
-                self.embedder_stats.clone(),
+                self.embedder_stats,
                 self.threads,
                 self.sender,
                 &context.doc_alloc,
@@ -311,7 +311,7 @@ struct Chunks<'a, 'b, 'extractor> {
     dimensions: usize,
     prompt: &'a Prompt,
     possible_embedding_mistakes: &'a PossibleEmbeddingMistakes,
-    embedder_stats: Arc<EmbedderStats>,
+    embedder_stats: &'a EmbedderStats,
     user_provided: &'a RefCell<EmbeddingExtractorData<'extractor>>,
     threads: &'a ThreadPoolNoAbort,
     sender: EmbeddingSender<'a, 'b>,
@@ -327,7 +327,7 @@ impl<'a, 'b, 'extractor> Chunks<'a, 'b, 'extractor> {
         prompt: &'a Prompt,
         user_provided: &'a RefCell<EmbeddingExtractorData<'extractor>>,
         possible_embedding_mistakes: &'a PossibleEmbeddingMistakes,
-        embedder_stats: Arc<EmbedderStats>,
+        embedder_stats: &'a EmbedderStats,
         threads: &'a ThreadPoolNoAbort,
         sender: EmbeddingSender<'a, 'b>,
         doc_alloc: &'a Bump,
@@ -378,7 +378,7 @@ impl<'a, 'b, 'extractor> Chunks<'a, 'b, 'extractor> {
             self.embedder_id,
             self.embedder_name,
             self.possible_embedding_mistakes,
-            self.embedder_stats.clone(),
+            self.embedder_stats,
             unused_vectors_distribution,
             self.threads,
             self.sender,
@@ -397,7 +397,7 @@ impl<'a, 'b, 'extractor> Chunks<'a, 'b, 'extractor> {
             self.embedder_id,
             self.embedder_name,
             self.possible_embedding_mistakes,
-            self.embedder_stats.clone(),
+            self.embedder_stats,
             unused_vectors_distribution,
             self.threads,
             self.sender,
@@ -416,7 +416,7 @@ impl<'a, 'b, 'extractor> Chunks<'a, 'b, 'extractor> {
         embedder_id: u8,
         embedder_name: &str,
         possible_embedding_mistakes: &PossibleEmbeddingMistakes,
-        embedder_stats: Arc<EmbedderStats>,
+        embedder_stats: &EmbedderStats,
         unused_vectors_distribution: &UnusedVectorsDistributionBump,
         threads: &ThreadPoolNoAbort,
         sender: EmbeddingSender<'a, 'b>,

--- a/crates/milli/src/update/new/extract/vectors/mod.rs
+++ b/crates/milli/src/update/new/extract/vectors/mod.rs
@@ -1,4 +1,3 @@
-use std::f32::consts::E;
 use std::{cell::RefCell, sync::Arc};
 
 use bumpalo::collections::Vec as BVec;

--- a/crates/milli/src/update/new/extract/vectors/mod.rs
+++ b/crates/milli/src/update/new/extract/vectors/mod.rs
@@ -450,7 +450,7 @@ impl<'a, 'b, 'extractor> Chunks<'a, 'b, 'extractor> {
             return Err(crate::Error::UserError(crate::UserError::DocumentEmbeddingError(msg)));
         }
 
-        let res = match embedder.embed_index_ref(texts.as_slice(), threads) {
+        let res = match embedder.embed_index_ref(texts.as_slice(), threads, None) {
             Ok(embeddings) => {
                 for (docid, embedding) in ids.into_iter().zip(embeddings) {
                     sender.set_vector(*docid, embedder_id, embedding).unwrap();

--- a/crates/milli/src/update/new/indexer/extract.rs
+++ b/crates/milli/src/update/new/indexer/extract.rs
@@ -248,7 +248,7 @@ where
             embedders,
             embedding_sender,
             field_distribution,
-            Some(embedder_stats),
+            embedder_stats,
             request_threads(),
         );
         let mut datastore = ThreadLocal::with_capacity(rayon::current_num_threads());

--- a/crates/milli/src/update/new/indexer/extract.rs
+++ b/crates/milli/src/update/new/indexer/extract.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::sync::atomic::AtomicBool;
-use std::sync::OnceLock;
 use std::sync::Arc;
+use std::sync::OnceLock;
 
 use bumpalo::Bump;
 use roaring::RoaringBitmap;

--- a/crates/milli/src/update/new/indexer/extract.rs
+++ b/crates/milli/src/update/new/indexer/extract.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 use std::sync::atomic::AtomicBool;
 use std::sync::OnceLock;
+use std::sync::Arc;
 
 use bumpalo::Bump;
 use roaring::RoaringBitmap;
@@ -13,6 +14,7 @@ use super::super::thread_local::{FullySend, ThreadLocal};
 use super::super::FacetFieldIdsDelta;
 use super::document_changes::{extract, DocumentChanges, IndexingContext};
 use crate::index::IndexEmbeddingConfig;
+use crate::progress::EmbedderStats;
 use crate::progress::MergingWordCache;
 use crate::proximity::ProximityPrecision;
 use crate::update::new::extract::EmbeddingExtractor;
@@ -34,6 +36,7 @@ pub(super) fn extract_all<'pl, 'extractor, DC, MSP>(
     mut index_embeddings: Vec<IndexEmbeddingConfig>,
     document_ids: &mut RoaringBitmap,
     modified_docids: &mut RoaringBitmap,
+    embedder_stats: Arc<EmbedderStats>,
 ) -> Result<(FacetFieldIdsDelta, Vec<IndexEmbeddingConfig>)>
 where
     DC: DocumentChanges<'pl>,
@@ -245,6 +248,7 @@ where
             embedders,
             embedding_sender,
             field_distribution,
+            Some(embedder_stats),
             request_threads(),
         );
         let mut datastore = ThreadLocal::with_capacity(rayon::current_num_threads());

--- a/crates/milli/src/update/new/indexer/extract.rs
+++ b/crates/milli/src/update/new/indexer/extract.rs
@@ -1,6 +1,5 @@
 use std::collections::BTreeMap;
 use std::sync::atomic::AtomicBool;
-use std::sync::Arc;
 use std::sync::OnceLock;
 
 use bumpalo::Bump;
@@ -36,7 +35,7 @@ pub(super) fn extract_all<'pl, 'extractor, DC, MSP>(
     mut index_embeddings: Vec<IndexEmbeddingConfig>,
     document_ids: &mut RoaringBitmap,
     modified_docids: &mut RoaringBitmap,
-    embedder_stats: Arc<EmbedderStats>,
+    embedder_stats: &EmbedderStats,
 ) -> Result<(FacetFieldIdsDelta, Vec<IndexEmbeddingConfig>)>
 where
     DC: DocumentChanges<'pl>,

--- a/crates/milli/src/update/new/indexer/mod.rs
+++ b/crates/milli/src/update/new/indexer/mod.rs
@@ -1,5 +1,4 @@
 use std::sync::atomic::AtomicBool;
-use std::sync::Arc;
 use std::sync::{Once, RwLock};
 use std::thread::{self, Builder};
 
@@ -56,7 +55,7 @@ pub fn index<'pl, 'indexer, 'index, DC, MSP>(
     embedders: EmbeddingConfigs,
     must_stop_processing: &'indexer MSP,
     progress: &'indexer Progress,
-    embedder_stats: Arc<EmbedderStats>,
+    embedder_stats: &'indexer EmbedderStats,
 ) -> Result<ChannelCongestion>
 where
     DC: DocumentChanges<'pl>,

--- a/crates/milli/src/update/new/indexer/mod.rs
+++ b/crates/milli/src/update/new/indexer/mod.rs
@@ -1,7 +1,7 @@
 use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
 use std::sync::{Once, RwLock};
 use std::thread::{self, Builder};
-use std::sync::Arc;
 
 use big_s::S;
 use document_changes::{DocumentChanges, IndexingContext};

--- a/crates/milli/src/update/new/indexer/mod.rs
+++ b/crates/milli/src/update/new/indexer/mod.rs
@@ -1,6 +1,7 @@
 use std::sync::atomic::AtomicBool;
 use std::sync::{Once, RwLock};
 use std::thread::{self, Builder};
+use std::sync::Arc;
 
 use big_s::S;
 use document_changes::{DocumentChanges, IndexingContext};
@@ -19,7 +20,7 @@ use super::steps::IndexingStep;
 use super::thread_local::ThreadLocal;
 use crate::documents::PrimaryKey;
 use crate::fields_ids_map::metadata::{FieldIdMapWithMetadata, MetadataBuilder};
-use crate::progress::Progress;
+use crate::progress::{EmbedderStats, Progress};
 use crate::update::GrenadParameters;
 use crate::vector::{ArroyWrapper, EmbeddingConfigs};
 use crate::{FieldsIdsMap, GlobalFieldsIdsMap, Index, InternalError, Result, ThreadPoolNoAbort};
@@ -55,6 +56,7 @@ pub fn index<'pl, 'indexer, 'index, DC, MSP>(
     embedders: EmbeddingConfigs,
     must_stop_processing: &'indexer MSP,
     progress: &'indexer Progress,
+    embedder_stats: Arc<EmbedderStats>,
 ) -> Result<ChannelCongestion>
 where
     DC: DocumentChanges<'pl>,
@@ -158,6 +160,7 @@ where
                         index_embeddings,
                         document_ids,
                         modified_docids,
+                        embedder_stats,
                     )
                 })
                 .unwrap()

--- a/crates/milli/src/update/settings.rs
+++ b/crates/milli/src/update/settings.rs
@@ -475,7 +475,7 @@ impl<'a, 't, 'i> Settings<'a, 't, 'i> {
         progress_callback: &FP,
         should_abort: &FA,
         settings_diff: InnerIndexSettingsDiff,
-        embedder_stats: Arc<EmbedderStats>,
+        embedder_stats: Arc<EmbedderStats>, // Cant change
     ) -> Result<()>
     where
         FP: Fn(UpdateIndexingStep) + Sync,
@@ -1362,7 +1362,7 @@ impl<'a, 't, 'i> Settings<'a, 't, 'i> {
         mut self,
         progress_callback: FP,
         should_abort: FA,
-        embedder_stats: Arc<EmbedderStats>,
+        embedder_stats: Arc<EmbedderStats>, // Cant change
     ) -> Result<()>
     where
         FP: Fn(UpdateIndexingStep) + Sync,

--- a/crates/milli/src/update/settings.rs
+++ b/crates/milli/src/update/settings.rs
@@ -27,6 +27,7 @@ use crate::index::{
     DEFAULT_MIN_WORD_LEN_ONE_TYPO, DEFAULT_MIN_WORD_LEN_TWO_TYPOS,
 };
 use crate::order_by_map::OrderByMap;
+use crate::progress::EmbedderStats;
 use crate::prompt::{default_max_bytes, default_template_text, PromptData};
 use crate::proximity::ProximityPrecision;
 use crate::update::index_documents::IndexDocumentsMethod;
@@ -466,7 +467,7 @@ impl<'a, 't, 'i> Settings<'a, 't, 'i> {
 
     #[tracing::instrument(
         level = "trace"
-        skip(self, progress_callback, should_abort, settings_diff),
+        skip(self, progress_callback, should_abort, settings_diff, embedder_stats),
         target = "indexing::documents"
     )]
     fn reindex<FP, FA>(
@@ -474,6 +475,7 @@ impl<'a, 't, 'i> Settings<'a, 't, 'i> {
         progress_callback: &FP,
         should_abort: &FA,
         settings_diff: InnerIndexSettingsDiff,
+        embedder_stats: Option<Arc<EmbedderStats>>,
     ) -> Result<()>
     where
         FP: Fn(UpdateIndexingStep) + Sync,
@@ -505,6 +507,7 @@ impl<'a, 't, 'i> Settings<'a, 't, 'i> {
             IndexDocumentsConfig::default(),
             &progress_callback,
             &should_abort,
+            embedder_stats,
         )?;
 
         indexing_builder.execute_raw(output)?;
@@ -1355,7 +1358,7 @@ impl<'a, 't, 'i> Settings<'a, 't, 'i> {
         }
     }
 
-    pub fn execute<FP, FA>(mut self, progress_callback: FP, should_abort: FA) -> Result<()>
+    pub fn execute<FP, FA>(mut self, progress_callback: FP, should_abort: FA, embedder_stats: Option<Arc<EmbedderStats>>) -> Result<()>
     where
         FP: Fn(UpdateIndexingStep) + Sync,
         FA: Fn() -> bool + Sync,
@@ -1413,7 +1416,7 @@ impl<'a, 't, 'i> Settings<'a, 't, 'i> {
         );
 
         if inner_settings_diff.any_reindexing_needed() {
-            self.reindex(&progress_callback, &should_abort, inner_settings_diff)?;
+            self.reindex(&progress_callback, &should_abort, inner_settings_diff, embedder_stats)?;
         }
 
         Ok(())

--- a/crates/milli/src/update/settings.rs
+++ b/crates/milli/src/update/settings.rs
@@ -475,7 +475,7 @@ impl<'a, 't, 'i> Settings<'a, 't, 'i> {
         progress_callback: &FP,
         should_abort: &FA,
         settings_diff: InnerIndexSettingsDiff,
-        embedder_stats: Arc<EmbedderStats>, // Cant change
+        embedder_stats: &Arc<EmbedderStats>, // Cant change
     ) -> Result<()>
     where
         FP: Fn(UpdateIndexingStep) + Sync,
@@ -507,7 +507,7 @@ impl<'a, 't, 'i> Settings<'a, 't, 'i> {
             IndexDocumentsConfig::default(),
             &progress_callback,
             &should_abort,
-            embedder_stats,
+            &embedder_stats,
         )?;
 
         indexing_builder.execute_raw(output)?;
@@ -1421,7 +1421,7 @@ impl<'a, 't, 'i> Settings<'a, 't, 'i> {
         );
 
         if inner_settings_diff.any_reindexing_needed() {
-            self.reindex(&progress_callback, &should_abort, inner_settings_diff, embedder_stats)?;
+            self.reindex(&progress_callback, &should_abort, inner_settings_diff, &embedder_stats)?;
         }
 
         Ok(())

--- a/crates/milli/src/update/settings.rs
+++ b/crates/milli/src/update/settings.rs
@@ -1358,7 +1358,12 @@ impl<'a, 't, 'i> Settings<'a, 't, 'i> {
         }
     }
 
-    pub fn execute<FP, FA>(mut self, progress_callback: FP, should_abort: FA, embedder_stats: Arc<EmbedderStats>) -> Result<()>
+    pub fn execute<FP, FA>(
+        mut self,
+        progress_callback: FP,
+        should_abort: FA,
+        embedder_stats: Arc<EmbedderStats>,
+    ) -> Result<()>
     where
         FP: Fn(UpdateIndexingStep) + Sync,
         FA: Fn() -> bool + Sync,

--- a/crates/milli/src/update/settings.rs
+++ b/crates/milli/src/update/settings.rs
@@ -507,7 +507,7 @@ impl<'a, 't, 'i> Settings<'a, 't, 'i> {
             IndexDocumentsConfig::default(),
             &progress_callback,
             &should_abort,
-            &embedder_stats,
+            embedder_stats,
         )?;
 
         indexing_builder.execute_raw(output)?;

--- a/crates/milli/src/update/settings.rs
+++ b/crates/milli/src/update/settings.rs
@@ -475,7 +475,7 @@ impl<'a, 't, 'i> Settings<'a, 't, 'i> {
         progress_callback: &FP,
         should_abort: &FA,
         settings_diff: InnerIndexSettingsDiff,
-        embedder_stats: &Arc<EmbedderStats>, // Cant change
+        embedder_stats: &Arc<EmbedderStats>,
     ) -> Result<()>
     where
         FP: Fn(UpdateIndexingStep) + Sync,
@@ -1362,7 +1362,7 @@ impl<'a, 't, 'i> Settings<'a, 't, 'i> {
         mut self,
         progress_callback: FP,
         should_abort: FA,
-        embedder_stats: Arc<EmbedderStats>, // Cant change
+        embedder_stats: Arc<EmbedderStats>,
     ) -> Result<()>
     where
         FP: Fn(UpdateIndexingStep) + Sync,

--- a/crates/milli/src/update/settings.rs
+++ b/crates/milli/src/update/settings.rs
@@ -475,7 +475,7 @@ impl<'a, 't, 'i> Settings<'a, 't, 'i> {
         progress_callback: &FP,
         should_abort: &FA,
         settings_diff: InnerIndexSettingsDiff,
-        embedder_stats: Option<Arc<EmbedderStats>>,
+        embedder_stats: Arc<EmbedderStats>,
     ) -> Result<()>
     where
         FP: Fn(UpdateIndexingStep) + Sync,
@@ -1358,7 +1358,7 @@ impl<'a, 't, 'i> Settings<'a, 't, 'i> {
         }
     }
 
-    pub fn execute<FP, FA>(mut self, progress_callback: FP, should_abort: FA, embedder_stats: Option<Arc<EmbedderStats>>) -> Result<()>
+    pub fn execute<FP, FA>(mut self, progress_callback: FP, should_abort: FA, embedder_stats: Arc<EmbedderStats>) -> Result<()>
     where
         FP: Fn(UpdateIndexingStep) + Sync,
         FA: Fn() -> bool + Sync,

--- a/crates/milli/src/vector/composite.rs
+++ b/crates/milli/src/vector/composite.rs
@@ -173,12 +173,14 @@ impl SubEmbedder {
     ) -> std::result::Result<Embedding, EmbedError> {
         match self {
             SubEmbedder::HuggingFace(embedder) => embedder.embed_one(text),
-            SubEmbedder::OpenAi(embedder) => {
-                embedder.embed(&[text], deadline, embedder_stats)?.pop().ok_or_else(EmbedError::missing_embedding)
-            }
-            SubEmbedder::Ollama(embedder) => {
-                embedder.embed(&[text], deadline, embedder_stats)?.pop().ok_or_else(EmbedError::missing_embedding)
-            }
+            SubEmbedder::OpenAi(embedder) => embedder
+                .embed(&[text], deadline, embedder_stats)?
+                .pop()
+                .ok_or_else(EmbedError::missing_embedding),
+            SubEmbedder::Ollama(embedder) => embedder
+                .embed(&[text], deadline, embedder_stats)?
+                .pop()
+                .ok_or_else(EmbedError::missing_embedding),
             SubEmbedder::UserProvided(embedder) => embedder.embed_one(text),
             SubEmbedder::Rest(embedder) => embedder
                 .embed_ref(&[text], deadline, embedder_stats)?
@@ -198,10 +200,16 @@ impl SubEmbedder {
     ) -> std::result::Result<Vec<Vec<Embedding>>, EmbedError> {
         match self {
             SubEmbedder::HuggingFace(embedder) => embedder.embed_index(text_chunks),
-            SubEmbedder::OpenAi(embedder) => embedder.embed_index(text_chunks, threads, embedder_stats),
-            SubEmbedder::Ollama(embedder) => embedder.embed_index(text_chunks, threads, embedder_stats),
+            SubEmbedder::OpenAi(embedder) => {
+                embedder.embed_index(text_chunks, threads, embedder_stats)
+            }
+            SubEmbedder::Ollama(embedder) => {
+                embedder.embed_index(text_chunks, threads, embedder_stats)
+            }
             SubEmbedder::UserProvided(embedder) => embedder.embed_index(text_chunks),
-            SubEmbedder::Rest(embedder) => embedder.embed_index(text_chunks, threads, embedder_stats),
+            SubEmbedder::Rest(embedder) => {
+                embedder.embed_index(text_chunks, threads, embedder_stats)
+            }
         }
     }
 
@@ -214,8 +222,12 @@ impl SubEmbedder {
     ) -> std::result::Result<Vec<Embedding>, EmbedError> {
         match self {
             SubEmbedder::HuggingFace(embedder) => embedder.embed_index_ref(texts),
-            SubEmbedder::OpenAi(embedder) => embedder.embed_index_ref(texts, threads, embedder_stats),
-            SubEmbedder::Ollama(embedder) => embedder.embed_index_ref(texts, threads, embedder_stats),
+            SubEmbedder::OpenAi(embedder) => {
+                embedder.embed_index_ref(texts, threads, embedder_stats)
+            }
+            SubEmbedder::Ollama(embedder) => {
+                embedder.embed_index_ref(texts, threads, embedder_stats)
+            }
             SubEmbedder::UserProvided(embedder) => embedder.embed_index_ref(texts),
             SubEmbedder::Rest(embedder) => embedder.embed_index_ref(texts, threads, embedder_stats),
         }

--- a/crates/milli/src/vector/composite.rs
+++ b/crates/milli/src/vector/composite.rs
@@ -196,7 +196,7 @@ impl SubEmbedder {
         &self,
         text_chunks: Vec<Vec<String>>,
         threads: &ThreadPoolNoAbort,
-        embedder_stats: Option<Arc<EmbedderStats>>,
+        embedder_stats: Arc<EmbedderStats>,
     ) -> std::result::Result<Vec<Vec<Embedding>>, EmbedError> {
         match self {
             SubEmbedder::HuggingFace(embedder) => embedder.embed_index(text_chunks),
@@ -218,7 +218,7 @@ impl SubEmbedder {
         &self,
         texts: &[&str],
         threads: &ThreadPoolNoAbort,
-        embedder_stats: Option<Arc<EmbedderStats>>,
+        embedder_stats: Arc<EmbedderStats>,
     ) -> std::result::Result<Vec<Embedding>, EmbedError> {
         match self {
             SubEmbedder::HuggingFace(embedder) => embedder.embed_index_ref(texts),

--- a/crates/milli/src/vector/composite.rs
+++ b/crates/milli/src/vector/composite.rs
@@ -1,4 +1,3 @@
-use std::sync::Arc;
 use std::time::Instant;
 
 use arroy::Distance;
@@ -154,7 +153,7 @@ impl SubEmbedder {
         &self,
         texts: Vec<String>,
         deadline: Option<Instant>,
-        embedder_stats: Option<Arc<EmbedderStats>>,
+        embedder_stats: Option<&EmbedderStats>,
     ) -> std::result::Result<Vec<Embedding>, EmbedError> {
         match self {
             SubEmbedder::HuggingFace(embedder) => embedder.embed(texts),
@@ -169,7 +168,7 @@ impl SubEmbedder {
         &self,
         text: &str,
         deadline: Option<Instant>,
-        embedder_stats: Option<Arc<EmbedderStats>>,
+        embedder_stats: Option<&EmbedderStats>,
     ) -> std::result::Result<Embedding, EmbedError> {
         match self {
             SubEmbedder::HuggingFace(embedder) => embedder.embed_one(text),
@@ -196,7 +195,7 @@ impl SubEmbedder {
         &self,
         text_chunks: Vec<Vec<String>>,
         threads: &ThreadPoolNoAbort,
-        embedder_stats: Arc<EmbedderStats>,
+        embedder_stats: &EmbedderStats,
     ) -> std::result::Result<Vec<Vec<Embedding>>, EmbedError> {
         match self {
             SubEmbedder::HuggingFace(embedder) => embedder.embed_index(text_chunks),
@@ -218,7 +217,7 @@ impl SubEmbedder {
         &self,
         texts: &[&str],
         threads: &ThreadPoolNoAbort,
-        embedder_stats: Arc<EmbedderStats>,
+        embedder_stats: &EmbedderStats,
     ) -> std::result::Result<Vec<Embedding>, EmbedError> {
         match self {
             SubEmbedder::HuggingFace(embedder) => embedder.embed_index_ref(texts),

--- a/crates/milli/src/vector/mod.rs
+++ b/crates/milli/src/vector/mod.rs
@@ -749,7 +749,7 @@ impl Embedder {
         &self,
         text_chunks: Vec<Vec<String>>,
         threads: &ThreadPoolNoAbort,
-        embedder_stats: Option<Arc<EmbedderStats>>,
+        embedder_stats: Arc<EmbedderStats>,
     ) -> std::result::Result<Vec<Vec<Embedding>>, EmbedError> {
         match self {
             Embedder::HuggingFace(embedder) => embedder.embed_index(text_chunks),
@@ -772,7 +772,7 @@ impl Embedder {
         &self,
         texts: &[&str],
         threads: &ThreadPoolNoAbort,
-        embedder_stats: Option<Arc<EmbedderStats>>,
+        embedder_stats: Arc<EmbedderStats>,
     ) -> std::result::Result<Vec<Embedding>, EmbedError> {
         match self {
             Embedder::HuggingFace(embedder) => embedder.embed_index_ref(texts),

--- a/crates/milli/src/vector/mod.rs
+++ b/crates/milli/src/vector/mod.rs
@@ -719,12 +719,14 @@ impl Embedder {
         }
         let embedding = match self {
             Embedder::HuggingFace(embedder) => embedder.embed_one(text),
-            Embedder::OpenAi(embedder) => {
-                embedder.embed(&[text], deadline, None)?.pop().ok_or_else(EmbedError::missing_embedding)
-            }
-            Embedder::Ollama(embedder) => {
-                embedder.embed(&[text], deadline, None)?.pop().ok_or_else(EmbedError::missing_embedding)
-            }
+            Embedder::OpenAi(embedder) => embedder
+                .embed(&[text], deadline, None)?
+                .pop()
+                .ok_or_else(EmbedError::missing_embedding),
+            Embedder::Ollama(embedder) => embedder
+                .embed(&[text], deadline, None)?
+                .pop()
+                .ok_or_else(EmbedError::missing_embedding),
             Embedder::UserProvided(embedder) => embedder.embed_one(text),
             Embedder::Rest(embedder) => embedder
                 .embed_ref(&[text], deadline, None)?
@@ -751,11 +753,17 @@ impl Embedder {
     ) -> std::result::Result<Vec<Vec<Embedding>>, EmbedError> {
         match self {
             Embedder::HuggingFace(embedder) => embedder.embed_index(text_chunks),
-            Embedder::OpenAi(embedder) => embedder.embed_index(text_chunks, threads, embedder_stats),
-            Embedder::Ollama(embedder) => embedder.embed_index(text_chunks, threads, embedder_stats),
+            Embedder::OpenAi(embedder) => {
+                embedder.embed_index(text_chunks, threads, embedder_stats)
+            }
+            Embedder::Ollama(embedder) => {
+                embedder.embed_index(text_chunks, threads, embedder_stats)
+            }
             Embedder::UserProvided(embedder) => embedder.embed_index(text_chunks),
             Embedder::Rest(embedder) => embedder.embed_index(text_chunks, threads, embedder_stats),
-            Embedder::Composite(embedder) => embedder.index.embed_index(text_chunks, threads, embedder_stats),
+            Embedder::Composite(embedder) => {
+                embedder.index.embed_index(text_chunks, threads, embedder_stats)
+            }
         }
     }
 
@@ -772,7 +780,9 @@ impl Embedder {
             Embedder::Ollama(embedder) => embedder.embed_index_ref(texts, threads, embedder_stats),
             Embedder::UserProvided(embedder) => embedder.embed_index_ref(texts),
             Embedder::Rest(embedder) => embedder.embed_index_ref(texts, threads, embedder_stats),
-            Embedder::Composite(embedder) => embedder.index.embed_index_ref(texts, threads, embedder_stats),
+            Embedder::Composite(embedder) => {
+                embedder.index.embed_index_ref(texts, threads, embedder_stats)
+            }
         }
     }
 

--- a/crates/milli/src/vector/mod.rs
+++ b/crates/milli/src/vector/mod.rs
@@ -749,7 +749,7 @@ impl Embedder {
         &self,
         text_chunks: Vec<Vec<String>>,
         threads: &ThreadPoolNoAbort,
-        embedder_stats: Arc<EmbedderStats>,
+        embedder_stats: &EmbedderStats,
     ) -> std::result::Result<Vec<Vec<Embedding>>, EmbedError> {
         match self {
             Embedder::HuggingFace(embedder) => embedder.embed_index(text_chunks),
@@ -772,7 +772,7 @@ impl Embedder {
         &self,
         texts: &[&str],
         threads: &ThreadPoolNoAbort,
-        embedder_stats: Arc<EmbedderStats>,
+        embedder_stats: &EmbedderStats,
     ) -> std::result::Result<Vec<Embedding>, EmbedError> {
         match self {
             Embedder::HuggingFace(embedder) => embedder.embed_index_ref(texts),

--- a/crates/milli/src/vector/ollama.rs
+++ b/crates/milli/src/vector/ollama.rs
@@ -121,21 +121,21 @@ impl Embedder {
         &self,
         text_chunks: Vec<Vec<String>>,
         threads: &ThreadPoolNoAbort,
-        embedder_stats: Option<Arc<EmbedderStats>>,
+        embedder_stats: Arc<EmbedderStats>,
     ) -> Result<Vec<Vec<Embedding>>, EmbedError> {
         // This condition helps reduce the number of active rayon jobs
         // so that we avoid consuming all the LMDB rtxns and avoid stack overflows.
         if threads.active_operations() >= REQUEST_PARALLELISM {
             text_chunks
                 .into_iter()
-                .map(move |chunk| self.embed(&chunk, None, embedder_stats.clone()))
+                .map(move |chunk| self.embed(&chunk, None, Some(embedder_stats.clone())))
                 .collect()
         } else {
             threads
                 .install(move || {
                     text_chunks
                         .into_par_iter()
-                        .map(move |chunk| self.embed(&chunk, None, embedder_stats.clone()))
+                        .map(move |chunk| self.embed(&chunk, None, Some(embedder_stats.clone())))
                         .collect()
                 })
                 .map_err(|error| EmbedError {
@@ -149,14 +149,14 @@ impl Embedder {
         &self,
         texts: &[&str],
         threads: &ThreadPoolNoAbort,
-        embedder_stats: Option<Arc<EmbedderStats>>,
+        embedder_stats: Arc<EmbedderStats>,
     ) -> Result<Vec<Vec<f32>>, EmbedError> {
         // This condition helps reduce the number of active rayon jobs
         // so that we avoid consuming all the LMDB rtxns and avoid stack overflows.
         if threads.active_operations() >= REQUEST_PARALLELISM {
             let embeddings: Result<Vec<Vec<Embedding>>, _> = texts
                 .chunks(self.prompt_count_in_chunk_hint())
-                .map(move |chunk| self.embed(chunk, None, embedder_stats.clone()))
+                .map(move |chunk| self.embed(chunk, None, Some(embedder_stats.clone())))
                 .collect();
 
             let embeddings = embeddings?;
@@ -166,7 +166,7 @@ impl Embedder {
                 .install(move || {
                     let embeddings: Result<Vec<Vec<Embedding>>, _> = texts
                         .par_chunks(self.prompt_count_in_chunk_hint())
-                        .map(move |chunk| self.embed(chunk, None, embedder_stats.clone()))
+                        .map(move |chunk| self.embed(chunk, None, Some(embedder_stats.clone())))
                         .collect();
 
                     let embeddings = embeddings?;

--- a/crates/milli/src/vector/ollama.rs
+++ b/crates/milli/src/vector/ollama.rs
@@ -106,7 +106,7 @@ impl Embedder {
         &self,
         texts: &[S],
         deadline: Option<Instant>,
-        embedder_stats: Option<Arc<EmbedderStats>>
+        embedder_stats: Option<Arc<EmbedderStats>>,
     ) -> Result<Vec<Embedding>, EmbedError> {
         match self.rest_embedder.embed_ref(texts, deadline, embedder_stats) {
             Ok(embeddings) => Ok(embeddings),
@@ -126,11 +126,17 @@ impl Embedder {
         // This condition helps reduce the number of active rayon jobs
         // so that we avoid consuming all the LMDB rtxns and avoid stack overflows.
         if threads.active_operations() >= REQUEST_PARALLELISM {
-            text_chunks.into_iter().map(move |chunk| self.embed(&chunk, None, embedder_stats.clone())).collect()
+            text_chunks
+                .into_iter()
+                .map(move |chunk| self.embed(&chunk, None, embedder_stats.clone()))
+                .collect()
         } else {
             threads
                 .install(move || {
-                    text_chunks.into_par_iter().map(move |chunk| self.embed(&chunk, None, embedder_stats.clone())).collect()
+                    text_chunks
+                        .into_par_iter()
+                        .map(move |chunk| self.embed(&chunk, None, embedder_stats.clone()))
+                        .collect()
                 })
                 .map_err(|error| EmbedError {
                     kind: EmbedErrorKind::PanicInThreadPool(error),
@@ -143,7 +149,7 @@ impl Embedder {
         &self,
         texts: &[&str],
         threads: &ThreadPoolNoAbort,
-        embedder_stats: Option<Arc<EmbedderStats>>
+        embedder_stats: Option<Arc<EmbedderStats>>,
     ) -> Result<Vec<Vec<f32>>, EmbedError> {
         // This condition helps reduce the number of active rayon jobs
         // so that we avoid consuming all the LMDB rtxns and avoid stack overflows.

--- a/crates/milli/src/vector/ollama.rs
+++ b/crates/milli/src/vector/ollama.rs
@@ -1,3 +1,4 @@
+use std::sync::Arc;
 use std::time::Instant;
 
 use rayon::iter::{IntoParallelIterator as _, ParallelIterator as _};
@@ -7,6 +8,7 @@ use super::error::{EmbedError, EmbedErrorKind, NewEmbedderError, NewEmbedderErro
 use super::rest::{Embedder as RestEmbedder, EmbedderOptions as RestEmbedderOptions};
 use super::{DistributionShift, EmbeddingCache, REQUEST_PARALLELISM};
 use crate::error::FaultSource;
+use crate::progress::EmbedderStats;
 use crate::vector::Embedding;
 use crate::ThreadPoolNoAbort;
 
@@ -104,8 +106,9 @@ impl Embedder {
         &self,
         texts: &[S],
         deadline: Option<Instant>,
+        embedder_stats: Option<Arc<EmbedderStats>>
     ) -> Result<Vec<Embedding>, EmbedError> {
-        match self.rest_embedder.embed_ref(texts, deadline) {
+        match self.rest_embedder.embed_ref(texts, deadline, embedder_stats) {
             Ok(embeddings) => Ok(embeddings),
             Err(EmbedError { kind: EmbedErrorKind::RestOtherStatusCode(404, error), fault: _ }) => {
                 Err(EmbedError::ollama_model_not_found(error))
@@ -118,15 +121,16 @@ impl Embedder {
         &self,
         text_chunks: Vec<Vec<String>>,
         threads: &ThreadPoolNoAbort,
+        embedder_stats: Option<Arc<EmbedderStats>>,
     ) -> Result<Vec<Vec<Embedding>>, EmbedError> {
         // This condition helps reduce the number of active rayon jobs
         // so that we avoid consuming all the LMDB rtxns and avoid stack overflows.
         if threads.active_operations() >= REQUEST_PARALLELISM {
-            text_chunks.into_iter().map(move |chunk| self.embed(&chunk, None)).collect()
+            text_chunks.into_iter().map(move |chunk| self.embed(&chunk, None, embedder_stats.clone())).collect()
         } else {
             threads
                 .install(move || {
-                    text_chunks.into_par_iter().map(move |chunk| self.embed(&chunk, None)).collect()
+                    text_chunks.into_par_iter().map(move |chunk| self.embed(&chunk, None, embedder_stats.clone())).collect()
                 })
                 .map_err(|error| EmbedError {
                     kind: EmbedErrorKind::PanicInThreadPool(error),
@@ -139,13 +143,14 @@ impl Embedder {
         &self,
         texts: &[&str],
         threads: &ThreadPoolNoAbort,
+        embedder_stats: Option<Arc<EmbedderStats>>
     ) -> Result<Vec<Vec<f32>>, EmbedError> {
         // This condition helps reduce the number of active rayon jobs
         // so that we avoid consuming all the LMDB rtxns and avoid stack overflows.
         if threads.active_operations() >= REQUEST_PARALLELISM {
             let embeddings: Result<Vec<Vec<Embedding>>, _> = texts
                 .chunks(self.prompt_count_in_chunk_hint())
-                .map(move |chunk| self.embed(chunk, None))
+                .map(move |chunk| self.embed(chunk, None, embedder_stats.clone()))
                 .collect();
 
             let embeddings = embeddings?;
@@ -155,7 +160,7 @@ impl Embedder {
                 .install(move || {
                     let embeddings: Result<Vec<Vec<Embedding>>, _> = texts
                         .par_chunks(self.prompt_count_in_chunk_hint())
-                        .map(move |chunk| self.embed(chunk, None))
+                        .map(move |chunk| self.embed(chunk, None, embedder_stats.clone()))
                         .collect();
 
                     let embeddings = embeddings?;

--- a/crates/milli/src/vector/openai.rs
+++ b/crates/milli/src/vector/openai.rs
@@ -1,5 +1,4 @@
 use std::fmt;
-use std::sync::Arc;
 use std::time::Instant;
 
 use ordered_float::OrderedFloat;
@@ -217,7 +216,7 @@ impl Embedder {
         &self,
         texts: &[S],
         deadline: Option<Instant>,
-        embedder_stats: Option<Arc<EmbedderStats>>,
+        embedder_stats: Option<&EmbedderStats>,
     ) -> Result<Vec<Embedding>, EmbedError> {
         match self.rest_embedder.embed_ref(texts, deadline, embedder_stats) {
             Ok(embeddings) => Ok(embeddings),
@@ -262,21 +261,21 @@ impl Embedder {
         &self,
         text_chunks: Vec<Vec<String>>,
         threads: &ThreadPoolNoAbort,
-        embedder_stats: Arc<EmbedderStats>,
+        embedder_stats: &EmbedderStats,
     ) -> Result<Vec<Vec<Embedding>>, EmbedError> {
         // This condition helps reduce the number of active rayon jobs
         // so that we avoid consuming all the LMDB rtxns and avoid stack overflows.
         if threads.active_operations() >= REQUEST_PARALLELISM {
             text_chunks
                 .into_iter()
-                .map(move |chunk| self.embed(&chunk, None, Some(embedder_stats.clone())))
+                .map(move |chunk| self.embed(&chunk, None, Some(embedder_stats)))
                 .collect()
         } else {
             threads
                 .install(move || {
                     text_chunks
                         .into_par_iter()
-                        .map(move |chunk| self.embed(&chunk, None, Some(embedder_stats.clone())))
+                        .map(move |chunk| self.embed(&chunk, None, Some(embedder_stats)))
                         .collect()
                 })
                 .map_err(|error| EmbedError {
@@ -290,14 +289,14 @@ impl Embedder {
         &self,
         texts: &[&str],
         threads: &ThreadPoolNoAbort,
-        embedder_stats: Arc<EmbedderStats>,
+        embedder_stats: &EmbedderStats,
     ) -> Result<Vec<Vec<f32>>, EmbedError> {
         // This condition helps reduce the number of active rayon jobs
         // so that we avoid consuming all the LMDB rtxns and avoid stack overflows.
         if threads.active_operations() >= REQUEST_PARALLELISM {
             let embeddings: Result<Vec<Vec<Embedding>>, _> = texts
                 .chunks(self.prompt_count_in_chunk_hint())
-                .map(move |chunk| self.embed(chunk, None, Some(embedder_stats.clone())))
+                .map(move |chunk| self.embed(chunk, None, Some(embedder_stats)))
                 .collect();
             let embeddings = embeddings?;
             Ok(embeddings.into_iter().flatten().collect())
@@ -306,7 +305,7 @@ impl Embedder {
                 .install(move || {
                     let embeddings: Result<Vec<Vec<Embedding>>, _> = texts
                         .par_chunks(self.prompt_count_in_chunk_hint())
-                        .map(move |chunk| self.embed(chunk, None, Some(embedder_stats.clone())))
+                        .map(move |chunk| self.embed(chunk, None, Some(embedder_stats)))
                         .collect();
 
                     let embeddings = embeddings?;

--- a/crates/milli/src/vector/openai.rs
+++ b/crates/milli/src/vector/openai.rs
@@ -262,21 +262,21 @@ impl Embedder {
         &self,
         text_chunks: Vec<Vec<String>>,
         threads: &ThreadPoolNoAbort,
-        embedder_stats: Option<Arc<EmbedderStats>>,
+        embedder_stats: Arc<EmbedderStats>,
     ) -> Result<Vec<Vec<Embedding>>, EmbedError> {
         // This condition helps reduce the number of active rayon jobs
         // so that we avoid consuming all the LMDB rtxns and avoid stack overflows.
         if threads.active_operations() >= REQUEST_PARALLELISM {
             text_chunks
                 .into_iter()
-                .map(move |chunk| self.embed(&chunk, None, embedder_stats.clone()))
+                .map(move |chunk| self.embed(&chunk, None, Some(embedder_stats.clone())))
                 .collect()
         } else {
             threads
                 .install(move || {
                     text_chunks
                         .into_par_iter()
-                        .map(move |chunk| self.embed(&chunk, None, embedder_stats.clone()))
+                        .map(move |chunk| self.embed(&chunk, None, Some(embedder_stats.clone())))
                         .collect()
                 })
                 .map_err(|error| EmbedError {
@@ -290,14 +290,14 @@ impl Embedder {
         &self,
         texts: &[&str],
         threads: &ThreadPoolNoAbort,
-        embedder_stats: Option<Arc<EmbedderStats>>,
+        embedder_stats: Arc<EmbedderStats>,
     ) -> Result<Vec<Vec<f32>>, EmbedError> {
         // This condition helps reduce the number of active rayon jobs
         // so that we avoid consuming all the LMDB rtxns and avoid stack overflows.
         if threads.active_operations() >= REQUEST_PARALLELISM {
             let embeddings: Result<Vec<Vec<Embedding>>, _> = texts
                 .chunks(self.prompt_count_in_chunk_hint())
-                .map(move |chunk| self.embed(chunk, None, embedder_stats.clone()))
+                .map(move |chunk| self.embed(chunk, None, Some(embedder_stats.clone())))
                 .collect();
             let embeddings = embeddings?;
             Ok(embeddings.into_iter().flatten().collect())
@@ -306,7 +306,7 @@ impl Embedder {
                 .install(move || {
                     let embeddings: Result<Vec<Vec<Embedding>>, _> = texts
                         .par_chunks(self.prompt_count_in_chunk_hint())
-                        .map(move |chunk| self.embed(chunk, None, embedder_stats.clone()))
+                        .map(move |chunk| self.embed(chunk, None, Some(embedder_stats.clone())))
                         .collect();
 
                     let embeddings = embeddings?;

--- a/crates/milli/src/vector/openai.rs
+++ b/crates/milli/src/vector/openai.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::sync::Arc;
 use std::time::Instant;
 
 use ordered_float::OrderedFloat;
@@ -9,6 +10,7 @@ use super::error::{EmbedError, NewEmbedderError};
 use super::rest::{Embedder as RestEmbedder, EmbedderOptions as RestEmbedderOptions};
 use super::{DistributionShift, EmbeddingCache, REQUEST_PARALLELISM};
 use crate::error::FaultSource;
+use crate::progress::EmbedderStats;
 use crate::vector::error::EmbedErrorKind;
 use crate::vector::Embedding;
 use crate::ThreadPoolNoAbort;
@@ -215,8 +217,9 @@ impl Embedder {
         &self,
         texts: &[S],
         deadline: Option<Instant>,
+        embedder_stats: Option<Arc<EmbedderStats>>,
     ) -> Result<Vec<Embedding>, EmbedError> {
-        match self.rest_embedder.embed_ref(texts, deadline) {
+        match self.rest_embedder.embed_ref(texts, deadline, embedder_stats) {
             Ok(embeddings) => Ok(embeddings),
             Err(EmbedError { kind: EmbedErrorKind::RestBadRequest(error, _), fault: _ }) => {
                 tracing::warn!(error=?error, "OpenAI: received `BAD_REQUEST`. Input was maybe too long, retrying on tokenized version. For best performance, limit the size of your document template.");
@@ -238,7 +241,7 @@ impl Embedder {
             let encoded = self.tokenizer.encode_ordinary(text);
             let len = encoded.len();
             if len < max_token_count {
-                all_embeddings.append(&mut self.rest_embedder.embed_ref(&[text], deadline)?);
+                all_embeddings.append(&mut self.rest_embedder.embed_ref(&[text], deadline, None)?);
                 continue;
             }
 
@@ -255,15 +258,16 @@ impl Embedder {
         &self,
         text_chunks: Vec<Vec<String>>,
         threads: &ThreadPoolNoAbort,
+        embedder_stats: Option<Arc<EmbedderStats>>,
     ) -> Result<Vec<Vec<Embedding>>, EmbedError> {
         // This condition helps reduce the number of active rayon jobs
         // so that we avoid consuming all the LMDB rtxns and avoid stack overflows.
         if threads.active_operations() >= REQUEST_PARALLELISM {
-            text_chunks.into_iter().map(move |chunk| self.embed(&chunk, None)).collect()
+            text_chunks.into_iter().map(move |chunk| self.embed(&chunk, None, embedder_stats.clone())).collect()
         } else {
             threads
                 .install(move || {
-                    text_chunks.into_par_iter().map(move |chunk| self.embed(&chunk, None)).collect()
+                    text_chunks.into_par_iter().map(move |chunk| self.embed(&chunk, None, embedder_stats.clone())).collect()
                 })
                 .map_err(|error| EmbedError {
                     kind: EmbedErrorKind::PanicInThreadPool(error),
@@ -276,13 +280,14 @@ impl Embedder {
         &self,
         texts: &[&str],
         threads: &ThreadPoolNoAbort,
+        embedder_stats: Option<Arc<EmbedderStats>>,
     ) -> Result<Vec<Vec<f32>>, EmbedError> {
         // This condition helps reduce the number of active rayon jobs
         // so that we avoid consuming all the LMDB rtxns and avoid stack overflows.
         if threads.active_operations() >= REQUEST_PARALLELISM {
             let embeddings: Result<Vec<Vec<Embedding>>, _> = texts
                 .chunks(self.prompt_count_in_chunk_hint())
-                .map(move |chunk| self.embed(chunk, None))
+                .map(move |chunk| self.embed(chunk, None, embedder_stats.clone()))
                 .collect();
             let embeddings = embeddings?;
             Ok(embeddings.into_iter().flatten().collect())
@@ -291,7 +296,7 @@ impl Embedder {
                 .install(move || {
                     let embeddings: Result<Vec<Vec<Embedding>>, _> = texts
                         .par_chunks(self.prompt_count_in_chunk_hint())
-                        .map(move |chunk| self.embed(chunk, None))
+                        .map(move |chunk| self.embed(chunk, None, embedder_stats.clone()))
                         .collect();
 
                     let embeddings = embeddings?;

--- a/crates/milli/src/vector/rest.rs
+++ b/crates/milli/src/vector/rest.rs
@@ -295,6 +295,10 @@ fn embed<S>(
 where
     S: Serialize,
 {
+    use std::backtrace::Backtrace;
+
+    println!("Embedder stats? {}", embedder_stats.is_some());
+
     let request = data.client.post(&data.url);
     let request = if let Some(bearer) = &data.bearer {
         request.set("Authorization", bearer)

--- a/crates/milli/src/vector/rest.rs
+++ b/crates/milli/src/vector/rest.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeMap;
-use std::sync::Arc;
 use std::time::Instant;
 
 use deserr::Deserr;
@@ -170,7 +169,7 @@ impl Embedder {
         &self,
         texts: Vec<String>,
         deadline: Option<Instant>,
-        embedder_stats: Option<Arc<EmbedderStats>>,
+        embedder_stats: Option<&EmbedderStats>,
     ) -> Result<Vec<Embedding>, EmbedError> {
         embed(
             &self.data,
@@ -186,7 +185,7 @@ impl Embedder {
         &self,
         texts: &[S],
         deadline: Option<Instant>,
-        embedder_stats: Option<Arc<EmbedderStats>>,
+        embedder_stats: Option<&EmbedderStats>,
     ) -> Result<Vec<Embedding>, EmbedError>
     where
         S: AsRef<str> + Serialize,
@@ -208,21 +207,21 @@ impl Embedder {
         &self,
         text_chunks: Vec<Vec<String>>,
         threads: &ThreadPoolNoAbort,
-        embedder_stats: Arc<EmbedderStats>,
+        embedder_stats: &EmbedderStats,
     ) -> Result<Vec<Vec<Embedding>>, EmbedError> {
         // This condition helps reduce the number of active rayon jobs
         // so that we avoid consuming all the LMDB rtxns and avoid stack overflows.
         if threads.active_operations() >= REQUEST_PARALLELISM {
             text_chunks
                 .into_iter()
-                .map(move |chunk| self.embed(chunk, None, Some(embedder_stats.clone())))
+                .map(move |chunk| self.embed(chunk, None, Some(embedder_stats)))
                 .collect()
         } else {
             threads
                 .install(move || {
                     text_chunks
                         .into_par_iter()
-                        .map(move |chunk| self.embed(chunk, None, Some(embedder_stats.clone())))
+                        .map(move |chunk| self.embed(chunk, None, Some(embedder_stats)))
                         .collect()
                 })
                 .map_err(|error| EmbedError {
@@ -236,14 +235,14 @@ impl Embedder {
         &self,
         texts: &[&str],
         threads: &ThreadPoolNoAbort,
-        embedder_stats: Arc<EmbedderStats>,
+        embedder_stats: &EmbedderStats,
     ) -> Result<Vec<Embedding>, EmbedError> {
         // This condition helps reduce the number of active rayon jobs
         // so that we avoid consuming all the LMDB rtxns and avoid stack overflows.
         if threads.active_operations() >= REQUEST_PARALLELISM {
             let embeddings: Result<Vec<Vec<Embedding>>, _> = texts
                 .chunks(self.prompt_count_in_chunk_hint())
-                .map(move |chunk| self.embed_ref(chunk, None, Some(embedder_stats.clone())))
+                .map(move |chunk| self.embed_ref(chunk, None, Some(embedder_stats)))
                 .collect();
 
             let embeddings = embeddings?;
@@ -253,7 +252,7 @@ impl Embedder {
                 .install(move || {
                     let embeddings: Result<Vec<Vec<Embedding>>, _> = texts
                         .par_chunks(self.prompt_count_in_chunk_hint())
-                        .map(move |chunk| self.embed_ref(chunk, None, Some(embedder_stats.clone())))
+                        .map(move |chunk| self.embed_ref(chunk, None, Some(embedder_stats)))
                         .collect();
 
                     let embeddings = embeddings?;
@@ -303,7 +302,7 @@ fn embed<S>(
     expected_count: usize,
     expected_dimension: Option<usize>,
     deadline: Option<Instant>,
-    embedder_stats: Option<Arc<EmbedderStats>>,
+    embedder_stats: Option<&EmbedderStats>,
 ) -> Result<Vec<Embedding>, EmbedError>
 where
     S: Serialize,
@@ -323,7 +322,7 @@ where
 
     for attempt in 0..10 {
         if let Some(embedder_stats) = &embedder_stats {
-            embedder_stats.as_ref().total_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            embedder_stats.total_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         }
         let response = request.clone().send_json(&body);
         let result = check_response(response, data.configuration_source).and_then(|response| {
@@ -367,7 +366,7 @@ where
     }
 
     if let Some(embedder_stats) = &embedder_stats {
-        embedder_stats.as_ref().total_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        embedder_stats.total_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     }
     let response = request.send_json(&body);
     let result = check_response(response, data.configuration_source).and_then(|response| {

--- a/crates/milli/src/vector/rest.rs
+++ b/crates/milli/src/vector/rest.rs
@@ -295,10 +295,6 @@ fn embed<S>(
 where
     S: Serialize,
 {
-    use std::backtrace::Backtrace;
-
-    println!("Embedder stats? {}", embedder_stats.is_some());
-
     let request = data.client.post(&data.url);
     let request = if let Some(bearer) = &data.bearer {
         request.set("Authorization", bearer)
@@ -314,9 +310,8 @@ where
 
     for attempt in 0..10 {
         if let Some(embedder_stats) = &embedder_stats {
-            embedder_stats.as_ref().total_requests.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            embedder_stats.as_ref().total_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         }
-        // TODO: also catch 403 errors
         let response = request.clone().send_json(&body);
         let result = check_response(response, data.configuration_source).and_then(|response| {
             response_to_embedding(response, data, expected_count, expected_dimension)
@@ -358,7 +353,7 @@ where
     }
 
     if let Some(embedder_stats) = &embedder_stats {
-        embedder_stats.as_ref().total_requests.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        embedder_stats.as_ref().total_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     }
     let response = request.send_json(&body);
     let result = check_response(response, data.configuration_source).and_then(|response| {

--- a/crates/milli/src/vector/rest.rs
+++ b/crates/milli/src/vector/rest.rs
@@ -316,6 +316,7 @@ where
         if let Some(embedder_stats) = &embedder_stats {
             embedder_stats.as_ref().total_requests.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         }
+        // TODO: also catch 403 errors
         let response = request.clone().send_json(&body);
         let result = check_response(response, data.configuration_source).and_then(|response| {
             response_to_embedding(response, data, expected_count, expected_dimension)

--- a/crates/milli/src/vector/rest.rs
+++ b/crates/milli/src/vector/rest.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::sync::Arc;
 use std::time::Instant;
 
 use deserr::Deserr;
@@ -14,6 +15,7 @@ use super::{
 };
 use crate::error::FaultSource;
 use crate::ThreadPoolNoAbort;
+use crate::progress::EmbedderStats;
 
 // retrying in case of failure
 pub struct Retry {
@@ -168,19 +170,21 @@ impl Embedder {
         &self,
         texts: Vec<String>,
         deadline: Option<Instant>,
+        embedder_stats: Option<Arc<EmbedderStats>>,
     ) -> Result<Vec<Embedding>, EmbedError> {
-        embed(&self.data, texts.as_slice(), texts.len(), Some(self.dimensions), deadline)
+        embed(&self.data, texts.as_slice(), texts.len(), Some(self.dimensions), deadline, embedder_stats)
     }
 
     pub fn embed_ref<S>(
         &self,
         texts: &[S],
         deadline: Option<Instant>,
+        embedder_stats: Option<Arc<EmbedderStats>>,
     ) -> Result<Vec<Embedding>, EmbedError>
     where
         S: AsRef<str> + Serialize,
     {
-        embed(&self.data, texts, texts.len(), Some(self.dimensions), deadline)
+        embed(&self.data, texts, texts.len(), Some(self.dimensions), deadline, embedder_stats)
     }
 
     pub fn embed_tokens(
@@ -188,7 +192,7 @@ impl Embedder {
         tokens: &[u32],
         deadline: Option<Instant>,
     ) -> Result<Embedding, EmbedError> {
-        let mut embeddings = embed(&self.data, tokens, 1, Some(self.dimensions), deadline)?;
+        let mut embeddings = embed(&self.data, tokens, 1, Some(self.dimensions), deadline, None)?;
         // unwrap: guaranteed that embeddings.len() == 1, otherwise the previous line terminated in error
         Ok(embeddings.pop().unwrap())
     }
@@ -197,15 +201,16 @@ impl Embedder {
         &self,
         text_chunks: Vec<Vec<String>>,
         threads: &ThreadPoolNoAbort,
+        embedder_stats: Option<Arc<EmbedderStats>>,
     ) -> Result<Vec<Vec<Embedding>>, EmbedError> {
         // This condition helps reduce the number of active rayon jobs
         // so that we avoid consuming all the LMDB rtxns and avoid stack overflows.
         if threads.active_operations() >= REQUEST_PARALLELISM {
-            text_chunks.into_iter().map(move |chunk| self.embed(chunk, None)).collect()
+            text_chunks.into_iter().map(move |chunk| self.embed(chunk, None, embedder_stats.clone())).collect()
         } else {
             threads
                 .install(move || {
-                    text_chunks.into_par_iter().map(move |chunk| self.embed(chunk, None)).collect()
+                    text_chunks.into_par_iter().map(move |chunk| self.embed(chunk, None, embedder_stats.clone())).collect()
                 })
                 .map_err(|error| EmbedError {
                     kind: EmbedErrorKind::PanicInThreadPool(error),
@@ -218,13 +223,14 @@ impl Embedder {
         &self,
         texts: &[&str],
         threads: &ThreadPoolNoAbort,
+        embedder_stats: Option<Arc<EmbedderStats>>
     ) -> Result<Vec<Embedding>, EmbedError> {
         // This condition helps reduce the number of active rayon jobs
         // so that we avoid consuming all the LMDB rtxns and avoid stack overflows.
         if threads.active_operations() >= REQUEST_PARALLELISM {
             let embeddings: Result<Vec<Vec<Embedding>>, _> = texts
                 .chunks(self.prompt_count_in_chunk_hint())
-                .map(move |chunk| self.embed_ref(chunk, None))
+                .map(move |chunk| self.embed_ref(chunk, None, embedder_stats.clone()))
                 .collect();
 
             let embeddings = embeddings?;
@@ -234,7 +240,7 @@ impl Embedder {
                 .install(move || {
                     let embeddings: Result<Vec<Vec<Embedding>>, _> = texts
                         .par_chunks(self.prompt_count_in_chunk_hint())
-                        .map(move |chunk| self.embed_ref(chunk, None))
+                        .map(move |chunk| self.embed_ref(chunk, None, embedder_stats.clone()))
                         .collect();
 
                     let embeddings = embeddings?;
@@ -272,7 +278,7 @@ impl Embedder {
 }
 
 fn infer_dimensions(data: &EmbedderData) -> Result<usize, NewEmbedderError> {
-    let v = embed(data, ["test"].as_slice(), 1, None, None)
+    let v = embed(data, ["test"].as_slice(), 1, None, None, None)
         .map_err(NewEmbedderError::could_not_determine_dimension)?;
     // unwrap: guaranteed that v.len() == 1, otherwise the previous line terminated in error
     Ok(v.first().unwrap().len())
@@ -284,6 +290,7 @@ fn embed<S>(
     expected_count: usize,
     expected_dimension: Option<usize>,
     deadline: Option<Instant>,
+    embedder_stats: Option<Arc<EmbedderStats>>,
 ) -> Result<Vec<Embedding>, EmbedError>
 where
     S: Serialize,
@@ -302,6 +309,9 @@ where
     let body = data.request.inject_texts(inputs);
 
     for attempt in 0..10 {
+        if let Some(embedder_stats) = &embedder_stats {
+            embedder_stats.as_ref().total_requests.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        }
         let response = request.clone().send_json(&body);
         let result = check_response(response, data.configuration_source).and_then(|response| {
             response_to_embedding(response, data, expected_count, expected_dimension)
@@ -311,6 +321,12 @@ where
             Ok(response) => return Ok(response),
             Err(retry) => {
                 tracing::warn!("Failed: {}", retry.error);
+                if let Some(embedder_stats) = &embedder_stats {
+                    if let Ok(mut errors) = embedder_stats.errors.write() {
+                        errors.0 = Some(retry.error.to_string());
+                        errors.1 += 1;
+                    }
+                }
                 if let Some(deadline) = deadline {
                     let now = std::time::Instant::now();
                     if now > deadline {
@@ -336,12 +352,26 @@ where
         std::thread::sleep(retry_duration);
     }
 
+    if let Some(embedder_stats) = &embedder_stats {
+        embedder_stats.as_ref().total_requests.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
     let response = request.send_json(&body);
-    let result = check_response(response, data.configuration_source);
-    result.map_err(Retry::into_error).and_then(|response| {
+    let result = check_response(response, data.configuration_source).and_then(|response| {
         response_to_embedding(response, data, expected_count, expected_dimension)
-            .map_err(Retry::into_error)
-    })
+    });
+
+    match result {
+        Ok(response) => Ok(response),
+        Err(retry) => {
+            if let Some(embedder_stats) = &embedder_stats {
+                if let Ok(mut errors) = embedder_stats.errors.write() {
+                    errors.0 = Some(retry.error.to_string());
+                    errors.1 += 1;
+                }
+            }
+            Err(retry.into_error())
+        }
+    }
 }
 
 fn check_response(

--- a/crates/milli/src/vector/rest.rs
+++ b/crates/milli/src/vector/rest.rs
@@ -208,21 +208,21 @@ impl Embedder {
         &self,
         text_chunks: Vec<Vec<String>>,
         threads: &ThreadPoolNoAbort,
-        embedder_stats: Option<Arc<EmbedderStats>>,
+        embedder_stats: Arc<EmbedderStats>,
     ) -> Result<Vec<Vec<Embedding>>, EmbedError> {
         // This condition helps reduce the number of active rayon jobs
         // so that we avoid consuming all the LMDB rtxns and avoid stack overflows.
         if threads.active_operations() >= REQUEST_PARALLELISM {
             text_chunks
                 .into_iter()
-                .map(move |chunk| self.embed(chunk, None, embedder_stats.clone()))
+                .map(move |chunk| self.embed(chunk, None, Some(embedder_stats.clone())))
                 .collect()
         } else {
             threads
                 .install(move || {
                     text_chunks
                         .into_par_iter()
-                        .map(move |chunk| self.embed(chunk, None, embedder_stats.clone()))
+                        .map(move |chunk| self.embed(chunk, None, Some(embedder_stats.clone())))
                         .collect()
                 })
                 .map_err(|error| EmbedError {
@@ -236,14 +236,14 @@ impl Embedder {
         &self,
         texts: &[&str],
         threads: &ThreadPoolNoAbort,
-        embedder_stats: Option<Arc<EmbedderStats>>,
+        embedder_stats: Arc<EmbedderStats>,
     ) -> Result<Vec<Embedding>, EmbedError> {
         // This condition helps reduce the number of active rayon jobs
         // so that we avoid consuming all the LMDB rtxns and avoid stack overflows.
         if threads.active_operations() >= REQUEST_PARALLELISM {
             let embeddings: Result<Vec<Vec<Embedding>>, _> = texts
                 .chunks(self.prompt_count_in_chunk_hint())
-                .map(move |chunk| self.embed_ref(chunk, None, embedder_stats.clone()))
+                .map(move |chunk| self.embed_ref(chunk, None, Some(embedder_stats.clone())))
                 .collect();
 
             let embeddings = embeddings?;
@@ -253,7 +253,7 @@ impl Embedder {
                 .install(move || {
                     let embeddings: Result<Vec<Vec<Embedding>>, _> = texts
                         .par_chunks(self.prompt_count_in_chunk_hint())
-                        .map(move |chunk| self.embed_ref(chunk, None, embedder_stats.clone()))
+                        .map(move |chunk| self.embed_ref(chunk, None, Some(embedder_stats.clone())))
                         .collect();
 
                     let embeddings = embeddings?;

--- a/crates/milli/src/vector/rest.rs
+++ b/crates/milli/src/vector/rest.rs
@@ -335,10 +335,11 @@ where
             Err(retry) => {
                 tracing::warn!("Failed: {}", retry.error);
                 if let Some(embedder_stats) = &embedder_stats {
-                    if let Ok(mut errors) = embedder_stats.errors.write() {
-                        errors.0 = Some(retry.error.to_string());
-                        errors.1 += 1;
-                    }
+                    let stringified_error = retry.error.to_string();
+                    let mut errors =
+                        embedder_stats.errors.write().unwrap_or_else(|p| p.into_inner());
+                    errors.0 = Some(stringified_error);
+                    errors.1 += 1;
                 }
                 if let Some(deadline) = deadline {
                     let now = std::time::Instant::now();
@@ -377,11 +378,11 @@ where
         Ok(response) => Ok(response),
         Err(retry) => {
             if let Some(embedder_stats) = &embedder_stats {
-                if let Ok(mut errors) = embedder_stats.errors.write() {
-                    errors.0 = Some(retry.error.to_string());
-                    errors.1 += 1;
-                }
-            }
+                let stringified_error = retry.error.to_string();
+                let mut errors = embedder_stats.errors.write().unwrap_or_else(|p| p.into_inner());
+                errors.0 = Some(stringified_error);
+                errors.1 += 1;
+            };
             Err(retry.into_error())
         }
     }

--- a/crates/milli/tests/search/distinct.rs
+++ b/crates/milli/tests/search/distinct.rs
@@ -19,7 +19,7 @@ macro_rules! test_distinct {
             let config = milli::update::IndexerConfig::default();
             let mut builder = Settings::new(&mut wtxn, &index, &config);
             builder.set_distinct_field(S(stringify!($distinct)));
-            builder.execute(|_| (), || false).unwrap();
+            builder.execute(|_| (), || false, None).unwrap();
             wtxn.commit().unwrap();
 
             let rtxn = index.read_txn().unwrap();

--- a/crates/milli/tests/search/distinct.rs
+++ b/crates/milli/tests/search/distinct.rs
@@ -19,7 +19,7 @@ macro_rules! test_distinct {
             let config = milli::update::IndexerConfig::default();
             let mut builder = Settings::new(&mut wtxn, &index, &config);
             builder.set_distinct_field(S(stringify!($distinct)));
-            builder.execute(|_| (), || false, None).unwrap();
+            builder.execute(|_| (), || false, Default::default()).unwrap();
             wtxn.commit().unwrap();
 
             let rtxn = index.read_txn().unwrap();

--- a/crates/milli/tests/search/facet_distribution.rs
+++ b/crates/milli/tests/search/facet_distribution.rs
@@ -25,7 +25,7 @@ fn test_facet_distribution_with_no_facet_values() {
         FilterableAttributesRule::Field(S("genres")),
         FilterableAttributesRule::Field(S("tags")),
     ]);
-    builder.execute(|_| (), || false).unwrap();
+    builder.execute(|_| (), || false, None).unwrap();
     wtxn.commit().unwrap();
 
     // index documents

--- a/crates/milli/tests/search/facet_distribution.rs
+++ b/crates/milli/tests/search/facet_distribution.rs
@@ -74,7 +74,7 @@ fn test_facet_distribution_with_no_facet_values() {
         embedders,
         &|| false,
         &Progress::default(),
-        Default::default(),
+        &Default::default(),
     )
     .unwrap();
 

--- a/crates/milli/tests/search/facet_distribution.rs
+++ b/crates/milli/tests/search/facet_distribution.rs
@@ -25,7 +25,7 @@ fn test_facet_distribution_with_no_facet_values() {
         FilterableAttributesRule::Field(S("genres")),
         FilterableAttributesRule::Field(S("tags")),
     ]);
-    builder.execute(|_| (), || false, None).unwrap();
+    builder.execute(|_| (), || false, Default::default()).unwrap();
     wtxn.commit().unwrap();
 
     // index documents
@@ -74,6 +74,7 @@ fn test_facet_distribution_with_no_facet_values() {
         embedders,
         &|| false,
         &Progress::default(),
+        Default::default(),
     )
     .unwrap();
 

--- a/crates/milli/tests/search/mod.rs
+++ b/crates/milli/tests/search/mod.rs
@@ -63,7 +63,7 @@ pub fn setup_search_index_with_criteria(criteria: &[Criterion]) -> Index {
         S("america") => vec![S("the united states")],
     });
     builder.set_searchable_fields(vec![S("title"), S("description")]);
-    builder.execute(|_| (), || false).unwrap();
+    builder.execute(|_| (), || false, None).unwrap();
     wtxn.commit().unwrap();
 
     // index documents

--- a/crates/milli/tests/search/mod.rs
+++ b/crates/milli/tests/search/mod.rs
@@ -63,7 +63,7 @@ pub fn setup_search_index_with_criteria(criteria: &[Criterion]) -> Index {
         S("america") => vec![S("the united states")],
     });
     builder.set_searchable_fields(vec![S("title"), S("description")]);
-    builder.execute(|_| (), || false, None).unwrap();
+    builder.execute(|_| (), || false, Default::default()).unwrap();
     wtxn.commit().unwrap();
 
     // index documents
@@ -114,6 +114,7 @@ pub fn setup_search_index_with_criteria(criteria: &[Criterion]) -> Index {
         embedders,
         &|| false,
         &Progress::default(),
+        Default::default(),
     )
     .unwrap();
 

--- a/crates/milli/tests/search/mod.rs
+++ b/crates/milli/tests/search/mod.rs
@@ -114,7 +114,7 @@ pub fn setup_search_index_with_criteria(criteria: &[Criterion]) -> Index {
         embedders,
         &|| false,
         &Progress::default(),
-        Default::default(),
+        &Default::default(),
     )
     .unwrap();
 

--- a/crates/milli/tests/search/phrase_search.rs
+++ b/crates/milli/tests/search/phrase_search.rs
@@ -10,7 +10,7 @@ fn set_stop_words(index: &Index, stop_words: &[&str]) {
     let mut builder = Settings::new(&mut wtxn, index, &config);
     let stop_words = stop_words.iter().map(|s| s.to_string()).collect();
     builder.set_stop_words(stop_words);
-    builder.execute(|_| (), || false).unwrap();
+    builder.execute(|_| (), || false, None).unwrap();
     wtxn.commit().unwrap();
 }
 

--- a/crates/milli/tests/search/phrase_search.rs
+++ b/crates/milli/tests/search/phrase_search.rs
@@ -10,7 +10,7 @@ fn set_stop_words(index: &Index, stop_words: &[&str]) {
     let mut builder = Settings::new(&mut wtxn, index, &config);
     let stop_words = stop_words.iter().map(|s| s.to_string()).collect();
     builder.set_stop_words(stop_words);
-    builder.execute(|_| (), || false, None).unwrap();
+    builder.execute(|_| (), || false, Default::default()).unwrap();
     wtxn.commit().unwrap();
 }
 

--- a/crates/milli/tests/search/query_criteria.rs
+++ b/crates/milli/tests/search/query_criteria.rs
@@ -236,7 +236,7 @@ fn criteria_mixup() {
         let mut wtxn = index.write_txn().unwrap();
         let mut builder = Settings::new(&mut wtxn, &index, &config);
         builder.set_criteria(criteria.clone());
-        builder.execute(|_| (), || false).unwrap();
+        builder.execute(|_| (), || false, None).unwrap();
         wtxn.commit().unwrap();
 
         let rtxn = index.read_txn().unwrap();
@@ -276,7 +276,7 @@ fn criteria_ascdesc() {
         S("name"),
         S("age"),
     });
-    builder.execute(|_| (), || false).unwrap();
+    builder.execute(|_| (), || false, None).unwrap();
 
     wtxn.commit().unwrap();
     let mut wtxn = index.write_txn().unwrap();
@@ -358,7 +358,7 @@ fn criteria_ascdesc() {
         let mut wtxn = index.write_txn().unwrap();
         let mut builder = Settings::new(&mut wtxn, &index, &config);
         builder.set_criteria(vec![criterion.clone()]);
-        builder.execute(|_| (), || false).unwrap();
+        builder.execute(|_| (), || false, None).unwrap();
         wtxn.commit().unwrap();
 
         let rtxn = index.read_txn().unwrap();

--- a/crates/milli/tests/search/query_criteria.rs
+++ b/crates/milli/tests/search/query_criteria.rs
@@ -236,7 +236,7 @@ fn criteria_mixup() {
         let mut wtxn = index.write_txn().unwrap();
         let mut builder = Settings::new(&mut wtxn, &index, &config);
         builder.set_criteria(criteria.clone());
-        builder.execute(|_| (), || false, None).unwrap();
+        builder.execute(|_| (), || false, Default::default()).unwrap();
         wtxn.commit().unwrap();
 
         let rtxn = index.read_txn().unwrap();
@@ -276,7 +276,7 @@ fn criteria_ascdesc() {
         S("name"),
         S("age"),
     });
-    builder.execute(|_| (), || false, None).unwrap();
+    builder.execute(|_| (), || false, Default::default()).unwrap();
 
     wtxn.commit().unwrap();
     let mut wtxn = index.write_txn().unwrap();
@@ -344,6 +344,7 @@ fn criteria_ascdesc() {
         embedders,
         &|| false,
         &Progress::default(),
+        Default::default(),
     )
     .unwrap();
 
@@ -358,7 +359,7 @@ fn criteria_ascdesc() {
         let mut wtxn = index.write_txn().unwrap();
         let mut builder = Settings::new(&mut wtxn, &index, &config);
         builder.set_criteria(vec![criterion.clone()]);
-        builder.execute(|_| (), || false, None).unwrap();
+        builder.execute(|_| (), || false, Default::default()).unwrap();
         wtxn.commit().unwrap();
 
         let rtxn = index.read_txn().unwrap();

--- a/crates/milli/tests/search/query_criteria.rs
+++ b/crates/milli/tests/search/query_criteria.rs
@@ -344,7 +344,7 @@ fn criteria_ascdesc() {
         embedders,
         &|| false,
         &Progress::default(),
-        Default::default(),
+        &Default::default(),
     )
     .unwrap();
 

--- a/crates/milli/tests/search/typo_tolerance.rs
+++ b/crates/milli/tests/search/typo_tolerance.rs
@@ -46,7 +46,7 @@ fn test_typo_tolerance_one_typo() {
     let config = IndexerConfig::default();
     let mut builder = Settings::new(&mut txn, &index, &config);
     builder.set_min_word_len_one_typo(4);
-    builder.execute(|_| (), || false).unwrap();
+    builder.execute(|_| (), || false, None).unwrap();
 
     // typo is now supported for 4 letters words
     let mut search = Search::new(&txn, &index);
@@ -92,7 +92,7 @@ fn test_typo_tolerance_two_typo() {
     let config = IndexerConfig::default();
     let mut builder = Settings::new(&mut txn, &index, &config);
     builder.set_min_word_len_two_typos(7);
-    builder.execute(|_| (), || false).unwrap();
+    builder.execute(|_| (), || false, None).unwrap();
 
     // typo is now supported for 4 letters words
     let mut search = Search::new(&txn, &index);
@@ -180,7 +180,7 @@ fn test_typo_disabled_on_word() {
     // `zealand` doesn't allow typos anymore
     exact_words.insert("zealand".to_string());
     builder.set_exact_words(exact_words);
-    builder.execute(|_| (), || false).unwrap();
+    builder.execute(|_| (), || false, None).unwrap();
 
     let mut search = Search::new(&txn, &index);
     search.query("zealand");
@@ -218,7 +218,7 @@ fn test_disable_typo_on_attribute() {
     let mut builder = Settings::new(&mut txn, &index, &config);
     // disable typos on `description`
     builder.set_exact_attributes(vec!["description".to_string()].into_iter().collect());
-    builder.execute(|_| (), || false).unwrap();
+    builder.execute(|_| (), || false, None).unwrap();
 
     let mut search = Search::new(&txn, &index);
     search.query("antebelum");

--- a/crates/milli/tests/search/typo_tolerance.rs
+++ b/crates/milli/tests/search/typo_tolerance.rs
@@ -153,7 +153,7 @@ fn test_typo_disabled_on_word() {
         embedders,
         &|| false,
         &Progress::default(),
-        Default::default(),
+        &Default::default(),
     )
     .unwrap();
 

--- a/crates/milli/tests/search/typo_tolerance.rs
+++ b/crates/milli/tests/search/typo_tolerance.rs
@@ -46,7 +46,7 @@ fn test_typo_tolerance_one_typo() {
     let config = IndexerConfig::default();
     let mut builder = Settings::new(&mut txn, &index, &config);
     builder.set_min_word_len_one_typo(4);
-    builder.execute(|_| (), || false, None).unwrap();
+    builder.execute(|_| (), || false, Default::default()).unwrap();
 
     // typo is now supported for 4 letters words
     let mut search = Search::new(&txn, &index);
@@ -92,7 +92,7 @@ fn test_typo_tolerance_two_typo() {
     let config = IndexerConfig::default();
     let mut builder = Settings::new(&mut txn, &index, &config);
     builder.set_min_word_len_two_typos(7);
-    builder.execute(|_| (), || false, None).unwrap();
+    builder.execute(|_| (), || false, Default::default()).unwrap();
 
     // typo is now supported for 4 letters words
     let mut search = Search::new(&txn, &index);
@@ -153,6 +153,7 @@ fn test_typo_disabled_on_word() {
         embedders,
         &|| false,
         &Progress::default(),
+        Default::default(),
     )
     .unwrap();
 
@@ -180,7 +181,7 @@ fn test_typo_disabled_on_word() {
     // `zealand` doesn't allow typos anymore
     exact_words.insert("zealand".to_string());
     builder.set_exact_words(exact_words);
-    builder.execute(|_| (), || false, None).unwrap();
+    builder.execute(|_| (), || false, Default::default()).unwrap();
 
     let mut search = Search::new(&txn, &index);
     search.query("zealand");
@@ -218,7 +219,7 @@ fn test_disable_typo_on_attribute() {
     let mut builder = Settings::new(&mut txn, &index, &config);
     // disable typos on `description`
     builder.set_exact_attributes(vec!["description".to_string()].into_iter().collect());
-    builder.execute(|_| (), || false, None).unwrap();
+    builder.execute(|_| (), || false, Default::default()).unwrap();
 
     let mut search = Search::new(&txn, &index);
     search.query("antebelum");


### PR DESCRIPTION
# Pull Request

## Related issue

Fixes #5706

## What does this PR do?

This PR adds an `embedder` object in the `stats` of a Batch. This object presents the number of requests made to the embedder and the number of failures, along with the last error. This is obtainable in real-time, before the tasks completes.

```diff
{
  "uid": 0,
  "progress": {
    "steps": [
      { 
        "currentStep": "extracting words",
        "finished": 2,
        "total": 9,
      },
      {
        "currentStep": "document",
        "finished": 30546,
        "total": 31944,
      }
    ],
    "percentage": 32.8471
  },
  "details": {
    "receivedDocuments": 6,
    "indexedDocuments": 6
  },
  "stats": {
    "totalNbTasks": 1,
    "status": {
      "succeeded": 1
    },
    "types": {
      "documentAdditionOrUpdate": 1
    },
    "indexUids": {
      "INDEX_NAME": 1
    }, 
    "progressTrace": { … },
    "writeChannelCongestion": { … },
    "internalDatabaseSizes": { … },
+   "embedderRequests": {
+     "total": 12,
+     "failed": 5,
+     "lastError": "runtime error: received internal error HTTP 500 from embedding server\n  - server replied with `{\"error\":\"Service Unavailable\",\"text\":\"will_error\"}`"
+   }
  },
  "duration": "PT0.250518S",
  "startedAt": "2024-12-10T15:20:30.18182Z",
  "finishedAt": "2024-12-10T15:20:30.432338Z",
  "batchStrategy": "batched all enqueued tasks"
}
```


## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
