### PR TITLE
Add request uid to search routes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,9 +444,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arroy"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08e6111f351d004bd13e95ab540721272136fd3218b39d3ec95a2ea1c4e6a0a6"
+checksum = "733ce4c7a5250d770985c56466fac41238ffdaec0502bee64a4289e300164c5e"
 dependencies = [
  "bytemuck",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1086,9 +1086,9 @@ dependencies = [
 
 [[package]]
 name = "charabia"
-version = "0.9.6"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b01abfd2db0eb8c4e7a47ccab5d1f67993736f4e76923ed9ae281c49070645d"
+checksum = "7c2f456825b7f15eac01a1cae40c12c3f55e931d4327e6e4fa59508d664e9568"
 dependencies = [
  "aho-corasick",
  "csv",

--- a/crates/meilisearch/src/routes/indexes/search_analytics.rs
+++ b/crates/meilisearch/src/routes/indexes/search_analytics.rs
@@ -234,6 +234,7 @@ impl<Method: AggregateMethod> SearchAggregator<Method> {
             facet_stats: _,
             degraded,
             used_negative_operator,
+            request_uid: _,
         } = result;
 
         self.total_succeeded = self.total_succeeded.saturating_add(1);

--- a/crates/meilisearch/src/search/federated/perform.rs
+++ b/crates/meilisearch/src/search/federated/perform.rs
@@ -17,6 +17,7 @@ use meilisearch_types::milli::vector::Embedding;
 use meilisearch_types::milli::{self, DocumentId, OrderBy, TimeBudget, DEFAULT_VALUES_PER_FACET};
 use roaring::RoaringBitmap;
 use tokio::task::JoinHandle;
+use uuid::Uuid;
 
 use super::super::ranking_rules::{self, RankingRules};
 use super::super::{
@@ -39,6 +40,7 @@ pub async fn perform_federated_search(
     federation: Federation,
     features: RoFeatures,
     is_proxy: bool,
+    request_uid: Uuid,
 ) -> Result<FederatedSearchResult, ResponseError> {
     if is_proxy {
         features.check_network("Performing a remote federated search")?;
@@ -170,6 +172,7 @@ pub async fn perform_federated_search(
         facet_stats,
         facets_by_index,
         remote_errors: partitioned_queries.has_remote.then_some(remote_errors),
+        request_uid: Some(request_uid),
     })
 }
 
@@ -439,6 +442,7 @@ fn merge_metadata(
         degraded: degraded_for_host,
         used_negative_operator: host_used_negative_operator,
         remote_errors: _,
+        request_uid: _,
     } in remote_results
     {
         let this_remote_duration = Duration::from_millis(*processing_time_ms as u64);

--- a/crates/meilisearch/src/search/federated/types.rs
+++ b/crates/meilisearch/src/search/federated/types.rs
@@ -16,6 +16,7 @@ use meilisearch_types::milli::order_by_map::OrderByMap;
 use meilisearch_types::milli::OrderBy;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
+use uuid::Uuid;
 
 use super::super::{ComputedFacets, FacetStats, HitsInfo, SearchHit, SearchQueryWithIndex};
 use crate::milli::vector::Embedding;
@@ -131,6 +132,8 @@ pub struct FederatedSearchResult {
     pub facet_stats: Option<BTreeMap<String, FacetStats>>,
     #[serde(default, skip_serializing_if = "FederatedFacets::is_empty")]
     pub facets_by_index: FederatedFacets,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_uid: Option<Uuid>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub remote_errors: Option<BTreeMap<String, ResponseError>>,
@@ -156,6 +159,7 @@ impl fmt::Debug for FederatedSearchResult {
             facet_stats,
             facets_by_index,
             remote_errors,
+            request_uid,
         } = self;
 
         let mut debug = f.debug_struct("SearchResult");
@@ -187,6 +191,9 @@ impl fmt::Debug for FederatedSearchResult {
         }
         if let Some(remote_errors) = remote_errors {
             debug.field("remote_errors", &remote_errors);
+        }
+        if let Some(request_uid) = request_uid {
+            debug.field("request_uid", &request_uid);
         }
 
         debug.finish()

--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -36,6 +36,7 @@ use serde_json::{json, Value};
 #[cfg(test)]
 mod mod_test;
 use utoipa::ToSchema;
+use uuid::Uuid;
 
 use crate::error::MeilisearchHttpError;
 
@@ -851,6 +852,8 @@ pub struct SearchResult {
     pub facet_distribution: Option<BTreeMap<String, IndexMap<String, u64>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub facet_stats: Option<BTreeMap<String, FacetStats>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request_uid: Option<Uuid>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub semantic_hit_count: Option<u32>,
@@ -872,6 +875,7 @@ impl fmt::Debug for SearchResult {
             hits_info,
             facet_distribution,
             facet_stats,
+            request_uid,
             semantic_hit_count,
             degraded,
             used_negative_operator,
@@ -900,6 +904,9 @@ impl fmt::Debug for SearchResult {
         }
         if let Some(semantic_hit_count) = semantic_hit_count {
             debug.field("semantic_hit_count", &semantic_hit_count);
+        }
+        if let Some(request_uid) = request_uid {
+            debug.field("request_uid", &request_uid);
         }
 
         debug.finish()
@@ -1120,6 +1127,7 @@ pub fn perform_search(
     search_kind: SearchKind,
     retrieve_vectors: RetrieveVectors,
     features: RoFeatures,
+    request_uid: Uuid,
 ) -> Result<SearchResult, ResponseError> {
     let before_search = Instant::now();
     let rtxn = index.read_txn()?;
@@ -1237,6 +1245,7 @@ pub fn perform_search(
         degraded,
         used_negative_operator,
         semantic_hit_count,
+        request_uid: Some(request_uid),
     };
     Ok(result)
 }

--- a/crates/milli/Cargo.toml
+++ b/crates/milli/Cargo.toml
@@ -87,7 +87,7 @@ rhai = { version = "1.22.2", features = [
     "no_time",
     "sync",
 ] }
-arroy = "0.6.1"
+arroy = "0.6.2"
 rand = "0.8.5"
 tracing = "0.1.41"
 ureq = { version = "2.12.1", features = ["json"] }

--- a/crates/milli/Cargo.toml
+++ b/crates/milli/Cargo.toml
@@ -18,7 +18,7 @@ bincode = "1.3.3"
 bstr = "1.12.0"
 bytemuck = { version = "1.23.1", features = ["extern_crate_alloc"] }
 byteorder = "1.5.0"
-charabia = { version = "0.9.6", default-features = false }
+charabia = { version = "0.9.7", default-features = false }
 concat-arrays = "0.1.2"
 convert_case = "0.8.0"
 crossbeam-channel = "0.5.15"


### PR DESCRIPTION
## Related issue

linear: https://linear.app/meilisearch/issue/EXP-109/add-requestid-to-search-response

## List

- Add `requestUid` field to search response for:
  - `/indexes/<index_uid>/search`
  - `/indexes/multi-search`
- Add debug logs
