### PR TITLE
Set `search_k` to `max_hits * n_trees` when using finite pagination

### DIFF
--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -1050,7 +1050,7 @@ pub fn prepare_search<'t>(
         .map(|x| x as usize)
         .unwrap_or(DEFAULT_PAGINATION_MAX_TOTAL_HITS);
 
-    search.exhaustive_number_hits(is_finite_pagination);
+    search.is_exhaustive_pagination(is_finite_pagination);
     search.max_total_hits(Some(max_total_hits));
     search.scoring_strategy(
         if query.show_ranking_score

--- a/crates/milli/src/search/hybrid.rs
+++ b/crates/milli/src/search/hybrid.rs
@@ -209,7 +209,7 @@ impl Search<'_> {
             terms_matching_strategy: self.terms_matching_strategy,
             scoring_strategy: ScoringStrategy::Detailed,
             words_limit: self.words_limit,
-            exhaustive_number_hits: self.exhaustive_number_hits,
+            is_exhaustive_pagination: self.is_exhaustive_pagination,
             max_total_hits: self.max_total_hits,
             rtxn: self.rtxn,
             index: self.index,

--- a/crates/milli/src/search/new/mod.rs
+++ b/crates/milli/src/search/new/mod.rs
@@ -377,6 +377,7 @@ fn get_ranking_rules_for_vector<'ctx>(
     embedder_name: &str,
     embedder: &Embedder,
     quantized: bool,
+    search_k_div_trees: Option<usize>,
 ) -> Result<Vec<BoxRankingRule<'ctx, PlaceholderQuery>>> {
     // query graph search
 
@@ -405,6 +406,7 @@ fn get_ranking_rules_for_vector<'ctx>(
                         embedder_name,
                         embedder,
                         quantized,
+                        search_k_div_trees,
                     )?;
                     ranking_rules.push(Box::new(vector_sort));
                     vector = true;
@@ -637,6 +639,7 @@ pub fn execute_vector_search(
     embedder_name: &str,
     embedder: &Embedder,
     quantized: bool,
+    search_k_div_trees: Option<usize>,
     time_budget: TimeBudget,
     ranking_score_threshold: Option<f64>,
 ) -> Result<PartialSearchResult> {
@@ -653,6 +656,7 @@ pub fn execute_vector_search(
         embedder_name,
         embedder,
         quantized,
+        search_k_div_trees,
     )?;
 
     let mut placeholder_search_logger = logger::DefaultSearchLogger;

--- a/crates/milli/src/search/new/tests/distinct.rs
+++ b/crates/milli/src/search/new/tests/distinct.rs
@@ -572,7 +572,7 @@ fn test_distinct_all_candidates() {
     let mut s = Search::new(&txn, &index);
     s.terms_matching_strategy(TermsMatchingStrategy::Last);
     s.sort_criteria(vec![AscDesc::Desc(Member::Field(S("rank1")))]);
-    s.exhaustive_number_hits(true);
+    s.is_exhaustive_pagination(true);
 
     let SearchResult { documents_ids, candidates, .. } = s.execute().unwrap();
     let candidates = candidates.iter().collect::<Vec<_>>();

--- a/crates/milli/tests/search/distinct.rs
+++ b/crates/milli/tests/search/distinct.rs
@@ -29,7 +29,7 @@ macro_rules! test_distinct {
             search.query(search::TEST_QUERY);
             search.limit($limit);
             search.offset($offset);
-            search.exhaustive_number_hits($exhaustive);
+            search.is_exhaustive_pagination($exhaustive);
 
             search.terms_matching_strategy(TermsMatchingStrategy::default());
 


### PR DESCRIPTION
# Pull Request

## Related issue
Related to #4704

## What does this PR do?

In theory, setting arroy's `search_k` to `max_hits * n_trees` would ensure there are no duplicated results over different paginated pages, nor missing results.
