### PR TITLE
Fix the LMDB fork memory leak

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2838,9 +2838,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "heed"
-version = "0.22.1-nested-rtxns"
+version = "0.22.1-nested-rtxns-6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ff115ba5712b1f1fc7617b195f5c2f139e29c397ff79da040cd19db75ccc240"
+checksum = "c69e07cd539834bedcfa938f3d7d8520cce1ad2b0776c122b5ccdf8fd5bafe12"
 dependencies = [
  "bitflags 2.9.4",
  "byteorder",
@@ -3888,9 +3888,9 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lmdb-master-sys"
-version = "0.2.6-nested-rtxns"
+version = "0.2.6-nested-rtxns-6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ff85130e3c994b36877045fbbb138d521dea7197bfc19dc3d5d95101a8e20a"
+checksum = "e113d9bf240f974fbe7fd516cbfd8c422e925c0655495501c7237548425493d0"
 dependencies = [
  "cc",
  "doxygen-rs",

--- a/crates/milli/Cargo.toml
+++ b/crates/milli/Cargo.toml
@@ -34,7 +34,7 @@ grenad = { version = "0.5.0", default-features = false, features = [
     "rayon",
     "tempfile",
 ] }
-heed = { version = "0.22.1-nested-rtxns", default-features = false, features = [
+heed = { version = "0.22.1-nested-rtxns-6", default-features = false, features = [
     "serde-json",
     "serde-bincode",
 ] }


### PR DESCRIPTION
This PR fixes the memory leak introduced in our patched version of LMDB. Please review [the LMDB PR](https://github.com/meilisearch/lmdb/pull/3) and [the heed PR](https://github.com/meilisearch/heed/pull/307), where the majority of the work was done.