### PR TITLE
Fix scheduled CI failure

### DIFF
--- a/crates/openapi-generator/Cargo.toml
+++ b/crates/openapi-generator/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-meilisearch = { path = "../meilisearch" }
+meilisearch = { path = "../meilisearch" , default-features = false}
 serde_json = "1.0"
 clap = { version = "4.5.40", features = ["derive"] }
 anyhow = "1.0.98"


### PR DESCRIPTION
Disabled default features on the `meilisearch` dependency in `openapi-generator` to prevent `lindera` from being pulled in during the scheduled CI build, fixes #5850. 