### PR TITLE
Fix chat settings dumpless upgrade

### DIFF
--- a/crates/meilisearch-types/src/features.rs
+++ b/crates/meilisearch-types/src/features.rs
@@ -168,9 +168,16 @@ pub struct ChatCompletionPrompts {
     pub search_description: String,
     #[serde(default)]
     pub search_q_param: String,
+    #[serde(default = "default_search_filter_param")]
     pub search_filter_param: String,
     #[serde(default)]
     pub search_index_uid_param: String,
+}
+
+/// This function is used for when the search_filter_param is
+/// not provided and this can happen when the database is in v1.15.
+fn default_search_filter_param() -> String {
+    DEFAULT_CHAT_SEARCH_FILTER_PARAM_PROMPT.to_string()
 }
 
 impl Default for ChatCompletionPrompts {

--- a/crates/meilisearch-types/src/features.rs
+++ b/crates/meilisearch-types/src/features.rs
@@ -162,10 +162,14 @@ impl ChatCompletionSource {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ChatCompletionPrompts {
+    #[serde(default)]
     pub system: String,
+    #[serde(default)]
     pub search_description: String,
+    #[serde(default)]
     pub search_q_param: String,
     pub search_filter_param: String,
+    #[serde(default)]
     pub search_index_uid_param: String,
 }
 


### PR DESCRIPTION
Fix a bug when using the dumpless upgrade when chat settings were already present in the index. This bug was introduced in https://github.com/meilisearch/meilisearch/pull/5710, and I mislabeled the PR as `no db change` when, in reality, it was.