### PR TITLE
Document template: Correctly render when indexing first item in array

### DIFF
--- a/crates/milli/src/prompt/document.rs
+++ b/crates/milli/src/prompt/document.rs
@@ -304,7 +304,7 @@ impl ArrayView for ParseableArray<'_> {
 
     fn get(&self, index: i64) -> Option<&dyn ValueView> {
         let index = convert_index(index, self.size());
-        if index <= 0 {
+        if index < 0 {
             return None;
         }
         let v = self.0.get(index as usize)?;


### PR DESCRIPTION
In a fragment or document template, Meilisearch would not render the template/fragment when it referenced index 0 of an array.

Content: [internal slack channel](https://meilisearch.slack.com/archives/CD7Q2UKGB/p1757948589965599)

