### PR TITLE
fix the dumpless upgrade again

### DIFF
--- a/crates/index-scheduler/src/upgrade/mod.rs
+++ b/crates/index-scheduler/src/upgrade/mod.rs
@@ -39,6 +39,7 @@ pub fn upgrade_index_scheduler(
         (1, 13, _) => 0,
         (1, 14, _) => 0,
         (1, 15, _) => 0,
+        (1, 16, _) => 0,
         (major, minor, patch) => {
             if major > current_major
                 || (major == current_major && minor > current_minor)


### PR DESCRIPTION
We forgot to update the version in the dumpless upgrade of the index-scheduler 😓 