### PR TITLE
Override "default" source base url with the config one to support AWS bedrock OpenAI API

### DIFF
--- a/crates/meilisearch/src/routes/chats/config.rs
+++ b/crates/meilisearch/src/routes/chats/config.rs
@@ -24,8 +24,9 @@ impl Config {
                 if let Some(api_key) = chat_settings.api_key.as_ref() {
                     config = config.with_api_key(api_key);
                 }
+                // config base url always overrides the one from the source
                 let base_url = chat_settings.base_url.as_deref();
-                if let Some(base_url) = chat_settings.source.base_url().or(base_url) {
+                if let Some(base_url) = base_url.or(chat_settings.source.base_url()) {
                     config = config.with_api_base(base_url);
                 }
                 Self::OpenAiCompatible(config)


### PR DESCRIPTION
[Internal discussion](https://linear.app/meilisearch/issue/ENGPROD-2114/making-the-chat-route-compatible-with-aws-bedrock-openai-route#comment-39313caf)

## Breaking change

Technically a breaking change, because the source URL from the config is no longer ignored for the OpenAI source

## Draft

Requires updating the async-openai dependency after landing https://github.com/meilisearch/async-openai/pull/1