### PR TITLE
Bump hannoy to v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2698,9 +2698,9 @@ dependencies = [
 
 [[package]]
 name = "hannoy"
-version = "0.1.0-nested-rtxns"
+version = "0.1.1-nested-rtxns"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be82bf3f2108ddc8885e3d306fcd7f4692066bfe26065ca8b42ba417f3c26dd1"
+checksum = "a6dc795dd70b98ef5afdee133db91be022c87f1a7232fe9a715a5fc7e275a1cc"
 dependencies = [
  "bytemuck",
  "byteorder",

--- a/crates/milli/Cargo.toml
+++ b/crates/milli/Cargo.toml
@@ -91,7 +91,7 @@ rhai = { version = "1.23.6", features = [
     "sync",
 ] }
 arroy = "0.6.4-nested-rtxns"
-hannoy = { version = "0.1.0-nested-rtxns", features = ["arroy"] }
+hannoy = { version = "0.1.1-nested-rtxns", features = ["arroy"] }
 rand = "0.8.5"
 tracing = "0.1.41"
 ureq = { version = "2.12.1", features = ["json"] }


### PR DESCRIPTION
This PR bumps hannoy to v0.1.1 to fix a bug that improves the recall. This was a regression from v0.1.0 and is fixed now. We don't have to reindex the HNSW disk-based graph, but the recall is impacted when using hannoy v0.1.0.

EDIT: Converted to draft as we [may have spotted a bug](https://github.com/nnethercott/hannoy/blob/e7fda85e366ce8556db30781951a2bda3718bdf3/src/hnsw.rs#L453-L454) on Hannoy v0.1.1 👀 Waiting for @nnethercott's answer.