### PR TITLE
Adapt JS tests in SDK tests CI

### DIFF
--- a/.github/workflows/sdks-tests.yml
+++ b/.github/workflows/sdks-tests.yml
@@ -323,6 +323,8 @@ jobs:
       - uses: actions/checkout@v5
         with:
           repository: meilisearch/meilisearch-js-plugins
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
       - name: Setup node
         uses: actions/setup-node@v5
         with:


### PR DESCRIPTION
Fix not-working SDK tests for JS SDK and meilisearch-js-plugin: https://github.com/meilisearch/meilisearch/actions/runs/20123798780

Proof it's working: https://github.com/meilisearch/meilisearch/actions/runs/20819788983