### PR TITLE
fix(index-scheduler): align snapshot map_size to page size on Windows

### DIFF
--- a/crates/index-scheduler/src/lib.rs
+++ b/crates/index-scheduler/src/lib.rs
@@ -437,7 +437,7 @@ impl IndexScheduler {
         let mut index_count = budget / base_map_size;
         if index_count < 2 {
             // take a bit less than half than the budget to make sure we can always afford to open an index
-            let map_size = (budget * 2) / 5;
+            let map_size = clamp_to_page_size((budget * 2) / 5);
             // single index of max budget
             tracing::debug!("1 index of {map_size}B can be opened simultaneously.");
             return IndexBudget { map_size, index_count: 1, task_db_size };


### PR DESCRIPTION
## Related issue
Fixes #6051

## Description
On Windows, memory mapping requires the file size to be a multiple of the system page size (typically 4096 bytes).
Previously, the `map_size` calculation for snapshots could result in unaligned values (e.g., `1310824018739`), causing `batch failed` errors during snapshot creation.

This PR applies `clamp_to_page_size` to the budget calculation to ensure alignment.

## Requirements
- [x] If some tests cannot be automated, manual rigorous tests should be applied.

## How Has This Been Tested?
- Reproduced the crash on Windows 11 by triggering a snapshot on a running instance.
- Applied the fix and verified that `POST /snapshots` now returns `202 Accepted` and creates the snapshot successfully without error logs.