### PR TITLE
Remove Gemini from the LLM-providers list

### DIFF
--- a/crates/meilisearch-types/src/features.rs
+++ b/crates/meilisearch-types/src/features.rs
@@ -114,7 +114,6 @@ pub enum ChatCompletionSource {
     OpenAi,
     AzureOpenAi,
     Mistral,
-    Gemini,
     VLlm,
 }
 
@@ -134,7 +133,6 @@ impl ChatCompletionSource {
             AzureOpenAi if Self::old_openai_model(model) => System,
             AzureOpenAi => Developer,
             Mistral => System,
-            Gemini => System,
             VLlm => System,
         }
     }
@@ -154,7 +152,6 @@ impl ChatCompletionSource {
         match self {
             OpenAi => Some("https://api.openai.com/v1/"),
             Mistral => Some("https://api.mistral.ai/v1/"),
-            Gemini => Some("https://generativelanguage.googleapis.com/v1beta/openai"),
             AzureOpenAi | VLlm => None,
         }
     }

--- a/crates/meilisearch/src/routes/chats/config.rs
+++ b/crates/meilisearch/src/routes/chats/config.rs
@@ -13,7 +13,7 @@ impl Config {
     pub fn new(chat_settings: &DbChatSettings) -> Self {
         use meilisearch_types::features::ChatCompletionSource::*;
         match chat_settings.source {
-            OpenAi | Mistral | Gemini | VLlm => {
+            OpenAi | Mistral | VLlm => {
                 let mut config = OpenAIConfig::default();
                 if let Some(org_id) = chat_settings.org_id.as_ref() {
                     config = config.with_org_id(org_id);

--- a/crates/meilisearch/src/routes/chats/settings.rs
+++ b/crates/meilisearch/src/routes/chats/settings.rs
@@ -218,7 +218,6 @@ pub enum ChatCompletionSource {
     #[default]
     OpenAi,
     Mistral,
-    Gemini,
     AzureOpenAi,
     VLlm,
 }
@@ -229,7 +228,6 @@ impl From<ChatCompletionSource> for DbChatCompletionSource {
         match source {
             OpenAi => DbChatCompletionSource::OpenAi,
             Mistral => DbChatCompletionSource::Mistral,
-            Gemini => DbChatCompletionSource::Gemini,
             AzureOpenAi => DbChatCompletionSource::AzureOpenAi,
             VLlm => DbChatCompletionSource::VLlm,
         }


### PR DESCRIPTION
This PR removes Gemini from the list of supported providers. The main reason is that the function/tool call support and error reporting are incompatible with OpenAI. It is **very** different. You can see that in https://github.com/meilisearch/meilisearch/issues/5684#issuecomment-2996668744.

I prefer removing the support* than having something broken. We will [reintroduce it later](https://github.com/meilisearch/meilisearch/issues/5634).