### PR TITLE
Update from Alpine 3.20 to 3.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Compile
-FROM    rust:1.89-alpine3.20 AS compiler
+FROM    rust:1.89-alpine3.21 AS compiler
 
 RUN     apk add -q --no-cache build-base openssl-dev
 
@@ -20,7 +20,7 @@ RUN     set -eux; \
         cargo build --release -p meilisearch -p meilitool
 
 # Run
-FROM    alpine:3.20
+FROM    alpine:3.21
 LABEL   org.opencontainers.image.source="https://github.com/meilisearch/meilisearch"
 
 ENV     MEILI_HTTP_ADDR 0.0.0.0:7700


### PR DESCRIPTION
Replaces: https://github.com/meilisearch/meilisearch/pull/5866

⚠️ Possible to test with prototype-v1.22.1.docker-alpine-3.21