### PR TITLE
Fix error that rust-analyzer reports because it is compiling all code with the `test` cfg

### DIFF
--- a/crates/index-scheduler/src/test_utils.rs
+++ b/crates/index-scheduler/src/test_utils.rs
@@ -126,7 +126,7 @@ impl IndexScheduler {
         std::fs::create_dir_all(&options.auth_path).unwrap();
         let auth_env = open_auth_store_env(&options.auth_path).unwrap();
         let index_scheduler =
-            Self::new(options, auth_env, version, None, sender, planned_failures).unwrap();
+            Self::new_test(options, auth_env, version, None, sender, planned_failures).unwrap();
 
         // To be 100% consistent between all test we're going to start the scheduler right now
         // and ensure it's in the expected starting state.


### PR DESCRIPTION
If using rust-analyzer, you might have noticed false positives in terms of reported errors:

<img width="1348" height="560" alt="Capture d’écran 2025-11-06 à 18 20 10" src="https://github.com/user-attachments/assets/7bd2cf1c-d308-445d-aa22-543947209f90" />


The cause was that `IndexScheduler::new` has a different signature (4 or 6 arguments) depending on whether the cfg is `test` or not.

Rust analyzer compiles all code with the `test` configuration, causing the non-test code to error on missing arguments.

This PR solves this small hurdle by separating the constructors for index scheduler between the test and non-test variant, and calling the test one in test contexts.

As much as the code as possible was factored between both constructors, although one must note that a tiny bit of duplication was introduced (calling `IndexScheduler::run`) on the created index scheduler) and the test parameters are set using mutation.