### PR TITLE
Add support for XLM Roberta models

### DIFF
--- a/crates/meilisearch-types/src/network.rs
+++ b/crates/meilisearch-types/src/network.rs
@@ -1,5 +1,6 @@
-use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
 #[serde(rename_all = "camelCase")]

--- a/crates/meilisearch/tests/vector/huggingface.rs
+++ b/crates/meilisearch/tests/vector/huggingface.rs
@@ -1,6 +1,7 @@
+use meili_snap::snapshot;
+
 use crate::common::{GetAllDocumentsOptions, Server};
 use crate::json;
-use meili_snap::snapshot;
 
 #[actix_rt::test]
 async fn hf_bge_m3_force_cls_settings() {
@@ -25,7 +26,8 @@ async fn hf_bge_m3_force_cls_settings() {
     server.wait_task(response.uid()).await.succeeded();
 
     // Try to embed one simple document
-    let (task, code) = index.add_documents(json!([{ "id": 1, "title": "Hello world" }]), None).await;
+    let (task, code) =
+        index.add_documents(json!([{ "id": 1, "title": "Hello world" }]), None).await;
     snapshot!(code, @"202 Accepted");
     server.wait_task(task.uid()).await.succeeded();
 

--- a/crates/meilisearch/tests/vector/mod.rs
+++ b/crates/meilisearch/tests/vector/mod.rs
@@ -1,11 +1,11 @@
 mod binary_quantized;
 mod fragments;
+mod huggingface;
 #[cfg(feature = "test-ollama")]
 mod ollama;
 mod openai;
 mod rest;
 mod settings;
-mod huggingface;
 
 use std::collections::HashMap;
 use std::str::FromStr;

--- a/crates/milli/src/vector/embedder/hf.rs
+++ b/crates/milli/src/vector/embedder/hf.rs
@@ -344,15 +344,14 @@ impl Embedder {
             })?;
             ModelKind::Modern(ModernBert::load(vb, &config).map_err(NewEmbedderError::load_model)?)
         } else if is_xlm_roberta {
-            let config: XlmRobertaConfig =
-                serde_json::from_str(&config_str).map_err(|inner| {
-                    NewEmbedderError::deserialize_config(
-                        options.model.clone(),
-                        config_str.clone(),
-                        config_filename.clone(),
-                        inner,
-                    )
-                })?;
+            let config: XlmRobertaConfig = serde_json::from_str(&config_str).map_err(|inner| {
+                NewEmbedderError::deserialize_config(
+                    options.model.clone(),
+                    config_str.clone(),
+                    config_filename.clone(),
+                    inner,
+                )
+            })?;
             ModelKind::XlmRoberta(
                 XLMRobertaModel::new(&config, vb).map_err(NewEmbedderError::load_model)?,
             )


### PR DESCRIPTION
## Related issue
I conducted numerous tests using the Meilisearch Composite embedder at scale on Meilisearch Cloud, and the results seem promising. However, we are currently limited in the models we can embed. To complete my test on the composite embedder for Meilisearch Cloud, I would need to be able to use not only BERT or ModernBert models but also XLM-Roberta-based models. My target is to use [baai/bge-m3 ](https://huggingface.co/BAAI/bge-m3) model. 

I added the test, tried locally, and it should work. However, the test needs to load the BGE-M3 model, and that seems like an exaggeration to do it every time we need to do a test. Should we remove this from the default tests? 

This involves no changes in the DB. 

## Requirements

⚠️ Ensure the following requirements before merging ⚠️
- [x] Automated tests have been added.
- [x] If some tests cannot be automated, manual rigorous tests should be applied.
- [x] ⚠️ If there is any change in the DB: 
    - [] Test that any impacted DB still works as expected after using `--experimental-dumpless-upgrade` on a DB created with the last released Meilisearch
    - [ ] Test that during the upgrade, **search is still available** (artificially make the upgrade longer if needed)
    - [ ] Set the `db change` label.
- [ ] If necessary, the feature have been tested in the Cloud production environment (with [prototypes](./documentation/prototypes.md)) and the Cloud UI is ready.
- [ ] If necessary, the [documentation](https://github.com/meilisearch/documentation) related to the implemented feature in the PR is ready.
- [ ] If necessary, the [integrations](https://github.com/meilisearch/integration-guides) related to the implemented feature in the PR are ready.
