### PR TITLE
Send the version when returning prometheus metrics

### DIFF
--- a/crates/meilisearch/src/routes/metrics.rs
+++ b/crates/meilisearch/src/routes/metrics.rs
@@ -1,4 +1,3 @@
-use actix_web::http::header;
 use actix_web::web::{self, Data};
 use actix_web::HttpResponse;
 use index_scheduler::{IndexScheduler, Query};
@@ -8,7 +7,6 @@ use meilisearch_types::keys::actions;
 use meilisearch_types::tasks::Status;
 use prometheus::{Encoder, TextEncoder};
 use time::OffsetDateTime;
-use tracing::Instrument;
 use utoipa::OpenApi;
 
 use crate::extractors::authentication::policies::ActionPolicy;


### PR DESCRIPTION
In the latest version of the prometheus scraper they introduced a breaking change that makes our metrics route unusable.
That PR fixes that

See https://linear.app/meilisearch/issue/SP-1155/huggingface-meilisearchuggingface-meilisearchh-remy-metrics-endpoint#comment-51cab239