### PR TITLE
Add test for chat completion settings in dumps

### DIFF
--- a/crates/dump/src/writer.rs
+++ b/crates/dump/src/writer.rs
@@ -349,6 +349,9 @@ pub(crate) mod test {
         .
         ├---- batches/
         │    └---- queue.jsonl
+        ├---- chat-completions-settings/
+        │    ├---- azure-config.json
+        │    └---- default.json
         ├---- indexes/
         │    └---- doggos/
         │    │    ├---- documents.jsonl


### PR DESCRIPTION
## Summary

Adds test coverage for chat completion settings in the dump create/read roundtrip test, as requested in #5736.

## Changes

- Added `create_test_chat_completion_settings()` helper that creates two chat completion configurations (OpenAI and Azure OpenAI)
- Extended `test_creating_and_read_dump()` to write chat completion settings during dump creation
- Extended `test_creating_and_read_dump()` to verify chat completion settings are correctly read back from the dump
- Updated the writer test's directory hierarchy snapshot to include the `chat-completions-settings/` directory

Fixes #5736