### PR TITLE
fix: index chat settings `searchParameters` incorrectly set with `limit: 20` when sending empty object

### DIFF
--- a/crates/milli/src/update/chat.rs
+++ b/crates/milli/src/update/chat.rs
@@ -93,7 +93,7 @@ pub struct ChatSearchParams {
     pub hybrid: Setting<HybridQuery>,
 
     #[serde(default, skip_serializing_if = "Setting::is_not_set")]
-    #[deserr(default = Setting::Set(20))]
+    #[deserr(default)]
     #[schema(value_type = Option<usize>)]
     pub limit: Setting<usize>,
 


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #5771

## What does this PR do?
Issue when calling `PUT request to /indexes/{index_uid}/settings/chat` with `searchParameters: {}`
- Fixes an issue where sending `searchParameters: {}` in index chat settings would incorrectly set the limit to 20 instead of resetting to empty defaults
- Removes the unnecessary default value `Setting::Set(20)` from the `limit` field in `ChatSearchParams`