### PR TITLE
Skip the macOS and Windows CI in the merge queue

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -53,6 +53,7 @@ jobs:
       matrix:
         os: [macos-14, windows-2022]
         features: ["", "--features enterprise"]
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v5
       - name: Cache dependencies


### PR DESCRIPTION
This PR is a quality-of-life improvement that removes macOS and Windows CI from the merge queue, as they are already tested in the pull request and in a scheduled job every day. We are currently only concerned with the Ubuntu ones.