### PR TITLE
Bump Hannoy to fix unreachable documents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2613,14 +2613,15 @@ dependencies = [
 
 [[package]]
 name = "hannoy"
-version = "0.0.5"
+version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b6a412d145918473a8257706599a1088c505047eef9cc6c63c494c95786044f"
+checksum = "0dba13a271c49a119a97862ebf0a74131d879832868400d9fcd937b790058fdd"
 dependencies = [
  "bytemuck",
  "byteorder",
  "hashbrown 0.15.5",
  "heed",
+ "madvise",
  "min-max-heap",
  "page_size",
  "papaya",
@@ -3748,6 +3749,15 @@ name = "macro_rules_attribute-proc_macro"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
+
+[[package]]
+name = "madvise"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e1e75c3c34c2b34cec9f127418cb35240c7ebee5de36a51437e6b382c161b86"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "manifest-dir-macros"

--- a/crates/milli/Cargo.toml
+++ b/crates/milli/Cargo.toml
@@ -88,7 +88,7 @@ rhai = { version = "1.22.2", features = [
     "sync",
 ] }
 arroy = "0.6.3"
-hannoy = "0.0.5"
+hannoy = { version = "0.0.8", features = ["arroy"] }
 rand = "0.8.5"
 tracing = "0.1.41"
 ureq = { version = "2.12.1", features = ["json"] }

--- a/crates/milli/src/vector/store.rs
+++ b/crates/milli/src/vector/store.rs
@@ -705,7 +705,7 @@ impl VectorStore {
         &'a self,
         rtxn: &'a RoTxn<'a>,
         db: hannoy::Database<D>,
-    ) -> impl Iterator<Item = Result<hannoy::Reader<'a, D>, hannoy::Error>> + 'a {
+    ) -> impl Iterator<Item = Result<hannoy::Reader<D>, hannoy::Error>> + 'a {
         vector_store_range_for_embedder(self.embedder_index).filter_map(move |index| {
             match hannoy::Reader::open(rtxn, index, db) {
                 Ok(reader) => match reader.is_empty(rtxn) {


### PR DESCRIPTION
This PR updates Hannoy to fix a bug that returned documents with a zero ranking score.