### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/bench-manual.yml
+++ b/.github/workflows/bench-manual.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: benchmarks
     timeout-minutes: 180 # 3h
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@1.91.1
         with:
           profile: minimal

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           repo_token: ${{ env.GH_TOKEN }}
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         if: success()
         with:
           fetch-depth: 0 # fetch full history to be able to get main commit sha

--- a/.github/workflows/bench-push-indexing.yml
+++ b/.github/workflows/bench-push-indexing.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: benchmarks
     timeout-minutes: 180 # 3h
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@1.91.1
 
       # Run benchmarks

--- a/.github/workflows/benchmarks-manual.yml
+++ b/.github/workflows/benchmarks-manual.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: benchmarks
     timeout-minutes: 4320 # 72h
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@1.91.1
         with:
           profile: minimal

--- a/.github/workflows/benchmarks-pr.yml
+++ b/.github/workflows/benchmarks-pr.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           repo_token: ${{ env.GH_TOKEN }}
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         if: success()
         with:
           fetch-depth: 0 # fetch full history to be able to get main commit sha

--- a/.github/workflows/benchmarks-push-indexing.yml
+++ b/.github/workflows/benchmarks-push-indexing.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: benchmarks
     timeout-minutes: 4320 # 72h
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@1.91.1
         with:
           profile: minimal

--- a/.github/workflows/benchmarks-push-search-geo.yml
+++ b/.github/workflows/benchmarks-push-search-geo.yml
@@ -14,7 +14,7 @@ jobs:
     name: Run and upload benchmarks
     runs-on: benchmarks
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@1.91.1
         with:
           profile: minimal

--- a/.github/workflows/benchmarks-push-search-songs.yml
+++ b/.github/workflows/benchmarks-push-search-songs.yml
@@ -14,7 +14,7 @@ jobs:
     name: Run and upload benchmarks
     runs-on: benchmarks
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@1.91.1
         with:
           profile: minimal

--- a/.github/workflows/benchmarks-push-search-wiki.yml
+++ b/.github/workflows/benchmarks-push-search-wiki.yml
@@ -14,7 +14,7 @@ jobs:
     name: Run and upload benchmarks
     runs-on: benchmarks
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@1.91.1
         with:
           profile: minimal

--- a/.github/workflows/check-openapi-file.yml
+++ b/.github/workflows/check-openapi-file.yml
@@ -20,7 +20,7 @@ jobs:
     name: Check OpenAPI specification
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@1.91.1
@@ -29,7 +29,7 @@ jobs:
         uses: Swatinem/rust-cache@v2.8.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 

--- a/.github/workflows/db-change-comments.yml
+++ b/.github/workflows/db-change-comments.yml
@@ -44,7 +44,7 @@ jobs:
     if: github.event.label.name == 'db change'
     steps:
       - name: Add comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/db-change-missing.yml
+++ b/.github/workflows/db-change-missing.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Check db change labels
         id: check_labels
         env:

--- a/.github/workflows/dependency-issue.yml
+++ b/.github/workflows/dependency-issue.yml
@@ -13,7 +13,7 @@ jobs:
       ISSUE_TEMPLATE: issue-template.md
       GH_TOKEN: ${{ secrets.MEILI_BOT_GH_PAT }}
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     - name: Download the issue template
       run: curl -s https://raw.githubusercontent.com/meilisearch/meilisearch/main/.github/templates/dependency-issue.md > $ISSUE_TEMPLATE
     - name: Create issue

--- a/.github/workflows/flaky-tests.yml
+++ b/.github/workflows/flaky-tests.yml
@@ -12,7 +12,7 @@ jobs:
       # Use ubuntu-22.04 to compile with glibc 2.35
       image: ubuntu:22.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Clean space as per https://github.com/actions/virtual-environments/issues/709
         run: |
           sudo rm -rf "/opt/ghc" || true

--- a/.github/workflows/fuzzer-indexing.yml
+++ b/.github/workflows/fuzzer-indexing.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 4320 # 72h
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@1.91.1
 
       # Run benchmarks

--- a/.github/workflows/latest-git-tag.yml
+++ b/.github/workflows/latest-git-tag.yml
@@ -10,7 +10,7 @@ jobs:
     name: Check the version validity
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Check release validity
         if: github.event_name == 'release'
         run: bash .github/scripts/check-release.sh
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: check-version
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: rickstaa/action-create-tag@v1
         with:
           tag: "latest"

--- a/.github/workflows/publish-apt-brew-pkg.yml
+++ b/.github/workflows/publish-apt-brew-pkg.yml
@@ -9,7 +9,7 @@ jobs:
     name: Check the version validity
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Check release validity
         run: bash .github/scripts/check-release.sh
 
@@ -34,7 +34,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@1.91.1
       - name: Install cargo-deb
         run: cargo install cargo-deb
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Build deb package
         run: cargo deb -p meilisearch -o target/debian/meilisearch.deb
       - name: Upload debian pkg to release

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -35,7 +35,7 @@ jobs:
 
     permissions: {}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Prepare
         run: |
@@ -90,7 +90,7 @@ jobs:
           touch "${{ runner.temp }}/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: digests-${{ matrix.edition }}-${{ env.PLATFORM_PAIR }}
           path: ${{ runner.temp }}/digests/*
@@ -114,7 +114,7 @@ jobs:
       id-token: write # This is needed to use Cosign in keyless mode
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       # If we are running a cron or manual job ('schedule' or 'workflow_dispatch' event), it means we are publishing the `nightly` tag, so not considered stable.
       # If we have pushed a tag, and the tag has the v<nmumber>.<number>.<number> format, it means we are publishing an official release, so considered stable.
@@ -157,7 +157,7 @@ jobs:
         uses: sigstore/cosign-installer@d7543c93d881b35a8faa02e8e3605f69b7a1ce62 # tag=v3.10.0
 
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: ${{ runner.temp }}/digests
           pattern: digests-${{ matrix.edition }}-*
@@ -212,7 +212,7 @@ jobs:
       - name: Notify meilisearch-cloud 
         # Do not send if nightly build (i.e. 'schedule' or 'workflow_dispatch' event)
         if: ${{ (github.event_name == 'push') && (matrix.edition == 'enterprise') }}
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.MEILI_BOT_GH_PAT }}
           repository: meilisearch/meilisearch-cloud
@@ -223,7 +223,7 @@ jobs:
       - name: Notify meilisearch-kubernetes
         # Do not send if nightly build (i.e. 'schedule' or 'workflow_dispatch' event), or if not stable
         if: ${{ github.event_name == 'push' && matrix.edition == 'community' && steps.check-tag-format.outputs.stable == 'true' }}
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.MEILI_BOT_GH_PAT }}
           repository: meilisearch/meilisearch-kubernetes

--- a/.github/workflows/publish-release-assets.yml
+++ b/.github/workflows/publish-release-assets.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     # No need to check the version for dry run (cron or workflow_dispatch)
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       # Check if the tag has the v<nmumber>.<number>.<number> format.
       # If yes, it means we are publishing an official release.
       # If no, we are releasing a RC, so no need to check the version.
@@ -78,7 +78,7 @@ jobs:
             extra-args: "--target aarch64-unknown-linux-gnu"
     needs: check-version
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@1.91.1
       - name: Build
         run: cargo build --release --locked ${{ matrix.feature-flag }} ${{ matrix.extra-args }}
@@ -98,7 +98,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Setup Rust
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/sdks-tests.yml
+++ b/.github/workflows/sdks-tests.yml
@@ -22,7 +22,7 @@ jobs:
     outputs:
       docker-image: ${{ steps.define-image.outputs.docker-image }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Define the Docker image we need to use
         id: define-image
         env:
@@ -50,7 +50,7 @@ jobs:
       MEILISEARCH_VERSION: ${{ needs.define-docker-image.outputs.docker-image }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           repository: meilisearch/meilisearch-dotnet
       - name: Setup .NET Core
@@ -79,7 +79,7 @@ jobs:
         ports:
           - "7700:7700"
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           repository: meilisearch/meilisearch-dart
       - uses: dart-lang/setup-dart@v1
@@ -107,7 +107,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: stable
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           repository: meilisearch/meilisearch-go
       - name: Get dependencies
@@ -133,7 +133,7 @@ jobs:
         ports:
           - "7700:7700"
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           repository: meilisearch/meilisearch-java
       - name: Set up Java
@@ -160,7 +160,7 @@ jobs:
         ports:
           - "7700:7700"
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           repository: meilisearch/meilisearch-js
       - name: Install pnpm
@@ -197,7 +197,7 @@ jobs:
         ports:
           - "7700:7700"
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           repository: meilisearch/meilisearch-php
       - name: Install PHP
@@ -226,7 +226,7 @@ jobs:
         ports:
           - "7700:7700"
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           repository: meilisearch/meilisearch-python
       - name: Set up Python
@@ -251,7 +251,7 @@ jobs:
         ports:
           - "7700:7700"
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           repository: meilisearch/meilisearch-ruby
       - name: Set up Ruby 3
@@ -276,7 +276,7 @@ jobs:
         ports:
           - "7700:7700"
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           repository: meilisearch/meilisearch-rust
       - name: Build
@@ -297,7 +297,7 @@ jobs:
         ports:
           - "7700:7700"
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           repository: meilisearch/meilisearch-swift
       - name: Run tests
@@ -320,7 +320,7 @@ jobs:
         ports:
           - "7700:7700"
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           repository: meilisearch/meilisearch-js-plugins
       - name: Install pnpm
@@ -355,7 +355,7 @@ jobs:
     env:
       RAILS_VERSION: "7.0"
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           repository: meilisearch/meilisearch-rails
       - name: Install SQLite dependencies
@@ -385,7 +385,7 @@ jobs:
         ports:
           - "7700:7700"
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           repository: meilisearch/meilisearch-symfony
       - name: Install PHP

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -22,7 +22,7 @@ jobs:
         runner: [ubuntu-22.04, ubuntu-22.04-arm]
         features: ["", "--features enterprise"]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: check free space before
         run: df -h
       - name: Clean space as per https://github.com/actions/virtual-environments/issues/709
@@ -60,7 +60,7 @@ jobs:
         features: ["", "--features enterprise"]
     if: github.event_name != 'merge_group'
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2.8.0
       - uses: dtolnay/rust-toolchain@1.91.1
@@ -85,7 +85,7 @@ jobs:
         features: ["", "--features enterprise"]
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2.8.0
       - uses: dtolnay/rust-toolchain@1.91.1
@@ -105,7 +105,7 @@ jobs:
     runs-on: ubuntu-22.04
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Clean space as per https://github.com/actions/virtual-environments/issues/709
         run: |
           sudo rm -rf "/opt/ghc" || true
@@ -126,7 +126,7 @@ jobs:
     env:
       MEILI_TEST_OLLAMA_SERVER: "http://localhost:11434"
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Clean space as per https://github.com/actions/virtual-environments/issues/709
         run: |
           sudo rm -rf "/opt/ghc" || true
@@ -163,7 +163,7 @@ jobs:
     runs-on: ubuntu-22.04
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Clean space as per https://github.com/actions/virtual-environments/issues/709
         run: |
           sudo rm -rf "/opt/ghc" || true
@@ -185,7 +185,7 @@ jobs:
     name: Build in release
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Clean space as per https://github.com/actions/virtual-environments/issues/709
         run: |
           sudo rm -rf "/opt/ghc" || true
@@ -205,7 +205,7 @@ jobs:
       matrix:
         features: ["", "--features enterprise"]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Clean space as per https://github.com/actions/virtual-environments/issues/709
         run: |
           sudo rm -rf "/opt/ghc" || true
@@ -227,7 +227,7 @@ jobs:
     name: Run Rustfmt
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Clean space as per https://github.com/actions/virtual-environments/issues/709
         run: |
           sudo rm -rf "/opt/ghc" || true
@@ -253,7 +253,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Clean space as per https://github.com/actions/virtual-environments/issues/709
         run: |
           sudo rm -rf "/opt/ghc" || true

--- a/.github/workflows/update-cargo-toml-version.yml
+++ b/.github/workflows/update-cargo-toml-version.yml
@@ -17,7 +17,7 @@ jobs:
     name: Update version in Cargo.toml
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Clean space as per https://github.com/actions/virtual-environments/issues/709
         run: |
           sudo rm -rf "/opt/ghc" || true


### PR DESCRIPTION
## Related issue

Fixes #...

## Requirements

- [ ] Automated tests have been added.
- [ ] If some tests cannot be automated, manual rigorous tests should be applied.
- [ ] ⚠️ If there is any change in the DB:  
    - [ ] Test that any impacted DB still works as expected after using `--experimental-dumpless-upgrade` on a DB created with the last released Meilisearch  
    - [ ] Test that during the upgrade, **search is still available** (artificially make the upgrade longer if needed)  
    - [ ] Set the `db change` label.  
- [ ] If necessary, the feature have been tested in the Cloud production environment (with [prototypes](https://github.com/meilisearch/documentation/prototypes.md)) and the Cloud UI is ready.  
- [ ] If necessary, the [documentation](https://github.com/meilisearch/documentation) related to the implemented feature in the PR is ready.  
- [ ] If necessary, the [integrations](https://github.com/meilisearch/integration-guides) related to the implemented feature in the PR are ready.  

## PR Description

This PR updates outdated GitHub Action versions to `v6` across multiple workflows. The changes include:

- Updated `actions/checkout` from `v5` to `v6` in `.github/workflows/dependency-issue.yml`
- Updated `actions/checkout` from `v5` to `v6` in `.github/workflows/benchmarks-push-search-songs.yml`
- Updated `actions/checkout` from `v5` to `v6` in `.github/workflows/db-change-missing.yml`
- Updated `actions/checkout` from `v5` to `v6` in `.github/workflows/benchmarks-push-search-geo.yml`
- Updated `peter-evans/repository-dispatch` from `v3` to `v4` in `.github/workflows/publish-docker-images.yml`
- Updated `actions/upload-artifact` from `v4` to `v6` in `.github/workflows/publish-docker-images.yml`
- Updated `actions/checkout` from `v5` to `v6` in `.github/workflows/sdks-tests.yml`
- Updated `actions/checkout` from `v5` to `v6` in `.github/workflows/test-suite.yml`
- Updated `actions/checkout` from `v5` to `v6` in `.github/workflows/flaky-tests.yml`
- Updated `actions/checkout` from `v5` to `v6` in `.github/workflows/check-openapi-file.yml`
- Updated `actions/checkout` from `v5` to `v6` in `.github/workflows/latest-git-tag.yml`
- Updated `actions/checkout` from `v5` to `v6` in `.github/workflows/bench-pr.yml`
- Updated `actions/checkout` from `v5` to `v6` in `.github/workflows/benchmarks-pr.yml`
- Updated `actions/download-artifact` from `v4` to `v7` in `.github/workflows/publish-docker-images.yml`
- Updated `actions/checkout` from `v5` to `v6` in `.github/workflows/publish-apt-brew-pkg.yml`
- Updated `actions/checkout` from `v5` to `v6` in `.github/workflows/benchmarks-push-search-wiki.yml`
- Updated `actions/checkout` from `v5` to `v6` in `.github/workflows/bench-manual.yml`
- Updated `actions/checkout` from `v5` to `v6` in `.github/workflows/benchmarks-manual.yml`
- Updated `actions/checkout` from `v5` to `v6` in `.github/workflows/bench-push-indexing.yml`
- Updated `actions/setup-node` from `v4` to `v6` in `.github/workflows/check-openapi-file.yml`
- Updated `actions/checkout` from `v5` to `v6` in `.github/workflows/update-cargo-toml-version.yml`
- Updated `actions/checkout` from `v5` to `v6` in `.github/workflows/publish-release-assets.yml`
- Updated `actions/checkout` from `v5` to `v6` in `.github/workflows/benchmarks-push-indexing.yml`
- Updated `actions/github-script` from `v7` to `v8` in `.github/workflows/db-change-comments.yml`
- Updated `actions/checkout` from `v5` to `v6` in `.github/workflows/fuzzer-indexing.yml`  

The changes ensure compatibility with the latest GitHub Actions and are tested in the CI pipeline. No DB changes were made, so the `db change` label is not required.