### PR TITLE
Fix sort on /documents endpoint when field has no values

### DIFF
--- a/crates/meilisearch/tests/documents/get_documents.rs
+++ b/crates/meilisearch/tests/documents/get_documents.rs
@@ -1602,4 +1602,3 @@ async fn get_document_sort_desc_includes_docs_without_field() {
     }
     "###);
 }
-

--- a/crates/milli/src/documents/sort.rs
+++ b/crates/milli/src/documents/sort.rs
@@ -258,8 +258,7 @@ impl<'ctx> SortedDocumentsIteratorBuilder<'ctx> {
         } else {
             let number_iter =
                 descending_facet_sort(rtxn, number_db, field_id, faceted_candidates.clone())?;
-            let string_iter =
-                descending_facet_sort(rtxn, string_db, field_id, faceted_candidates)?;
+            let string_iter = descending_facet_sort(rtxn, string_db, field_id, faceted_candidates)?;
 
             (itertools::Either::Right(number_iter), itertools::Either::Right(string_iter))
         };


### PR DESCRIPTION
## Related issue

Fixes #5998
Fixes #5992

## What does this PR do?

Fixes two bugs when sorting documents via `/documents` and `/documents/fetch` endpoints:

1. Sorting failed with error "Attribute `X` is not sortable. Available sortable attributes are: `X`" when no document had ever contained the sortable field
2. Documents without the sortable field were excluded from results

## Changes

- Modified `recursive_sort()` to skip sort criteria for fields in settings but not yet in any document (instead of erroring)
- Modified `build_facet()` to include documents without the facet field at the end of results (following existing `build_geo()` pattern)
- Added tests for both scenarios

## Requirements

⚠️ Ensure the following requirements before merging ⚠️
- [x] Automated tests have been added.
- [x] If some tests cannot be automated, manual rigorous tests should be applied.
- [ ] ⚠️ If there is any change in the DB: 
    - [ ] Test that any impacted DB still works as expected after using `--experimental-dumpless-upgrade` on a DB created with the last released Meilisearch
    - [ ] Test that during the upgrade, **search is still available** (artificially make the upgrade longer if needed)
    - [ ] Set the `db change` label.
- [x] If necessary, the feature have been tested in the Cloud production environment (with prototypes) and the Cloud UI is ready.
- [x] If necessary, the [documentation](https://github.com/meilisearch/documentation) related to the implemented feature in the PR is ready.
- [x] If necessary, the [integrations](https://github.com/meilisearch/integration-guides) related to the implemented feature in the PR are ready.