### PR TITLE
Add `/fields` route to get all the fields of an index

### DIFF
--- a/crates/meilisearch-types/src/error.rs
+++ b/crates/meilisearch-types/src/error.rs
@@ -442,6 +442,14 @@ InvalidChatCompletionSearchQueryParamPrompt    , InvalidRequest       , BAD_REQU
 InvalidChatCompletionSearchFilterParamPrompt   , InvalidRequest       , BAD_REQUEST ;
 InvalidChatCompletionSearchIndexUidParamPrompt , InvalidRequest       , BAD_REQUEST ;
 InvalidChatCompletionPreQueryPrompt            , InvalidRequest       , BAD_REQUEST ;
+InvalidIndexFieldsFilter                       , InvalidRequest       , BAD_REQUEST ;
+InvalidIndexFieldsFilterAttributePatterns      , InvalidRequest       , BAD_REQUEST ;
+InvalidIndexFieldsFilterDisplayed              , InvalidRequest       , BAD_REQUEST ;
+InvalidIndexFieldsFilterSearchable             , InvalidRequest       , BAD_REQUEST ;
+InvalidIndexFieldsFilterSortable               , InvalidRequest       , BAD_REQUEST ;
+InvalidIndexFieldsFilterDistinct               , InvalidRequest       , BAD_REQUEST ;
+InvalidIndexFieldsFilterRankingRule            , InvalidRequest       , BAD_REQUEST ;
+InvalidIndexFieldsFilterFilterable             , InvalidRequest       , BAD_REQUEST ;
 RequiresEnterpriseEdition                      , InvalidRequest       , UNAVAILABLE_FOR_LEGAL_REASONS ;
 // Webhooks
 InvalidWebhooks                                , InvalidRequest       , BAD_REQUEST ;

--- a/crates/meilisearch-types/src/keys.rs
+++ b/crates/meilisearch-types/src/keys.rs
@@ -383,6 +383,9 @@ pub enum Action {
     #[serde(rename = "indexes.compact")]
     #[deserr(rename = "indexes.compact")]
     IndexesCompact,
+    #[serde(rename = "fields.post")]
+    #[deserr(rename = "fields.post")]
+    FieldsPost,
 }
 
 impl Action {
@@ -440,6 +443,7 @@ impl Action {
             WEBHOOKS_DELETE => Some(Self::WebhooksDelete),
             WEBHOOKS_CREATE => Some(Self::WebhooksCreate),
             WEBHOOKS_ALL => Some(Self::WebhooksAll),
+            FIELDS_POST => Some(Self::FieldsPost),
             _otherwise => None,
         }
     }
@@ -494,6 +498,7 @@ impl Action {
             WebhooksUpdate => false,
             WebhooksDelete => false,
             WebhooksCreate => false,
+            FieldsPost => true,
         }
     }
 
@@ -528,6 +533,7 @@ pub mod actions {
     pub const SETTINGS_UPDATE: u8 = SettingsUpdate.repr();
     pub const STATS_ALL: u8 = StatsAll.repr();
     pub const STATS_GET: u8 = StatsGet.repr();
+    pub const FIELDS_POST: u8 = FieldsPost.repr();
     pub const METRICS_ALL: u8 = MetricsAll.repr();
     pub const METRICS_GET: u8 = MetricsGet.repr();
     pub const DUMPS_ALL: u8 = DumpsAll.repr();

--- a/crates/meilisearch/tests/auth/api_keys.rs
+++ b/crates/meilisearch/tests/auth/api_keys.rs
@@ -419,14 +419,14 @@ async fn error_add_api_key_invalid_parameters_actions() {
     let (response, code) = server.add_api_key(content).await;
 
     meili_snap::snapshot!(code, @"400 Bad Request");
-    meili_snap::snapshot!(meili_snap::json_string!(response, { ".createdAt" => "[ignored]", ".updatedAt" => "[ignored]" }), @r###"
+    meili_snap::snapshot!(meili_snap::json_string!(response, { ".createdAt" => "[ignored]", ".updatedAt" => "[ignored]" }), @r#"
     {
-      "message": "Unknown value `doc.add` at `.actions[0]`: expected one of `*`, `search`, `documents.*`, `documents.add`, `documents.get`, `documents.delete`, `indexes.*`, `indexes.create`, `indexes.get`, `indexes.update`, `indexes.delete`, `indexes.swap`, `tasks.*`, `tasks.cancel`, `tasks.delete`, `tasks.get`, `settings.*`, `settings.get`, `settings.update`, `stats.*`, `stats.get`, `metrics.*`, `metrics.get`, `dumps.*`, `dumps.create`, `snapshots.*`, `snapshots.create`, `version`, `keys.create`, `keys.get`, `keys.update`, `keys.delete`, `experimental.get`, `experimental.update`, `export`, `network.get`, `network.update`, `chatCompletions`, `chats.*`, `chats.get`, `chats.delete`, `chatsSettings.*`, `chatsSettings.get`, `chatsSettings.update`, `*.get`, `webhooks.get`, `webhooks.update`, `webhooks.delete`, `webhooks.create`, `webhooks.*`, `indexes.compact`",
+      "message": "Unknown value `doc.add` at `.actions[0]`: expected one of `*`, `search`, `documents.*`, `documents.add`, `documents.get`, `documents.delete`, `indexes.*`, `indexes.create`, `indexes.get`, `indexes.update`, `indexes.delete`, `indexes.swap`, `tasks.*`, `tasks.cancel`, `tasks.delete`, `tasks.get`, `settings.*`, `settings.get`, `settings.update`, `stats.*`, `stats.get`, `metrics.*`, `metrics.get`, `dumps.*`, `dumps.create`, `snapshots.*`, `snapshots.create`, `version`, `keys.create`, `keys.get`, `keys.update`, `keys.delete`, `experimental.get`, `experimental.update`, `export`, `network.get`, `network.update`, `chatCompletions`, `chats.*`, `chats.get`, `chats.delete`, `chatsSettings.*`, `chatsSettings.get`, `chatsSettings.update`, `*.get`, `webhooks.get`, `webhooks.update`, `webhooks.delete`, `webhooks.create`, `webhooks.*`, `indexes.compact`, `fields.post`",
       "code": "invalid_api_key_actions",
       "type": "invalid_request",
       "link": "https://docs.meilisearch.com/errors#invalid_api_key_actions"
     }
-    "###);
+    "#);
 }
 
 #[actix_rt::test]

--- a/crates/meilisearch/tests/auth/errors.rs
+++ b/crates/meilisearch/tests/auth/errors.rs
@@ -91,14 +91,14 @@ async fn create_api_key_bad_actions() {
     // can't parse
     let (response, code) = server.add_api_key(json!({ "actions": ["doggo"] })).await;
     snapshot!(code, @"400 Bad Request");
-    snapshot!(json_string!(response), @r###"
+    snapshot!(json_string!(response), @r#"
     {
-      "message": "Unknown value `doggo` at `.actions[0]`: expected one of `*`, `search`, `documents.*`, `documents.add`, `documents.get`, `documents.delete`, `indexes.*`, `indexes.create`, `indexes.get`, `indexes.update`, `indexes.delete`, `indexes.swap`, `tasks.*`, `tasks.cancel`, `tasks.delete`, `tasks.get`, `settings.*`, `settings.get`, `settings.update`, `stats.*`, `stats.get`, `metrics.*`, `metrics.get`, `dumps.*`, `dumps.create`, `snapshots.*`, `snapshots.create`, `version`, `keys.create`, `keys.get`, `keys.update`, `keys.delete`, `experimental.get`, `experimental.update`, `export`, `network.get`, `network.update`, `chatCompletions`, `chats.*`, `chats.get`, `chats.delete`, `chatsSettings.*`, `chatsSettings.get`, `chatsSettings.update`, `*.get`, `webhooks.get`, `webhooks.update`, `webhooks.delete`, `webhooks.create`, `webhooks.*`, `indexes.compact`",
+      "message": "Unknown value `doggo` at `.actions[0]`: expected one of `*`, `search`, `documents.*`, `documents.add`, `documents.get`, `documents.delete`, `indexes.*`, `indexes.create`, `indexes.get`, `indexes.update`, `indexes.delete`, `indexes.swap`, `tasks.*`, `tasks.cancel`, `tasks.delete`, `tasks.get`, `settings.*`, `settings.get`, `settings.update`, `stats.*`, `stats.get`, `metrics.*`, `metrics.get`, `dumps.*`, `dumps.create`, `snapshots.*`, `snapshots.create`, `version`, `keys.create`, `keys.get`, `keys.update`, `keys.delete`, `experimental.get`, `experimental.update`, `export`, `network.get`, `network.update`, `chatCompletions`, `chats.*`, `chats.get`, `chats.delete`, `chatsSettings.*`, `chatsSettings.get`, `chatsSettings.update`, `*.get`, `webhooks.get`, `webhooks.update`, `webhooks.delete`, `webhooks.create`, `webhooks.*`, `indexes.compact`, `fields.post`",
       "code": "invalid_api_key_actions",
       "type": "invalid_request",
       "link": "https://docs.meilisearch.com/errors#invalid_api_key_actions"
     }
-    "###);
+    "#);
 }
 
 #[actix_rt::test]

--- a/crates/meilisearch/tests/common/index.rs
+++ b/crates/meilisearch/tests/common/index.rs
@@ -3,6 +3,7 @@ use std::marker::PhantomData;
 use std::panic::{catch_unwind, resume_unwind, UnwindSafe};
 
 use actix_web::http::StatusCode;
+use serde::Serialize;
 use urlencoding::encode as urlencode;
 
 use super::encoder::Encoder;
@@ -461,6 +462,15 @@ impl<State> Index<'_, State> {
         self.service.get(url).await
     }
 
+    pub async fn fields(&self, params: &ListFieldsPayload<'_>) -> (Value, StatusCode) {
+        self.service
+            .post(
+                format!("/indexes/{}/fields", urlencode(self.uid.as_str())),
+                serde_json::to_value(params).unwrap().into(),
+            )
+            .await
+    }
+
     pub async fn get_batch(&self, batch_id: u32) -> (Value, StatusCode) {
         let url = format!("/batches/{}", batch_id);
         self.service.get(url).await
@@ -633,4 +643,36 @@ pub struct GetAllDocumentsOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sort: Option<Vec<&'static str>>,
     pub retrieve_vectors: bool,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ListFieldsPayload<'a> {
+    pub offset: usize,
+    pub limit: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filter: Option<ListFieldsFilterPayload<'a>>,
+}
+
+impl Default for ListFieldsPayload<'_> {
+    fn default() -> Self {
+        Self { offset: 0, limit: 20, filter: None }
+    }
+}
+
+#[derive(Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ListFieldsFilterPayload<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub attribute_patterns: Option<&'a [&'a str]>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub displayed: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sortable: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub searchable: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ranking_rule: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filterable: Option<bool>,
 }

--- a/crates/meilisearch/tests/index/fields.rs
+++ b/crates/meilisearch/tests/index/fields.rs
@@ -1,0 +1,161 @@
+use crate::common::index::{ListFieldsFilterPayload, ListFieldsPayload};
+use crate::common::{shared_does_not_exists_index, Server};
+use crate::json;
+
+#[actix_rt::test]
+async fn error_get_fields_unexisting_index() {
+    let index = shared_does_not_exists_index().await;
+    let (response, code) = index.fields(&ListFieldsPayload::default()).await;
+    insta::assert_json_snapshot!((code.as_u16(), response));
+}
+
+#[actix_rt::test]
+async fn get_fields_empty_index() {
+    let server = Server::new_shared();
+    let index = server.unique_index();
+    let (task, code) = index.create(None).await;
+    insta::assert_snapshot!(code);
+    server.wait_task(task.uid()).await.succeeded();
+
+    let (response, code) = index.fields(&ListFieldsPayload::default()).await;
+    insta::assert_json_snapshot!((code.as_u16(), response));
+}
+
+#[actix_rt::test]
+async fn get_fields_with_documents_and_filters() {
+    let server = Server::new_shared();
+    let index = server.unique_index();
+
+    // create index and add a few documents
+    index.create(None).await; // 202 accepted
+    let docs = json!([
+        { "id": 1, "title": "Titanic", "genre": "drama" },
+        { "id": 2, "title": "Shazam!", "color": "blue" }
+    ]);
+    let (task, code) = index.add_documents(docs, Some("id")).await;
+    insta::assert_json_snapshot!((code.as_u16(), &task), {
+        "[1].taskUid" => "[uid]",
+        "[1].enqueuedAt" => "[date]",
+        "[1].indexUid" => "[uid]",
+    });
+    server.wait_task(task.uid()).await.succeeded();
+
+    // fetch fields without any param
+    let (response, code) = index.fields(&ListFieldsPayload::default()).await;
+
+    insta::assert_json_snapshot!((code.as_u16(), response), {
+        "[1]" => insta::sorted_redaction(),
+    });
+
+    // search parameter should filter
+    let (response, code) = index
+        .fields(&ListFieldsPayload {
+            filter: Some(ListFieldsFilterPayload {
+                attribute_patterns: Some(&["ti*"]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        })
+        .await;
+
+    insta::assert_json_snapshot!((code.as_u16(), response), {
+        "[1]" => insta::sorted_redaction(),
+    });
+}
+
+#[actix_rt::test]
+async fn fields_after_uploading_recipe_and_settings() {
+    let server = Server::new_shared();
+    let index = server.unique_index();
+
+    // create index with primary key `id`
+    let (task, code) = index.create(Some("id")).await;
+    insta::assert_json_snapshot!((code.as_u16(), &task), {
+        "[1].taskUid" => "[uid]",
+        "[1].enqueuedAt" => "[date]",
+        "[1].indexUid" => "[uid]",
+    });
+    server.wait_task(task.uid()).await.succeeded();
+
+    // upload recipe document
+    let doc = json!([
+        {
+            "id": 1,
+            "title": "Spaghetti Carbonara",
+            "description": "A classic Italian pasta dish with eggs, cheese, pancetta, and black pepper.",
+            "difficulty": "medium",
+            "preparation_time_minutes": 15,
+            "cooking_time_minutes": 20,
+            "total_time_minutes": 35,
+            "servings": 4,
+            "calories_per_serving": 450,
+            "cuisine": {
+                "type": "Italian",
+                "region": "Rome",
+                "is_authentic": true
+            },
+            "ingredients": [{"name": "spaghetti"}],
+            "instructions": [{"step": 1, "description": "Bring water to boil"}],
+            "tags": ["pasta", "italian"],
+            "nutrition": {"calories": 450, "protein": 20, "carbs": 45, "fat": 20},
+            "is_vegetarian": false,
+            "is_vegan": false,
+            "is_gluten_free": false,
+            "is_dairy_free": false,
+            "created_at": "2023-01-10T14:30:00Z",
+            "updated_at": "2023-06-15T09:15:30Z",
+            "image_url": "https://example.com/images/spaghetti-carbonara.jpg"
+        }
+    ]);
+    let (task, code) = index.add_documents(doc, Some("id")).await;
+    insta::assert_json_snapshot!((code.as_u16(), &task), {
+        "[1].taskUid" => "[uid]",
+        "[1].enqueuedAt" => "[date]",
+        "[1].indexUid" => "[uid]",
+    });
+    server.wait_task(task.uid()).await.succeeded();
+
+    // upload settings
+    let settings = json!({
+        "displayedAttributes": [
+            "id", "title", "description", "difficulty",
+            "preparation_time_minutes", "cooking_time_minutes", "total_time_minutes",
+            "servings", "calories_per_serving", "cuisine", "tags", "nutrition",
+            "is_vegetarian", "is_vegan", "is_gluten_free", "is_dairy_free", "image_url"
+        ],
+        "searchableAttributes": [
+            "title", "tags", "description", "ingredients.name",
+            "cuisine.type", "cuisine.region", "instructions.description"
+        ],
+        "filterableAttributes": [
+            {
+                "attributePatterns": ["nutrition.*", "*_time_minutes"],
+                "features": {
+                    "facetSearch": false,
+                    "filter": {
+                        "equality": true,
+                        "comparison": true
+                    }
+                }
+            }
+        ],
+        "sortableAttributes": [
+            "preparation_time_minutes", "cooking_time_minutes", "total_time_minutes",
+            "calories_per_serving", "servings", "created_at", "nutrition.calories",
+            "nutrition.protein", "nutrition.carbs", "nutrition.fat"
+        ]
+    });
+    let (task, code) = index.update_settings(settings).await;
+    insta::assert_json_snapshot!((code.as_u16(), &task), {
+        "[1].taskUid" => "[uid]",
+        "[1].enqueuedAt" => "[date]",
+        "[1].indexUid" => "[uid]",
+    });
+    server.wait_task(task.uid()).await.succeeded();
+
+    // fetch fields - large limit to get all
+    let (resp, code) = index.fields(&ListFieldsPayload { limit: 500, ..Default::default() }).await;
+    insta::assert_json_snapshot!((code.as_u16(), resp), {
+        "[1]" => insta::sorted_redaction(),
+    });
+}

--- a/crates/meilisearch/tests/index/mod.rs
+++ b/crates/meilisearch/tests/index/mod.rs
@@ -1,6 +1,7 @@
 mod create_index;
 mod delete_index;
 mod errors;
+mod fields;
 mod get_index;
 mod rename_index;
 mod stats;

--- a/crates/meilisearch/tests/index/snapshots/integration__index__fields__error_get_fields_unexisting_index.snap
+++ b/crates/meilisearch/tests/index/snapshots/integration__index__fields__error_get_fields_unexisting_index.snap
@@ -1,0 +1,13 @@
+---
+source: crates/meilisearch/tests/index/fields.rs
+expression: "(code.as_u16(), response)"
+---
+[
+  404,
+  {
+    "message": "Index `DOES_NOT_EXISTS` not found.",
+    "code": "index_not_found",
+    "type": "invalid_request",
+    "link": "https://docs.meilisearch.com/errors#index_not_found"
+  }
+]

--- a/crates/meilisearch/tests/index/snapshots/integration__index__fields__fields_after_uploading_recipe_and_settings-2.snap
+++ b/crates/meilisearch/tests/index/snapshots/integration__index__fields__fields_after_uploading_recipe_and_settings-2.snap
@@ -1,0 +1,14 @@
+---
+source: crates/meilisearch/tests/index/fields.rs
+expression: "(code.as_u16(), &task)"
+---
+[
+  202,
+  {
+    "taskUid": "[uid]",
+    "indexUid": "[uid]",
+    "status": "enqueued",
+    "type": "documentAdditionOrUpdate",
+    "enqueuedAt": "[date]"
+  }
+]

--- a/crates/meilisearch/tests/index/snapshots/integration__index__fields__fields_after_uploading_recipe_and_settings-3.snap
+++ b/crates/meilisearch/tests/index/snapshots/integration__index__fields__fields_after_uploading_recipe_and_settings-3.snap
@@ -1,0 +1,14 @@
+---
+source: crates/meilisearch/tests/index/fields.rs
+expression: "(code.as_u16(), &task)"
+---
+[
+  202,
+  {
+    "taskUid": "[uid]",
+    "indexUid": "[uid]",
+    "status": "enqueued",
+    "type": "settingsUpdate",
+    "enqueuedAt": "[date]"
+  }
+]

--- a/crates/meilisearch/tests/index/snapshots/integration__index__fields__fields_after_uploading_recipe_and_settings-4.snap
+++ b/crates/meilisearch/tests/index/snapshots/integration__index__fields__fields_after_uploading_recipe_and_settings-4.snap
@@ -1,0 +1,877 @@
+---
+source: crates/meilisearch/tests/index/fields.rs
+expression: "(code.as_u16(), resp)"
+---
+[
+  200,
+  [
+    {
+      "name": "calories_per_serving",
+      "displayed": {
+        "enabled": true
+      },
+      "searchable": {
+        "enabled": false
+      },
+      "sortable": {
+        "enabled": true
+      },
+      "distinct": {
+        "enabled": false
+      },
+      "rankingRule": {
+        "enabled": false
+      },
+      "filterable": {
+        "enabled": false,
+        "sortBy": "alpha",
+        "facetSearch": false,
+        "equality": false,
+        "comparison": false
+      },
+      "localized": {
+        "locales": []
+      }
+    },
+    {
+      "name": "cooking_time_minutes",
+      "displayed": {
+        "enabled": true
+      },
+      "searchable": {
+        "enabled": false
+      },
+      "sortable": {
+        "enabled": true
+      },
+      "distinct": {
+        "enabled": false
+      },
+      "rankingRule": {
+        "enabled": false
+      },
+      "filterable": {
+        "enabled": true,
+        "sortBy": "alpha",
+        "facetSearch": false,
+        "equality": true,
+        "comparison": true
+      },
+      "localized": {
+        "locales": []
+      }
+    },
+    {
+      "name": "created_at",
+      "displayed": {
+        "enabled": false
+      },
+      "searchable": {
+        "enabled": false
+      },
+      "sortable": {
+        "enabled": true
+      },
+      "distinct": {
+        "enabled": false
+      },
+      "rankingRule": {
+        "enabled": false
+      },
+      "filterable": {
+        "enabled": false,
+        "sortBy": "alpha",
+        "facetSearch": false,
+        "equality": false,
+        "comparison": false
+      },
+      "localized": {
+        "locales": []
+      }
+    },
+    {
+      "name": "cuisine",
+      "displayed": {
+        "enabled": true
+      },
+      "searchable": {
+        "enabled": false
+      },
+      "sortable": {
+        "enabled": false
+      },
+      "distinct": {
+        "enabled": false
+      },
+      "rankingRule": {
+        "enabled": false
+      },
+      "filterable": {
+        "enabled": false,
+        "sortBy": "alpha",
+        "facetSearch": false,
+        "equality": false,
+        "comparison": false
+      },
+      "localized": {
+        "locales": []
+      }
+    },
+    {
+      "name": "cuisine.is_authentic",
+      "displayed": {
+        "enabled": false
+      },
+      "searchable": {
+        "enabled": false
+      },
+      "sortable": {
+        "enabled": false
+      },
+      "distinct": {
+        "enabled": false
+      },
+      "rankingRule": {
+        "enabled": false
+      },
+      "filterable": {
+        "enabled": false,
+        "sortBy": "alpha",
+        "facetSearch": false,
+        "equality": false,
+        "comparison": false
+      },
+      "localized": {
+        "locales": []
+      }
+    },
+    {
+      "name": "cuisine.region",
+      "displayed": {
+        "enabled": false
+      },
+      "searchable": {
+        "enabled": true
+      },
+      "sortable": {
+        "enabled": false
+      },
+      "distinct": {
+        "enabled": false
+      },
+      "rankingRule": {
+        "enabled": false
+      },
+      "filterable": {
+        "enabled": false,
+        "sortBy": "alpha",
+        "facetSearch": false,
+        "equality": false,
+        "comparison": false
+      },
+      "localized": {
+        "locales": []
+      }
+    },
+    {
+      "name": "cuisine.type",
+      "displayed": {
+        "enabled": false
+      },
+      "searchable": {
+        "enabled": true
+      },
+      "sortable": {
+        "enabled": false
+      },
+      "distinct": {
+        "enabled": false
+      },
+      "rankingRule": {
+        "enabled": false
+      },
+      "filterable": {
+        "enabled": false,
+        "sortBy": "alpha",
+        "facetSearch": false,
+        "equality": false,
+        "comparison": false
+      },
+      "localized": {
+        "locales": []
+      }
+    },
+    {
+      "name": "description",
+      "displayed": {
+        "enabled": true
+      },
+      "searchable": {
+        "enabled": true
+      },
+      "sortable": {
+        "enabled": false
+      },
+      "distinct": {
+        "enabled": false
+      },
+      "rankingRule": {
+        "enabled": false
+      },
+      "filterable": {
+        "enabled": false,
+        "sortBy": "alpha",
+        "facetSearch": false,
+        "equality": false,
+        "comparison": false
+      },
+      "localized": {
+        "locales": []
+      }
+    },
+    {
+      "name": "difficulty",
+      "displayed": {
+        "enabled": true
+      },
+      "searchable": {
+        "enabled": false
+      },
+      "sortable": {
+        "enabled": false
+      },
+      "distinct": {
+        "enabled": false
+      },
+      "rankingRule": {
+        "enabled": false
+      },
+      "filterable": {
+        "enabled": false,
+        "sortBy": "alpha",
+        "facetSearch": false,
+        "equality": false,
+        "comparison": false
+      },
+      "localized": {
+        "locales": []
+      }
+    },
+    {
+      "name": "id",
+      "displayed": {
+        "enabled": true
+      },
+      "searchable": {
+        "enabled": false
+      },
+      "sortable": {
+        "enabled": false
+      },
+      "distinct": {
+        "enabled": false
+      },
+      "rankingRule": {
+        "enabled": false
+      },
+      "filterable": {
+        "enabled": false,
+        "sortBy": "alpha",
+        "facetSearch": false,
+        "equality": false,
+        "comparison": false
+      },
+      "localized": {
+        "locales": []
+      }
+    },
+    {
+      "name": "image_url",
+      "displayed": {
+        "enabled": true
+      },
+      "searchable": {
+        "enabled": false
+      },
+      "sortable": {
+        "enabled": false
+      },
+      "distinct": {
+        "enabled": false
+      },
+      "rankingRule": {
+        "enabled": false
+      },
+      "filterable": {
+        "enabled": false,
+        "sortBy": "alpha",
+        "facetSearch": false,
+        "equality": false,
+        "comparison": false
+      },
+      "localized": {
+        "locales": []
+      }
+    },
+    {
+      "name": "ingredients",
+      "displayed": {
+        "enabled": false
+      },
+      "searchable": {
+        "enabled": false
+      },
+      "sortable": {
+        "enabled": false
+      },
+      "distinct": {
+        "enabled": false
+      },
+      "rankingRule": {
+        "enabled": false
+      },
+      "filterable": {
+        "enabled": false,
+        "sortBy": "alpha",
+        "facetSearch": false,
+        "equality": false,
+        "comparison": false
+      },
+      "localized": {
+        "locales": []
+      }
+    },
+    {
+      "name": "ingredients.name",
+      "displayed": {
+        "enabled": false
+      },
+      "searchable": {
+        "enabled": true
+      },
+      "sortable": {
+        "enabled": false
+      },
+      "distinct": {
+        "enabled": false
+      },
+      "rankingRule": {
+        "enabled": false
+      },
+      "filterable": {
+        "enabled": false,
+        "sortBy": "alpha",
+        "facetSearch": false,
+        "equality": false,
+        "comparison": false
+      },
+      "localized": {
+        "locales": []
+      }
+    },
+    {
+      "name": "instructions",
+      "displayed": {
+        "enabled": false
+      },
+      "searchable": {
+        "enabled": false
+      },
+      "sortable": {
+        "enabled": false
+      },
+      "distinct": {
+        "enabled": false
+      },
+      "rankingRule": {
+        "enabled": false
+      },
+      "filterable": {
+        "enabled": false,
+        "sortBy": "alpha",
+        "facetSearch": false,
+        "equality": false,
+        "comparison": false
+      },
+      "localized": {
+        "locales": []
+      }
+    },
+    {
+      "name": "instructions.description",
+      "displayed": {
+        "enabled": false
+      },
+      "searchable": {
+        "enabled": true
+      },
+      "sortable": {
+        "enabled": false
+      },
+      "distinct": {
+        "enabled": false
+      },
+      "rankingRule": {
+        "enabled": false
+      },
+      "filterable": {
+        "enabled": false,
+        "sortBy": "alpha",
+        "facetSearch": false,
+        "equality": false,
+        "comparison": false
+      },
+      "localized": {
+        "locales": []
+      }
+    },
+    {
+      "name": "instructions.step",
+      "displayed": {
+        "enabled": false
+      },
+      "searchable": {
+        "enabled": false
+      },
+      "sortable": {
+        "enabled": false
+      },
+      "distinct": {
+        "enabled": false
+      },
+      "rankingRule": {
+        "enabled": false
+      },
+      "filterable": {
+        "enabled": false,
+        "sortBy": "alpha",
+        "facetSearch": false,
+        "equality": false,
+        "comparison": false
+      },
+      "localized": {
+        "locales": []
+      }
+    },
+    {
+      "name": "is_dairy_free",
+      "displayed": {
+        "enabled": true
+      },
+      "searchable": {
+        "enabled": false
+      },
+      "sortable": {
+        "enabled": false
+      },
+      "distinct": {
+        "enabled": false
+      },
+      "rankingRule": {
+        "enabled": false
+      },
+      "filterable": {
+        "enabled": false,
+        "sortBy": "alpha",
+        "facetSearch": false,
+        "equality": false,
+        "comparison": false
+      },
+      "localized": {
+        "locales": []
+      }
+    },
+    {
+      "name": "is_gluten_free",
+      "displayed": {
+        "enabled": true
+      },
+      "searchable": {
+        "enabled": false
+      },
+      "sortable": {
+        "enabled": false
+      },
+      "distinct": {
+        "enabled": false
+      },
+      "rankingRule": {
+        "enabled": false
+      },
+      "filterable": {
+        "enabled": false,
+        "sortBy": "alpha",
+        "facetSearch": false,
+        "equality": false,
+        "comparison": false
+      },
+      "localized": {
+        "locales": []
+      }
+    },
+    {
+      "name": "is_vegan",
+      "displayed": {
+        "enabled": true
+      },
+      "searchable": {
+        "enabled": false
+      },
+      "sortable": {
+        "enabled": false
+      },
+      "distinct": {
+        "enabled": false
+      },
+      "rankingRule": {
+        "enabled": false
+      },
+      "filterable": {
+        "enabled": false,
+        "sortBy": "alpha",
+        "facetSearch": false,
+        "equality": false,
+        "comparison": false
+      },
+      "localized": {
+        "locales": []
+      }
+    },
+    {
+      "name": "is_vegetarian",
+      "displayed": {
+        "enabled": true
+      },
+      "searchable": {
+        "enabled": false
+      },
+      "sortable": {
+        "enabled": false
+      },
+      "distinct": {
+        "enabled": false
+      },
+      "rankingRule": {
+        "enabled": false
+      },
+      "filterable": {
+        "enabled": false,
+        "sortBy": "alpha",
+        "facetSearch": false,
+        "equality": false,
+        "comparison": false
+      },
+      "localized": {
+        "locales": []
+      }
+    },
+    {
+      "name": "nutrition",
+      "displayed": {
+        "enabled": true
+      },
+      "searchable": {
+        "enabled": false
+      },
+      "sortable": {
+        "enabled": false
+      },
+      "distinct": {
+        "enabled": false
+      },
+      "rankingRule": {
+        "enabled": false
+      },
+      "filterable": {
+        "enabled": false,
+        "sortBy": "alpha",
+        "facetSearch": false,
+        "equality": false,
+        "comparison": false
+      },
+      "localized": {
+        "locales": []
+      }
+    },
+    {
+      "name": "nutrition.calories",
+      "displayed": {
+        "enabled": false
+      },
+      "searchable": {
+        "enabled": false
+      },
+      "sortable": {
+        "enabled": true
+      },
+      "distinct": {
+        "enabled": false
+      },
+      "rankingRule": {
+        "enabled": false
+      },
+      "filterable": {
+        "enabled": true,
+        "sortBy": "alpha",
+        "facetSearch": false,
+        "equality": true,
+        "comparison": true
+      },
+      "localized": {
+        "locales": []
+      }
+    },
+    {
+      "name": "nutrition.carbs",
+      "displayed": {
+        "enabled": false
+      },
+      "searchable": {
+        "enabled": false
+      },
+      "sortable": {
+        "enabled": true
+      },
+      "distinct": {
+        "enabled": false
+      },
+      "rankingRule": {
+        "enabled": false
+      },
+      "filterable": {
+        "enabled": true,
+        "sortBy": "alpha",
+        "facetSearch": false,
+        "equality": true,
+        "comparison": true
+      },
+      "localized": {
+        "locales": []
+      }
+    },
+    {
+      "name": "nutrition.fat",
+      "displayed": {
+        "enabled": false
+      },
+      "searchable": {
+        "enabled": false
+      },
+      "sortable": {
+        "enabled": true
+      },
+      "distinct": {
+        "enabled": false
+      },
+      "rankingRule": {
+        "enabled": false
+      },
+      "filterable": {
+        "enabled": true,
+        "sortBy": "alpha",
+        "facetSearch": false,
+        "equality": true,
+        "comparison": true
+      },
+      "localized": {
+        "locales": []
+      }
+    },
+    {
+      "name": "nutrition.protein",
+      "displayed": {
+        "enabled": false
+      },
+      "searchable": {
+        "enabled": false
+      },
+      "sortable": {
+        "enabled": true
+      },
+      "distinct": {
+        "enabled": false
+      },
+      "rankingRule": {
+        "enabled": false
+      },
+      "filterable": {
+        "enabled": true,
+        "sortBy": "alpha",
+        "facetSearch": false,
+        "equality": true,
+        "comparison": true
+      },
+      "localized": {
+        "locales": []
+      }
+    },
+    {
+      "name": "preparation_time_minutes",
+      "displayed": {
+        "enabled": true
+      },
+      "searchable": {
+        "enabled": false
+      },
+      "sortable": {
+        "enabled": true
+      },
+      "distinct": {
+        "enabled": false
+      },
+      "rankingRule": {
+        "enabled": false
+      },
+      "filterable": {
+        "enabled": true,
+        "sortBy": "alpha",
+        "facetSearch": false,
+        "equality": true,
+        "comparison": true
+      },
+      "localized": {
+        "locales": []
+      }
+    },
+    {
+      "name": "servings",
+      "displayed": {
+        "enabled": true
+      },
+      "searchable": {
+        "enabled": false
+      },
+      "sortable": {
+        "enabled": true
+      },
+      "distinct": {
+        "enabled": false
+      },
+      "rankingRule": {
+        "enabled": false
+      },
+      "filterable": {
+        "enabled": false,
+        "sortBy": "alpha",
+        "facetSearch": false,
+        "equality": false,
+        "comparison": false
+      },
+      "localized": {
+        "locales": []
+      }
+    },
+    {
+      "name": "tags",
+      "displayed": {
+        "enabled": true
+      },
+      "searchable": {
+        "enabled": true
+      },
+      "sortable": {
+        "enabled": false
+      },
+      "distinct": {
+        "enabled": false
+      },
+      "rankingRule": {
+        "enabled": false
+      },
+      "filterable": {
+        "enabled": false,
+        "sortBy": "alpha",
+        "facetSearch": false,
+        "equality": false,
+        "comparison": false
+      },
+      "localized": {
+        "locales": []
+      }
+    },
+    {
+      "name": "title",
+      "displayed": {
+        "enabled": true
+      },
+      "searchable": {
+        "enabled": true
+      },
+      "sortable": {
+        "enabled": false
+      },
+      "distinct": {
+        "enabled": false
+      },
+      "rankingRule": {
+        "enabled": false
+      },
+      "filterable": {
+        "enabled": false,
+        "sortBy": "alpha",
+        "facetSearch": false,
+        "equality": false,
+        "comparison": false
+      },
+      "localized": {
+        "locales": []
+      }
+    },
+    {
+      "name": "total_time_minutes",
+      "displayed": {
+        "enabled": true
+      },
+      "searchable": {
+        "enabled": false
+      },
+      "sortable": {
+        "enabled": true
+      },
+      "distinct": {
+        "enabled": false
+      },
+      "rankingRule": {
+        "enabled": false
+      },
+      "filterable": {
+        "enabled": true,
+        "sortBy": "alpha",
+        "facetSearch": false,
+        "equality": true,
+        "comparison": true
+      },
+      "localized": {
+        "locales": []
+      }
+    },
+    {
+      "name": "updated_at",
+      "displayed": {
+        "enabled": false
+      },
+      "searchable": {
+        "enabled": false
+      },
+      "sortable": {
+        "enabled": false
+      },
+      "distinct": {
+        "enabled": false
+      },
+      "rankingRule": {
+        "enabled": false
+      },
+      "filterable": {
+        "enabled": false,
+        "sortBy": "alpha",
+        "facetSearch": false,
+        "equality": false,
+        "comparison": false
+      },
+      "localized": {
+        "locales": []
+      }
+    }
+  ]
+]

--- a/crates/meilisearch/tests/index/snapshots/integration__index__fields__fields_after_uploading_recipe_and_settings.snap
+++ b/crates/meilisearch/tests/index/snapshots/integration__index__fields__fields_after_uploading_recipe_and_settings.snap
@@ -1,0 +1,14 @@
+---
+source: crates/meilisearch/tests/index/fields.rs
+expression: "(code.as_u16(), &task)"
+---
+[
+  202,
+  {
+    "taskUid": "[uid]",
+    "indexUid": "[uid]",
+    "status": "enqueued",
+    "type": "indexCreation",
+    "enqueuedAt": "[date]"
+  }
+]

--- a/crates/meilisearch/tests/index/snapshots/integration__index__fields__get_fields_empty_index-2.snap
+++ b/crates/meilisearch/tests/index/snapshots/integration__index__fields__get_fields_empty_index-2.snap
@@ -1,0 +1,8 @@
+---
+source: crates/meilisearch/tests/index/fields.rs
+expression: "(code.as_u16(), response)"
+---
+[
+  200,
+  []
+]

--- a/crates/meilisearch/tests/index/snapshots/integration__index__fields__get_fields_empty_index-3.snap
+++ b/crates/meilisearch/tests/index/snapshots/integration__index__fields__get_fields_empty_index-3.snap
@@ -1,0 +1,5 @@
+---
+source: crates/meilisearch/tests/index/fields.rs
+expression: response
+---
+[]

--- a/crates/meilisearch/tests/index/snapshots/integration__index__fields__get_fields_empty_index.snap
+++ b/crates/meilisearch/tests/index/snapshots/integration__index__fields__get_fields_empty_index.snap
@@ -1,0 +1,5 @@
+---
+source: crates/meilisearch/tests/index/fields.rs
+expression: code
+---
+202 Accepted

--- a/crates/meilisearch/tests/index/snapshots/integration__index__fields__get_fields_with_documents_and_filters-2.snap
+++ b/crates/meilisearch/tests/index/snapshots/integration__index__fields__get_fields_with_documents_and_filters-2.snap
@@ -1,0 +1,121 @@
+---
+source: crates/meilisearch/tests/index/fields.rs
+expression: "(code.as_u16(), response)"
+---
+[
+  200,
+  [
+    {
+      "name": "color",
+      "displayed": {
+        "enabled": true
+      },
+      "searchable": {
+        "enabled": true
+      },
+      "sortable": {
+        "enabled": false
+      },
+      "distinct": {
+        "enabled": false
+      },
+      "rankingRule": {
+        "enabled": false
+      },
+      "filterable": {
+        "enabled": false,
+        "sortBy": "alpha",
+        "facetSearch": false,
+        "equality": false,
+        "comparison": false
+      },
+      "localized": {
+        "locales": []
+      }
+    },
+    {
+      "name": "genre",
+      "displayed": {
+        "enabled": true
+      },
+      "searchable": {
+        "enabled": true
+      },
+      "sortable": {
+        "enabled": false
+      },
+      "distinct": {
+        "enabled": false
+      },
+      "rankingRule": {
+        "enabled": false
+      },
+      "filterable": {
+        "enabled": false,
+        "sortBy": "alpha",
+        "facetSearch": false,
+        "equality": false,
+        "comparison": false
+      },
+      "localized": {
+        "locales": []
+      }
+    },
+    {
+      "name": "id",
+      "displayed": {
+        "enabled": true
+      },
+      "searchable": {
+        "enabled": true
+      },
+      "sortable": {
+        "enabled": false
+      },
+      "distinct": {
+        "enabled": false
+      },
+      "rankingRule": {
+        "enabled": false
+      },
+      "filterable": {
+        "enabled": false,
+        "sortBy": "alpha",
+        "facetSearch": false,
+        "equality": false,
+        "comparison": false
+      },
+      "localized": {
+        "locales": []
+      }
+    },
+    {
+      "name": "title",
+      "displayed": {
+        "enabled": true
+      },
+      "searchable": {
+        "enabled": true
+      },
+      "sortable": {
+        "enabled": false
+      },
+      "distinct": {
+        "enabled": false
+      },
+      "rankingRule": {
+        "enabled": false
+      },
+      "filterable": {
+        "enabled": false,
+        "sortBy": "alpha",
+        "facetSearch": false,
+        "equality": false,
+        "comparison": false
+      },
+      "localized": {
+        "locales": []
+      }
+    }
+  ]
+]

--- a/crates/meilisearch/tests/index/snapshots/integration__index__fields__get_fields_with_documents_and_filters-3.snap
+++ b/crates/meilisearch/tests/index/snapshots/integration__index__fields__get_fields_with_documents_and_filters-3.snap
@@ -1,0 +1,37 @@
+---
+source: crates/meilisearch/tests/index/fields.rs
+expression: "(code.as_u16(), response)"
+---
+[
+  200,
+  [
+    {
+      "name": "title",
+      "displayed": {
+        "enabled": true
+      },
+      "searchable": {
+        "enabled": true
+      },
+      "sortable": {
+        "enabled": false
+      },
+      "distinct": {
+        "enabled": false
+      },
+      "rankingRule": {
+        "enabled": false
+      },
+      "filterable": {
+        "enabled": false,
+        "sortBy": "alpha",
+        "facetSearch": false,
+        "equality": false,
+        "comparison": false
+      },
+      "localized": {
+        "locales": []
+      }
+    }
+  ]
+]

--- a/crates/meilisearch/tests/index/snapshots/integration__index__fields__get_fields_with_documents_and_filters.snap
+++ b/crates/meilisearch/tests/index/snapshots/integration__index__fields__get_fields_with_documents_and_filters.snap
@@ -1,0 +1,14 @@
+---
+source: crates/meilisearch/tests/index/fields.rs
+expression: "(code.as_u16(), &task)"
+---
+[
+  202,
+  {
+    "taskUid": "[uid]",
+    "indexUid": "[uid]",
+    "status": "enqueued",
+    "type": "documentAdditionOrUpdate",
+    "enqueuedAt": "[date]"
+  }
+]

--- a/crates/milli/src/fields_ids_map.rs
+++ b/crates/milli/src/fields_ids_map.rs
@@ -7,7 +7,7 @@ use crate::FieldId;
 mod global;
 pub mod metadata;
 pub use global::GlobalFieldsIdsMap;
-pub use metadata::{FieldIdMapWithMetadata, MetadataBuilder};
+pub use metadata::{FieldIdMapWithMetadata, FieldSortOrder, MetadataBuilder};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FieldsIdsMap {

--- a/crates/milli/src/filterable_attributes_rules.rs
+++ b/crates/milli/src/filterable_attributes_rules.rs
@@ -76,10 +76,10 @@ impl FilterableAttributesPatterns {
 pub struct FilterableAttributesFeatures {
     #[serde(default)]
     #[deserr(default)]
-    facet_search: bool,
+    pub facet_search: bool,
     #[serde(default)]
     #[deserr(default)]
-    filter: FilterFeatures,
+    pub filter: FilterFeatures,
 }
 
 impl FilterableAttributesFeatures {
@@ -156,10 +156,10 @@ impl<E: DeserializeError> Deserr<E> for FilterableAttributesRule {
 pub struct FilterFeatures {
     #[serde(default = "default_true")]
     #[deserr(default = true)]
-    equality: bool,
+    pub equality: bool,
     #[serde(default)]
     #[deserr(default)]
-    comparison: bool,
+    pub comparison: bool,
 }
 
 fn default_true() -> bool {

--- a/crates/milli/src/lib.rs
+++ b/crates/milli/src/lib.rs
@@ -67,7 +67,7 @@ pub use self::error::{
 pub use self::external_documents_ids::ExternalDocumentsIds;
 pub use self::fieldids_weights_map::FieldidsWeightsMap;
 pub use self::fields_ids_map::{
-    FieldIdMapWithMetadata, FieldsIdsMap, GlobalFieldsIdsMap, MetadataBuilder,
+    FieldIdMapWithMetadata, FieldSortOrder, FieldsIdsMap, GlobalFieldsIdsMap, MetadataBuilder,
 };
 pub use self::filterable_attributes_rules::{
     FilterFeatures, FilterableAttributesFeatures, FilterableAttributesPatterns,

--- a/crates/milli/src/order_by_map.rs
+++ b/crates/milli/src/order_by_map.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::OrderBy;
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone, Debug)]
 pub struct OrderByMap(HashMap<String, OrderBy>);
 
 impl OrderByMap {


### PR DESCRIPTION
## Summary

Adds a new `POST /indexes/{indexUid}/fields` endpoint that returns detailed metadata about all fields in an index. This endpoint provides comprehensive information about each field's configuration, including display, search, filtering, and localization settings.

## What's New

- **New endpoint**: `POST /indexes/{indexUid}/fields`

For each field in an index, the endpoint returns:

```json
{
	"name": "cuisine.type",
	"displayed":  { "enabled": true },
	"searchable": { "enabled": true },
	"sortable": { "enabled": false },
	"distinct":   { "enabled": false },
	"rankingRule": {
	  "enabled": true,
	  "order": "asc"
	},
	"filterable": {
	    "enabled": false,
	    "sortBy": "alpha",
	    "facetSearch": true,
	    "equality": true,
	    "comparison": true
	},
	"localized":  { "locales": ["eng", "fra"] }
}
```

### Query Features

All those properties are optional. When multiple filter properties are provided, they work together using AND logic.

```jsonc
{
  // Pagination controls
  "offset": 0,
  "limit": 20,
  
  // Filter configuration - all filters are optional and can be combined
  "filter": {
    // Match fields using attribute patterns (supports wildcards: * for any characters)
    // Examples: "cuisine.*" matches cuisine.type, cuisine.region
    //           "user*" matches user_id, username, user_profile
    //           "*_id" matches all fields ending with _id
    "attributePatterns": ["cuisine.*", "*_timestamp"],
    
    // Filter by whether fields are displayed in search results
    // true = only displayed fields, false = only hidden fields
    "displayed": true,
    
    // Filter by whether fields are searchable (indexed for full-text search)
    // true = only searchable fields, false = only non-searchable fields
    "searchable": true,
    
    // Filter by whether fields can be used for sorting results
    // true = only sortable fields, false = only non-sortable fields
    "sortable": true,
    
    // Filter by whether the field is used as the distinct attribute
    // true = only the distinct field, false = only non-distinct fields
    "distinct": true,
    
    // Filter by whether the field is used in ranking rules
    // true = only fields used in ranking, false = only fields not used in ranking
    "rankingRule": true,
    
    // Filter by whether the field can be used for filtering/faceting
    // true = only filterable fields, false = only non-filterable fields
    "filterable": true
  }
}
```

## Potential Refactoring Opportunity

The enhancements made to `MetadataBuilder::from_index()` in this PR now provide comprehensive access to field metadata and index settings information. This means that in places where the codebase currently calls `MetadataBuilder::from_index()` followed by the `settings()` function (defined in `crates/meilisearch-types/src/settings.rs`) to retrieve index settings, the `settings()` call may no longer be necessary—`MetadataBuilder` alone now provides what's needed.

`MetadataBuilder` currently takes ownership of many strings, which seems unnecessary given that its lifetime could be tied to the LMDB read transaction it's built from, allowing it to use string references instead. The same could be done to some of the collections defined in the `MetadataBuilder` struct.



