### PR TITLE
Introduce a task to compact an index

### DIFF
--- a/crates/dump/src/lib.rs
+++ b/crates/dump/src/lib.rs
@@ -158,6 +158,9 @@ pub enum KindDump {
     UpgradeDatabase {
         from: (u32, u32, u32),
     },
+    CompactIndex {
+        index_uid: String,
+    },
 }
 
 impl From<Task> for TaskDump {
@@ -240,6 +243,7 @@ impl From<KindWithContent> for KindDump {
             KindWithContent::UpgradeDatabase { from: version } => {
                 KindDump::UpgradeDatabase { from: version }
             }
+            KindWithContent::CompactIndex { index_uid } => KindDump::CompactIndex { index_uid },
         }
     }
 }

--- a/crates/index-scheduler/src/dump.rs
+++ b/crates/index-scheduler/src/dump.rs
@@ -234,6 +234,7 @@ impl<'a> Dump<'a> {
                     }
                 }
                 KindDump::UpgradeDatabase { from } => KindWithContent::UpgradeDatabase { from },
+                KindDump::CompactIndex { index_uid } => KindWithContent::CompactIndex { index_uid },
             },
         };
 

--- a/crates/index-scheduler/src/insta_snapshot.rs
+++ b/crates/index-scheduler/src/insta_snapshot.rs
@@ -317,6 +317,9 @@ fn snapshot_details(d: &Details) -> String {
         Details::UpgradeDatabase { from, to } => {
             format!("{{ from: {from:?}, to: {to:?} }}")
         }
+        Details::CompactIndex { index_uid, pre_compaction_size, post_compaction_size } => {
+            format!("{{ index_uid: {index_uid:?}, pre_compaction_size: {pre_compaction_size:?}, post_compaction_size: {post_compaction_size:?} }}")
+        }
     }
 }
 

--- a/crates/index-scheduler/src/scheduler/autobatcher.rs
+++ b/crates/index-scheduler/src/scheduler/autobatcher.rs
@@ -25,6 +25,7 @@ enum AutobatchKind {
     IndexDeletion,
     IndexUpdate,
     IndexSwap,
+    CompactIndex,
 }
 
 impl AutobatchKind {
@@ -68,6 +69,7 @@ impl From<KindWithContent> for AutobatchKind {
             KindWithContent::IndexCreation { .. } => AutobatchKind::IndexCreation,
             KindWithContent::IndexUpdate { .. } => AutobatchKind::IndexUpdate,
             KindWithContent::IndexSwap { .. } => AutobatchKind::IndexSwap,
+            KindWithContent::CompactIndex { .. } => AutobatchKind::CompactIndex,
             KindWithContent::TaskCancelation { .. }
             | KindWithContent::TaskDeletion { .. }
             | KindWithContent::DumpCreation { .. }
@@ -116,6 +118,9 @@ pub enum BatchKind {
         id: TaskId,
     },
     IndexSwap {
+        id: TaskId,
+    },
+    CompactIndex {
         id: TaskId,
     },
 }
@@ -179,6 +184,13 @@ impl BatchKind {
             K::IndexSwap => (
                 Break((
                     BatchKind::IndexSwap { id: task_id },
+                    BatchStopReason::TaskCannotBeBatched { kind, id: task_id },
+                )),
+                false,
+            ),
+            K::CompactIndex => (
+                Break((
+                    BatchKind::CompactIndex { id: task_id },
                     BatchStopReason::TaskCannotBeBatched { kind, id: task_id },
                 )),
                 false,
@@ -287,8 +299,10 @@ impl BatchKind {
         };
 
         match (self, autobatch_kind) {
-            // We don't batch any of these operations  
-            (this, K::IndexCreation | K::IndexUpdate | K::IndexSwap | K::DocumentEdition) => Break((this, BatchStopReason::TaskCannotBeBatched { kind, id })),
+            // We don't batch any of these operations
+            (this, K::IndexCreation | K::IndexUpdate | K::IndexSwap | K::DocumentEdition | K::CompactIndex) => {
+                Break((this, BatchStopReason::TaskCannotBeBatched { kind, id }))
+            },
             // We must not batch tasks that don't have the same index creation rights if the index doesn't already exists.
             (this, kind) if !index_already_exists && this.allow_index_creation() == Some(false) && kind.allow_index_creation() == Some(true) => {
                 Break((this, BatchStopReason::IndexCreationMismatch { id }))
@@ -483,6 +497,7 @@ impl BatchKind {
                 | BatchKind::IndexDeletion { .. }
                 | BatchKind::IndexUpdate { .. }
                 | BatchKind::IndexSwap { .. }
+                | BatchKind::CompactIndex { .. }
                 | BatchKind::DocumentEdition { .. },
                 _,
             ) => {

--- a/crates/index-scheduler/src/scheduler/create_batch.rs
+++ b/crates/index-scheduler/src/scheduler/create_batch.rs
@@ -55,6 +55,10 @@ pub(crate) enum Batch {
     UpgradeDatabase {
         tasks: Vec<Task>,
     },
+    CompactIndex {
+        index_uid: String,
+        task: Task,
+    },
 }
 
 #[derive(Debug)]
@@ -110,7 +114,8 @@ impl Batch {
             | Batch::Dump(task)
             | Batch::IndexCreation { task, .. }
             | Batch::Export { task }
-            | Batch::IndexUpdate { task, .. } => {
+            | Batch::IndexUpdate { task, .. }
+            | Batch::CompactIndex { task, .. } => {
                 RoaringBitmap::from_sorted_iter(std::iter::once(task.uid)).unwrap()
             }
             Batch::SnapshotCreation(tasks)
@@ -155,7 +160,8 @@ impl Batch {
             IndexOperation { op, .. } => Some(op.index_uid()),
             IndexCreation { index_uid, .. }
             | IndexUpdate { index_uid, .. }
-            | IndexDeletion { index_uid, .. } => Some(index_uid),
+            | IndexDeletion { index_uid, .. }
+            | CompactIndex { index_uid, .. } => Some(index_uid),
         }
     }
 }
@@ -175,6 +181,7 @@ impl fmt::Display for Batch {
             Batch::IndexUpdate { .. } => f.write_str("IndexUpdate")?,
             Batch::IndexDeletion { .. } => f.write_str("IndexDeletion")?,
             Batch::IndexSwap { .. } => f.write_str("IndexSwap")?,
+            Batch::CompactIndex { .. } => f.write_str("CompactIndex")?,
             Batch::Export { .. } => f.write_str("Export")?,
             Batch::UpgradeDatabase { .. } => f.write_str("UpgradeDatabase")?,
         };
@@ -429,6 +436,12 @@ impl IndexScheduler {
                     self.queue.tasks.get_task(rtxn, id)?.ok_or(Error::CorruptedTaskQueue)?;
                 current_batch.processing(Some(&mut task));
                 Ok(Some(Batch::IndexSwap { task }))
+            }
+            BatchKind::CompactIndex { id } => {
+                let mut task =
+                    self.queue.tasks.get_task(rtxn, id)?.ok_or(Error::CorruptedTaskQueue)?;
+                current_batch.processing(Some(&mut task));
+                Ok(Some(Batch::CompactIndex { index_uid, task }))
             }
         }
     }

--- a/crates/index-scheduler/src/scheduler/process_batch.rs
+++ b/crates/index-scheduler/src/scheduler/process_batch.rs
@@ -418,6 +418,9 @@ impl IndexScheduler {
                 task.status = Status::Succeeded;
                 Ok((vec![task], ProcessBatchInfo::default()))
             }
+            Batch::CompactIndex { index_uid, mut task } => {
+                todo!("Implement compact index")
+            }
             Batch::Export { mut task } => {
                 let KindWithContent::Export { url, api_key, payload_size, indexes } = &task.kind
                 else {

--- a/crates/index-scheduler/src/utils.rs
+++ b/crates/index-scheduler/src/utils.rs
@@ -256,14 +256,15 @@ pub fn swap_index_uid_in_task(task: &mut Task, swap: (&str, &str)) {
     use KindWithContent as K;
     let mut index_uids = vec![];
     match &mut task.kind {
-        K::DocumentAdditionOrUpdate { index_uid, .. } => index_uids.push(index_uid),
-        K::DocumentEdition { index_uid, .. } => index_uids.push(index_uid),
-        K::DocumentDeletion { index_uid, .. } => index_uids.push(index_uid),
-        K::DocumentDeletionByFilter { index_uid, .. } => index_uids.push(index_uid),
-        K::DocumentClear { index_uid } => index_uids.push(index_uid),
-        K::SettingsUpdate { index_uid, .. } => index_uids.push(index_uid),
-        K::IndexDeletion { index_uid } => index_uids.push(index_uid),
-        K::IndexCreation { index_uid, .. } => index_uids.push(index_uid),
+        K::DocumentAdditionOrUpdate { index_uid, .. }
+        | K::DocumentEdition { index_uid, .. }
+        | K::DocumentDeletion { index_uid, .. }
+        | K::DocumentDeletionByFilter { index_uid, .. }
+        | K::DocumentClear { index_uid }
+        | K::SettingsUpdate { index_uid, .. }
+        | K::IndexDeletion { index_uid }
+        | K::IndexCreation { index_uid, .. }
+        | K::CompactIndex { index_uid, .. } => index_uids.push(index_uid),
         K::IndexUpdate { index_uid, new_index_uid, .. } => {
             index_uids.push(index_uid);
             if let Some(new_uid) = new_index_uid {
@@ -617,6 +618,13 @@ impl crate::IndexScheduler {
                     }
                     Details::UpgradeDatabase { from: _, to: _ } => {
                         assert_eq!(kind.as_kind(), Kind::UpgradeDatabase);
+                    }
+                    Details::CompactIndex {
+                        index_uid: _,
+                        pre_compaction_size: _,
+                        post_compaction_size: _,
+                    } => {
+                        assert_eq!(kind.as_kind(), Kind::CompactIndex);
                     }
                 }
             }

--- a/crates/meilisearch-auth/src/store.rs
+++ b/crates/meilisearch-auth/src/store.rs
@@ -109,6 +109,7 @@ impl HeedAuthStore {
                             Action::IndexesGet,
                             Action::IndexesUpdate,
                             Action::IndexesSwap,
+                            Action::IndexesCompact,
                         ]
                         .iter(),
                     );

--- a/crates/meilisearch-types/src/keys.rs
+++ b/crates/meilisearch-types/src/keys.rs
@@ -380,6 +380,9 @@ pub enum Action {
     #[serde(rename = "webhooks.*")]
     #[deserr(rename = "webhooks.*")]
     WebhooksAll,
+    #[serde(rename = "indexes.compact")]
+    #[deserr(rename = "indexes.compact")]
+    IndexesCompact,
 }
 
 impl Action {
@@ -398,6 +401,7 @@ impl Action {
             INDEXES_UPDATE => Some(Self::IndexesUpdate),
             INDEXES_DELETE => Some(Self::IndexesDelete),
             INDEXES_SWAP => Some(Self::IndexesSwap),
+            INDEXES_COMPACT => Some(Self::IndexesCompact),
             TASKS_ALL => Some(Self::TasksAll),
             TASKS_CANCEL => Some(Self::TasksCancel),
             TASKS_DELETE => Some(Self::TasksDelete),
@@ -462,6 +466,7 @@ impl Action {
             IndexesUpdate => false,
             IndexesDelete => false,
             IndexesSwap => false,
+            IndexesCompact => false,
             TasksCancel => false,
             TasksDelete => false,
             TasksGet => true,
@@ -513,6 +518,7 @@ pub mod actions {
     pub const INDEXES_UPDATE: u8 = IndexesUpdate.repr();
     pub const INDEXES_DELETE: u8 = IndexesDelete.repr();
     pub const INDEXES_SWAP: u8 = IndexesSwap.repr();
+    pub const INDEXES_COMPACT: u8 = IndexesCompact.repr();
     pub const TASKS_ALL: u8 = TasksAll.repr();
     pub const TASKS_CANCEL: u8 = TasksCancel.repr();
     pub const TASKS_DELETE: u8 = TasksDelete.repr();
@@ -614,6 +620,7 @@ pub(crate) mod test {
         assert!(WebhooksDelete.repr() == 47 && WEBHOOKS_DELETE == 47);
         assert!(WebhooksCreate.repr() == 48 && WEBHOOKS_CREATE == 48);
         assert!(WebhooksAll.repr() == 49 && WEBHOOKS_ALL == 49);
+        assert!(IndexesCompact.repr() == 50 && INDEXES_COMPACT == 50);
     }
 
     #[test]

--- a/crates/meilisearch-types/src/task_view.rs
+++ b/crates/meilisearch-types/src/task_view.rs
@@ -142,6 +142,11 @@ pub struct DetailsView {
     pub old_index_uid: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub new_index_uid: Option<String>,
+    // index compaction
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pre_compaction_size: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub post_compaction_size: Option<String>,
 }
 
 impl DetailsView {
@@ -314,6 +319,24 @@ impl DetailsView {
                 // We should never be able to batch multiple renames at the same time.
                 (Some(left), Some(_right)) => Some(left),
             },
+            pre_compaction_size: match (
+                self.pre_compaction_size.clone(),
+                other.pre_compaction_size.clone(),
+            ) {
+                (None, None) => None,
+                (None, Some(size)) | (Some(size), None) => Some(size),
+                // We should never be able to batch multiple renames at the same time.
+                (Some(left), Some(_right)) => Some(left),
+            },
+            post_compaction_size: match (
+                self.post_compaction_size.clone(),
+                other.post_compaction_size.clone(),
+            ) {
+                (None, None) => None,
+                (None, Some(size)) | (Some(size), None) => Some(size),
+                // We should never be able to batch multiple renames at the same time.
+                (Some(left), Some(_right)) => Some(left),
+            },
         }
     }
 }
@@ -415,6 +438,15 @@ impl From<Details> for DetailsView {
                 upgrade_to: Some(format!("v{}.{}.{}", to.0, to.1, to.2)),
                 ..Default::default()
             },
+            Details::CompactIndex { pre_compaction_size, post_compaction_size, .. } => {
+                DetailsView {
+                    pre_compaction_size: pre_compaction_size
+                        .map(|size| size.get_appropriate_unit(UnitType::Both).to_string()),
+                    post_compaction_size: post_compaction_size
+                        .map(|size| size.get_appropriate_unit(UnitType::Both).to_string()),
+                    ..Default::default()
+                }
+            }
         }
     }
 }

--- a/crates/meilisearch/src/routes/indexes/compact.rs
+++ b/crates/meilisearch/src/routes/indexes/compact.rs
@@ -1,0 +1,100 @@
+use actix_web::web::{self, Data};
+use actix_web::{HttpRequest, HttpResponse};
+use index_scheduler::IndexScheduler;
+use meilisearch_types::error::ResponseError;
+use meilisearch_types::index_uid::IndexUid;
+use meilisearch_types::keys::actions;
+use meilisearch_types::tasks::KindWithContent;
+use serde::Serialize;
+use tracing::debug;
+use utoipa::OpenApi;
+
+use super::ActionPolicy;
+use crate::analytics::{Aggregate, Analytics};
+use crate::extractors::authentication::GuardedData;
+use crate::extractors::sequential_extractor::SeqHandler;
+use crate::routes::SummarizedTaskView;
+
+#[derive(OpenApi)]
+#[openapi(
+    paths(compact),
+    tags(
+        (
+            name = "Compact an index",
+            description = "The /compact route uses compacts the database to reoganize and make it smaller and more efficient.",
+            external_docs(url = "https://www.meilisearch.com/docs/reference/api/compact"),
+        ),
+    ),
+)]
+pub struct CompactApi;
+
+pub fn configure(cfg: &mut web::ServiceConfig) {
+    cfg.service(web::resource("").route(web::post().to(SeqHandler(compact))));
+}
+
+/// Compact an index
+#[utoipa::path(
+    post,
+    path = "{indexUid}/compact",
+    tag = "Compact an index",
+    security(("Bearer" = ["search", "*"])),
+    params(("indexUid" = String, Path, example = "movies", description = "Index Unique Identifier", nullable = false)),
+    responses(
+        (status = ACCEPTED, description = "Task successfully enqueued", body = SummarizedTaskView, content_type = "application/json", example = json!(
+            {
+                "taskUid": 147,
+                "indexUid": null,
+                "status": "enqueued",
+                "type": "documentDeletion",
+                "enqueuedAt": "2024-08-08T17:05:55.791772Z"
+            }
+        )),
+        (status = 401, description = "The authorization header is missing", body = ResponseError, content_type = "application/json", example = json!(
+            {
+                "message": "The Authorization header is missing. It must use the bearer authorization method.",
+                "code": "missing_authorization_header",
+                "type": "auth",
+                "link": "https://docs.meilisearch.com/errors#missing_authorization_header"
+            }
+        )),
+    )
+)]
+pub async fn compact(
+    index_scheduler: GuardedData<ActionPolicy<{ actions::INDEXES_COMPACT }>, Data<IndexScheduler>>,
+    index_uid: web::Path<String>,
+    req: HttpRequest,
+    analytics: web::Data<Analytics>,
+) -> Result<HttpResponse, ResponseError> {
+    let index_uid = IndexUid::try_from(index_uid.into_inner())?;
+
+    analytics.publish(IndexesCompactAggregator, &req);
+
+    let task = KindWithContent::CompactIndex { index_uid: index_uid.to_string() };
+    let task =
+        match tokio::task::spawn_blocking(move || index_scheduler.register(task, None, false))
+            .await?
+        {
+            Ok(task) => task,
+            Err(e) => return Err(e.into()),
+        };
+
+    debug!(returns = ?task, "Compact the {index_uid} index");
+    Ok(HttpResponse::Accepted().json(SummarizedTaskView::from(task)))
+}
+
+#[derive(Serialize)]
+pub struct IndexesCompactAggregator;
+
+impl Aggregate for IndexesCompactAggregator {
+    fn event_name(&self) -> &'static str {
+        "Indexes Compacted"
+    }
+
+    fn aggregate(self: Box<Self>, _new: Box<Self>) -> Box<Self> {
+        Box::new(Self)
+    }
+
+    fn into_event(self: Box<Self>) -> serde_json::Value {
+        serde_json::to_value(*self).unwrap_or_default()
+    }
+}

--- a/crates/meilisearch/src/routes/indexes/mod.rs
+++ b/crates/meilisearch/src/routes/indexes/mod.rs
@@ -28,6 +28,7 @@ use crate::extractors::sequential_extractor::SeqHandler;
 use crate::routes::is_dry_run;
 use crate::Opt;
 
+pub mod compact;
 pub mod documents;
 mod enterprise_edition;
 pub mod facet_search;
@@ -49,8 +50,9 @@ pub use enterprise_edition::proxy::{PROXY_ORIGIN_REMOTE_HEADER, PROXY_ORIGIN_TAS
         (path = "/", api = facet_search::FacetSearchApi),
         (path = "/", api = similar::SimilarApi),
         (path = "/", api = settings::SettingsApi),
+        (path = "/", api = compact::CompactApi),
     ),
-    paths(list_indexes, create_index, get_index, update_index, delete_index, get_index_stats),
+    paths(list_indexes, create_index, get_index, update_index, delete_index, get_index_stats, compact::compact),
     tags(
         (
             name = "Indexes",
@@ -80,7 +82,8 @@ pub fn configure(cfg: &mut web::ServiceConfig) {
             .service(web::scope("/search").configure(search::configure))
             .service(web::scope("/facet-search").configure(facet_search::configure))
             .service(web::scope("/similar").configure(similar::configure))
-            .service(web::scope("/settings").configure(settings::configure)),
+            .service(web::scope("/settings").configure(settings::configure))
+            .service(web::scope("/compact").configure(compact::configure)),
     );
 }
 


### PR DESCRIPTION
This PR introduces a new method for compacting an index. We have observed significant performance improvements in production and aim to integrate this functionality upstream. In the following screenshot, the compaction was performed at the cursor.

<img width="1141" height="877" alt="Capture d’écran 2025-10-02 à 15 05 41" src="https://github.com/user-attachments/assets/20ea8f90-6302-47a8-a5e9-706c58eb98b1" />
