### PR TITLE
Fix task attribution during index swap to prevent cross-index task loss

### DIFF
--- a/crates/index-scheduler/src/scheduler/process_batch.rs
+++ b/crates/index-scheduler/src/scheduler/process_batch.rs
@@ -662,13 +662,8 @@ impl IndexScheduler {
         // 2. Get the task set for index = name that appeared before the index swap task
         let mut index_lhs_task_ids = self.queue.tasks.index_tasks(wtxn, lhs)?;
         index_lhs_task_ids.remove_range(task_id..);
-        let index_rhs_task_ids = if rename {
-            let mut index_rhs_task_ids = self.queue.tasks.index_tasks(wtxn, rhs)?;
-            index_rhs_task_ids.remove_range(task_id..);
-            index_rhs_task_ids
-        } else {
-            RoaringBitmap::new()
-        };
+        let mut index_rhs_task_ids = self.queue.tasks.index_tasks(wtxn, rhs)?;
+        index_rhs_task_ids.remove_range(task_id..);
 
         // 3. before_name -> new_name in the task's KindWithContent
         progress.update_progress(InnerSwappingTwoIndexes::UpdateTheTasks);

--- a/crates/index-scheduler/src/scheduler/snapshots/test.rs/swap_indexes/first_swap_processed.snap
+++ b/crates/index-scheduler/src/scheduler/snapshots/test.rs/swap_indexes/first_swap_processed.snap
@@ -7,9 +7,9 @@ source: crates/index-scheduler/src/scheduler/test.rs
 ----------------------------------------------------------------------
 ### All Tasks:
 0 {uid: 0, batch_uid: 0, status: succeeded, details: { primary_key: Some("id"), old_new_uid: None, new_index_uid: None }, kind: IndexCreation { index_uid: "b", primary_key: Some("id") }}
-1 {uid: 1, batch_uid: 1, status: succeeded, details: { primary_key: Some("id"), old_new_uid: None, new_index_uid: None }, kind: IndexCreation { index_uid: "b", primary_key: Some("id") }}
+1 {uid: 1, batch_uid: 1, status: succeeded, details: { primary_key: Some("id"), old_new_uid: None, new_index_uid: None }, kind: IndexCreation { index_uid: "a", primary_key: Some("id") }}
 2 {uid: 2, batch_uid: 2, status: succeeded, details: { primary_key: Some("id"), old_new_uid: None, new_index_uid: None }, kind: IndexCreation { index_uid: "d", primary_key: Some("id") }}
-3 {uid: 3, batch_uid: 3, status: succeeded, details: { primary_key: Some("id"), old_new_uid: None, new_index_uid: None }, kind: IndexCreation { index_uid: "d", primary_key: Some("id") }}
+3 {uid: 3, batch_uid: 3, status: succeeded, details: { primary_key: Some("id"), old_new_uid: None, new_index_uid: None }, kind: IndexCreation { index_uid: "c", primary_key: Some("id") }}
 4 {uid: 4, batch_uid: 4, status: succeeded, details: { swaps: [IndexSwap { indexes: ("a", "b"), rename: false }, IndexSwap { indexes: ("c", "d"), rename: false }] }, kind: IndexSwap { swaps: [IndexSwap { indexes: ("a", "b"), rename: false }, IndexSwap { indexes: ("c", "d"), rename: false }] }}
 5 {uid: 5, status: enqueued, details: { swaps: [IndexSwap { indexes: ("a", "c"), rename: false }] }, kind: IndexSwap { swaps: [IndexSwap { indexes: ("a", "c"), rename: false }] }}
 ----------------------------------------------------------------------
@@ -22,10 +22,10 @@ succeeded [0,1,2,3,4,]
 "indexSwap" [4,5,]
 ----------------------------------------------------------------------
 ### Index Tasks:
-a [4,5,]
-b [0,1,4,]
-c [4,5,]
-d [2,3,4,]
+a [1,4,5,]
+b [0,4,]
+c [3,4,5,]
+d [2,4,]
 ----------------------------------------------------------------------
 ### Index Mapper:
 a: { number_of_documents: 0, field_distribution: {} }

--- a/crates/index-scheduler/src/scheduler/snapshots/test.rs/swap_indexes/second_swap_processed.snap
+++ b/crates/index-scheduler/src/scheduler/snapshots/test.rs/swap_indexes/second_swap_processed.snap
@@ -7,9 +7,9 @@ source: crates/index-scheduler/src/scheduler/test.rs
 ----------------------------------------------------------------------
 ### All Tasks:
 0 {uid: 0, batch_uid: 0, status: succeeded, details: { primary_key: Some("id"), old_new_uid: None, new_index_uid: None }, kind: IndexCreation { index_uid: "b", primary_key: Some("id") }}
-1 {uid: 1, batch_uid: 1, status: succeeded, details: { primary_key: Some("id"), old_new_uid: None, new_index_uid: None }, kind: IndexCreation { index_uid: "b", primary_key: Some("id") }}
+1 {uid: 1, batch_uid: 1, status: succeeded, details: { primary_key: Some("id"), old_new_uid: None, new_index_uid: None }, kind: IndexCreation { index_uid: "c", primary_key: Some("id") }}
 2 {uid: 2, batch_uid: 2, status: succeeded, details: { primary_key: Some("id"), old_new_uid: None, new_index_uid: None }, kind: IndexCreation { index_uid: "d", primary_key: Some("id") }}
-3 {uid: 3, batch_uid: 3, status: succeeded, details: { primary_key: Some("id"), old_new_uid: None, new_index_uid: None }, kind: IndexCreation { index_uid: "d", primary_key: Some("id") }}
+3 {uid: 3, batch_uid: 3, status: succeeded, details: { primary_key: Some("id"), old_new_uid: None, new_index_uid: None }, kind: IndexCreation { index_uid: "a", primary_key: Some("id") }}
 4 {uid: 4, batch_uid: 4, status: succeeded, details: { swaps: [IndexSwap { indexes: ("c", "b"), rename: false }, IndexSwap { indexes: ("a", "d"), rename: false }] }, kind: IndexSwap { swaps: [IndexSwap { indexes: ("c", "b"), rename: false }, IndexSwap { indexes: ("a", "d"), rename: false }] }}
 5 {uid: 5, batch_uid: 5, status: succeeded, details: { swaps: [IndexSwap { indexes: ("a", "c"), rename: false }] }, kind: IndexSwap { swaps: [IndexSwap { indexes: ("a", "c"), rename: false }] }}
 ----------------------------------------------------------------------
@@ -22,10 +22,10 @@ succeeded [0,1,2,3,4,5,]
 "indexSwap" [4,5,]
 ----------------------------------------------------------------------
 ### Index Tasks:
-a [5,]
-b [0,1,4,]
-c [4,5,]
-d [2,3,4,]
+a [3,4,5,]
+b [0,4,]
+c [1,4,5,]
+d [2,4,]
 ----------------------------------------------------------------------
 ### Index Mapper:
 a: { number_of_documents: 0, field_distribution: {} }

--- a/crates/index-scheduler/src/scheduler/snapshots/test.rs/swap_indexes/third_empty_swap_processed.snap
+++ b/crates/index-scheduler/src/scheduler/snapshots/test.rs/swap_indexes/third_empty_swap_processed.snap
@@ -7,9 +7,9 @@ source: crates/index-scheduler/src/scheduler/test.rs
 ----------------------------------------------------------------------
 ### All Tasks:
 0 {uid: 0, batch_uid: 0, status: succeeded, details: { primary_key: Some("id"), old_new_uid: None, new_index_uid: None }, kind: IndexCreation { index_uid: "b", primary_key: Some("id") }}
-1 {uid: 1, batch_uid: 1, status: succeeded, details: { primary_key: Some("id"), old_new_uid: None, new_index_uid: None }, kind: IndexCreation { index_uid: "b", primary_key: Some("id") }}
+1 {uid: 1, batch_uid: 1, status: succeeded, details: { primary_key: Some("id"), old_new_uid: None, new_index_uid: None }, kind: IndexCreation { index_uid: "c", primary_key: Some("id") }}
 2 {uid: 2, batch_uid: 2, status: succeeded, details: { primary_key: Some("id"), old_new_uid: None, new_index_uid: None }, kind: IndexCreation { index_uid: "d", primary_key: Some("id") }}
-3 {uid: 3, batch_uid: 3, status: succeeded, details: { primary_key: Some("id"), old_new_uid: None, new_index_uid: None }, kind: IndexCreation { index_uid: "d", primary_key: Some("id") }}
+3 {uid: 3, batch_uid: 3, status: succeeded, details: { primary_key: Some("id"), old_new_uid: None, new_index_uid: None }, kind: IndexCreation { index_uid: "a", primary_key: Some("id") }}
 4 {uid: 4, batch_uid: 4, status: succeeded, details: { swaps: [IndexSwap { indexes: ("c", "b"), rename: false }, IndexSwap { indexes: ("a", "d"), rename: false }] }, kind: IndexSwap { swaps: [IndexSwap { indexes: ("c", "b"), rename: false }, IndexSwap { indexes: ("a", "d"), rename: false }] }}
 5 {uid: 5, batch_uid: 5, status: succeeded, details: { swaps: [IndexSwap { indexes: ("a", "c"), rename: false }] }, kind: IndexSwap { swaps: [IndexSwap { indexes: ("a", "c"), rename: false }] }}
 6 {uid: 6, batch_uid: 6, status: succeeded, details: { swaps: [] }, kind: IndexSwap { swaps: [] }}
@@ -23,10 +23,10 @@ succeeded [0,1,2,3,4,5,6,]
 "indexSwap" [4,5,6,]
 ----------------------------------------------------------------------
 ### Index Tasks:
-a [5,]
-b [0,1,4,]
-c [4,5,]
-d [2,3,4,]
+a [3,4,5,]
+b [0,4,]
+c [1,4,5,]
+d [2,4,]
 ----------------------------------------------------------------------
 ### Index Mapper:
 a: { number_of_documents: 0, field_distribution: {} }

--- a/crates/meilisearch/tests/swap_indexes/mod.rs
+++ b/crates/meilisearch/tests/swap_indexes/mod.rs
@@ -103,7 +103,7 @@ async fn swap_indexes() {
         {
           "uid": 1,
           "batchUid": 1,
-          "indexUid": "b",
+          "indexUid": "a",
           "status": "succeeded",
           "type": "documentAdditionOrUpdate",
           "canceledBy": null,
@@ -266,7 +266,7 @@ async fn swap_indexes() {
         {
           "uid": 4,
           "batchUid": 4,
-          "indexUid": "d",
+          "indexUid": "c",
           "status": "succeeded",
           "type": "documentAdditionOrUpdate",
           "canceledBy": null,
@@ -341,7 +341,7 @@ async fn swap_indexes() {
         {
           "uid": 0,
           "batchUid": 0,
-          "indexUid": "b",
+          "indexUid": "a",
           "status": "succeeded",
           "type": "documentAdditionOrUpdate",
           "canceledBy": null,


### PR DESCRIPTION
### Context

We were investigating reports of tasks being incorrectly removed after an index swap followed by an index deletion, we traced the issue back to how tasks were reassigned during swaps.

### Root cause

Given two indexes A and B, the index swap implementation only reassigned tasks in one direction, causing A’s tasks to be moved to B while B’s tasks were left unchanged.

### Fix

This PR corrects the swap behavior so that task attribution is symetrical. A's tasks move to B while B's tasks move to A.
