### PR TITLE
Check LMDB-patch with mutexes works well

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2790,8 +2790,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "heed"
 version = "0.22.1-nested-rtxns-6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c69e07cd539834bedcfa938f3d7d8520cce1ad2b0776c122b5ccdf8fd5bafe12"
+source = "git+https://github.com/meilisearch/heed?branch=allow-nested-rtxn-from-wtxn#464a9c33f76e0679115eef7379c9bdde9d5e1eda"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",
@@ -2808,14 +2807,12 @@ dependencies = [
 [[package]]
 name = "heed-traits"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3130048d404c57ce5a1ac61a903696e8fcde7e8c2991e9fcfc1f27c3ef74ff"
+source = "git+https://github.com/meilisearch/heed?branch=allow-nested-rtxn-from-wtxn#464a9c33f76e0679115eef7379c9bdde9d5e1eda"
 
 [[package]]
 name = "heed-types"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c255bdf46e07fb840d120a36dcc81f385140d7191c76a7391672675c01a55d"
+source = "git+https://github.com/meilisearch/heed?branch=allow-nested-rtxn-from-wtxn#464a9c33f76e0679115eef7379c9bdde9d5e1eda"
 dependencies = [
  "bincode 1.3.3",
  "byteorder",
@@ -3805,8 +3802,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 [[package]]
 name = "lmdb-master-sys"
 version = "0.2.6-nested-rtxns-6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e113d9bf240f974fbe7fd516cbfd8c422e925c0655495501c7237548425493d0"
+source = "git+https://github.com/meilisearch/heed?branch=allow-nested-rtxn-from-wtxn#464a9c33f76e0679115eef7379c9bdde9d5e1eda"
 dependencies = [
  "cc",
  "doxygen-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,3 +52,6 @@ opt-level = 3
 opt-level = 3
 [profile.dev.package.gemm-f16]
 opt-level = 3
+
+[patch.crates-io]
+heed = { git = "https://github.com/meilisearch/heed", branch = "allow-nested-rtxn-from-wtxn" }


### PR DESCRIPTION
This PR verifies that LMDB [with mutexes to manage nested read transactions works with Meilisearch](https://bugs.openldap.org/show_bug.cgi?id=10395).