### PR TITLE
Do not exclude explicitly null fields when sorting

### DIFF
--- a/crates/milli/src/update/new/extract/faceted/extract_facets.rs
+++ b/crates/milli/src/update/new/extract/faceted/extract_facets.rs
@@ -323,8 +323,10 @@ impl FacetedDocidsExtractor {
             }
             // Null
             // key: fid
+            // Track null values for both filterable and sortable fields
             Value::Null
-                if depth == perm_json_p::Depth::OnBaseKey && features.is_filterable_null() =>
+                if depth == perm_json_p::Depth::OnBaseKey
+                    && (features.is_filterable_null() || meta.is_sortable()) =>
             {
                 buffer.clear();
                 buffer.push(FacetKind::Null as u8);


### PR DESCRIPTION
## Related issue

None yet - something I noticed in my project that deployed a local Meilisearch on user's machines: https://github.com/chrisbenincasa/tunarr

Happy to open one to discuss further if necessary

## Requirements

⚠️ Ensure the following requirements before merging ⚠️
- [x] Automated tests have been added.
- [ ] If some tests cannot be automated, manual rigorous tests should be applied.
- [x] ⚠️ If there is any change in the DB: 
    - [ ] Test that any impacted DB still works as expected after using `--experimental-dumpless-upgrade` on a DB created with the last released Meilisearch **This seemed to work for me but I can perform something more official if necessary**
    - [ ] Test that during the upgrade, **search is still available** (artificially make the upgrade longer if needed)
    - [ ] Set the `db change` label.
- [ ] If necessary, the feature have been tested in the Cloud production environment (with [prototypes](./documentation/prototypes.md)) and the Cloud UI is ready. **Don't know know to do this**
- [ ] If necessary, the [documentation](https://github.com/meilisearch/documentation) related to the implemented feature in the PR is ready.
- [ ] If necessary, the [integrations](https://github.com/meilisearch/integration-guides) related to the implemented feature in the PR are ready.

## Open Questions
* Is there an implication that I may not be aware off to adding these null fields to the sortable index if necessary? 