### PR TITLE
Fix flaky last_error test

### DIFF
--- a/crates/meilisearch/tests/vector/rest.rs
+++ b/crates/meilisearch/tests/vector/rest.rs
@@ -2183,6 +2183,7 @@ async fn last_error_stats() {
     snapshot!(json_string!(response["results"][0], {
         ".progress" => "[ignored]",
         ".stats.embedderRequests.total" => "[ignored]",
+        ".stats.embedderRequests.failed" => "[ignored]",
         ".startedAt" => "[ignored]"
     }), @r#"
     {
@@ -2205,7 +2206,7 @@ async fn last_error_stats() {
         },
         "embedderRequests": {
           "total": "[ignored]",
-          "failed": 5,
+          "failed": "[ignored]",
           "lastError": "runtime error: received internal error HTTP 500 from embedding server\n  - server replied with `Service Unavailable`"
         }
       },


### PR DESCRIPTION
Sometimes only 4 errors out of the 5 had the time to be recorded. This isn't what matters anyway, what matters is that the object is here and the error is correct. I added the number of failed requests to the ignore list