### PR TITLE
Update charabia v0.9.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1132,9 +1132,9 @@ dependencies = [
 
 [[package]]
 name = "charabia"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbdc8cd8f999e8b8b13ed71d30962bbf98cf39e2f2a9f1ae1ba354199239d66e"
+checksum = "51689ee7cc84c8de789fc2874711d816055b93406cfd4135c40d1c82dd24b928"
 dependencies = [
  "aho-corasick",
  "csv",

--- a/crates/milli/Cargo.toml
+++ b/crates/milli/Cargo.toml
@@ -18,7 +18,7 @@ bincode = "1.3.3"
 bstr = "1.12.0"
 bytemuck = { version = "1.23.1", features = ["extern_crate_alloc"] }
 byteorder = "1.5.0"
-charabia = { version = "0.9.8", default-features = false }
+charabia = { version = "0.9.9", default-features = false }
 cellulite = "0.3.1-nested-rtxns-2"
 concat-arrays = "0.1.2"
 convert_case = "0.8.0"


### PR DESCRIPTION
## Related issue

Charabia v0.9.9 introduces a better word segmentation for Thai, Khmer, and German languages

```
Before: "Feuchteschutz" -> ["Feuchteschutz"]
After: "Feuchteschutz" -> ["Feuchte", "schutz"]

Before: "insgesamt" -> ["insgesamt"]
After: "insgesamt" -> ["ins", "gesamt"]
```
