### PR TITLE
Mark Cargo.lock as not linguist-generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+Cargo.lock -linguist-generated


### PR DESCRIPTION
This PR [tells GitHub, using a linguist config](https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github), to unmark the Cargo.lock file from the list of generated files so that it is always displayed in the PR file explorer.