### PR TITLE
Fix macos-amd64 compilation

### DIFF
--- a/crates/xtask/src/common/instance/release.rs
+++ b/crates/xtask/src/common/instance/release.rs
@@ -178,6 +178,7 @@ pub fn get_arch() -> anyhow::Result<&'static str> {
     #[cfg(not(all(target_os = "linux", target_arch = "aarch64")))]
     #[cfg(not(all(target_os = "linux", target_arch = "x86_64")))]
     #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+    #[cfg(not(all(target_os = "macos", target_arch = "x86_64")))]
     anyhow::bail!("unsupported platform")
 }
 


### PR DESCRIPTION
Asset publication was broken in v1.29.0 for macos-amd64 (the more recent macos-aarch64 is fine, though).

This PR fixes the compilation issue that caused the publication failure.

## Tests

- [x] [Dry run of the publish assets workflow](https://github.com/meilisearch/meilisearch/actions/runs/20027977525/job/57429789916) that should be green