### PR TITLE
Fix ssl failure with local certificates

### DIFF
--- a/crates/meilisearch/src/option.rs
+++ b/crates/meilisearch/src/option.rs
@@ -707,9 +707,13 @@ impl Opt {
             let certs = load_certs(cert_path.to_path_buf())?;
             let privkey = load_private_key(key_path.to_path_buf())?;
             let ocsp = load_ocsp(&self.ssl_ocsp_path)?;
-            let mut config = config
-                .with_single_cert_with_ocsp(certs, privkey, ocsp)
-                .map_err(|_| anyhow::anyhow!("bad certificates/private key"))?;
+
+            let mut config = (if ocsp.is_empty() {
+                config.with_single_cert(certs, privkey)
+            } else {
+                config.with_single_cert_with_ocsp(certs, privkey, ocsp)
+            })
+            .map_err(|_| anyhow::anyhow!("bad certificates/private key"))?;
 
             config.key_log = Arc::new(rustls::KeyLogFile::new());
 


### PR DESCRIPTION
## Related issue

Fixes #5696

This is a quickfix around a regression bug from rustls. The issue is that empty `ocsp`  are not ignored which should be the correct behaviour from rustls docs.
An actual [fix](https://github.com/rustls/rustls/pull/2733) in rustls has been merged. 

The workaround is so simple that I made this PR but I let Meilisearch team decides if they prefer to merge it
or wait for the fix in rustls to reach meilisearch codebase.