### PR TITLE
Fix the Document Fetch pagination bug when Sort is applied

### DIFF
--- a/crates/milli/src/documents/sort.rs
+++ b/crates/milli/src/documents/sort.rs
@@ -108,7 +108,7 @@ impl Iterator for SortedDocumentsIterator<'_> {
                 continue;
             } else {
                 // The current iterator is large enough, so we can forward the call to it.
-                return inner.nth(to_skip + 1);
+                return inner.nth(to_skip);
             }
         }
 


### PR DESCRIPTION
The last document of the previous page was duplicated as the first document of the current page. This was due to a bug in the custom nth function of the sort ranking rule, skipping `n-1` documents instead of `n`.

## Related issue

Fixes #5998
Fixes #5992
Fixes #5943
