### PR TITLE
Parallelize preparing payloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -737,6 +737,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "boxcar"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f64beae40a84da1b4b26ff2761a5b895c12adc41dc25aaee1c4f2bbfe97a6e"
+
+[[package]]
 name = "brotli"
 version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3928,6 +3934,7 @@ dependencies = [
  "big_s",
  "bimap",
  "bincode",
+ "boxcar",
  "bstr",
  "bumpalo",
  "bumparaw-collections",
@@ -3970,6 +3977,7 @@ dependencies = [
  "obkv",
  "once_cell",
  "ordered-float 5.0.0",
+ "papaya",
  "rand 0.8.5",
  "rayon",
  "rhai",
@@ -4409,6 +4417,16 @@ checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "papaya"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f92dd0b07c53a0a0c764db2ace8c541dc47320dad97c2200c2a637ab9dd2328f"
+dependencies = [
+ "equivalent",
+ "seize",
 ]
 
 [[package]]
@@ -5460,6 +5478,16 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.12",
  "time",
+]
+
+[[package]]
+name = "seize"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4b8d813387d566f627f3ea1b914c068aac94c40ae27ec43f5f33bde65abefe7"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/milli/Cargo.toml
+++ b/crates/milli/Cargo.toml
@@ -109,6 +109,8 @@ utoipa = { version = "5.4.0", features = [
     "openapi_extensions",
 ] }
 lru = "0.14.0"
+boxcar = "0.2.14"
+papaya = "0.2.3"
 
 [dev-dependencies]
 mimalloc = { version = "0.1.47", default-features = false }


### PR DESCRIPTION
This PR introduces performance improvements for the prepared payloads when preparing and extracting the documents from the payloads. It is capable of managing one payload file by thread at a time. Each thread extracts the documents and their document ID based on the guessed primary key (or the one already in the index).