### PR TITLE
Fix links to update and migration

### DIFF
--- a/crates/meilisearch-types/src/versioning.rs
+++ b/crates/meilisearch-types/src/versioning.rs
@@ -72,7 +72,7 @@ pub fn parse_version(version: &str) -> Result<(u32, u32, u32), VersionFileError>
 pub enum VersionFileError {
     #[error(
         "Meilisearch (v{}) failed to infer the version of the database.
-        To update Meilisearch please follow our guide on https://www.meilisearch.com/docs/learn/update_and_migration/updating.",
+        To update Meilisearch please follow our guide on <https://www.meilisearch.com/docs/learn/update_and_migration/updating>.",
         env!("CARGO_PKG_VERSION").to_string()
     )]
     MissingVersionFile,
@@ -80,7 +80,7 @@ pub enum VersionFileError {
     MalformedVersionFile { context: String },
     #[error(
         "Your database version ({major}.{minor}.{patch}) is incompatible with your current engine version ({}).\n\
-        To migrate data between Meilisearch versions, please follow our guide on https://www.meilisearch.com/docs/learn/update_and_migration/updating.",
+        To migrate data between Meilisearch versions, please follow our guide on <https://www.meilisearch.com/docs/learn/update_and_migration/updating>.",
         env!("CARGO_PKG_VERSION").to_string()
     )]
     VersionMismatch { major: u32, minor: u32, patch: u32 },


### PR DESCRIPTION
I don't know if this solves the problem, but I've seen it done in other files in the project. The problem is that the link currently contains a dot, resulting in a 307 redirect to the documentation home page.

<img width="1117" height="157" alt="image" src="https://github.com/user-attachments/assets/cb6e9df7-c042-4998-93d5-15dffe2c9a42" />
