### PR TITLE
Bump hannoy to v0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2698,9 +2698,9 @@ dependencies = [
 
 [[package]]
 name = "hannoy"
-version = "0.1.0-nested-rtxns"
+version = "0.1.2-nested-rtxns"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be82bf3f2108ddc8885e3d306fcd7f4692066bfe26065ca8b42ba417f3c26dd1"
+checksum = "533c952127a7e73448f26af313ac7b98012516561e48e953781cd6b30e573436"
 dependencies = [
  "bytemuck",
  "byteorder",

--- a/crates/milli/Cargo.toml
+++ b/crates/milli/Cargo.toml
@@ -91,7 +91,7 @@ rhai = { version = "1.23.6", features = [
     "sync",
 ] }
 arroy = "0.6.4-nested-rtxns"
-hannoy = { version = "0.1.0-nested-rtxns", features = ["arroy"] }
+hannoy = { version = "0.1.2-nested-rtxns", features = ["arroy"] }
 rand = "0.8.5"
 tracing = "0.1.41"
 ureq = { version = "2.12.1", features = ["json"] }


### PR DESCRIPTION
This PR bumps [hannoy to v0.1.2-nested-rtxns](https://github.com/nnethercott/hannoy/releases/tag/v0.1.2-nested-rtxns), which fixed some graph-related recall issues. It is related to #6055 but does not rebuild the vector store graph.