### PR TITLE
Remove version from the name of the test job in CI

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   test-linux:
-    name: Tests on ubuntu-24.04
+    name: Tests on Ubuntu
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:


### PR DESCRIPTION
## Pull Request

Since we can change rule sets for requirements on PRs, we might as well remove the version from Ubuntu, which can be incorrect when we upgrade (it's currently the ubuntu-22.04 container with glibc2.35, running on a Ubuntu 24.04 VM).