### PR TITLE
feat: use parallel deletion for fid-based databases in standard path

### DIFF
--- a/crates/meilisearch/src/routes/indexes/mod.rs
+++ b/crates/meilisearch/src/routes/indexes/mod.rs
@@ -1,16 +1,6 @@
 use std::collections::BTreeSet;
 use std::convert::Infallible;
 
-use super::{
-    get_task_id, Pagination, PaginationView, SummarizedTaskView, PAGINATION_DEFAULT_LIMIT,
-};
-use crate::analytics::{Aggregate, Analytics};
-use crate::extractors::authentication::policies::*;
-use crate::extractors::authentication::{AuthenticationError, GuardedData};
-use crate::extractors::sequential_extractor::SeqHandler;
-use crate::proxy::{proxy, task_network_and_check_leader_and_version, Body};
-use crate::routes::is_dry_run;
-use crate::Opt;
 use actix_web::web::Data;
 use actix_web::{web, HttpRequest, HttpResponse};
 use deserr::actix_web::{AwebJson, AwebQueryParameter};
@@ -32,6 +22,17 @@ use serde::{Serialize, Serializer};
 use time::OffsetDateTime;
 use tracing::debug;
 use utoipa::{IntoParams, OpenApi, ToSchema};
+
+use super::{
+    get_task_id, Pagination, PaginationView, SummarizedTaskView, PAGINATION_DEFAULT_LIMIT,
+};
+use crate::analytics::{Aggregate, Analytics};
+use crate::extractors::authentication::policies::*;
+use crate::extractors::authentication::{AuthenticationError, GuardedData};
+use crate::extractors::sequential_extractor::SeqHandler;
+use crate::proxy::{proxy, task_network_and_check_leader_and_version, Body};
+use crate::routes::is_dry_run;
+use crate::Opt;
 
 pub mod compact;
 pub mod documents;


### PR DESCRIPTION
## Summary

Copies the parallel deletion method from the dumpless upgrade path (v1_32.rs) to the standard indexing path in mod.rs. This improves performance when deleting entries for field IDs that are no longer searchable.

## Changes

- Added \compute_fst_bounds()\ to divide work using FST word dictionary
- Added \etch_keys_to_delete_in_parallel()\ for parallel key fetching using nested read transactions
- Added \delete_old_word_fid_docids_parallel()\ to orchestrate parallel deletion
- Removed ThreadPool creation - uses existing rayon threadpool directly

## Notes

As requested in #6105, the code is duplicated (not imported) to freeze the dumpless upgrade code and prevent accidental breakage.

Closes #6105