### PR TITLE
Add experimental tunnel to expose Meilisearch via public URL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -866,6 +866,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "burrow-client"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edbe0e8dca20064686fdf3fdcd4ce8bcdb44a34f5e39a574e90523c1b1638603"
+dependencies = [
+ "anyhow",
+ "burrow-core",
+ "bytes",
+ "futures",
+ "futures-util",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "serde_json",
+ "tokio",
+ "tokio-tungstenite",
+ "tracing",
+ "tungstenite",
+ "uuid",
+ "yamux",
+]
+
+[[package]]
+name = "burrow-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a4f12df631876f4665180425fb95c87ad52f50f746d939f7780838e08a7d06"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "serde",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
 name = "byte-unit"
 version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1433,6 +1469,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -1668,6 +1714,12 @@ checksum = "06d2e3287df1c007e74221c49ca10a95d557349e54b3a75dc2fb14712c751f04"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "deadpool"
@@ -3218,9 +3270,12 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.1",
+ "system-configuration",
  "tokio",
+ "tower-layer",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -4235,6 +4290,7 @@ dependencies = [
  "bstr",
  "build-info",
  "bumpalo",
+ "burrow-client",
  "byte-unit",
  "bytes",
  "cargo_toml",
@@ -4621,6 +4677,12 @@ name = "nohash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0f889fb66f7acdf83442c35775764b51fed3c606ab9cee51500dbde2cf528ca"
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
@@ -6251,7 +6313,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
 dependencies = [
  "bitflags 2.10.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -6822,6 +6884,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7120,8 +7203,12 @@ checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
+ "rustls",
+ "rustls-pki-types",
  "tokio",
+ "tokio-rustls",
  "tungstenite",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -7401,8 +7488,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
 dependencies = [
  "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
  "log",
  "rand 0.9.2",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
  "thiserror 2.0.17",
  "utf-8",
 ]
@@ -7997,8 +8090,8 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link 0.1.3",
- "windows-result",
- "windows-strings",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -8057,6 +8150,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8066,12 +8170,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -8407,6 +8529,22 @@ name = "yada"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aed111bd9e48a802518765906cbdadf0b45afb72b9c81ab049a3b86252adffdd"
+
+[[package]]
+name = "yamux"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deab71f2e20691b4728b349c6cee8fc7223880fa67b6b4f92225ec32225447e5"
+dependencies = [
+ "futures",
+ "log",
+ "nohash-hasher",
+ "parking_lot",
+ "pin-project",
+ "rand 0.9.2",
+ "static_assertions",
+ "web-time",
+]
 
 [[package]]
 name = "yansi"

--- a/crates/meilisearch/Cargo.toml
+++ b/crates/meilisearch/Cargo.toml
@@ -116,6 +116,7 @@ urlencoding = "2.1.3"
 backoff = { version = "0.4.0", features = ["tokio"] }
 humantime = { version = "2.3.0", default-features = false }
 cidr = { version = "0.3.2", features = ["serde"] }
+burrow-client = "0.1.0"
 
 [dev-dependencies]
 actix-rt = "2.11.0"

--- a/crates/meilisearch/src/analytics/segment_analytics.rs
+++ b/crates/meilisearch/src/analytics/segment_analytics.rs
@@ -291,6 +291,7 @@ impl Infos {
             config_file_path,
             no_analytics: _,
             experimental_personalization_api_key,
+            experimental_tunnel: _,
             s3_snapshot_options,
         } = options;
 

--- a/crates/meilisearch/src/option.rs
+++ b/crates/meilisearch/src/option.rs
@@ -76,6 +76,7 @@ const MEILI_EXPERIMENTAL_PERSONALIZATION_API_KEY: &str =
     "MEILI_EXPERIMENTAL_PERSONALIZATION_API_KEY";
 
 const MEILI_EXPERIMENTAL_ALLOWED_IP_NETWORKS: &str = "MEILI_EXPERIMENTAL_ALLOWED_IP_NETWORKS";
+const MEILI_EXPERIMENTAL_TUNNEL: &str = "MEILI_EXPERIMENTAL_TUNNEL";
 
 // Related to S3 snapshots
 const MEILI_S3_BUCKET_URL: &str = "MEILI_S3_BUCKET_URL";
@@ -514,6 +515,13 @@ pub struct Opt {
     #[serde(default)]
     pub experimental_allowed_ip_networks: Vec<cidr::AnyIpCidr>,
 
+    /// Experimental tunnel feature. When enabled, Meilisearch will connect to
+    /// the burrow tunnel server to expose this instance via a public URL
+    /// at <instance-uid>.meilisearch.link.
+    #[clap(long, env = MEILI_EXPERIMENTAL_TUNNEL)]
+    #[serde(default)]
+    pub experimental_tunnel: bool,
+
     #[serde(flatten)]
     #[clap(flatten)]
     pub indexer_options: IndexerOpts,
@@ -625,6 +633,7 @@ impl Opt {
             experimental_no_snapshot_compaction,
             experimental_personalization_api_key,
             experimental_allowed_ip_networks,
+            experimental_tunnel,
             s3_snapshot_options,
         } = self;
         export_to_env_if_not_present(MEILI_DB_PATH, db_path);
@@ -745,6 +754,11 @@ impl Opt {
                 experimental_allowed_ip_networks,
             );
         }
+
+        export_to_env_if_not_present(
+            MEILI_EXPERIMENTAL_TUNNEL,
+            experimental_tunnel.to_string(),
+        );
 
         indexer_options.export_to_env();
         if let Some(s3_snapshot_options) = s3_snapshot_options {


### PR DESCRIPTION
## Summary
- Add `--experimental-tunnel` flag that connects to the burrow tunnel server at `new.meilisearch.link`
- When enabled, the instance is publicly accessible at `<instance-uid-suffix>.meilisearch.link`
- The tunnel is non-fatal: if connection fails, Meilisearch continues running locally
- Public URL is displayed in the launch resume right after the local listening address
- The tunnel is using [burrow](https://github.com/meilisearch/burrow) built for that purpose

## Test plan
- [ ] `cargo run -p meilisearch` works as before without the flag
- [ ] `cargo run -p meilisearch -- --experimental-tunnel` connects the tunnel and prints the public URL
- [ ] Verify the public URL is reachable and proxies to the local instance
- [ ] Verify that if the tunnel server is unreachable, Meilisearch starts normally with a warning