### PR TITLE
Fix attributesToSearchOn returning error on empty index

### DIFF
--- a/crates/milli/src/search/new/mod.rs
+++ b/crates/milli/src/search/new/mod.rs
@@ -180,6 +180,14 @@ impl<'ctx> SearchContext<'ctx> {
                 None if user_defined_searchable.is_none() => continue,
                 // The field is not searchable => User error
                 None => {
+                    // If the field is in the user-defined searchable attributes but not yet
+                    // indexed (e.g., empty index), we should skip rather than error.
+                    if let Some(defined_searchable) = &user_defined_searchable {
+                        if defined_searchable.iter().any(|s| s == field_name) {
+                            continue;
+                        }
+                    }
+
                     let (valid_fields, hidden_fields) = self.index.remove_hidden_fields(
                         self.txn,
                         searchable_fields_weights.iter().map(|(name, _, _)| name),

--- a/crates/milli/src/search/new/tests/attribute_search_on.rs
+++ b/crates/milli/src/search/new/tests/attribute_search_on.rs
@@ -1,0 +1,28 @@
+use crate::index::tests::TempIndex;
+
+fn create_empty_index() -> TempIndex {
+    let index = TempIndex::new();
+
+    index
+        .update_settings(|s| {
+            s.set_primary_key("id".to_string());
+            s.set_searchable_fields(vec!["name".to_string(), "title".to_string()]);
+        })
+        .unwrap();
+
+    index
+}
+
+#[test]
+fn test_attributes_to_search_on_empty_index() {
+    let index = create_empty_index();
+    let txn = index.read_txn().unwrap();
+
+    let mut search = index.search(&txn);
+    let attrs = ["title".to_string()];
+    search.searchable_attributes(&attrs);
+    search.query("doc");
+
+    let result = search.execute().unwrap();
+    assert!(result.documents_ids.is_empty());
+}

--- a/crates/milli/src/search/new/tests/mod.rs
+++ b/crates/milli/src/search/new/tests/mod.rs
@@ -1,4 +1,5 @@
 pub mod attribute_fid;
+pub mod attribute_search_on;
 pub mod attribute_position;
 pub mod cutoff;
 pub mod distinct;


### PR DESCRIPTION
Hey there 👋

I ran into #5921 while working with empty indexes — using `attributesToSearchOn` on an index with no documents throws an `InvalidSearchableAttribute` error, even when the field is correctly configured as searchable.

## The problem

When an index has user-defined searchable attributes but no documents yet, `searchable_fields_weights` is empty (nothing has been indexed). The validation in `attributes_to_search_on()` sees that the field isn't in the weights map, checks that `user_defined_searchable` is `Some` (it is — the user configured it), and immediately returns an error.

The field is legitimately configured, it just hasn't been indexed because there are no documents.

## The fix

Before returning the `InvalidSearchableAttribute` error, I added a check to see if the requested field actually exists in the user-defined searchable attributes. If it does, we skip validation for that field — it's a valid field that simply has no indexed data yet.

This is a minimal, targeted fix that doesn't change behavior for any other case:
- Unknown fields still correctly return errors
- Fields not in searchable attributes still correctly return errors
- Non-empty indexes are completely unaffected

## Testing

Added a test case that creates an empty index with searchable fields configured, then searches with `attributesToSearchOn` — previously this would panic/error, now it returns empty results as expected.

Fixes #5921