### PR TITLE
Update mini-dashboard v0.2.22

### DIFF
--- a/crates/meilisearch/Cargo.toml
+++ b/crates/meilisearch/Cargo.toml
@@ -170,5 +170,5 @@ german = ["meilisearch-types/german"]
 turkish = ["meilisearch-types/turkish"]
 
 [package.metadata.mini-dashboard]
-assets-url = "https://github.com/meilisearch/mini-dashboard/releases/download/v0.2.21/build.zip"
-sha1 = "94f56a8e24e2e3a1bc1bd7d9ceaa23464a5e241a"
+assets-url = "https://github.com/meilisearch/mini-dashboard/releases/download/v0.2.22/build.zip"
+sha1 = "b70b2036b5f167da9ea0b637da8b320c7ea88254"


### PR DESCRIPTION
# Pull Request

## Related issue
related to https://github.com/meilisearch/mini-dashboard/pull/641

## What does this PR do?
- update mini-dashboard to make sure the API key is used when calling the export route