### PR TITLE
Support full or sharded replication

### DIFF
--- a/crates/meilisearch/src/routes/indexes/documents.rs
+++ b/crates/meilisearch/src/routes/indexes/documents.rs
@@ -362,7 +362,7 @@ pub async fn delete_document(
         tokio::task::spawn_blocking(move || index_scheduler.register(task, uid, dry_run)).await??
     };
 
-    if network.remotes.len() > 0 && !dry_run {
+    if !network.remotes.is_empty() && !dry_run {
         proxy(&index_scheduler, &index_uid, &req, network, Body::none(), &task).await?;
     }
 
@@ -1075,7 +1075,7 @@ async fn document_addition(
         }
     };
 
-    if network.remotes.len() > 0 {
+    if !network.remotes.is_empty() {
         if let Some(file) = file {
             proxy(
                 &index_scheduler,
@@ -1193,7 +1193,7 @@ pub async fn delete_documents_batch(
         tokio::task::spawn_blocking(move || index_scheduler.register(task, uid, dry_run)).await??
     };
 
-    if network.remotes.len() > 0 && !dry_run {
+    if !network.remotes.is_empty() && !dry_run {
         proxy(&index_scheduler, &index_uid, &req, network, Body::Inline(body), &task).await?;
     }
 
@@ -1285,7 +1285,7 @@ pub async fn delete_documents_by_filter(
         tokio::task::spawn_blocking(move || index_scheduler.register(task, uid, dry_run)).await??
     };
 
-    if network.remotes.len() > 0 && !dry_run {
+    if !network.remotes.is_empty() && !dry_run {
         proxy(&index_scheduler, &index_uid, &req, network, Body::Inline(filter), &task).await?;
     }
 
@@ -1435,7 +1435,7 @@ pub async fn edit_documents_by_function(
         tokio::task::spawn_blocking(move || index_scheduler.register(task, uid, dry_run)).await??
     };
 
-    if network.remotes.len() > 0 && !dry_run {
+    if !network.remotes.is_empty() && !dry_run {
         proxy(&index_scheduler, &index_uid, &req, network, Body::Inline(params), &task).await?;
     }
 
@@ -1504,7 +1504,7 @@ pub async fn clear_all_documents(
         tokio::task::spawn_blocking(move || index_scheduler.register(task, uid, dry_run)).await??
     };
 
-    if network.remotes.len() > 0 && !dry_run {
+    if !network.remotes.is_empty() && !dry_run {
         proxy(&index_scheduler, &index_uid, &req, network, Body::none(), &task).await?;
     }
 

--- a/crates/meilisearch/src/routes/indexes/mod.rs
+++ b/crates/meilisearch/src/routes/indexes/mod.rs
@@ -287,7 +287,7 @@ pub async fn create_index(
 
         // ensure index is created on all remotes
         let network = index_scheduler.network();
-        if network.remotes.len() > 0 && !dry_run {
+        if !network.remotes.is_empty() && !dry_run {
             let create_request = IndexCreateRequest { primary_key, uid: uid.clone() };
             proxy(&index_scheduler, &uid, &req, network, Body::Inline(create_request), &task).await?;
         }


### PR DESCRIPTION
## Related issue

Fixes #3494

## Description

Using the network sharding feature results in the data being distributed over the nodes using the [must_process](https://github.com/meilisearch/meilisearch/blob/c45172a4bf2eb514856c597f213fa0a19904632f/crates/milli/src/update/new/indexer/enterprise_edition/sharding.rs#L14) check and this results in performance gains. However, it comes at the cost of multipoint failure resilience, i.e. if either node fails, the data becomes inconsistent.

In setups where it is preferable to have full replicas, we should allow for full replication configurations. This PR modifies the check for when to replicate data to only condition on when there are remotes configured. Although it maintains the sharding logic, allowing for both fully or sharded replication configurations.

## Requirements

⚠️ Ensure the following requirements before merging ⚠️
- [ ] Automated tests have been added.
- [ ] If some tests cannot be automated, manual rigorous tests should be applied.
- [ ] ⚠️ If there is any change in the DB: 
    - [ ] Test that any impacted DB still works as expected after using `--experimental-dumpless-upgrade` on a DB created with the last released Meilisearch
    - [ ] Test that during the upgrade, **search is still available** (artificially make the upgrade longer if needed)
    - [ ] Set the `db change` label.
- [ ] If necessary, the feature have been tested in the Cloud production environment (with [prototypes](./documentation/prototypes.md)) and the Cloud UI is ready.
- [ ] If necessary, the [documentation](https://github.com/meilisearch/documentation) related to the implemented feature in the PR is ready.
- [ ] If necessary, the [integrations](https://github.com/meilisearch/integration-guides) related to the implemented feature in the PR are ready.
