### PR TITLE
Add chat-related metrics on the prometheus route

### DIFF
--- a/crates/meilisearch/src/metrics.rs
+++ b/crates/meilisearch/src/metrics.rs
@@ -15,12 +15,14 @@ lazy_static! {
         "Meilisearch number of degraded search requests"
     ))
     .expect("Can't create a metric");
-    pub static ref MEILISEARCH_CHAT_INTERNAL_SEARCH_REQUESTS: IntGauge =
-        register_int_gauge!(opts!(
-            "meilisearch_chat_internal_search_requests",
+    pub static ref MEILISEARCH_CHAT_SEARCH_REQUESTS: IntCounterVec = register_int_counter_vec!(
+        opts!(
+            "meilisearch_chat_search_requests",
             "Meilisearch number of search requests performed by the chat route itself"
-        ))
-        .expect("Can't create a metric");
+        ),
+        &["type"]
+    )
+    .expect("Can't create a metric");
     pub static ref MEILISEARCH_CHAT_PROMPT_TOKENS_USAGE: IntCounterVec = register_int_counter_vec!(
         opts!("meilisearch_chat_prompt_tokens_usage", "Meilisearch Chat Prompt Tokens Usage"),
         &["workspace", "model"]

--- a/crates/meilisearch/src/routes/chats/chat_completions.rs
+++ b/crates/meilisearch/src/routes/chats/chat_completions.rs
@@ -49,8 +49,8 @@ use crate::error::MeilisearchHttpError;
 use crate::extractors::authentication::policies::ActionPolicy;
 use crate::extractors::authentication::{extract_token_from_request, GuardedData, Policy as _};
 use crate::metrics::{
-    MEILISEARCH_CHAT_COMPLETION_TOKENS_USAGE, MEILISEARCH_CHAT_INTERNAL_SEARCH_REQUESTS,
-    MEILISEARCH_CHAT_PROMPT_TOKENS_USAGE, MEILISEARCH_CHAT_TOTAL_TOKENS_USAGE,
+    MEILISEARCH_CHAT_COMPLETION_TOKENS_USAGE, MEILISEARCH_CHAT_PROMPT_TOKENS_USAGE,
+    MEILISEARCH_CHAT_SEARCH_REQUESTS, MEILISEARCH_CHAT_TOTAL_TOKENS_USAGE,
     MEILISEARCH_DEGRADED_SEARCH_REQUESTS,
 };
 use crate::routes::chats::utils::SseEventSender;
@@ -290,7 +290,7 @@ async fn process_search_request(
     let output = output?;
     let mut documents = Vec::new();
     if let Ok((ref rtxn, ref search_result)) = output {
-        MEILISEARCH_CHAT_INTERNAL_SEARCH_REQUESTS.inc();
+        MEILISEARCH_CHAT_SEARCH_REQUESTS.with_label_values(&["internal"]).inc();
         if search_result.degraded {
             MEILISEARCH_DEGRADED_SEARCH_REQUESTS.inc();
         }


### PR DESCRIPTION
This PR exposes more metrics on the `/metrics` route:
 - [x] The number of searches performed by the chat completions itself
   - [x] Use labels to type the counts (internal ~and external~)
 - [x] The number of completion, prompt and total tokens
   - [x] Associated to the model, chat workspace and type
   - [x] Rename the chat label "workspace"
   - [x] Remove the "type" label and create three different counters `meilisearch_chat_completion_tokens_usage`
 - [x] Do a test again and update the example below 👇 

```
# HELP meilisearch_chat_completion_tokens_usage Meilisearch Chat Completion Tokens Usage
# TYPE meilisearch_chat_completion_tokens_usage counter
meilisearch_chat_completion_tokens_usage{model="gpt-3.5-turbo",workspace="default"} 393

# HELP meilisearch_chat_prompt_tokens_usage Meilisearch Chat Prompt Tokens Usage
# TYPE meilisearch_chat_prompt_tokens_usage counter
meilisearch_chat_prompt_tokens_usage{model="gpt-3.5-turbo",workspace="default"} 1613

# HELP meilisearch_chat_search_requests Meilisearch number of search requests performed by the chat route itself
# TYPE meilisearch_chat_search_requests counter
meilisearch_chat_search_requests{type="internal"} 1

# HELP meilisearch_chat_total_tokens_usage Meilisearch Chat Total Tokens Usage
# TYPE meilisearch_chat_total_tokens_usage counter
meilisearch_chat_total_tokens_usage{model="gpt-3.5-turbo",workspace="default"} 2006
```