### PR TITLE
fix: correct typos in comments and error messages

### DIFF
--- a/crates/dump/src/reader/mod.rs
+++ b/crates/dump/src/reader/mod.rs
@@ -242,10 +242,10 @@ pub(crate) mod test {
         //
         // "vector", configured with an embedder
         // contains:
-        // - one document with an overriden vector,
+        // - one document with an overridden vector,
         // - one document with a natural vector
         // - one document with a _vectors map containing one additional embedder name and a natural vector
-        // - one document with a _vectors map containing one additional embedder name and an overriden vector
+        // - one document with a _vectors map containing one additional embedder name and an overridden vector
         //
         // "novector", no embedder
         // contains:

--- a/crates/meilisearch-types/src/index_uid_pattern.rs
+++ b/crates/meilisearch-types/src/index_uid_pattern.rs
@@ -36,12 +36,12 @@ impl IndexUidPattern {
         !self.0.ends_with('*')
     }
 
-    /// Returns wether this index uid matches this index uid pattern.
+    /// Returns whether this index uid matches this index uid pattern.
     pub fn matches(&self, uid: &IndexUid) -> bool {
         self.matches_str(uid.as_str())
     }
 
-    /// Returns wether this string matches this index uid pattern.
+    /// Returns whether this string matches this index uid pattern.
     pub fn matches_str(&self, uid: &str) -> bool {
         match self.0.strip_suffix('*') {
             Some(prefix) => uid.starts_with(prefix),

--- a/crates/milli/src/thread_pool_no_abort.rs
+++ b/crates/milli/src/thread_pool_no_abort.rs
@@ -59,7 +59,7 @@ impl ThreadPoolNoAbort {
 }
 
 #[derive(Error, Debug)]
-#[error("A panic occured. Read the logs to find more information about it")]
+#[error("A panic occurred. Read the logs to find more information about it")]
 pub struct PanicCatched;
 
 #[derive(Default)]

--- a/crates/milli/src/update/new/words_prefix_docids.rs
+++ b/crates/milli/src/update/new/words_prefix_docids.rs
@@ -112,7 +112,7 @@ impl<'i> WordPrefixDocids<'i> {
     }
 }
 
-/// Represents a prefix and the lenght the bitmap takes on disk.
+/// Represents a prefix and the length the bitmap takes on disk.
 struct PrefixEntry<'a> {
     prefix: &'a str,
     serialized_length: usize,


### PR DESCRIPTION
Fix several typos across the codebase:

- `overriden` → `overridden` in `crates/dump/src/reader/mod.rs`
- `wether` → `whether` in `crates/meilisearch-types/src/index_uid_pattern.rs`
- `lenght` → `length` in `crates/milli/src/update/new/words_prefix_docids.rs`
- `occured` → `occurred` in `crates/milli/src/thread_pool_no_abort.rs`