### PR TITLE
Run windows in the PR CI

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -50,17 +50,40 @@ jobs:
           command: test
           args: --locked --all ${{ matrix.features }}
 
-  test-others:
+  test-windows:
     name: Tests on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, windows-2022]
+        os: [windows-2022]
         features: ["", "--features enterprise"]
-    if: |
-      (contains(matrix.os, 'windows') && github.event_name != 'merge_group') ||
-      (contains(matrix.os, 'macos') && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'))
+    if: github.event_name != 'merge_group'
+    steps:
+      - uses: actions/checkout@v5
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2.8.0
+      - uses: dtolnay/rust-toolchain@1.91.1
+      - name: Run cargo build without any default features
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --locked --no-default-features --all
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --locked --all ${{ matrix.features }}
+
+  test-macos:
+    name: Tests on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-14]
+        features: ["", "--features enterprise"]
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v5
       - name: Cache dependencies


### PR DESCRIPTION
I recently encountered issues compiling my code on Windows, and this PR reintroduces the Windows CI in the PRs. As we primarily develop on macOS, we don't need this one to run in the CI. The Windows tests remain optional to add the PR to the merge queue.