### PR TITLE
Align contained_in matching with segment semantics

### DIFF
--- a/crates/permissive-json-pointer/src/lib.rs
+++ b/crates/permissive-json-pointer/src/lib.rs
@@ -28,12 +28,10 @@ fn contained_in(selector: &str, key: &str) -> bool {
         return true;
     }
 
-    if !selector.starts_with(key) {
-        return false;
+    match selector.strip_prefix(key) {
+        Some(rest) => rest.starts_with(SPLIT_SYMBOL) && rest.len() > SPLIT_SYMBOL.len_utf8(),
+        None => false,
     }
-
-    let rest = &selector[key.len()..];
-    rest.starts_with(SPLIT_SYMBOL) && rest.len() > SPLIT_SYMBOL.len_utf8()
 }
 
 /// Map the selected leaf values of a json allowing you to update only the fields that were selected.


### PR DESCRIPTION
## Generative AI tools

-  [x] This PR uses generative AI tooling and respect the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
 - Wording: propose better wordings for commits message, PR description,  etc. 
 - Check my implementation and suggest alternatives


## Issue
The `contained_in` documentation states that a selector with a trailing split symbol does not match its base key, for example:
```rust
// `animaux.` doesn't match `animaux`
contained_in("animaux.", "animaux")
```
However, in the previous implementation this case returned `true`. That allowed selectors like `race.` to pass through and resulted in an empty object being inserted into `new_value`.

Consider:
```rust
let json = json!({
    "name": "peanut",
    "age": 8,
    "race": {
        "name": "bernese mountain",
        "avg_age": 12,
        "size": "80cm"
    }
});
let value = json.as_object().unwrap();
let results: Value = select_values(value, vec!["name", "race."]).into();
```
Because `contained_in("race.", "race")` returned `true`, the resulting output incorrectly included an empty object:
```rust
results: Object {
    "name": String("peanut"),
    "race": Object {},
}
```
According to the documented behavior, the trailing-dot selector should be ignored and the expected output is:
```rust
results: Object {
    "name": String("peanut"),
}
```

## Solution
Handle the trailing-dot case by returning `true` only when there is content after the first `SPLIT_SYMBOL`.

## Linked Issue
Closes #6158 

