### PR TITLE
Shorten uncompacted snapshot creation by skipping the temporary copy

### DIFF
--- a/crates/file-store/src/lib.rs
+++ b/crates/file-store/src/lib.rs
@@ -33,6 +33,10 @@ impl FileStore {
         std::fs::create_dir_all(&path)?;
         Ok(FileStore { path })
     }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
 }
 
 impl FileStore {

--- a/crates/index-scheduler/src/index_mapper/mod.rs
+++ b/crates/index-scheduler/src/index_mapper/mod.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 use std::{fs, thread};
@@ -590,5 +590,9 @@ impl IndexMapper {
 
     pub fn set_currently_updating_index(&self, index: Option<(String, Index)>) {
         *self.currently_updating_index.write().unwrap() = index;
+    }
+
+    pub fn base_path(&self) -> &Path {
+        &self.base_path
     }
 }

--- a/crates/index-scheduler/src/scheduler/process_snapshot_creation.rs
+++ b/crates/index-scheduler/src/scheduler/process_snapshot_creation.rs
@@ -78,6 +78,22 @@ impl IndexScheduler {
     pub(super) fn process_snapshot(
         &self,
         progress: Progress,
+        tasks: Vec<Task>,
+    ) -> Result<Vec<Task>> {
+        let compaction_option = if self.scheduler.experimental_no_snapshot_compaction {
+            CompactionOption::Disabled
+        } else {
+            CompactionOption::Enabled
+        };
+        match compaction_option {
+            CompactionOption::Enabled => self.process_snapshot_with_temp(progress, tasks),
+            CompactionOption::Disabled => self.process_snapshot_with_pipe(progress, tasks),
+        }
+    }
+
+    fn process_snapshot_with_temp(
+        &self,
+        progress: Progress,
         mut tasks: Vec<Task>,
     ) -> Result<Vec<Task>> {
         progress.update_progress(SnapshotCreationProgress::StartTheSnapshotCreation);
@@ -105,12 +121,8 @@ impl IndexScheduler {
         progress.update_progress(SnapshotCreationProgress::SnapshotTheIndexScheduler);
         let dst = temp_snapshot_dir.path().join("tasks");
         fs::create_dir_all(&dst)?;
-        let compaction_option = if self.scheduler.experimental_no_snapshot_compaction {
-            CompactionOption::Disabled
-        } else {
-            CompactionOption::Enabled
-        };
-        self.env.copy_to_path(dst.join("data.mdb"), compaction_option)?;
+
+        self.env.copy_to_path(dst.join("data.mdb"), CompactionOption::Enabled)?;
 
         // 2.2 Remove the current snapshot tasks
         //
@@ -161,7 +173,7 @@ impl IndexScheduler {
             let dst = temp_snapshot_dir.path().join("indexes").join(uuid.to_string());
             fs::create_dir_all(&dst)?;
             index
-                .copy_to_path(dst.join("data.mdb"), compaction_option)
+                .copy_to_path(dst.join("data.mdb"), CompactionOption::Enabled)
                 .map_err(|e| Error::from_milli(e, Some(name.to_string())))?;
         }
 
@@ -171,7 +183,7 @@ impl IndexScheduler {
         progress.update_progress(SnapshotCreationProgress::SnapshotTheApiKeys);
         let dst = temp_snapshot_dir.path().join("auth");
         fs::create_dir_all(&dst)?;
-        self.scheduler.auth_env.copy_to_path(dst.join("data.mdb"), compaction_option)?;
+        self.scheduler.auth_env.copy_to_path(dst.join("data.mdb"), CompactionOption::Enabled)?;
 
         // 5. Copy and tarball the flat snapshot
         progress.update_progress(SnapshotCreationProgress::CreateTheTarball);
@@ -188,6 +200,114 @@ impl IndexScheduler {
         let file = temp_snapshot_file.persist(snapshot_path)?;
 
         // 5.3 Change the permission to make the snapshot readonly
+        let mut permissions = file.metadata()?.permissions();
+        permissions.set_readonly(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            #[allow(clippy::non_octal_unix_permissions)]
+            //                     rwxrwxrwx
+            permissions.set_mode(0b100100100);
+        }
+
+        file.set_permissions(permissions)?;
+
+        for task in &mut tasks {
+            task.status = Status::Succeeded;
+        }
+
+        Ok(tasks)
+    }
+
+    fn process_snapshot_with_pipe(
+        &self,
+        progress: Progress,
+        mut tasks: Vec<Task>,
+    ) -> Result<Vec<Task>> {
+        progress.update_progress(SnapshotCreationProgress::StartTheSnapshotCreation);
+
+        fs::create_dir_all(&self.scheduler.snapshots_path)?;
+
+        // 1. Find the base path and original name of the database
+
+        // TODO find a better way to get this path
+        let mut base_path = self.env.path().to_owned();
+        base_path.pop();
+        let base_path = base_path;
+        let db_name = base_path.file_name().and_then(OsStr::to_str).unwrap_or("data.ms");
+
+        // 2. Start the tarball builder. The tarball will be created on another thread from piped data.
+
+        let mut builder = compression::PipedArchiveBuilder::new(
+            self.scheduler.snapshots_path.clone(),
+            format!("{db_name}.snapshot"),
+            base_path,
+        );
+
+        // 3. Snapshot the VERSION file
+        builder.add_file_to_archive(self.scheduler.version_file_path.clone())?;
+
+        // 4. Snapshot the index-scheduler LMDB env
+        //
+        // When we call copy_to_path, LMDB opens a read transaction by itself,
+        // we can't provide our own. It is an issue as we would like to know
+        // the update files to copy but new ones can be enqueued between the copy
+        // of the env and the new transaction we open to retrieve the enqueued tasks.
+        // So we prefer opening a new transaction after copying the env and copy more
+        // update files than not enough.
+        //
+        // Note that there cannot be any update files deleted between those
+        // two read operations as the task processing is synchronous.
+
+        // 4.1 First copy the LMDB env of the index-scheduler
+        progress.update_progress(SnapshotCreationProgress::SnapshotTheIndexScheduler);
+        builder.add_env_to_archive(&self.env)?;
+
+        // 4.2 Create a read transaction on the index-scheduler
+        let rtxn = self.env.read_txn()?;
+
+        // 4.3 Only copy the update files of the enqueued tasks
+        progress.update_progress(SnapshotCreationProgress::SnapshotTheUpdateFiles);
+        builder.add_dir_to_archive(self.queue.file_store.path().to_path_buf())?;
+        let enqueued = self.queue.tasks.get_status(&rtxn, Status::Enqueued)?;
+        let (atomic, update_file_progress) = AtomicUpdateFileStep::new(enqueued.len() as u32);
+        progress.update_progress(update_file_progress);
+        for task_id in enqueued {
+            let task =
+                self.queue.tasks.get_task(&rtxn, task_id)?.ok_or(Error::CorruptedTaskQueue)?;
+            if let Some(content_uuid) = task.content_uuid() {
+                let src = self.queue.file_store.get_update_path(content_uuid);
+                builder.add_file_to_archive(src)?;
+            }
+            atomic.fetch_add(1, Ordering::Relaxed);
+        }
+
+        // 5. Snapshot every index
+        progress.update_progress(SnapshotCreationProgress::SnapshotTheIndexes);
+        builder.add_dir_to_archive(self.index_mapper.base_path().to_path_buf())?;
+        let index_mapping = self.index_mapper.index_mapping;
+        let nb_indexes = index_mapping.len(&rtxn)? as u32;
+
+        for (i, result) in index_mapping.iter(&rtxn)?.enumerate() {
+            let (name, _) = result?;
+            progress.update_progress(VariableNameStep::<SnapshotCreationProgress>::new(
+                name, i as u32, nb_indexes,
+            ));
+            let index = self.index_mapper.index(&rtxn, name)?;
+            builder.add_env_to_archive(index.raw_env())?;
+        }
+
+        drop(rtxn);
+
+        // 6. Snapshot the auth LMDB env
+        progress.update_progress(SnapshotCreationProgress::SnapshotTheApiKeys);
+        builder.add_env_to_archive(&self.scheduler.auth_env)?;
+
+        // 7. Finalize the tarball
+        progress.update_progress(SnapshotCreationProgress::CreateTheTarball);
+        let file = builder.finish()?;
+
+        // 8. Change the permission to make the snapshot readonly
         let mut permissions = file.metadata()?.permissions();
         permissions.set_readonly(true);
         #[cfg(unix)]

--- a/crates/meilisearch-types/src/compression.rs
+++ b/crates/meilisearch-types/src/compression.rs
@@ -1,11 +1,15 @@
 use std::fs::{create_dir_all, File};
-use std::io::Write;
-use std::path::Path;
+use std::io::{Read, Write};
+use std::os::fd::AsRawFd;
+use std::path::{Path, PathBuf};
+use std::sync::mpsc::{Receiver, Sender};
+use std::thread::JoinHandle;
 
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
 use flate2::Compression;
-use tar::{Archive, Builder};
+use milli::heed::Env;
+use tar::{Archive, Builder, Header};
 
 pub fn to_tar_gz(src: impl AsRef<Path>, dest: impl AsRef<Path>) -> anyhow::Result<()> {
     let mut f = File::create(dest)?;
@@ -25,4 +29,136 @@ pub fn from_tar_gz(src: impl AsRef<Path>, dest: impl AsRef<Path>) -> anyhow::Res
     create_dir_all(&dest)?;
     ar.unpack(&dest)?;
     Ok(())
+}
+
+pub struct PipedArchiveBuilder {
+    send: Sender<CompressionMessage>,
+    join_handle: JoinHandle<anyhow::Result<File>>,
+}
+
+enum CompressionMessage {
+    Env { path: PathBuf, reader: std::io::PipeReader },
+    File { path: PathBuf },
+    Dir { path: PathBuf },
+}
+
+impl PipedArchiveBuilder {
+    pub fn new(dest_dir: PathBuf, dest_filename: String, base_path: PathBuf) -> Self {
+        let (send, recv) = std::sync::mpsc::channel();
+        let join_handle = std::thread::Builder::new()
+            .name("piped-archive-builer".into())
+            .spawn(|| Self::run(dest_dir, dest_filename, recv, base_path))
+            .unwrap();
+        Self { send, join_handle }
+    }
+
+    pub fn add_env_to_archive<T>(&mut self, env: &Env<T>) -> anyhow::Result<()> {
+        let (reader, writer) = std::io::pipe()?;
+        let path = env.path().to_path_buf();
+        // make sure that the environment cannot change while it is being added to the archive,
+        // as any concurrent change would corrupt the copy.
+        let env_wtxn = env.write_txn()?;
+
+        self.send.send(CompressionMessage::Env { path, reader });
+        // SAFETY: the writer end of the pipe is available for write access
+        unsafe { env.copy_to_fd(writer.as_raw_fd(), milli::heed::CompactionOption::Disabled)? }
+
+        // no change we might want to commit
+        env_wtxn.abort();
+        Ok(())
+    }
+
+    pub fn add_file_to_archive(&mut self, path: PathBuf) -> anyhow::Result<()> {
+        self.send.send(CompressionMessage::File { path });
+        Ok(())
+    }
+
+    pub fn add_dir_to_archive(&mut self, path: PathBuf) -> anyhow::Result<()> {
+        self.send.send(CompressionMessage::Dir { path });
+        Ok(())
+    }
+
+    pub fn finish(self) -> anyhow::Result<File> {
+        drop(self.send);
+        /// FIXME catch panic
+        let file = self.join_handle.join().unwrap()?;
+        Ok(file)
+    }
+
+    fn run(
+        dest_dir: PathBuf,
+        dest_filename: String,
+        recv: Receiver<CompressionMessage>,
+        base_path: PathBuf,
+    ) -> anyhow::Result<File> {
+        let mut temp_archive = tempfile::NamedTempFile::new_in(&dest_dir)?;
+
+        let gz_encoder = GzEncoder::new(&mut temp_archive, Compression::default());
+        let mut tar_encoder = Builder::new(gz_encoder);
+        let base_path_in_archive = PathInArchive::from_absolute_and_base(&base_path, &base_path);
+        // add the root
+        tar_encoder.append_dir(base_path_in_archive.as_path(), &base_path)?;
+        while let Ok(message) = recv.recv() {
+            match message {
+                CompressionMessage::Env { path, reader } => {
+                    let dir_path_in_archive =
+                        PathInArchive::from_absolute_and_base(&path, &base_path);
+
+                    tar_encoder.append_dir(dir_path_in_archive.as_path(), &path)?;
+
+                    let path = path.join("data.mdb");
+                    Self::add_to_archive(&mut tar_encoder, &path, &base_path, reader)?;
+                }
+                CompressionMessage::File { path } => {
+                    let path_in_archive = PathInArchive::from_absolute_and_base(&path, &base_path);
+                    tar_encoder.append_path_with_name(&path, path_in_archive.as_path())?;
+                }
+                CompressionMessage::Dir { path } => {
+                    let path_in_archive = PathInArchive::from_absolute_and_base(&path, &base_path);
+
+                    tar_encoder.append_dir(path_in_archive.as_path(), &path)?;
+                }
+            }
+        }
+
+        let gz_encoder = tar_encoder.into_inner()?;
+        gz_encoder.finish()?;
+        temp_archive.flush()?;
+        let archive = temp_archive.persist(dest_dir.join(dest_filename))?;
+        Ok(archive)
+    }
+
+    fn add_to_archive(
+        tar_encoder: &mut Builder<impl Write>,
+        path: &Path,
+        base: &Path,
+        reader: impl Read,
+    ) -> anyhow::Result<()> {
+        let stats = path.metadata()?;
+        let mut header = Header::new_gnu();
+        header.set_metadata_in_mode(&stats, tar::HeaderMode::Complete);
+        let path_in_archive = PathInArchive::from_absolute_and_base(path, base);
+
+        tar_encoder.append_data(&mut header, path_in_archive.as_path(), reader)?;
+        Ok(())
+    }
+}
+
+struct PathInArchive(PathBuf);
+
+impl PathInArchive {
+    pub fn from_absolute_and_base(absolute: &Path, base: &Path) -> Self {
+        /// FIXME
+        let canonical = absolute.canonicalize().unwrap();
+        let relative = match canonical.strip_prefix(base) {
+            Ok(stripped) => Path::new(&".").join(stripped),
+            Err(_) => absolute.to_path_buf(),
+        };
+
+        Self(relative)
+    }
+
+    pub fn as_path(&self) -> &Path {
+        self.0.as_path()
+    }
 }

--- a/crates/milli/src/index.rs
+++ b/crates/milli/src/index.rs
@@ -1983,6 +1983,11 @@ impl Index {
 
         Ok(sizes)
     }
+
+    /// The underlying env for raw access
+    pub fn raw_env(&self) -> &heed::Env<WithoutTls> {
+        &self.env
+    }
 }
 
 pub struct EmbeddingsWithMetadata {


### PR DESCRIPTION
[Internal issue](https://linear.app/meilisearch/issue/SCA-227/shorten-snapshot-creation-by-skipping-the-temporary-copy)

## Draft status

- [ ] No cancellation
- [ ] Missing error handling
- [ ] Consider revamping the progress in accordance with the 
- [ ] Perform *in-situ* tests to assess performance gains in real life scenarios