### PR TITLE
Export and import chat completions workspace settings in dumps

### DIFF
--- a/crates/index-scheduler/src/processing.rs
+++ b/crates/index-scheduler/src/processing.rs
@@ -103,6 +103,7 @@ make_enum_progress! {
     pub enum DumpCreationProgress {
         StartTheDumpCreation,
         DumpTheApiKeys,
+        DumpTheChatCompletionSettings,
         DumpTheTasks,
         DumpTheBatches,
         DumpTheIndexes,


### PR DESCRIPTION
This PR adds support for the chat completions settings in the dumps. Before this PR, the support was partial, and the chat completions settings (workspace settings) were skipped. With this PR, everything is correctly exported and imported.