### PR TITLE
Bump hannoy to 0.1.4-nested-rtxns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2698,9 +2698,9 @@ dependencies = [
 
 [[package]]
 name = "hannoy"
-version = "0.1.3-nested-rtxns"
+version = "0.1.4-nested-rtxns"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccefa5359b5cd1ca44f6c47ffc75c981744caf9e500ac317578409d99f01c6b"
+checksum = "2b5cb94fb057860b28a394a6f739f40192c707e0e043283f30f1b8755dad473f"
 dependencies = [
  "bytemuck",
  "byteorder",

--- a/crates/milli/Cargo.toml
+++ b/crates/milli/Cargo.toml
@@ -91,7 +91,7 @@ rhai = { version = "1.23.6", features = [
     "sync",
 ] }
 arroy = "0.6.4-nested-rtxns"
-hannoy = { version = "0.1.3-nested-rtxns", features = ["arroy"] }
+hannoy = { version = "0.1.4-nested-rtxns", features = ["arroy"] }
 rand = "0.8.5"
 tracing = "0.1.41"
 ureq = { version = "2.12.1", features = ["json"] }


### PR DESCRIPTION
This PR bumps hannoy to v0.1.4-nested-rtxns.

### Changelog

We updated our internal vector store to speed up the dumpless upgrade by improving the graph rebuilding
and improve the speed and relevance of the search by using the explore factor as a limit to stop document searches rather than the query limit.