### PR TITLE
Allow any IP for SDK tests

### DIFF
--- a/.github/workflows/sdks-tests.yml
+++ b/.github/workflows/sdks-tests.yml
@@ -76,6 +76,7 @@ jobs:
         env:
           MEILI_MASTER_KEY: ${{ env.MEILI_MASTER_KEY }}
           MEILI_NO_ANALYTICS: ${{ env.MEILI_NO_ANALYTICS }}
+          MEILI_EXPERIMENTAL_ALLOWED_IP_NETWORKS: "any"
         ports:
           - "7700:7700"
     steps:
@@ -131,6 +132,7 @@ jobs:
         env:
           MEILI_MASTER_KEY: ${{ env.MEILI_MASTER_KEY }}
           MEILI_NO_ANALYTICS: ${{ env.MEILI_NO_ANALYTICS }}
+          MEILI_EXPERIMENTAL_ALLOWED_IP_NETWORKS: "any"
         ports:
           - "7700:7700"
     steps:
@@ -226,6 +228,7 @@ jobs:
         env:
           MEILI_MASTER_KEY: ${{ env.MEILI_MASTER_KEY }}
           MEILI_NO_ANALYTICS: ${{ env.MEILI_NO_ANALYTICS }}
+          MEILI_EXPERIMENTAL_ALLOWED_IP_NETWORKS: "any"
         ports:
           - "7700:7700"
     steps:
@@ -251,6 +254,7 @@ jobs:
         env:
           MEILI_MASTER_KEY: ${{ env.MEILI_MASTER_KEY }}
           MEILI_NO_ANALYTICS: ${{ env.MEILI_NO_ANALYTICS }}
+          MEILI_EXPERIMENTAL_ALLOWED_IP_NETWORKS: "any"
         ports:
           - "7700:7700"
     steps:
@@ -276,6 +280,7 @@ jobs:
         env:
           MEILI_MASTER_KEY: ${{ env.MEILI_MASTER_KEY }}
           MEILI_NO_ANALYTICS: ${{ env.MEILI_NO_ANALYTICS }}
+          MEILI_EXPERIMENTAL_ALLOWED_IP_NETWORKS: "any"
         ports:
           - "7700:7700"
     steps:
@@ -297,6 +302,7 @@ jobs:
         env:
           MEILI_MASTER_KEY: ${{ env.MEILI_MASTER_KEY }}
           MEILI_NO_ANALYTICS: ${{ env.MEILI_NO_ANALYTICS }}
+          MEILI_EXPERIMENTAL_ALLOWED_IP_NETWORKS: "any"
         ports:
           - "7700:7700"
     steps:
@@ -320,6 +326,7 @@ jobs:
         env:
           MEILI_MASTER_KEY: ${{ env.MEILI_MASTER_KEY }}
           MEILI_NO_ANALYTICS: ${{ env.MEILI_NO_ANALYTICS }}
+          MEILI_EXPERIMENTAL_ALLOWED_IP_NETWORKS: "any"
         ports:
           - "7700:7700"
     steps:
@@ -353,6 +360,7 @@ jobs:
         env:
           MEILI_MASTER_KEY: ${{ env.MEILI_MASTER_KEY }}
           MEILI_NO_ANALYTICS: ${{ env.MEILI_NO_ANALYTICS }}
+          MEILI_EXPERIMENTAL_ALLOWED_IP_NETWORKS: "any"
         ports:
           - "7700:7700"
     env:
@@ -385,6 +393,7 @@ jobs:
         env:
           MEILI_MASTER_KEY: ${{ env.MEILI_MASTER_KEY }}
           MEILI_NO_ANALYTICS: ${{ env.MEILI_NO_ANALYTICS }}
+          MEILI_EXPERIMENTAL_ALLOWED_IP_NETWORKS: "any"
         ports:
           - "7700:7700"
     steps:


### PR DESCRIPTION
## Related issue

Fixes broken SDK tests by allowing any IP to be configured in the network; the test suites of these SDKs require it:
- JS
- PHP
- Go

## Generative AI tools

- [ ] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respect the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - *list of used tools and what they were used for*

## Requirements

⚠️ Ensure the following requirements before merging ⚠️
- [x] Automated tests have been added.
- [x] If some tests cannot be automated, manual rigorous tests should be applied.
- [ ] ⚠️ If there is any change in the DB:
    - [ ] Test that any impacted DB still works as expected after using `--experimental-dumpless-upgrade` on a DB created with the last released Meilisearch
    - [ ] Test that during the upgrade, **search is still available** (artificially make the upgrade longer if needed)
    - [ ] Set the `db change` label.
- [ ] If necessary, the feature have been tested in the Cloud production environment (with [prototypes](./documentation/prototypes.md)) and the Cloud UI is ready.
- [x] If necessary, the [documentation](https://github.com/meilisearch/documentation) related to the implemented feature in the PR is ready.
- [x] If necessary, the [integrations](https://github.com/meilisearch/integration-guides) related to the implemented feature in the PR are ready.
