### PR TITLE
Show Dependabot dependency upgrade in the changelog

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,5 @@ updates:
     schedule:
       interval: "monthly"
     labels:
-      - 'skip changelog'
       - 'dependencies'
     rebase-strategy: disabled

--- a/.github/release-draft-template.yml
+++ b/.github/release-draft-template.yml
@@ -18,6 +18,7 @@ categories:
     label: 'security'
   - title: '⚙️ Maintenance/misc'
     label:
+      - 'dependencies'
       - 'maintenance'
       - 'documentation'
 template: |
@@ -26,8 +27,3 @@ template: |
   ❤️  Huge thanks to our contributors: $CONTRIBUTORS.
 no-changes-template: 'Changes are coming soon 😎'
 sort-direction: 'ascending'
-replacers:
-  - search: '/(?:and )?@dependabot-preview(?:\[bot\])?,?/g'
-    replace: ''
-  - search: '/(?:and )?@dependabot(?:\[bot\])?,?/g'
-    replace: ''


### PR DESCRIPTION
For full transparency and easier debugging in case of issue for us

We had issues on integration side by doing that, I want to avoid the issue here in the future, even if we do not use that much dependabot