### PR TITLE
Implement parallel cleanup of old field IDs

### DIFF
--- a/crates/milli/src/update/upgrade/v1_32.rs
+++ b/crates/milli/src/update/upgrade/v1_32.rs
@@ -196,7 +196,6 @@ fn fetch_keys_to_delete_in_parallel<'txn>(
                     let (_word, fid) =
                         StrBEU16Codec::bytes_decode(key_bytes).map_err(heed::Error::Decoding)?;
 
-                    // TODO optimize allocations
                     if fids_to_delete.contains(&fid) {
                         keys_to_delete.push(key_bytes.to_vec().into_boxed_slice());
                     }


### PR DESCRIPTION
This PR enhances [the algorithm to address inconsistencies in field-ID-based databases](https://github.com/meilisearch/meilisearch/pull/6076) by parallelizing it.

## Changelog

We improve the time it takes to perform the dumpless upgrade for instances before v1.32.0 by multi-threading the way we fetch entries in the database. By doing that, we noticed improvements from 2 hours and 50 minutes to a bit less than 7 minutes.