### PR TITLE
Add category to release draft

### DIFF
--- a/.github/release-draft-template.yml
+++ b/.github/release-draft-template.yml
@@ -23,7 +23,7 @@ categories:
 template: |
   $CHANGES
 
-  Thanks again to $CONTRIBUTORS! 🎉
+  ❤️  Huge thanks to our contributors: $CONTRIBUTORS.
 no-changes-template: 'Changes are coming soon 😎'
 sort-direction: 'ascending'
 replacers:

--- a/.github/release-draft-template.yml
+++ b/.github/release-draft-template.yml
@@ -3,13 +3,23 @@ tag-template: 'v$RESOLVED_VERSION'
 exclude-labels:
   - 'skip changelog'
 version-resolver:
-  major:
-    labels:
-      - 'breaking-change'
   minor:
     labels:
       - 'enhancement'
   default: patch
+categories:
+  - title: '⚠️ Breaking changes'
+    label: 'breaking-change'
+  - title: '🚀 Enhancements'
+    label: 'enhancement'
+  - title: '🐛 Bug Fixes'
+    label: 'bug'
+  - title: '🔒 Security'
+    label: 'security'
+  - title: '⚙️ Maintenance/misc'
+    label:
+      - 'maintenance'
+      - 'documentation'
 template: |
   $CHANGES
 


### PR DESCRIPTION

- Add categories in changelogs: helps for writing the changelog
- Remove the bump of major when using `breaking change` label because we use it mostly for exp feature. Can be risky to let it if the human doing the release does not notice it