### PR TITLE
Use constant time comparison to prevent timing attack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4052,6 +4052,7 @@ version = "1.31.0"
 dependencies = [
  "base64 0.22.1",
  "enum-iterator",
+ "hex",
  "hmac",
  "maplit",
  "meilisearch-types",

--- a/crates/meilisearch-auth/Cargo.toml
+++ b/crates/meilisearch-auth/Cargo.toml
@@ -13,6 +13,7 @@ license.workspace = true
 [dependencies]
 base64 = "0.22.1"
 enum-iterator = "2.3.0"
+hex = "0.4.3"
 hmac = "0.12.1"
 maplit = "1.0.2"
 meilisearch-types = { path = "../meilisearch-types" }


### PR DESCRIPTION
Fixes https://linear.app/meilisearch/issue/ENGPROD-2221/timing-attack-vulnerability-in-api-key-comparison

Risk of exploit really low, but fix easy to do and good practice
- OWASP: https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html#compare-password-hashes-using-safe-functions
> Compare Password Hashes Using Safe Functions
> [...]
>  Returns in constant time, to protect against timing attacks.

I chose to not use any new dependencies, and use the already improted one (`hmac`). But I could also use `subtle`, with `subtle::ConstantTimeEq` to avoid adding `verify_key_matches`. The code would be one line in this case. Let me know what you prefer

👉 If you estimate it's too risky for the performance or it brings too much complexity, we can also close this PR and justify we accept the risk.