### PR TITLE
Bump mini-dashboard version to fix display of image in local UI interface

### DIFF
--- a/crates/meilisearch/Cargo.toml
+++ b/crates/meilisearch/Cargo.toml
@@ -173,5 +173,5 @@ german = ["meilisearch-types/german"]
 turkish = ["meilisearch-types/turkish"]
 
 [package.metadata.mini-dashboard]
-assets-url = "https://github.com/meilisearch/mini-dashboard/releases/download/v0.2.23/build.zip"
-sha1 = "4b19a5a2021e57e7fae4696d3f5cfd949812e6b0"
+assets-url = "https://github.com/meilisearch/mini-dashboard/releases/download/v0.3.0/build.zip"
+sha1 = "cdd17ac43cd57d8bf1a889759644200f74514fba"


### PR DESCRIPTION
## Related issue

Bump mini-dashboard to [v0.3.0](https://github.com/meilisearch/mini-dashboard/releases/tag/v0.3.0)

## Requirements

⚠️ Ensure the following requirements before merging ⚠️
- [ ] Automated tests have been added.
- [x] If some tests cannot be automated, manual rigorous tests should be applied.
- [ ] ⚠️ If there is any change in the DB: 
    - [ ] Test that any impacted DB still works as expected after using `--experimental-dumpless-upgrade` on a DB created with the last released Meilisearch
    - [ ] Test that during the upgrade, **search is still available** (artificially make the upgrade longer if needed)
    - [ ] Set the `db change` label.
- [x] If necessary, the feature have been tested in the Cloud production environment (with [prototypes](./documentation/prototypes.md)) and the Cloud UI is ready.
- [x] If necessary, the [documentation](https://github.com/meilisearch/documentation) related to the implemented feature in the PR is ready.
- [x] If necessary, the [integrations](https://github.com/meilisearch/integration-guides) related to the implemented feature in the PR are ready.
