### PR TITLE
Fix incorrect document count in stats after clearing all documents

### DIFF
--- a/crates/milli/src/update/clear_documents.rs
+++ b/crates/milli/src/update/clear_documents.rs
@@ -125,7 +125,7 @@ mod tests {
         wtxn.commit().unwrap();
 
         let rtxn = index.read_txn().unwrap();
-        
+
         // Variables for statistics verification
         let stats = index.documents_stats(&rtxn).unwrap().unwrap();
 

--- a/crates/milli/src/update/clear_documents.rs
+++ b/crates/milli/src/update/clear_documents.rs
@@ -2,7 +2,7 @@ use heed::RwTxn;
 use roaring::RoaringBitmap;
 use time::OffsetDateTime;
 
-use crate::{FieldDistribution, Index, Result};
+use crate::{database_stats::DatabaseStats, FieldDistribution, Index, Result};
 
 pub struct ClearDocuments<'t, 'i> {
     wtxn: &'t mut RwTxn<'i>,
@@ -91,6 +91,10 @@ impl<'t, 'i> ClearDocuments<'t, 'i> {
         vector_arroy.clear(self.wtxn)?;
 
         documents.clear(self.wtxn)?;
+
+        // Update the stats of the documents database after clearing all documents.
+        let stats = DatabaseStats::new(self.index.documents.remap_data_type(), self.wtxn)?;
+        self.index.put_documents_stats(self.wtxn, stats)?;
 
         Ok(number_of_documents)
     }

--- a/crates/milli/src/update/clear_documents.rs
+++ b/crates/milli/src/update/clear_documents.rs
@@ -125,6 +125,9 @@ mod tests {
         wtxn.commit().unwrap();
 
         let rtxn = index.read_txn().unwrap();
+        
+        // Variables for statistics verification
+        let stats = index.documents_stats(&rtxn).unwrap().unwrap();
 
         // the value is 7 because there is `[id, name, age, country, _geo, _geo.lng, _geo.lat]`
         assert_eq!(index.fields_ids_map(&rtxn).unwrap().len(), 7);
@@ -146,5 +149,9 @@ mod tests {
         assert!(index.field_id_docid_facet_f64s.is_empty(&rtxn).unwrap());
         assert!(index.field_id_docid_facet_strings.is_empty(&rtxn).unwrap());
         assert!(index.documents.is_empty(&rtxn).unwrap());
+
+        // Verify that the statistics are correctly updated after clearing documents
+        assert_eq!(index.number_of_documents(&rtxn).unwrap(), 0);
+        assert_eq!(stats.number_of_entries(), 0);
     }
 }


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #5750 

## What does this PR do?
- Fixes incorrect document count in `/stats` endpoint after clearing all documents
- Adds database stats update after clearing documents in `ClearDocuments::execute()`
- Enhances existing test to verify stats are correctly updated to 0
- Ensures consistency between search results and stats endpoint

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?
