### PR TITLE
Bump hannoy to v0.1.6-nested-rtxns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3042,9 +3042,9 @@ dependencies = [
 
 [[package]]
 name = "hannoy"
-version = "0.1.5-nested-rtxns"
+version = "0.1.6-nested-rtxns"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59bbc14bb3224dacec32920d6058aa8f131581d532d60bcfcf3e15ca685d09ad"
+checksum = "2d590bd07da2aeeb4cac61805323b895d3841bc1750e71714d248767953483fb"
 dependencies = [
  "bytemuck",
  "byteorder",

--- a/crates/milli/Cargo.toml
+++ b/crates/milli/Cargo.toml
@@ -94,7 +94,7 @@ rhai = { version = "1.23.6", features = [
     "sync",
 ] }
 arroy = "0.6.4-nested-rtxns"
-hannoy = { version = "0.1.5-nested-rtxns", features = ["arroy"] }
+hannoy = { version = "0.1.6-nested-rtxns", features = ["arroy"] }
 rand = "0.8.5"
 tracing = "0.1.41"
 url = "2.5.7"


### PR DESCRIPTION
This PR bumps hannoy to benefit from a couple of improvements, [specifically removing the computation of the mean degree from the build stats](https://github.com/nnethercott/hannoy/pull/124) (removing a flat 320s when inserting a couple of embeddings into a 20M database).