### PR TITLE
Add dynamic search rules persistence module

### DIFF
--- a/crates/dump/src/reader/compat/v5_to_v6.rs
+++ b/crates/dump/src/reader/compat/v5_to_v6.rs
@@ -210,6 +210,12 @@ impl CompatV5ToV6 {
     pub fn webhooks(&self) -> Option<&v6::Webhooks> {
         None
     }
+
+    pub fn dynamic_search_rules(
+        &self,
+    ) -> Result<Box<dyn Iterator<Item = Result<(String, v6::DynamicSearchRule)>> + '_>> {
+        Ok(Box::new(std::iter::empty()))
+    }
 }
 
 pub enum CompatIndexV5ToV6 {

--- a/crates/dump/src/reader/mod.rs
+++ b/crates/dump/src/reader/mod.rs
@@ -145,6 +145,15 @@ impl DumpReader {
             DumpReader::Compat(compat) => compat.webhooks(),
         }
     }
+
+    pub fn dynamic_search_rules(
+        &self,
+    ) -> Result<Box<dyn Iterator<Item = Result<(String, v6::DynamicSearchRule)>> + '_>> {
+        match self {
+            DumpReader::Current(current) => current.dynamic_search_rules(),
+            DumpReader::Compat(_compat) => Ok(Box::new(std::iter::empty())),
+        }
+    }
 }
 
 impl From<V6Reader> for DumpReader {

--- a/crates/index-scheduler/src/dynamic_search_rules.rs
+++ b/crates/index-scheduler/src/dynamic_search_rules.rs
@@ -1,0 +1,52 @@
+use std::sync::{Arc, RwLock};
+
+use meilisearch_types::dynamic_search_rules::{DynamicSearchRule, DynamicSearchRules};
+use meilisearch_types::heed::types::{SerdeJson, Str};
+use meilisearch_types::heed::{Database, Env, RwTxn, WithoutTls};
+
+use crate::Result;
+
+const NUMBER_OF_DATABASES: u32 = 1;
+
+mod db_name {
+    pub const DYNAMIC_SEARCH_RULES: &str = "dynamic-search-rules";
+}
+
+#[derive(Clone)]
+pub(crate) struct DynamicSearchRulesStore {
+    pub(crate) persisted: Database<Str, SerdeJson<DynamicSearchRule>>,
+    runtime: Arc<RwLock<DynamicSearchRules>>,
+}
+
+impl DynamicSearchRulesStore {
+    pub(crate) const fn nb_db() -> u32 {
+        NUMBER_OF_DATABASES
+    }
+
+    pub fn new(env: &Env<WithoutTls>, wtxn: &mut RwTxn) -> Result<Self> {
+        let persisted = env.create_database(wtxn, Some(db_name::DYNAMIC_SEARCH_RULES))?;
+        let rules: DynamicSearchRules = persisted
+            .iter(wtxn)?
+            .filter_map(|entry| entry.ok())
+            .map(|(key, rule): (&str, DynamicSearchRule)| (key.to_string(), rule))
+            .collect();
+
+        Ok(Self { persisted, runtime: Arc::new(RwLock::new(rules)) })
+    }
+
+    pub fn put(&self, mut wtxn: RwTxn, value: DynamicSearchRules) -> Result<()> {
+        self.persisted.clear(&mut wtxn)?;
+        for (uid, rule) in &value {
+            self.persisted.put(&mut wtxn, uid, rule)?;
+        }
+        wtxn.commit()?;
+
+        let mut runtime = self.runtime.write().unwrap();
+        *runtime = value;
+        Ok(())
+    }
+
+    pub fn get(&self) -> DynamicSearchRules {
+        DynamicSearchRules::clone(&*self.runtime.read().unwrap())
+    }
+}

--- a/crates/index-scheduler/src/insta_snapshot.rs
+++ b/crates/index-scheduler/src/insta_snapshot.rs
@@ -31,6 +31,7 @@ pub fn snapshot_index_scheduler(scheduler: &IndexScheduler) -> String {
 
         index_mapper,
         features: _,
+        dynamic_search_rules: _,
         webhooks: _,
         test_breakpoint_sdr: _,
         planned_failures: _,

--- a/crates/index-scheduler/src/scheduler/process_dump_creation.rs
+++ b/crates/index-scheduler/src/scheduler/process_dump_creation.rs
@@ -275,6 +275,13 @@ impl IndexScheduler {
         let webhooks = self.webhooks_dump_view();
         dump.create_webhooks(webhooks)?;
 
+        // 8. Dump the dynamic search rules
+        let mut dump_dynamic_search_rules = dump.create_dynamic_search_rules()?;
+        for result in self.dynamic_search_rules.persisted.iter(&rtxn)? {
+            let (uid, rule) = result?;
+            dump_dynamic_search_rules.push_rule(uid, &rule)?;
+        }
+
         let dump_uid = started_at.format(format_description!(
                     "[year repr:full][month repr:numerical][day padding:zero]-[hour padding:zero][minute padding:zero][second padding:zero][subsecond digits:3]"
                 )).unwrap();

--- a/crates/meilisearch-types/Cargo.toml
+++ b/crates/meilisearch-types/Cargo.toml
@@ -37,7 +37,7 @@ tar = "0.4.44"
 tempfile = "3.23.0"
 thiserror = "2.0.17"
 time = { version = "0.3.47", features = [
-    "serde-well-known",
+    "serde",
     "formatting",
     "parsing",
     "macros",

--- a/crates/meilisearch-types/src/dynamic_search_rules.rs
+++ b/crates/meilisearch-types/src/dynamic_search_rules.rs
@@ -1,0 +1,289 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
+
+pub type DynamicSearchRules = BTreeMap<String, DynamicSearchRule>;
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct DynamicSearchRule {
+    pub uid: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub priority: Option<u64>,
+    #[serde(default)]
+    pub active: bool,
+    #[serde(default)]
+    pub conditions: Vec<Condition>,
+    pub actions: Vec<RuleAction>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(tag = "scope", rename_all = "camelCase")]
+pub enum Condition {
+    Query(QueryCondition),
+    Time(TimeCondition),
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct QueryCondition {
+    pub is_empty: bool,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct TimeCondition {
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "time::serde::rfc3339::option"
+    )]
+    pub start: Option<OffsetDateTime>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "time::serde::rfc3339::option"
+    )]
+    pub end: Option<OffsetDateTime>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct RuleAction {
+    pub selector: Selector,
+    pub action: Action,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct Selector {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub index_uid: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub filter: Option<serde_json::Value>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum Action {
+    Pin(PinArgs),
+    Boost(BoostArgs),
+    Bury(BuryArgs),
+    Hide(HideArgs),
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct PinArgs {
+    pub position: u32,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct BoostArgs {
+    pub score: f64,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct BuryArgs {
+    pub score: f64,
+}
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct HideArgs {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::de::DeserializeOwned;
+    use serde_json::{json, Value};
+    use std::fmt::Debug;
+    use time::macros::datetime;
+
+    fn round_trip<T>(expected: &T)
+    where
+        T: Serialize + DeserializeOwned + PartialEq + Debug,
+    {
+        let serialized: Value = serde_json::to_value(expected).unwrap();
+        let deserialized: T = serde_json::from_value(serialized).unwrap();
+        assert_eq!(&deserialized, expected);
+    }
+
+    #[test]
+    fn full_rule_round_trip() {
+        let expected = DynamicSearchRule {
+            uid: "black-friday-2025".to_string(),
+            description: Some("Black Friday 2025 Merchandising rules".to_string()),
+            priority: Some(1),
+            active: true,
+            conditions: vec![
+                Condition::Query(QueryCondition { is_empty: true }),
+                Condition::Time(TimeCondition {
+                    start: Some(datetime!(2025-11-28 0:00:00 UTC)),
+                    end: Some(datetime!(2025-11-28 23:59:59 UTC)),
+                }),
+            ],
+            actions: vec![
+                RuleAction {
+                    selector: Selector {
+                        index_uid: Some("products".to_string()),
+                        id: Some("123".to_string()),
+                        filter: None,
+                    },
+                    action: Action::Pin(PinArgs { position: 3 }),
+                },
+                RuleAction {
+                    selector: Selector {
+                        index_uid: None,
+                        id: None,
+                        filter: Some(json!({
+                            "attribute": "brand",
+                            "op": "eq",
+                            "value": "premium",
+                        })),
+                    },
+                    action: Action::Boost(BoostArgs { score: 1.5 }),
+                },
+                RuleAction {
+                    selector: Selector {
+                        index_uid: None,
+                        id: None,
+                        filter: Some(json!({
+                            "attribute": "category",
+                            "op": "eq",
+                            "value": "clearance",
+                        })),
+                    },
+                    action: Action::Bury(BuryArgs { score: 0.5 }),
+                },
+                RuleAction {
+                    selector: Selector {
+                        index_uid: None,
+                        id: Some("456".to_string()),
+                        filter: None,
+                    },
+                    action: Action::Hide(HideArgs {}),
+                },
+            ],
+        };
+
+        round_trip(&expected);
+        insta::assert_json_snapshot!(expected);
+    }
+
+    #[test]
+    fn minimal_rule_round_trip() {
+        let expected = DynamicSearchRule {
+            uid: "simple-rule".to_string(),
+            description: None,
+            priority: None,
+            active: false,
+            conditions: vec![],
+            actions: vec![RuleAction {
+                selector: Selector { index_uid: None, id: Some("42".to_string()), filter: None },
+                action: Action::Pin(PinArgs { position: 1 }),
+            }],
+        };
+
+        round_trip(&expected);
+        insta::assert_json_snapshot!(expected);
+    }
+
+    #[test]
+    fn all_actions_round_trip() {
+        let action = Action::Pin(PinArgs { position: 5 });
+        round_trip(&action);
+        insta::assert_json_snapshot!("pin", action);
+
+        let action = Action::Boost(BoostArgs { score: 2.0 });
+        round_trip(&action);
+        insta::assert_json_snapshot!("boost", action);
+
+        let action = Action::Bury(BuryArgs { score: 0.3 });
+        round_trip(&action);
+        insta::assert_json_snapshot!("bury", action);
+
+        let action = Action::Hide(HideArgs {});
+        round_trip(&action);
+        insta::assert_json_snapshot!("hide", action);
+    }
+
+    #[test]
+    fn all_conditions_round_trip() {
+        let condition = Condition::Query(QueryCondition { is_empty: true });
+        round_trip(&condition);
+        insta::assert_json_snapshot!("query", condition);
+
+        let condition = Condition::Time(TimeCondition {
+            start: Some(datetime!(2025-01-01 0:00:00 UTC)),
+            end: Some(datetime!(2025-12-31 23:59:59 UTC)),
+        });
+        round_trip(&condition);
+        insta::assert_json_snapshot!("time_both", condition);
+
+        let condition = Condition::Time(TimeCondition {
+            start: Some(datetime!(2025-01-01 0:00:00 UTC)),
+            end: None,
+        });
+        round_trip(&condition);
+        insta::assert_json_snapshot!("time_start", condition);
+
+        let condition = Condition::Time(TimeCondition {
+            start: None,
+            end: Some(datetime!(2025-12-31 23:59:59 UTC)),
+        });
+        round_trip(&condition);
+        insta::assert_json_snapshot!("time_end", condition);
+    }
+
+    #[test]
+    fn defaults_on_deserialization() {
+        let json = json!({
+            "uid": "defaults-test",
+            "actions": [
+                {
+                    "selector": {},
+                    "action": { "type": "hide" }
+                }
+            ]
+        });
+
+        let rule: DynamicSearchRule = serde_json::from_value(json).unwrap();
+        assert_eq!(rule.description, None);
+        assert_eq!(rule.priority, None);
+        assert!(!rule.active);
+        assert!(rule.conditions.is_empty());
+    }
+
+    #[test]
+    fn skip_serializing_none_fields() {
+        let rule = DynamicSearchRule {
+            uid: "no-optionals".to_string(),
+            description: None,
+            priority: None,
+            active: false,
+            conditions: vec![],
+            actions: vec![RuleAction {
+                selector: Selector { index_uid: None, id: None, filter: None },
+                action: Action::Hide(HideArgs {}),
+            }],
+        };
+
+        let serialized = serde_json::to_value(&rule).unwrap();
+        let obj = serialized.as_object().unwrap();
+        assert!(!obj.contains_key("version"));
+        assert!(!obj.contains_key("description"));
+        assert!(!obj.contains_key("priority"));
+
+        let selector = obj["actions"][0]["selector"].as_object().unwrap();
+        assert!(!selector.contains_key("indexUid"));
+        assert!(!selector.contains_key("id"));
+        assert!(!selector.contains_key("filter"));
+    }
+}

--- a/crates/meilisearch-types/src/lib.rs
+++ b/crates/meilisearch-types/src/lib.rs
@@ -14,6 +14,7 @@ pub use community_edition as current_edition;
 #[cfg(feature = "enterprise")]
 pub use enterprise_edition as current_edition;
 pub mod archive_ext;
+pub mod dynamic_search_rules;
 pub mod error;
 pub mod facet_values_sort;
 pub mod features;

--- a/crates/meilisearch-types/src/snapshots/meilisearch_types__dynamic_search_rules__tests__boost.snap
+++ b/crates/meilisearch-types/src/snapshots/meilisearch_types__dynamic_search_rules__tests__boost.snap
@@ -1,0 +1,8 @@
+---
+source: crates/meilisearch-types/src/dynamic_search_rules.rs
+expression: action
+---
+{
+  "type": "boost",
+  "score": 2.0
+}

--- a/crates/meilisearch-types/src/snapshots/meilisearch_types__dynamic_search_rules__tests__bury.snap
+++ b/crates/meilisearch-types/src/snapshots/meilisearch_types__dynamic_search_rules__tests__bury.snap
@@ -1,0 +1,8 @@
+---
+source: crates/meilisearch-types/src/dynamic_search_rules.rs
+expression: action
+---
+{
+  "type": "bury",
+  "score": 0.3
+}

--- a/crates/meilisearch-types/src/snapshots/meilisearch_types__dynamic_search_rules__tests__full_rule_round_trip.snap
+++ b/crates/meilisearch-types/src/snapshots/meilisearch_types__dynamic_search_rules__tests__full_rule_round_trip.snap
@@ -1,0 +1,67 @@
+---
+source: crates/meilisearch-types/src/dynamic_search_rules.rs
+expression: expected
+---
+{
+  "uid": "black-friday-2025",
+  "description": "Black Friday 2025 Merchandising rules",
+  "priority": 1,
+  "active": true,
+  "conditions": [
+    {
+      "scope": "query",
+      "isEmpty": true
+    },
+    {
+      "scope": "time",
+      "start": "2025-11-28T00:00:00Z",
+      "end": "2025-11-28T23:59:59Z"
+    }
+  ],
+  "actions": [
+    {
+      "selector": {
+        "indexUid": "products",
+        "id": "123"
+      },
+      "action": {
+        "type": "pin",
+        "position": 3
+      }
+    },
+    {
+      "selector": {
+        "filter": {
+          "attribute": "brand",
+          "op": "eq",
+          "value": "premium"
+        }
+      },
+      "action": {
+        "type": "boost",
+        "score": 1.5
+      }
+    },
+    {
+      "selector": {
+        "filter": {
+          "attribute": "category",
+          "op": "eq",
+          "value": "clearance"
+        }
+      },
+      "action": {
+        "type": "bury",
+        "score": 0.5
+      }
+    },
+    {
+      "selector": {
+        "id": "456"
+      },
+      "action": {
+        "type": "hide"
+      }
+    }
+  ]
+}

--- a/crates/meilisearch-types/src/snapshots/meilisearch_types__dynamic_search_rules__tests__hide.snap
+++ b/crates/meilisearch-types/src/snapshots/meilisearch_types__dynamic_search_rules__tests__hide.snap
@@ -1,0 +1,7 @@
+---
+source: crates/meilisearch-types/src/dynamic_search_rules.rs
+expression: action
+---
+{
+  "type": "hide"
+}

--- a/crates/meilisearch-types/src/snapshots/meilisearch_types__dynamic_search_rules__tests__minimal_rule_round_trip.snap
+++ b/crates/meilisearch-types/src/snapshots/meilisearch_types__dynamic_search_rules__tests__minimal_rule_round_trip.snap
@@ -1,0 +1,20 @@
+---
+source: crates/meilisearch-types/src/dynamic_search_rules.rs
+expression: expected
+---
+{
+  "uid": "simple-rule",
+  "active": false,
+  "conditions": [],
+  "actions": [
+    {
+      "selector": {
+        "id": "42"
+      },
+      "action": {
+        "type": "pin",
+        "position": 1
+      }
+    }
+  ]
+}

--- a/crates/meilisearch-types/src/snapshots/meilisearch_types__dynamic_search_rules__tests__pin.snap
+++ b/crates/meilisearch-types/src/snapshots/meilisearch_types__dynamic_search_rules__tests__pin.snap
@@ -1,0 +1,8 @@
+---
+source: crates/meilisearch-types/src/dynamic_search_rules.rs
+expression: action
+---
+{
+  "type": "pin",
+  "position": 5
+}

--- a/crates/meilisearch-types/src/snapshots/meilisearch_types__dynamic_search_rules__tests__query.snap
+++ b/crates/meilisearch-types/src/snapshots/meilisearch_types__dynamic_search_rules__tests__query.snap
@@ -1,0 +1,8 @@
+---
+source: crates/meilisearch-types/src/dynamic_search_rules.rs
+expression: condition
+---
+{
+  "scope": "query",
+  "isEmpty": true
+}

--- a/crates/meilisearch-types/src/snapshots/meilisearch_types__dynamic_search_rules__tests__time_both.snap
+++ b/crates/meilisearch-types/src/snapshots/meilisearch_types__dynamic_search_rules__tests__time_both.snap
@@ -1,0 +1,9 @@
+---
+source: crates/meilisearch-types/src/dynamic_search_rules.rs
+expression: condition
+---
+{
+  "scope": "time",
+  "start": "2025-01-01T00:00:00Z",
+  "end": "2025-12-31T23:59:59Z"
+}

--- a/crates/meilisearch-types/src/snapshots/meilisearch_types__dynamic_search_rules__tests__time_end.snap
+++ b/crates/meilisearch-types/src/snapshots/meilisearch_types__dynamic_search_rules__tests__time_end.snap
@@ -1,0 +1,8 @@
+---
+source: crates/meilisearch-types/src/dynamic_search_rules.rs
+expression: condition
+---
+{
+  "scope": "time",
+  "end": "2025-12-31T23:59:59Z"
+}

--- a/crates/meilisearch-types/src/snapshots/meilisearch_types__dynamic_search_rules__tests__time_start.snap
+++ b/crates/meilisearch-types/src/snapshots/meilisearch_types__dynamic_search_rules__tests__time_start.snap
@@ -1,0 +1,8 @@
+---
+source: crates/meilisearch-types/src/dynamic_search_rules.rs
+expression: condition
+---
+{
+  "scope": "time",
+  "start": "2025-01-01T00:00:00Z"
+}

--- a/crates/meilisearch/src/lib.rs
+++ b/crates/meilisearch/src/lib.rs
@@ -41,6 +41,7 @@ use http_client::policy::IpPolicy;
 use index_scheduler::versioning::Versioning;
 use index_scheduler::{IndexScheduler, IndexSchedulerOptions};
 use meilisearch_auth::{open_auth_store_env, AuthController};
+use meilisearch_types::dynamic_search_rules::DynamicSearchRules;
 use meilisearch_types::milli::constants::VERSION_MAJOR;
 use meilisearch_types::milli::documents::{DocumentsBatchBuilder, DocumentsBatchReader};
 use meilisearch_types::milli::progress::{EmbedderStats, Progress};
@@ -560,6 +561,15 @@ fn import_dump(
 
     let network = dump_reader.network()?.cloned().unwrap_or_default();
     index_scheduler.put_network(network)?;
+
+    let mut dynamic_search_rules = DynamicSearchRules::new();
+    for result in dump_reader.dynamic_search_rules()? {
+        let (uid, rule) = result?;
+        dynamic_search_rules.insert(uid, rule);
+    }
+    if !dynamic_search_rules.is_empty() {
+        index_scheduler.put_search_dynamic_rules(dynamic_search_rules)?;
+    }
 
     // 5.1 Use all cpus to process dump if `max_indexing_threads` not configured
     let backup_config;


### PR DESCRIPTION
## Related issue

Fixes https://linear.app/meilisearch/issue/EXP-892/implement-rule-storage
Fixes https://linear.app/meilisearch/issue/EXP-891/define-rule-data-structures


## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respect the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - *list of used tools and what they were used for*

## Requirements

⚠️ Ensure the following requirements before merging ⚠️
- [ ] Automated tests have been added.
- [ ] If some tests cannot be automated, manual rigorous tests should be applied.
- [x] ⚠️ If there is any change in the DB:
    - [ ] Test that any impacted DB still works as expected after using `--experimental-dumpless-upgrade` on a DB created with the last released Meilisearch
    - [ ] Test that during the upgrade, **search is still available** (artificially make the upgrade longer if needed)
    - [x] Set the `db change` label.
- [ ] If necessary, the feature have been tested in the Cloud production environment (with [prototypes](./documentation/prototypes.md)) and the Cloud UI is ready.
- [ ] If necessary, the [documentation](https://github.com/meilisearch/documentation) related to the implemented feature in the PR is ready.
- [ ] If necessary, the [integrations](https://github.com/meilisearch/integration-guides) related to the implemented feature in the PR are ready.
