### PR TITLE
Support protocol negociation on plain-text connections

### DIFF
--- a/crates/meilisearch/src/main.rs
+++ b/crates/meilisearch/src/main.rs
@@ -196,7 +196,7 @@ async fn run_http(
     if let Some(config) = opt_clone.get_ssl_config()? {
         http_server.bind_rustls_0_23(opt_clone.http_addr, config)?.run().await?;
     } else {
-        http_server.bind(&opt_clone.http_addr)?.run().await?;
+        http_server.bind_auto_h2c(&opt_clone.http_addr)?.run().await?;
     }
     Ok(())
 }


### PR DESCRIPTION
When a client sends a large request body and the server decides to reject it with 413 before the client finishes uploading:

1. Server sends the 413 response and closes (or tries to close) the connection
1. Client is still writing the request body
1. The server's close can cause a TCP RST (reset)
1. The RST can arrive at the client before or during its read of the response

The client might see a "connection reset" error instead of the actual 413 response. HTTP/2 handles this gracefully with stream multiplexing where a request can be rejected without nuking the connection. HTTP/1.1 doesn't have that luxury.

Currently, the server only has protocol negociation when using HTTPS. With this change the server can now do protocol negociation when dealing with plain-text connections.
