### PR TITLE
Add _geoDistance field to /documents endpoint when sorting by _geoPoint

### DIFF
--- a/crates/meilisearch/src/routes/indexes/documents.rs
+++ b/crates/meilisearch/src/routes/indexes/documents.rs
@@ -22,7 +22,7 @@ use meilisearch_types::milli::documents::sort::recursive_sort;
 use meilisearch_types::milli::index::EmbeddingsWithMetadata;
 use meilisearch_types::milli::update::IndexDocumentsMethod;
 use meilisearch_types::milli::vector::parsed_vectors::ExplicitVectors;
-use meilisearch_types::milli::{AscDesc, DocumentId};
+use meilisearch_types::milli::{AscDesc, DocumentId, Member};
 use meilisearch_types::serde_cs::vec::CS;
 use meilisearch_types::star_or::OptionStarOrList;
 use meilisearch_types::tasks::KindWithContent;
@@ -1644,9 +1644,9 @@ fn retrieve_documents<S: AsRef<str>>(
         })?
     }
 
-    let (it, number_of_documents) = if let Some(sort) = sort_criteria {
+    let (it, number_of_documents) = if let Some(ref sort) = sort_criteria {
         let number_of_documents = candidates.len();
-        let facet_sort = recursive_sort(index, &rtxn, sort, &candidates)?;
+        let facet_sort = recursive_sort(index, &rtxn, sort.to_vec(), &candidates)?;
         let iter = facet_sort.iter()?;
         let mut documents = Vec::with_capacity(limit);
         for result in iter.skip(offset).take(limit) {
@@ -1676,15 +1676,22 @@ fn retrieve_documents<S: AsRef<str>>(
 
     let documents: Vec<_> = it
         .map(|document| {
-            Ok(match &attributes_to_retrieve {
+            let document = document?;
+            let mut document = match &attributes_to_retrieve {
                 Some(attributes_to_retrieve) => permissive_json_pointer::select_values(
-                    &document?,
+                    &document,
                     attributes_to_retrieve.iter().map(|s| s.as_ref()).chain(
                         (retrieve_vectors == RetrieveVectors::Retrieve).then_some("_vectors"),
                     ),
                 ),
-                None => document?,
-            })
+                None => document,
+            };
+
+            if let Some(sorts) = &sort_criteria {
+                insert_geo_distance(sorts, &mut document);
+            }
+
+            Ok(document)
         })
         .collect::<Result<_, ResponseError>>()?;
 
@@ -1720,4 +1727,32 @@ fn retrieve_document<S: AsRef<str>>(
     };
 
     Ok(document)
+}
+
+fn insert_geo_distance(sorts: &[AscDesc], document: &mut Document) {
+    for sort in sorts {
+        if let AscDesc::Asc(Member::Geo(base)) | AscDesc::Desc(Member::Geo(base)) = sort {
+            if let Some(geo_point) = document.get("_geo") {
+                if let Some((lat, lng)) =
+                    extract_geo_value(&geo_point["lat"]).zip(extract_geo_value(&geo_point["lng"]))
+                {
+                    let distance =
+                        meilisearch_types::milli::distance_between_two_points(base, &[lat, lng]);
+                    document.insert(
+                        "_geoDistance".to_string(),
+                        serde_json::json!(distance.round() as usize),
+                    );
+                }
+            }
+            return;
+        }
+    }
+}
+
+fn extract_geo_value(value: &Value) -> Option<f64> {
+    match value {
+        Value::Number(n) => n.as_f64(),
+        Value::String(s) => s.parse().ok(),
+        _ => None,
+    }
 }


### PR DESCRIPTION
# Add _geoDistance field to /documents endpoint when sorting by _geoPoint

Fixes #5986

## Related issue

Fixes #5986

## What does this PR do?

This PR adds the `_geoDistance` field to the `/documents` endpoint response when documents are sorted by `_geoPoint`, bringing feature parity with the `/search` endpoint.

### Changes:
- Implemented `insert_geo_distance()` function in documents route to calculate distances
- Added `extract_geo_value()` helper to parse geo coordinates from JSON
- Automatically includes `_geoDistance` (in meters) for documents with valid `_geo` fields when geo-sorting is active
- Documents without `_geo` fields correctly omit `_geoDistance`

### Test Coverage:
- Added 3 comprehensive tests covering ascending sort, descending sort, and field selection
- Updated existing test snapshot to include new field

## Requirements

⚠️ Ensure the following requirements before merging ⚠️
- [x] Automated tests have been added.
- [ ] If some tests cannot be automated, manual rigorous tests should be applied.
- [ ] ⚠️ If there is any change in the DB: 
    - [ ] Test that any impacted DB still works as expected after using `--experimental-dumpless-upgrade` on a DB created with the last released Meilisearch
    - [ ] Test that during the upgrade, **search is still available** (artificially make the upgrade longer if needed)
    - [ ] Set the `db change` label.
- [ ] If necessary, the feature have been tested in the Cloud production environment (with [prototypes](./documentation/prototypes.md)) and the Cloud UI is ready.
- [ ] If necessary, the [documentation](https://github.com/meilisearch/documentation) related to the implemented feature in the PR is ready.
- [ ] If necessary, the [integrations](https://github.com/meilisearch/integration-guides) related to the implemented feature in the PR are ready.