### PR TITLE
fix(metrics): content-type must be versioned

### DIFF
--- a/crates/meilisearch/src/routes/metrics.rs
+++ b/crates/meilisearch/src/routes/metrics.rs
@@ -1,4 +1,3 @@
-use actix_web::http::header;
 use actix_web::web::{self, Data};
 use actix_web::HttpResponse;
 use index_scheduler::{IndexScheduler, Query};
@@ -181,5 +180,5 @@ pub async fn get_metrics(
 
     let response = String::from_utf8(buffer).expect("Failed to convert bytes to string");
 
-    Ok(HttpResponse::Ok().insert_header(header::ContentType(mime::TEXT_PLAIN)).body(response))
+    Ok(HttpResponse::Ok().insert_header(("content-type", "text/plain; version=0.0.4; charset=utf-8")).body(response))
 }


### PR DESCRIPTION
## Related issue

Metrics endpoints is not compatible with Prometheus V3.
Prom returns the following error: `unsupported content type \"text/html; charset=UTF-8\"`

When checking [the doc](https://prometheus.io/docs/prometheus/latest/migration/#scrape-protocols), prom v3 seem to be more restricted with the content type header returned by the endpoint. We tried to set the fallback_scrape_protocol param but same issue.

By comparing the content type header returned by our others endpoints, we can see there is a missing version param in the Content-Type header

Headers returned by your endpoint:
```
curl -H "Authorization: Bearer xxxxxx" https://xxxx.nyc.meilisearch.io/metrics -v
< HTTP/2 200
< content-type: text/plain; charset=UTF-8
< content-length: 52408
< vary: Origin, Access-Control-Request-Method, Access-Control-Request-Headers
< date: Tue, 02 Sep 2025 08:33:50 GMT
< server: kong/3.9.1
< x-kong-upstream-latency: 2
< x-kong-proxy-latency: 1
< via: 1.1 kong/3.9.1
< x-kong-request-id: 0b66f069b6931e086441364053bda85e
```

Here is a working endpoint:
```
❯ curl http://localhost:8080/metrics --head
HTTP/1.1 200 OK
date: Tue, 02 Sep 2025 08:28:39 GMT
server: uvicorn
content-type: text/plain; version=0.0.4; charset=utf-8
content-length: 62808
```