### PR TITLE
feat(chat): update prometheus metrics name

### DIFF
--- a/crates/meilisearch/src/metrics.rs
+++ b/crates/meilisearch/src/metrics.rs
@@ -15,30 +15,30 @@ lazy_static! {
         "Meilisearch number of degraded search requests"
     ))
     .expect("Can't create a metric");
-    pub static ref MEILISEARCH_CHAT_SEARCH_REQUESTS: IntCounterVec = register_int_counter_vec!(
+    pub static ref MEILISEARCH_CHAT_SEARCHES_TOTAL: IntCounterVec = register_int_counter_vec!(
         opts!(
-            "meilisearch_chat_search_requests",
-            "Meilisearch number of search requests performed by the chat route itself"
+            "meilisearch_chat_searches_total",
+            "Total number of searches performed by the chat route"
         ),
         &["type"]
     )
     .expect("Can't create a metric");
-    pub static ref MEILISEARCH_CHAT_PROMPT_TOKENS_USAGE: IntCounterVec = register_int_counter_vec!(
-        opts!("meilisearch_chat_prompt_tokens_usage", "Meilisearch Chat Prompt Tokens Usage"),
+    pub static ref MEILISEARCH_CHAT_PROMPT_TOKENS_TOTAL: IntCounterVec = register_int_counter_vec!(
+        opts!("meilisearch_chat_prompt_tokens_total", "Total number of prompt tokens consumed"),
         &["workspace", "model"]
     )
     .expect("Can't create a metric");
-    pub static ref MEILISEARCH_CHAT_COMPLETION_TOKENS_USAGE: IntCounterVec =
+    pub static ref MEILISEARCH_CHAT_COMPLETION_TOKENS_TOTAL: IntCounterVec =
         register_int_counter_vec!(
             opts!(
-                "meilisearch_chat_completion_tokens_usage",
-                "Meilisearch Chat Completion Tokens Usage"
+                "meilisearch_chat_completion_tokens_total",
+                "Total number of completion tokens consumed"
             ),
             &["workspace", "model"]
         )
         .expect("Can't create a metric");
-    pub static ref MEILISEARCH_CHAT_TOTAL_TOKENS_USAGE: IntCounterVec = register_int_counter_vec!(
-        opts!("meilisearch_chat_total_tokens_usage", "Meilisearch Chat Total Tokens Usage"),
+    pub static ref MEILISEARCH_CHAT_TOKENS_TOTAL: IntCounterVec = register_int_counter_vec!(
+        opts!("meilisearch_chat_tokens_total", "Total number of tokens consumed (prompt + completion)"),
         &["workspace", "model"]
     )
     .expect("Can't create a metric");


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #5786

## What does this PR do?

This PR renames chat-related counter metrics to follow Prometheus naming conventions by adding the `_total` suffix. This fixes the warning: "metric might not be a counter, name does not end in _total/_sum/_count/_bucket".

### Changes:
- `meilisearch_chat_prompt_tokens_usage` → `meilisearch_chat_prompt_tokens_total`
- `meilisearch_chat_completion_tokens_usage` → `meilisearch_chat_completion_tokens_total`
- `meilisearch_chat_total_tokens_usage` → `meilisearch_chat_tokens_total`
- `meilisearch_chat_search_requests` → `meilisearch_chat_searches_total`

All counter metrics now properly end with `_total` as required by Prometheus best practices.

Example output now:
```
# HELP meilisearch_chat_prompt_tokens_total Total number of prompt tokens consumed
# TYPE meilisearch_chat_prompt_tokens_total counter
meilisearch_chat_prompt_tokens_total{model="gpt-3.5-turbo",workspace="default"} 1613

# HELP meilisearch_chat_completion_tokens_total Total number of completion tokens consumed
# TYPE meilisearch_chat_completion_tokens_total counter
meilisearch_chat_completion_tokens_total{model="gpt-3.5-turbo",workspace="default"} 393

# HELP meilisearch_chat_tokens_total Total number of tokens consumed (prompt + completion)
# TYPE meilisearch_chat_tokens_total counter
meilisearch_chat_tokens_total{model="gpt-3.5-turbo",workspace="default"} 2006

# HELP meilisearch_chat_searches_total Total number of searches performed by the chat route
# TYPE meilisearch_chat_searches_total counter
meilisearch_chat_searches_total{type="internal"} 1
```