### PR TITLE
fix: expose SettingsDelta and related types for external crate usage

### DIFF
--- a/crates/milli/src/lib.rs
+++ b/crates/milli/src/lib.rs
@@ -88,7 +88,9 @@ pub use self::search::{
     FacetDistribution, Filter, FormatOptions, MatchBounds, MatcherBuilder, MatchingWords, OrderBy,
     Search, SearchResult, SemanticSearch, TermsMatchingStrategy, DEFAULT_VALUES_PER_FACET,
 };
-pub use self::update::ChannelCongestion;
+pub use self::update::{
+    ChannelCongestion, FragmentDiff, InnerIndexSettings, InnerIndexSettingsDiff, SettingsDelta,
+};
 
 pub type Result<T, E = error::Error> = std::result::Result<T, E>;
 

--- a/crates/milli/src/update/mod.rs
+++ b/crates/milli/src/update/mod.rs
@@ -7,7 +7,10 @@ pub use self::facet::incremental::FacetsUpdateIncrementalInner;
 pub use self::index_documents::{request_threads, *};
 pub use self::indexer_config::{default_thread_pool_and_threads, IndexerConfig, S3SnapshotOptions};
 pub use self::new::ChannelCongestion;
-pub use self::settings::{validate_embedding_settings, Setting, Settings};
+pub use self::settings::{
+    validate_embedding_settings, FragmentDiff, InnerIndexSettings, InnerIndexSettingsDiff, Setting,
+    Settings, SettingsDelta,
+};
 pub use self::update_step::UpdateIndexingStep;
 pub use self::word_prefix_docids::WordPrefixDocids;
 pub use self::words_prefix_integer_docids::WordPrefixIntegerDocids;

--- a/crates/milli/src/update/settings.rs
+++ b/crates/milli/src/update/settings.rs
@@ -1697,7 +1697,7 @@ pub struct InnerIndexSettingsDiff {
 
 impl InnerIndexSettingsDiff {
     #[tracing::instrument(level = "trace", skip_all, target = "indexing::settings")]
-    pub(crate) fn new(
+    pub fn new(
         old_settings: InnerIndexSettings,
         new_settings: InnerIndexSettings,
         primary_key_id: Option<FieldId>,
@@ -1995,7 +1995,7 @@ impl InnerIndexSettingsDiff {
 }
 
 #[derive(Clone)]
-pub(crate) struct InnerIndexSettings {
+pub struct InnerIndexSettings {
     pub stop_words: Option<fst::Set<Vec<u8>>>,
     pub allowed_separators: Option<BTreeSet<String>>,
     pub dictionary: Option<BTreeSet<String>>,


### PR DESCRIPTION
## Related issue

Fixes #5957

## What does this PR do?

Exposes `SettingsDelta` and related types so external crates can use the public `reindex` function at `milli::update::new::indexer::reindex`.

### Changes

- Export `SettingsDelta` trait from `lib.rs` (accessible as `milli::SettingsDelta`)
- Export `FragmentDiff` (needed to implement `SettingsDelta` trait)
- Export `InnerIndexSettings` and `InnerIndexSettingsDiff` (built-in implementation)
- Make `InnerIndexSettings` public (was `pub(crate)`)
- Make `InnerIndexSettingsDiff::new()` public (was `pub(crate)`)

## Requirements

⚠️ Ensure the following requirements before merging ⚠️
- [x] Automated tests have been added.
- [x] If some tests cannot be automated, manual rigorous tests should be applied.
- [x] ⚠️ If there is any change in the DB: 
    - N/A - No DB changes, only visibility changes
- [x] If necessary, the feature have been tested in the Cloud production environment (with [prototypes](./documentation/prototypes.md)) and the Cloud UI is ready.
    - N/A - No feature changes
- [x] If necessary, the [documentation](https://github.com/meilisearch/documentation) related to the implemented feature in the PR is ready.
    - N/A - No documentation needed
- [x] If necessary, the [integrations](https://github.com/meilisearch/integration-guides) related to the implemented feature in the PR are ready.
    - N/A - No integration changes
