### PR TITLE
Fix search failing when using `attributesToSearchOn` on an empty index

### DIFF
--- a/crates/milli/src/search/new/mod.rs
+++ b/crates/milli/src/search/new/mod.rs
@@ -176,8 +176,15 @@ impl<'ctx> SearchContext<'ctx> {
                 Some((_name, fid, weight)) => (*fid, *weight),
                 // The field is not searchable but the user didn't define any searchable attributes
                 None if user_defined_searchable.is_none() => continue,
-                // The field is not searchable => User error
+                // The field is not searchable
                 None => {
+                    // field exists in user settings
+                    if let Some(defined_searchable) = &user_defined_searchable {
+                        if defined_searchable.iter().any(|s| s == field_name) {
+                            continue;
+                        }
+                    }
+                    // field does not exist in user settings => user error
                     let (valid_fields, hidden_fields) = self.index.remove_hidden_fields(
                         self.txn,
                         searchable_fields_weights.iter().map(|(name, _, _)| name),


### PR DESCRIPTION
## Related issue

Fixes #5921 

## Description

Previously, search gave an error when the internal state was not yet complete and the attribute was not found. 
This shouldn't give an error if the attribute was present in the searchableAttributes.

Additional check was added to make sure that we don't give an error if the attribute was present in the user settings
