### PR TITLE
Bump hannoy to v0.1.0-nested-rtxns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2711,9 +2711,9 @@ dependencies = [
 
 [[package]]
 name = "hannoy"
-version = "0.0.9-nested-rtxns-2"
+version = "0.1.0-nested-rtxns"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06eda090938d9dcd568c8c2a5de383047ed9191578ebf4a342d2975d16e621f2"
+checksum = "be82bf3f2108ddc8885e3d306fcd7f4692066bfe26065ca8b42ba417f3c26dd1"
 dependencies = [
  "bytemuck",
  "byteorder",

--- a/crates/milli/Cargo.toml
+++ b/crates/milli/Cargo.toml
@@ -91,7 +91,7 @@ rhai = { version = "1.23.6", features = [
     "sync",
 ] }
 arroy = "0.6.4-nested-rtxns"
-hannoy = { version = "0.0.9-nested-rtxns-2", features = ["arroy"] }
+hannoy = { version = "0.1.0-nested-rtxns", features = ["arroy"] }
 rand = "0.8.5"
 tracing = "0.1.41"
 ureq = { version = "2.12.1", features = ["json"] }


### PR DESCRIPTION
This PR bumps hannoy to [v0.1.0-nested-rtxns](https://github.com/nnethercott/hannoy/releases/tag/v0.1.0-nested-rtxns), a special Meilisearch version that is based on v0.1.0 and fixes [a potentially highly impactful bug](https://github.com/nnethercott/hannoy/pull/110) (necessitating a full reindex).