### PR TITLE
Add _geo_list support for multiple geo points per document

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,129 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Meilisearch is a search engine written in Rust. It exposes a RESTful HTTP API (Actix-web) for search, document management, and index configuration. The core search/indexing engine lives in the `milli` crate. Tokenization is handled externally by the `charabia` library.
+
+## Build & Run Commands
+
+```bash
+# Build (dev)
+cargo build --locked
+
+# Build (release, recommended for testing performance)
+cargo build --release --locked
+
+# Run
+cargo run --release
+
+# Run tests (all crates)
+cargo test --locked
+
+# Run tests for a specific crate
+cargo test --locked -p milli
+cargo test --locked -p meilisearch
+
+# Run a single test by name
+cargo test --locked -p meilisearch test_name
+
+# Format check
+cargo fmt --all -- --check
+
+# Lint
+cargo clippy --all-targets -- --deny warnings -D clippy::todo
+
+# Build without default features (CI check)
+cargo build --locked --no-default-features --all
+
+# xtask automation tools
+cargo xtask --help
+
+# Test with all features (excluding cuda/ollama)
+cargo test --workspace --locked --features "$(cargo xtask list-features --exclude-feature cuda,test-ollama)"
+
+# Declarative workload tests
+cargo xtask test workloads/tests/*.json
+
+# Generate OpenAPI spec
+cd crates/openapi-generator && cargo run --release -- --pretty
+```
+
+## Faster Builds
+
+```bash
+export LINDERA_CACHE=$HOME/.cache/meili/lindera           # cache tokenizer build artifacts
+export MILLI_BENCH_DATASETS_PATH=$HOME/.cache/meili/benches # cache benchmark datasets
+export MEILI_NO_VERGEN=1                                    # skip version rebuild (dev only)
+```
+
+If you get "Too many open files": `ulimit -Sn 3000`
+
+## Workspace Architecture
+
+20-crate Cargo workspace. Key crates and their relationships:
+
+```
+meilisearch (HTTP server, routes, extractors, middleware)
+├── meilisearch-types (shared types, settings, task definitions)
+│   └── milli (core search engine: indexing, search, ranking, vectors)
+│       ├── filter-parser (filter query language parser)
+│       ├── flatten-serde-json (JSON flattening)
+│       └── json-depth-checker (JSON validation)
+├── index-scheduler (async task queue for all index mutations)
+├── meilisearch-auth (API key management, multi-tenancy)
+├── dump (database dump/restore)
+├── file-store (file storage abstraction)
+└── http-client (internal HTTP client)
+```
+
+Supporting crates: `meilitool` (CLI utility), `meili-snap` (snapshot test helpers), `build-info`, `openapi-generator`, `tracing-trace`, `xtask`, `benchmarks`, `fuzzers`.
+
+External vendored crates in `external-crates/`: `async-openai`, `async-openai-macros`.
+
+### Data Flow
+
+HTTP requests → Actix-web routes (`crates/meilisearch/src/routes/`) → auth check → route handlers → `IndexScheduler` (task queue for mutations) or direct search via `milli` → Heed/LMDB storage.
+
+### Key Modules in `meilisearch`
+
+- `routes/` — HTTP endpoint handlers (indexes, search, documents, settings, chats, etc.)
+- `search/` — search queue and request handling
+- `extractors/` — request parameter extraction
+- `option.rs` — CLI options and configuration
+
+### Key Modules in `milli`
+
+- `index.rs` — main Index interface
+- `search/` — search pipeline (full-text, hybrid, vector, faceted)
+- `update/` — index mutation operations
+- `documents/` — document indexing/storage
+- `vector/` — embedding/vector handling
+
+## Testing Conventions
+
+- Use `insta` for snapshot-based testing (preferred over manual assertions)
+- Set `MEILI_TEST_FULL_SNAPS=true` to see full snapshots instead of hashes
+- The `meili-snap` crate provides custom snapshot macros on top of insta
+- Integration tests are in `crates/meilisearch/tests/` organized by feature area
+- Enterprise features are gated behind `--features enterprise`
+
+## Code Style
+
+- Rust toolchain: 1.91.1
+- Rustfmt: `imports_granularity = "Module"`, `group_imports = "StdExternalCrate"`, `use_small_heuristics = "max"`
+- Clippy: `--deny warnings -D clippy::todo`; `tar::Archive::unpack` is disallowed (use `ArchiveExt::safe_unpack`)
+- Logging: use `tracing` with structured fields (no string interpolation). Profiling spans use targets `indexing::` or `search::` at TRACE level.
+- Commit messages: capitalized, imperative verb, no trailing punctuation
+
+## Feature Flags
+
+- `mini-dashboard` — embedded web dashboard (default)
+- `enterprise` — enterprise features (sharding, S3 snapshots)
+- `swagger` — enables Scalar API docs at `/scalar`
+- Language tokenization features: `chinese`, `japanese`, `hebrew`, `thai`, etc.
+
+## CI Environment
+
+CI sets `RUSTFLAGS="-D warnings"` and `RUST_BACKTRACE=1`. Tests run on Linux (x86_64 + ARM), Windows, and macOS.

--- a/crates/meilisearch-types/src/error.rs
+++ b/crates/meilisearch-types/src/error.rs
@@ -533,9 +533,9 @@ impl ErrorCode for milli::Error {
                 UserError::CriterionError(_) | UserError::MixedAttributeRankingRulesUsage => {
                     Code::InvalidSettingsRankingRules
                 }
-                UserError::InvalidGeoField { .. } | UserError::GeoJsonError(_) => {
-                    Code::InvalidDocumentGeoField
-                }
+                UserError::InvalidGeoField { .. }
+                | UserError::InvalidGeoListField { .. }
+                | UserError::GeoJsonError(_) => Code::InvalidDocumentGeoField,
                 UserError::InvalidVectorDimensions { .. }
                 | UserError::InvalidIndexingVectorDimensions { .. } => {
                     Code::InvalidVectorDimensions

--- a/crates/meilisearch/src/routes/indexes/mod.rs
+++ b/crates/meilisearch/src/routes/indexes/mod.rs
@@ -5,6 +5,7 @@ use actix_web::web::Data;
 use actix_web::{web, HttpRequest, HttpResponse};
 use deserr::actix_web::{AwebJson, AwebQueryParameter};
 use deserr::{DeserializeError, Deserr, ValuePointerRef};
+use fields::post_index_fields;
 use index_scheduler::IndexScheduler;
 use meilisearch_types::deserr::query_params::Param;
 use meilisearch_types::deserr::{immutable_field_error, DeserrJsonError, DeserrQueryParamError};

--- a/crates/meilisearch/src/search/federated/network/enterprise_edition.rs
+++ b/crates/meilisearch/src/search/federated/network/enterprise_edition.rs
@@ -5,8 +5,9 @@
 
 use std::collections::BTreeMap;
 
+use meilisearch_types::error::ResponseError;
 use meilisearch_types::milli::SHARD_FIELD;
-use meilisearch_types::{error::ResponseError, network::Network};
+use meilisearch_types::network::Network;
 use rand::seq::IteratorRandom as _;
 
 use crate::search::{fuse_filters, SearchQueryWithIndex};

--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -2351,11 +2351,33 @@ pub fn insert_geo_distance(sorts: &[String], document: &mut Document) {
     if let Some(capture_group) = sorts.iter().find_map(|sort| GEO_REGEX.captures(sort)) {
         // TODO: TAMO: milli encountered an internal error, what do we want to do?
         let base = [capture_group[1].parse().unwrap(), capture_group[2].parse().unwrap()];
+        let mut min_distance: Option<f64> = None;
+
+        // Check _geo
         let geo_point = &document.get("_geo").unwrap_or(&json!(null));
         if let Some((lat, lng)) =
             extract_geo_value(&geo_point["lat"]).zip(extract_geo_value(&geo_point["lng"]))
         {
             let distance = milli::distance_between_two_points(&base, &[lat, lng]);
+            min_distance = Some(distance);
+        }
+
+        // Check _geo_list
+        if let Some(Value::Array(geo_list)) = document.get("_geo_list") {
+            for point in geo_list {
+                if let Some((lat, lng)) =
+                    extract_geo_value(&point["lat"]).zip(extract_geo_value(&point["lng"]))
+                {
+                    let distance = milli::distance_between_two_points(&base, &[lat, lng]);
+                    min_distance = Some(match min_distance {
+                        Some(current_min) => current_min.min(distance),
+                        None => distance,
+                    });
+                }
+            }
+        }
+
+        if let Some(distance) = min_distance {
             document.insert("_geoDistance".to_string(), json!(distance.round() as usize));
         }
     }

--- a/crates/meilisearch/tests/search/geo.rs
+++ b/crates/meilisearch/tests/search/geo.rs
@@ -1,8 +1,10 @@
 use meili_snap::{json_string, snapshot};
-use meilisearch_types::milli::constants::RESERVED_GEO_FIELD_NAME;
+use meilisearch_types::milli::constants::{
+    RESERVED_GEO_FIELD_NAME, RESERVED_GEO_LIST_FIELD_NAME,
+};
 
 use super::test_settings_documents_indexing_swapping_and_search;
-use crate::common::shared_index_with_geo_documents;
+use crate::common::{shared_index_with_geo_documents, Server};
 use crate::json;
 
 #[actix_rt::test]
@@ -316,4 +318,718 @@ async fn geo_sort_with_words() {
       },
     )
     .await;
+}
+
+// =====================================================
+// _geo_list integration tests
+// =====================================================
+
+#[actix_rt::test]
+async fn geo_list_filter_geo_radius() {
+    // Documents with _geo_list: a company with multiple offices
+    // Office A is near (0, 0), Office B is near (48.8, 2.3) (Paris)
+    let documents = json!([
+        {
+            "id": 1,
+            "name": "Multi-Office Corp",
+            RESERVED_GEO_LIST_FIELD_NAME: [
+                { "lat": 0.0, "lng": 0.0 },
+                { "lat": 48.8566, "lng": 2.3522 }
+            ]
+        },
+        {
+            "id": 2,
+            "name": "Single-Office Corp",
+            RESERVED_GEO_LIST_FIELD_NAME: [
+                { "lat": 40.7128, "lng": -74.0060 }
+            ]
+        },
+        {
+            "id": 3,
+            "name": "No-Geo Corp"
+        }
+    ]);
+
+    // Filter near Paris — should match doc 1 (has a point near Paris) but not doc 2 (NYC only)
+    test_settings_documents_indexing_swapping_and_search(
+        &documents,
+        &json!({
+            "filterableAttributes": [RESERVED_GEO_LIST_FIELD_NAME],
+            "sortableAttributes": [RESERVED_GEO_LIST_FIELD_NAME]
+        }),
+        &json!({
+            "filter": "_geoRadius(48.8566, 2.3522, 10000)"
+        }),
+        |response, code| {
+            assert_eq!(code, 200, "{response}");
+            let hits = &response["hits"];
+            assert_eq!(hits.as_array().unwrap().len(), 1);
+            assert_eq!(hits[0]["id"], 1);
+        },
+    )
+    .await;
+}
+
+#[actix_rt::test]
+async fn geo_list_filter_geo_radius_no_match() {
+    let documents = json!([
+        {
+            "id": 1,
+            "name": "Company",
+            RESERVED_GEO_LIST_FIELD_NAME: [
+                { "lat": 40.7128, "lng": -74.0060 },
+                { "lat": 34.0522, "lng": -118.2437 }
+            ]
+        }
+    ]);
+
+    // Filter near Tokyo — neither NYC nor LA should match
+    test_settings_documents_indexing_swapping_and_search(
+        &documents,
+        &json!({
+            "filterableAttributes": [RESERVED_GEO_LIST_FIELD_NAME],
+            "sortableAttributes": [RESERVED_GEO_LIST_FIELD_NAME]
+        }),
+        &json!({
+            "filter": "_geoRadius(35.6762, 139.6503, 10000)"
+        }),
+        |response, code| {
+            assert_eq!(code, 200, "{response}");
+            let hits = &response["hits"];
+            assert_eq!(hits.as_array().unwrap().len(), 0);
+        },
+    )
+    .await;
+}
+
+#[actix_rt::test]
+async fn geo_list_sort_asc_closest_point() {
+    // Doc 1: has points at (0,0) and (50,50) — closest to (0,0) is 0 distance
+    // Doc 2: has point at (10,10) — distance ~1568 km from (0,0)
+    // Doc 3: has points at (30,30) and (20,20) — closest to (0,0) is (20,20) ~3111 km
+    let documents = json!([
+        {
+            "id": 1,
+            "name": "Near Origin",
+            RESERVED_GEO_LIST_FIELD_NAME: [
+                { "lat": 0.0, "lng": 0.0 },
+                { "lat": 50.0, "lng": 50.0 }
+            ]
+        },
+        {
+            "id": 2,
+            "name": "Moderate",
+            RESERVED_GEO_LIST_FIELD_NAME: [
+                { "lat": 10.0, "lng": 10.0 }
+            ]
+        },
+        {
+            "id": 3,
+            "name": "Far",
+            RESERVED_GEO_LIST_FIELD_NAME: [
+                { "lat": 30.0, "lng": 30.0 },
+                { "lat": 20.0, "lng": 20.0 }
+            ]
+        }
+    ]);
+
+    test_settings_documents_indexing_swapping_and_search(
+        &documents,
+        &json!({
+            "sortableAttributes": [RESERVED_GEO_LIST_FIELD_NAME],
+            "filterableAttributes": [RESERVED_GEO_LIST_FIELD_NAME]
+        }),
+        &json!({
+            "sort": ["_geoPoint(0.0, 0.0):asc"]
+        }),
+        |response, code| {
+            assert_eq!(code, 200, "{response}");
+            let hits = &response["hits"];
+            let ids: Vec<i64> =
+                hits.as_array().unwrap().iter().map(|h| h["id"].as_i64().unwrap()).collect();
+            // Doc 1 closest (point at origin), then doc 2 (10,10), then doc 3 (closest point is 20,20)
+            assert_eq!(ids, vec![1, 2, 3]);
+            // Doc 1 should have _geoDistance 0 (point at origin)
+            assert_eq!(hits[0]["_geoDistance"], 0);
+        },
+    )
+    .await;
+}
+
+#[actix_rt::test]
+async fn geo_list_sort_desc() {
+    let documents = json!([
+        {
+            "id": 1,
+            "name": "Near",
+            RESERVED_GEO_LIST_FIELD_NAME: [
+                { "lat": 0.0, "lng": 0.0 }
+            ]
+        },
+        {
+            "id": 2,
+            "name": "Far",
+            RESERVED_GEO_LIST_FIELD_NAME: [
+                { "lat": 50.0, "lng": 50.0 }
+            ]
+        }
+    ]);
+
+    test_settings_documents_indexing_swapping_and_search(
+        &documents,
+        &json!({
+            "sortableAttributes": [RESERVED_GEO_LIST_FIELD_NAME],
+            "filterableAttributes": [RESERVED_GEO_LIST_FIELD_NAME]
+        }),
+        &json!({
+            "sort": ["_geoPoint(0.0, 0.0):desc"]
+        }),
+        |response, code| {
+            assert_eq!(code, 200, "{response}");
+            let hits = &response["hits"];
+            let ids: Vec<i64> =
+                hits.as_array().unwrap().iter().map(|h| h["id"].as_i64().unwrap()).collect();
+            // Descending: farthest first
+            assert_eq!(ids, vec![2, 1]);
+        },
+    )
+    .await;
+}
+
+#[actix_rt::test]
+async fn geo_list_single_point_same_as_geo() {
+    // A single-element _geo_list should behave identically to _geo
+    let documents = json!([
+        {
+            "id": 1,
+            "name": "Single Point",
+            RESERVED_GEO_LIST_FIELD_NAME: [
+                { "lat": 48.8566, "lng": 2.3522 }
+            ]
+        }
+    ]);
+
+    test_settings_documents_indexing_swapping_and_search(
+        &documents,
+        &json!({
+            "sortableAttributes": [RESERVED_GEO_LIST_FIELD_NAME],
+            "filterableAttributes": [RESERVED_GEO_LIST_FIELD_NAME]
+        }),
+        &json!({
+            "filter": "_geoRadius(48.8566, 2.3522, 100)",
+            "sort": ["_geoPoint(48.8566, 2.3522):asc"]
+        }),
+        |response, code| {
+            assert_eq!(code, 200, "{response}");
+            let hits = &response["hits"];
+            assert_eq!(hits.as_array().unwrap().len(), 1);
+            assert_eq!(hits[0]["_geoDistance"], 0);
+        },
+    )
+    .await;
+}
+
+#[actix_rt::test]
+async fn geo_list_mixed_with_geo() {
+    // Doc 1 has _geo only (at origin)
+    // Doc 2 has _geo_list only (points at 10,10 and 20,20)
+    // Doc 3 has BOTH _geo (at 5,5) and _geo_list (at 30,30 and 40,40)
+    let documents = json!([
+        {
+            "id": 1,
+            "name": "Geo Only",
+            RESERVED_GEO_FIELD_NAME: { "lat": 0.0, "lng": 0.0 }
+        },
+        {
+            "id": 2,
+            "name": "GeoList Only",
+            RESERVED_GEO_LIST_FIELD_NAME: [
+                { "lat": 10.0, "lng": 10.0 },
+                { "lat": 20.0, "lng": 20.0 }
+            ]
+        },
+        {
+            "id": 3,
+            "name": "Both",
+            RESERVED_GEO_FIELD_NAME: { "lat": 5.0, "lng": 5.0 },
+            RESERVED_GEO_LIST_FIELD_NAME: [
+                { "lat": 30.0, "lng": 30.0 },
+                { "lat": 40.0, "lng": 40.0 }
+            ]
+        }
+    ]);
+
+    test_settings_documents_indexing_swapping_and_search(
+        &documents,
+        &json!({
+            "sortableAttributes": [RESERVED_GEO_FIELD_NAME, RESERVED_GEO_LIST_FIELD_NAME],
+            "filterableAttributes": [RESERVED_GEO_FIELD_NAME, RESERVED_GEO_LIST_FIELD_NAME]
+        }),
+        &json!({
+            "sort": ["_geoPoint(0.0, 0.0):asc"]
+        }),
+        |response, code| {
+            assert_eq!(code, 200, "{response}");
+            let hits = &response["hits"];
+            let ids: Vec<i64> =
+                hits.as_array().unwrap().iter().map(|h| h["id"].as_i64().unwrap()).collect();
+            // Doc 1 at origin (0), Doc 3 closest point is _geo at (5,5), Doc 2 closest point is (10,10)
+            assert_eq!(ids, vec![1, 3, 2]);
+        },
+    )
+    .await;
+}
+
+#[actix_rt::test]
+async fn geo_list_filter_geo_bounding_box() {
+    // Doc 1: points at (10, 10) and (50, 50) — (10,10) is in bounding box
+    // Doc 2: points at (60, 60) and (70, 70) — neither in bounding box
+    let documents = json!([
+        {
+            "id": 1,
+            "name": "Has Point In Box",
+            RESERVED_GEO_LIST_FIELD_NAME: [
+                { "lat": 10.0, "lng": 10.0 },
+                { "lat": 50.0, "lng": 50.0 }
+            ]
+        },
+        {
+            "id": 2,
+            "name": "Outside Box",
+            RESERVED_GEO_LIST_FIELD_NAME: [
+                { "lat": 60.0, "lng": 60.0 },
+                { "lat": 70.0, "lng": 70.0 }
+            ]
+        }
+    ]);
+
+    test_settings_documents_indexing_swapping_and_search(
+        &documents,
+        &json!({
+            "filterableAttributes": [RESERVED_GEO_LIST_FIELD_NAME],
+            "sortableAttributes": [RESERVED_GEO_LIST_FIELD_NAME]
+        }),
+        &json!({
+            "filter": "_geoBoundingBox([20, 20], [0, 0])"
+        }),
+        |response, code| {
+            assert_eq!(code, 200, "{response}");
+            let hits = &response["hits"];
+            assert_eq!(hits.as_array().unwrap().len(), 1);
+            assert_eq!(hits[0]["id"], 1);
+        },
+    )
+    .await;
+}
+
+#[actix_rt::test]
+async fn geo_list_document_update_replaces_points() {
+    let server = Server::new_shared();
+    let index = server.unique_index();
+
+    // Initial: doc with _geo_list at (0,0) and (10,10)
+    let (task, _) = index
+        .add_documents(
+            json!([
+                {
+                    "id": 1,
+                    "name": "Company",
+                    "_geo_list": [
+                        { "lat": 0.0, "lng": 0.0 },
+                        { "lat": 10.0, "lng": 10.0 }
+                    ]
+                }
+            ]),
+            None,
+        )
+        .await;
+    server.wait_task(task.uid()).await.succeeded();
+
+    let (task, _) = index
+        .update_settings(json!({
+            "filterableAttributes": ["_geo_list"],
+            "sortableAttributes": ["_geo_list"]
+        }))
+        .await;
+    server.wait_task(task.uid()).await.succeeded();
+
+    // Verify initial state: doc matches filter near origin
+    index
+        .search(json!({ "filter": "_geoRadius(0.0, 0.0, 100)" }), |response, code| {
+            assert_eq!(code, 200, "{response}");
+            assert_eq!(response["hits"].as_array().unwrap().len(), 1);
+        })
+        .await;
+
+    // Update: move all points far away
+    let (task, _) = index
+        .add_documents(
+            json!([
+                {
+                    "id": 1,
+                    "name": "Company",
+                    "_geo_list": [
+                        { "lat": 60.0, "lng": 60.0 },
+                        { "lat": 70.0, "lng": 70.0 }
+                    ]
+                }
+            ]),
+            None,
+        )
+        .await;
+    server.wait_task(task.uid()).await.succeeded();
+
+    // Old points should be gone: no match near origin
+    index
+        .search(json!({ "filter": "_geoRadius(0.0, 0.0, 100)" }), |response, code| {
+            assert_eq!(code, 200, "{response}");
+            assert_eq!(response["hits"].as_array().unwrap().len(), 0);
+        })
+        .await;
+
+    // New points should work
+    index
+        .search(json!({ "filter": "_geoRadius(60.0, 60.0, 100)" }), |response, code| {
+            assert_eq!(code, 200, "{response}");
+            assert_eq!(response["hits"].as_array().unwrap().len(), 1);
+        })
+        .await;
+}
+
+#[actix_rt::test]
+async fn geo_list_document_deletion() {
+    let server = Server::new_shared();
+    let index = server.unique_index();
+
+    let (task, _) = index
+        .add_documents(
+            json!([
+                {
+                    "id": 1,
+                    "name": "To Delete",
+                    "_geo_list": [
+                        { "lat": 48.8566, "lng": 2.3522 }
+                    ]
+                },
+                {
+                    "id": 2,
+                    "name": "To Keep",
+                    "_geo_list": [
+                        { "lat": 48.8566, "lng": 2.3522 }
+                    ]
+                }
+            ]),
+            None,
+        )
+        .await;
+    server.wait_task(task.uid()).await.succeeded();
+
+    let (task, _) = index
+        .update_settings(json!({
+            "filterableAttributes": ["_geo_list"],
+            "sortableAttributes": ["_geo_list"]
+        }))
+        .await;
+    server.wait_task(task.uid()).await.succeeded();
+
+    // Both docs match initially
+    index
+        .search(
+            json!({ "filter": "_geoRadius(48.8566, 2.3522, 100)" }),
+            |response, code| {
+                assert_eq!(code, 200, "{response}");
+                assert_eq!(response["hits"].as_array().unwrap().len(), 2);
+            },
+        )
+        .await;
+
+    // Delete doc 1
+    let (task, _) = index.delete_document(1).await;
+    server.wait_task(task.uid()).await.succeeded();
+
+    // Only doc 2 should remain
+    index
+        .search(
+            json!({ "filter": "_geoRadius(48.8566, 2.3522, 100)" }),
+            |response, code| {
+                assert_eq!(code, 200, "{response}");
+                let hits = &response["hits"];
+                assert_eq!(hits.as_array().unwrap().len(), 1);
+                assert_eq!(hits[0]["id"], 2);
+            },
+        )
+        .await;
+}
+
+#[actix_rt::test]
+async fn geo_list_with_string_lat_lng() {
+    // _geo_list should accept string lat/lng values just like _geo does
+    let documents = json!([
+        {
+            "id": 1,
+            "name": "String Coords",
+            RESERVED_GEO_LIST_FIELD_NAME: [
+                { "lat": "48.8566", "lng": "2.3522" },
+                { "lat": "40.7128", "lng": "-74.0060" }
+            ]
+        }
+    ]);
+
+    test_settings_documents_indexing_swapping_and_search(
+        &documents,
+        &json!({
+            "filterableAttributes": [RESERVED_GEO_LIST_FIELD_NAME],
+            "sortableAttributes": [RESERVED_GEO_LIST_FIELD_NAME]
+        }),
+        &json!({
+            "filter": "_geoRadius(48.8566, 2.3522, 100)",
+            "sort": ["_geoPoint(48.8566, 2.3522):asc"]
+        }),
+        |response, code| {
+            assert_eq!(code, 200, "{response}");
+            let hits = &response["hits"];
+            assert_eq!(hits.as_array().unwrap().len(), 1);
+            assert_eq!(hits[0]["_geoDistance"], 0);
+        },
+    )
+    .await;
+}
+
+#[actix_rt::test]
+async fn geo_list_error_not_an_array() {
+    let server = Server::new_shared();
+    let index = server.unique_index();
+
+    let (task, _) = index
+        .update_settings(json!({
+            "filterableAttributes": ["_geo_list"],
+            "sortableAttributes": ["_geo_list"]
+        }))
+        .await;
+    server.wait_task(task.uid()).await.succeeded();
+
+    let (task, _) = index
+        .add_documents(
+            json!([
+                {
+                    "id": "1",
+                    "_geo_list": { "lat": 0.0, "lng": 0.0 }
+                }
+            ]),
+            None,
+        )
+        .await;
+    let response = server.wait_task(task.uid()).await;
+    response.failed();
+    let (response, _) = index.get_task(task.uid()).await;
+    snapshot!(response["error"]["code"], @r###""invalid_document_geo_field""###);
+}
+
+#[actix_rt::test]
+async fn geo_list_error_element_not_object() {
+    let server = Server::new_shared();
+    let index = server.unique_index();
+
+    let (task, _) = index
+        .update_settings(json!({
+            "filterableAttributes": ["_geo_list"],
+            "sortableAttributes": ["_geo_list"]
+        }))
+        .await;
+    server.wait_task(task.uid()).await.succeeded();
+
+    let (task, _) = index
+        .add_documents(
+            json!([
+                {
+                    "id": "1",
+                    "_geo_list": ["not an object"]
+                }
+            ]),
+            None,
+        )
+        .await;
+    let response = server.wait_task(task.uid()).await;
+    response.failed();
+    let (response, _) = index.get_task(task.uid()).await;
+    snapshot!(response["error"]["code"], @r###""invalid_document_geo_field""###);
+}
+
+#[actix_rt::test]
+async fn geo_list_error_element_missing_lat_lng() {
+    let server = Server::new_shared();
+    let index = server.unique_index();
+
+    let (task, _) = index
+        .update_settings(json!({
+            "filterableAttributes": ["_geo_list"],
+            "sortableAttributes": ["_geo_list"]
+        }))
+        .await;
+    server.wait_task(task.uid()).await.succeeded();
+
+    let (task, _) = index
+        .add_documents(
+            json!([
+                {
+                    "id": "1",
+                    "_geo_list": [{ "foo": "bar" }]
+                }
+            ]),
+            None,
+        )
+        .await;
+    let response = server.wait_task(task.uid()).await;
+    response.failed();
+    let (response, _) = index.get_task(task.uid()).await;
+    snapshot!(response["error"]["code"], @r###""invalid_document_geo_field""###);
+}
+
+#[actix_rt::test]
+async fn geo_list_error_bad_latitude() {
+    let server = Server::new_shared();
+    let index = server.unique_index();
+
+    let (task, _) = index
+        .update_settings(json!({
+            "filterableAttributes": ["_geo_list"],
+            "sortableAttributes": ["_geo_list"]
+        }))
+        .await;
+    server.wait_task(task.uid()).await.succeeded();
+
+    // Use a non-numeric value for lat which is truly invalid
+    let (task, _) = index
+        .add_documents(
+            json!([
+                {
+                    "id": "1",
+                    "_geo_list": [{ "lat": true, "lng": 0.0 }]
+                }
+            ]),
+            None,
+        )
+        .await;
+    let response = server.wait_task(task.uid()).await;
+    response.failed();
+    let (response, _) = index.get_task(task.uid()).await;
+    snapshot!(response["error"]["code"], @r###""invalid_document_geo_field""###);
+}
+
+#[actix_rt::test]
+async fn geo_list_null_value_ignored() {
+    // A null _geo_list should be treated as absence of the field
+    let documents = json!([
+        {
+            "id": 1,
+            "name": "Null geo_list",
+            RESERVED_GEO_LIST_FIELD_NAME: null
+        },
+        {
+            "id": 2,
+            "name": "Has geo_list",
+            RESERVED_GEO_LIST_FIELD_NAME: [
+                { "lat": 48.8566, "lng": 2.3522 }
+            ]
+        }
+    ]);
+
+    test_settings_documents_indexing_swapping_and_search(
+        &documents,
+        &json!({
+            "filterableAttributes": [RESERVED_GEO_LIST_FIELD_NAME],
+            "sortableAttributes": [RESERVED_GEO_LIST_FIELD_NAME]
+        }),
+        &json!({
+            "filter": "_geoRadius(48.8566, 2.3522, 100)"
+        }),
+        |response, code| {
+            assert_eq!(code, 200, "{response}");
+            let hits = &response["hits"];
+            assert_eq!(hits.as_array().unwrap().len(), 1);
+            assert_eq!(hits[0]["id"], 2);
+        },
+    )
+    .await;
+}
+
+#[actix_rt::test]
+async fn geo_list_geo_distance_reflects_closest() {
+    // Verify that _geoDistance reflects the minimum distance across all _geo_list points
+    let documents = json!([
+        {
+            "id": 1,
+            "name": "Multi-point",
+            RESERVED_GEO_LIST_FIELD_NAME: [
+                { "lat": 0.0, "lng": 0.0 },
+                { "lat": 45.0, "lng": 45.0 }
+            ]
+        }
+    ]);
+
+    test_settings_documents_indexing_swapping_and_search(
+        &documents,
+        &json!({
+            "sortableAttributes": [RESERVED_GEO_LIST_FIELD_NAME],
+            "filterableAttributes": [RESERVED_GEO_LIST_FIELD_NAME]
+        }),
+        &json!({
+            "sort": ["_geoPoint(0.0, 0.0):asc"]
+        }),
+        |response, code| {
+            assert_eq!(code, 200, "{response}");
+            let hits = &response["hits"];
+            // The closest point is (0,0) so distance should be 0
+            assert_eq!(hits[0]["_geoDistance"], 0);
+        },
+    )
+    .await;
+}
+
+#[actix_rt::test]
+async fn geo_list_only_in_filterable_not_sortable() {
+    let server = Server::new_shared();
+    let index = server.unique_index();
+
+    let (task, _) = index
+        .add_documents(
+            json!([
+                {
+                    "id": 1,
+                    "_geo_list": [{ "lat": 48.8566, "lng": 2.3522 }]
+                }
+            ]),
+            None,
+        )
+        .await;
+    server.wait_task(task.uid()).await.succeeded();
+
+    // Only add to filterableAttributes, not sortableAttributes
+    let (task, _) = index
+        .update_settings(json!({
+            "filterableAttributes": ["_geo_list"]
+        }))
+        .await;
+    server.wait_task(task.uid()).await.succeeded();
+
+    // Filtering should work
+    index
+        .search(
+            json!({ "filter": "_geoRadius(48.8566, 2.3522, 100)" }),
+            |response, code| {
+                assert_eq!(code, 200, "{response}");
+                assert_eq!(response["hits"].as_array().unwrap().len(), 1);
+            },
+        )
+        .await;
+
+    // Sorting should fail (not in sortableAttributes)
+    index
+        .search(
+            json!({ "sort": ["_geoPoint(48.8566, 2.3522):asc"] }),
+            |response, code| {
+                assert_eq!(code, 400, "{response}");
+            },
+        )
+        .await;
 }

--- a/crates/meilisearch/tests/search/geo.rs
+++ b/crates/meilisearch/tests/search/geo.rs
@@ -1,7 +1,5 @@
 use meili_snap::{json_string, snapshot};
-use meilisearch_types::milli::constants::{
-    RESERVED_GEO_FIELD_NAME, RESERVED_GEO_LIST_FIELD_NAME,
-};
+use meilisearch_types::milli::constants::{RESERVED_GEO_FIELD_NAME, RESERVED_GEO_LIST_FIELD_NAME};
 
 use super::test_settings_documents_indexing_swapping_and_search;
 use crate::common::{shared_index_with_geo_documents, Server};
@@ -734,13 +732,10 @@ async fn geo_list_document_deletion() {
 
     // Both docs match initially
     index
-        .search(
-            json!({ "filter": "_geoRadius(48.8566, 2.3522, 100)" }),
-            |response, code| {
-                assert_eq!(code, 200, "{response}");
-                assert_eq!(response["hits"].as_array().unwrap().len(), 2);
-            },
-        )
+        .search(json!({ "filter": "_geoRadius(48.8566, 2.3522, 100)" }), |response, code| {
+            assert_eq!(code, 200, "{response}");
+            assert_eq!(response["hits"].as_array().unwrap().len(), 2);
+        })
         .await;
 
     // Delete doc 1
@@ -749,15 +744,12 @@ async fn geo_list_document_deletion() {
 
     // Only doc 2 should remain
     index
-        .search(
-            json!({ "filter": "_geoRadius(48.8566, 2.3522, 100)" }),
-            |response, code| {
-                assert_eq!(code, 200, "{response}");
-                let hits = &response["hits"];
-                assert_eq!(hits.as_array().unwrap().len(), 1);
-                assert_eq!(hits[0]["id"], 2);
-            },
-        )
+        .search(json!({ "filter": "_geoRadius(48.8566, 2.3522, 100)" }), |response, code| {
+            assert_eq!(code, 200, "{response}");
+            let hits = &response["hits"];
+            assert_eq!(hits.as_array().unwrap().len(), 1);
+            assert_eq!(hits[0]["id"], 2);
+        })
         .await;
 }
 
@@ -1014,22 +1006,16 @@ async fn geo_list_only_in_filterable_not_sortable() {
 
     // Filtering should work
     index
-        .search(
-            json!({ "filter": "_geoRadius(48.8566, 2.3522, 100)" }),
-            |response, code| {
-                assert_eq!(code, 200, "{response}");
-                assert_eq!(response["hits"].as_array().unwrap().len(), 1);
-            },
-        )
+        .search(json!({ "filter": "_geoRadius(48.8566, 2.3522, 100)" }), |response, code| {
+            assert_eq!(code, 200, "{response}");
+            assert_eq!(response["hits"].as_array().unwrap().len(), 1);
+        })
         .await;
 
     // Sorting should fail (not in sortableAttributes)
     index
-        .search(
-            json!({ "sort": ["_geoPoint(48.8566, 2.3522):asc"] }),
-            |response, code| {
-                assert_eq!(code, 400, "{response}");
-            },
-        )
+        .search(json!({ "sort": ["_geoPoint(48.8566, 2.3522):asc"] }), |response, code| {
+            assert_eq!(code, 400, "{response}");
+        })
         .await;
 }

--- a/crates/milli/src/constants.rs
+++ b/crates/milli/src/constants.rs
@@ -12,3 +12,4 @@ const fn parse_u32(s: &str) -> u32 {
 pub const RESERVED_VECTORS_FIELD_NAME: &str = "_vectors";
 pub const RESERVED_GEO_FIELD_NAME: &str = "_geo";
 pub const RESERVED_GEOJSON_FIELD_NAME: &str = "_geojson";
+pub const RESERVED_GEO_LIST_FIELD_NAME: &str = "_geo_list";

--- a/crates/milli/src/constants.rs
+++ b/crates/milli/src/constants.rs
@@ -10,6 +10,9 @@ const fn parse_u32(s: &str) -> u32 {
 }
 
 pub const RESERVED_VECTORS_FIELD_NAME: &str = "_vectors";
+/// A single geographic point as an object with `lat` and `lng` fields.
 pub const RESERVED_GEO_FIELD_NAME: &str = "_geo";
+/// A GeoJSON geometry object (Point, Polygon, MultiPolygon, etc.).
 pub const RESERVED_GEOJSON_FIELD_NAME: &str = "_geojson";
+/// An array of geographic points, each an object with `lat` and `lng` fields.
 pub const RESERVED_GEO_LIST_FIELD_NAME: &str = "_geo_list";

--- a/crates/milli/src/documents/geo_sort.rs
+++ b/crates/milli/src/documents/geo_sort.rs
@@ -80,8 +80,7 @@ pub fn fill_cache(
     // When _geo_list is involved, force the RTree strategy because the iterative
     // path reads independent lat/lng facet values that can't be correctly paired
     // for multi-point documents.
-    let use_rtree =
-        has_geo_list || strategy.use_rtree(geo_candidates.len() as usize);
+    let use_rtree = has_geo_list || strategy.use_rtree(geo_candidates.len() as usize);
 
     // lazily initialize the rtree if needed by the strategy, and cache it in `self.rtree`
     let rtree = if use_rtree {

--- a/crates/milli/src/documents/sort.rs
+++ b/crates/milli/src/documents/sort.rs
@@ -451,13 +451,18 @@ pub fn recursive_sort<'ctx>(
             let has_geo_list = sortable_fields.contains(RESERVED_GEO_LIST_FIELD_NAME);
             if has_geo || has_geo_list {
                 // Use _geo field IDs if available, otherwise fall back to _geo_list
-                let lat = fields_ids_map.id("_geo.lat")
-                    .or_else(|| fields_ids_map.id("_geo_list.lat"));
-                let lng = fields_ids_map.id("_geo.lng")
-                    .or_else(|| fields_ids_map.id("_geo_list.lng"));
+                let lat =
+                    fields_ids_map.id("_geo.lat").or_else(|| fields_ids_map.id("_geo_list.lat"));
+                let lng =
+                    fields_ids_map.id("_geo.lng").or_else(|| fields_ids_map.id("_geo_list.lng"));
                 if let (Some(lat), Some(lng)) = (lat, lng) {
                     need_geo_candidates = true;
-                    fields.push(AscDescId::Geo { field_ids: [lat, lng], target_point, ascending, has_geo_list });
+                    fields.push(AscDescId::Geo {
+                        field_ids: [lat, lng],
+                        target_point,
+                        ascending,
+                        has_geo_list,
+                    });
                     continue;
                 }
             }

--- a/crates/milli/src/documents/sort.rs
+++ b/crates/milli/src/documents/sort.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeSet, VecDeque};
 use heed::Database;
 use roaring::RoaringBitmap;
 
-use crate::constants::RESERVED_GEO_FIELD_NAME;
+use crate::constants::{RESERVED_GEO_FIELD_NAME, RESERVED_GEO_LIST_FIELD_NAME};
 use crate::documents::geo_sort::next_bucket;
 use crate::documents::GeoSortParameter;
 use crate::heed_codec::facet::{FacetGroupKeyCodec, FacetGroupValueCodec};
@@ -14,7 +14,7 @@ use crate::{is_faceted, AscDesc, DocumentId, Member, UserError};
 #[derive(Debug, Clone, Copy)]
 enum AscDescId {
     Facet { field_id: u16, ascending: bool },
-    Geo { field_ids: [u16; 2], target_point: [f64; 2], ascending: bool },
+    Geo { field_ids: [u16; 2], target_point: [f64; 2], ascending: bool, has_geo_list: bool },
 }
 
 /// A [`SortedDocumentsIterator`] allows efficient access to a continuous range of sorted documents.
@@ -208,7 +208,7 @@ impl<'ctx> SortedDocumentsIteratorBuilder<'ctx> {
                     *ascending,
                 )
             }
-            [AscDescId::Geo { field_ids, target_point, ascending }, next_fields @ ..] => {
+            [AscDescId::Geo { field_ids, target_point, ascending, has_geo_list }, next_fields @ ..] => {
                 SortedDocumentsIteratorBuilder::build_geo(
                     self.index,
                     self.rtxn,
@@ -220,6 +220,7 @@ impl<'ctx> SortedDocumentsIteratorBuilder<'ctx> {
                     *field_ids,
                     *target_point,
                     *ascending,
+                    *has_geo_list,
                 )
             }
         }
@@ -318,6 +319,7 @@ impl<'ctx> SortedDocumentsIteratorBuilder<'ctx> {
         field_ids: [u16; 2],
         target_point: [f64; 2],
         ascending: bool,
+        has_geo_list: bool,
     ) -> crate::Result<SortedDocumentsIterator<'ctx>> {
         let mut cache = VecDeque::new();
         let mut rtree = None;
@@ -341,6 +343,7 @@ impl<'ctx> SortedDocumentsIteratorBuilder<'ctx> {
                     &mut cache,
                     geo_candidates,
                     GeoSortParameter::default(),
+                    has_geo_list,
                 ) {
                     geo_remaining -= docids.len() as usize;
                     return Some(Ok(SortedDocumentsIteratorBuilder {
@@ -444,12 +447,17 @@ pub fn recursive_sort<'ctx>(
             .into());
         }
         if let Some((target_point, ascending)) = geofield {
-            if sortable_fields.contains(RESERVED_GEO_FIELD_NAME) {
-                if let (Some(lat), Some(lng)) =
-                    (fields_ids_map.id("_geo.lat"), fields_ids_map.id("_geo.lng"))
-                {
+            let has_geo = sortable_fields.contains(RESERVED_GEO_FIELD_NAME);
+            let has_geo_list = sortable_fields.contains(RESERVED_GEO_LIST_FIELD_NAME);
+            if has_geo || has_geo_list {
+                // Use _geo field IDs if available, otherwise fall back to _geo_list
+                let lat = fields_ids_map.id("_geo.lat")
+                    .or_else(|| fields_ids_map.id("_geo_list.lat"));
+                let lng = fields_ids_map.id("_geo.lng")
+                    .or_else(|| fields_ids_map.id("_geo_list.lng"));
+                if let (Some(lat), Some(lng)) = (lat, lng) {
                     need_geo_candidates = true;
-                    fields.push(AscDescId::Geo { field_ids: [lat, lng], target_point, ascending });
+                    fields.push(AscDescId::Geo { field_ids: [lat, lng], target_point, ascending, has_geo_list });
                     continue;
                 }
             }

--- a/crates/milli/src/fields_ids_map/metadata.rs
+++ b/crates/milli/src/fields_ids_map/metadata.rs
@@ -7,7 +7,8 @@ use heed::RoTxn;
 use super::FieldsIdsMap;
 use crate::attribute_patterns::{match_field_legacy, PatternMatch};
 use crate::constants::{
-    RESERVED_GEOJSON_FIELD_NAME, RESERVED_GEO_FIELD_NAME, RESERVED_VECTORS_FIELD_NAME,
+    RESERVED_GEOJSON_FIELD_NAME, RESERVED_GEO_FIELD_NAME, RESERVED_GEO_LIST_FIELD_NAME,
+    RESERVED_VECTORS_FIELD_NAME,
 };
 use crate::order_by_map::OrderByMap;
 use crate::{
@@ -31,6 +32,8 @@ pub struct Metadata {
     pub geo: bool,
     /// The field is a geo json field (`_geojson`).
     pub geo_json: bool,
+    /// The field is a geo list field (`_geo_list`, `_geo_list.lat`, `_geo_list.lng`).
+    pub geo_list: bool,
     /// The field is defined as a field that can be displayed.
     pub displayed: bool,
     /// The id of the localized attributes rule if the field is localized.
@@ -330,6 +333,7 @@ impl MetadataBuilder {
                 asc_desc: None,
                 geo: false,
                 geo_json: false,
+                geo_list: false,
                 localized_attributes_rule_id: None,
                 filterable_attributes_rule_id: None,
                 displayed: self.is_field_displayed(field),
@@ -360,6 +364,7 @@ impl MetadataBuilder {
                 asc_desc: None,
                 geo: true,
                 geo_json: false,
+                geo_list: false,
                 localized_attributes_rule_id: None,
                 filterable_attributes_rule_id,
                 displayed: self.is_field_displayed(field),
@@ -376,6 +381,23 @@ impl MetadataBuilder {
                 asc_desc: None,
                 geo: false,
                 geo_json: true,
+                geo_list: false,
+                localized_attributes_rule_id: None,
+                filterable_attributes_rule_id,
+                displayed: self.is_field_displayed(field),
+                sort_by: self.order_by_map.get(field),
+            };
+        }
+        if match_field_legacy(RESERVED_GEO_LIST_FIELD_NAME, field) == PatternMatch::Match {
+            return Metadata {
+                searchable: None,
+                exact: false,
+                sortable,
+                distinct: false,
+                asc_desc: None,
+                geo: false,
+                geo_json: false,
+                geo_list: true,
                 localized_attributes_rule_id: None,
                 filterable_attributes_rule_id,
                 displayed: self.is_field_displayed(field),
@@ -415,6 +437,7 @@ impl MetadataBuilder {
             asc_desc,
             geo: false,
             geo_json: false,
+            geo_list: false,
             localized_attributes_rule_id,
             filterable_attributes_rule_id,
             displayed: self.is_field_displayed(field),

--- a/crates/milli/src/filterable_attributes_rules.rs
+++ b/crates/milli/src/filterable_attributes_rules.rs
@@ -5,7 +5,9 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 use crate::attribute_patterns::{match_distinct_field, match_field_legacy, PatternMatch};
-use crate::constants::{RESERVED_GEOJSON_FIELD_NAME, RESERVED_GEO_FIELD_NAME};
+use crate::constants::{
+    RESERVED_GEOJSON_FIELD_NAME, RESERVED_GEO_FIELD_NAME, RESERVED_GEO_LIST_FIELD_NAME,
+};
 use crate::AttributePatterns;
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Clone, Debug, ToSchema)]
@@ -37,6 +39,10 @@ impl FilterableAttributesRule {
 
     pub fn has_geojson(&self) -> bool {
         matches!(self, FilterableAttributesRule::Field(field_name) if field_name == RESERVED_GEOJSON_FIELD_NAME)
+    }
+
+    pub fn has_geo_list(&self) -> bool {
+        matches!(self, FilterableAttributesRule::Field(field_name) if field_name == RESERVED_GEO_LIST_FIELD_NAME)
     }
 
     /// Get the features of the rule.

--- a/crates/milli/src/lib.rs
+++ b/crates/milli/src/lib.rs
@@ -67,9 +67,9 @@ pub use self::error::{
 };
 pub use self::external_documents_ids::ExternalDocumentsIds;
 pub use self::fieldids_weights_map::FieldidsWeightsMap;
+pub use self::fields_ids_map::metadata::Metadata;
 pub use self::fields_ids_map::{
-    metadata::Metadata, FieldIdMapWithMetadata, FieldSortOrder, FieldsIdsMap, GlobalFieldsIdsMap,
-    MetadataBuilder,
+    FieldIdMapWithMetadata, FieldSortOrder, FieldsIdsMap, GlobalFieldsIdsMap, MetadataBuilder,
 };
 pub use self::filterable_attributes_rules::{
     FilterFeatures, FilterableAttributesFeatures, FilterableAttributesPatterns,

--- a/crates/milli/src/score_details.rs
+++ b/crates/milli/src/score_details.rs
@@ -3,7 +3,8 @@ use std::cmp::Ordering;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
-use crate::{criterion::AttributeState, distance_between_two_points};
+use crate::criterion::AttributeState;
+use crate::distance_between_two_points;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum ScoreDetails {

--- a/crates/milli/src/search/facet/filter.rs
+++ b/crates/milli/src/search/facet/filter.rs
@@ -944,8 +944,7 @@ impl<'a> Filter<'a> {
                             .iter()
                             .filter(|point| {
                                 let [lat, lng] = point.data.1;
-                                let lat_ok =
-                                    lat >= bottom_left[0] && lat <= top_right[0];
+                                let lat_ok = lat >= bottom_left[0] && lat <= top_right[0];
                                 let lng_ok = if is_lng_wrapping {
                                     lng >= bottom_left[1] || lng <= top_right[1]
                                 } else {
@@ -1168,14 +1167,14 @@ mod tests {
         let filter = Filter::from_str("_geoRadius(42, 150, 10)").unwrap().unwrap();
         let error = filter.evaluate(&rtxn, &index).unwrap_err();
         snapshot!(error.to_string(), @r"
-        Attribute `_geo/_geojson` is not filterable. This index does not have configured filterable attributes.
+        Attribute `_geo/_geojson/_geo_list` is not filterable. This index does not have configured filterable attributes.
         12:14 _geoRadius(42, 150, 10)
         ");
 
         let filter = Filter::from_str("_geoBoundingBox([42, 150], [30, 10])").unwrap().unwrap();
         let error = filter.evaluate(&rtxn, &index).unwrap_err();
         snapshot!(error.to_string(), @r"
-        Attribute `_geo/_geojson` is not filterable. This index does not have configured filterable attributes.
+        Attribute `_geo/_geojson/_geo_list` is not filterable. This index does not have configured filterable attributes.
         18:20 _geoBoundingBox([42, 150], [30, 10])
         ");
 
@@ -1201,14 +1200,14 @@ mod tests {
         let filter = Filter::from_str("_geoRadius(-90, 150, 10)").unwrap().unwrap();
         let error = filter.evaluate(&rtxn, &index).unwrap_err();
         snapshot!(error.to_string(), @r"
-        Attribute `_geo/_geojson` is not filterable. Available filterable attribute patterns are: `title`.
+        Attribute `_geo/_geojson/_geo_list` is not filterable. Available filterable attribute patterns are: `title`.
         12:15 _geoRadius(-90, 150, 10)
         ");
 
         let filter = Filter::from_str("_geoBoundingBox([42, 150], [30, 10])").unwrap().unwrap();
         let error = filter.evaluate(&rtxn, &index).unwrap_err();
         snapshot!(error.to_string(), @r"
-        Attribute `_geo/_geojson` is not filterable. Available filterable attribute patterns are: `title`.
+        Attribute `_geo/_geojson/_geo_list` is not filterable. Available filterable attribute patterns are: `title`.
         18:20 _geoBoundingBox([42, 150], [30, 10])
         ");
 

--- a/crates/milli/src/search/facet/filter.rs
+++ b/crates/milli/src/search/facet/filter.rs
@@ -13,7 +13,8 @@ use serde_json::Value;
 
 use super::facet_range_search;
 use crate::constants::{
-    RESERVED_GEOJSON_FIELD_NAME, RESERVED_GEO_FIELD_NAME, RESERVED_VECTORS_FIELD_NAME,
+    RESERVED_GEOJSON_FIELD_NAME, RESERVED_GEO_FIELD_NAME, RESERVED_GEO_LIST_FIELD_NAME,
+    RESERVED_VECTORS_FIELD_NAME,
 };
 use crate::error::{Error, UserError};
 use crate::filterable_attributes_rules::{filtered_matching_patterns, matching_features};
@@ -753,7 +754,9 @@ impl<'a> Filter<'a> {
                 }
 
                 let mut r1 = None;
-                if index.is_geo_filtering_enabled(rtxn)? {
+                if index.is_geo_filtering_enabled(rtxn)?
+                    || index.is_geo_list_filtering_enabled(rtxn)?
+                {
                     let rtree = match index.geo_rtree(rtxn)? {
                         Some(rtree) => rtree,
                         None => return Ok(RoaringBitmap::new()),
@@ -788,7 +791,7 @@ impl<'a> Filter<'a> {
                     (None, None) => {
                         Err(point[0].as_external_error(FilterError::AttributeNotFilterable {
                             attribute: &format!(
-                                "{RESERVED_GEO_FIELD_NAME}/{RESERVED_GEOJSON_FIELD_NAME}"
+                                "{RESERVED_GEO_FIELD_NAME}/{RESERVED_GEOJSON_FIELD_NAME}/{RESERVED_GEO_LIST_FIELD_NAME}"
                             ),
                             filterable_patterns: filtered_matching_patterns(
                                 filterable_attribute_rules,
@@ -932,6 +935,33 @@ impl<'a> Filter<'a> {
                     r1 = Some(selected_lat & selected_lng);
                 }
 
+                // For _geo_list, use RTree-based bounding box to avoid false positives
+                // (independent lat/lng facet ranges could pair lat from point A with lng from point B)
+                if index.is_geo_list_filtering_enabled(rtxn)? {
+                    if let Some(rtree) = index.geo_rtree(rtxn)? {
+                        let is_lng_wrapping = top_right[1] < bottom_left[1];
+                        let geo_list_result: RoaringBitmap = rtree
+                            .iter()
+                            .filter(|point| {
+                                let [lat, lng] = point.data.1;
+                                let lat_ok =
+                                    lat >= bottom_left[0] && lat <= top_right[0];
+                                let lng_ok = if is_lng_wrapping {
+                                    lng >= bottom_left[1] || lng <= top_right[1]
+                                } else {
+                                    lng >= bottom_left[1] && lng <= top_right[1]
+                                };
+                                lat_ok && lng_ok
+                            })
+                            .map(|point| point.data.0)
+                            .collect();
+                        r1 = Some(match r1 {
+                            Some(existing) => existing | geo_list_result,
+                            None => geo_list_result,
+                        });
+                    }
+                }
+
                 let mut r2 = None;
                 if index.is_geojson_filtering_enabled(rtxn)? {
                     let polygon = geo_types::Polygon::new(
@@ -956,7 +986,7 @@ impl<'a> Filter<'a> {
                     (None, None) => Err(top_right_point[0].as_external_error(
                         FilterError::AttributeNotFilterable {
                             attribute: &format!(
-                                "{RESERVED_GEO_FIELD_NAME}/{RESERVED_GEOJSON_FIELD_NAME}"
+                                "{RESERVED_GEO_FIELD_NAME}/{RESERVED_GEOJSON_FIELD_NAME}/{RESERVED_GEO_LIST_FIELD_NAME}"
                             ),
                             filterable_patterns: filtered_matching_patterns(
                                 filterable_attribute_rules,

--- a/crates/milli/src/update/new/extract/faceted/facet_document.rs
+++ b/crates/milli/src/update/new/extract/faceted/facet_document.rs
@@ -6,7 +6,7 @@ use crate::attribute_patterns::PatternMatch;
 use crate::fields_ids_map::metadata::Metadata;
 use crate::filterable_attributes_rules::match_faceted_field;
 use crate::update::new::document::Document;
-use crate::update::new::extract::geo::extract_geo_coordinates;
+use crate::update::new::extract::geo::{extract_geo_coordinates, extract_geo_list_coordinates};
 use crate::update::new::extract::perm_json_p;
 use crate::{
     FieldId, FilterableAttributesRule, GlobalFieldsIdsMap, InternalError, Result, UserError,
@@ -117,6 +117,31 @@ pub fn extract_geo_document<'doc>(
 
             facet_fn(lat_fid, lat_meta, perm_json_p::Depth::OnBaseKey, &lat.into())?;
             facet_fn(lng_fid, lng_meta, perm_json_p::Depth::OnBaseKey, &lng.into())?;
+        }
+    }
+
+    Ok(())
+}
+
+pub fn extract_geo_list_document<'doc>(
+    document: impl Document<'doc>,
+    external_document_id: &str,
+    field_id_map: &mut GlobalFieldsIdsMap,
+    facet_fn: &mut impl FnMut(FieldId, Metadata, perm_json_p::Depth, &Value) -> Result<()>,
+) -> Result<()> {
+    if let Some(geo_list_value) = document.geo_list_field()? {
+        if let Some(points) =
+            extract_geo_list_coordinates(external_document_id, geo_list_value)?
+        {
+            let ((lat_fid, lat_meta), (lng_fid, lng_meta)) = field_id_map
+                .id_with_metadata_or_insert("_geo_list.lat")
+                .zip(field_id_map.id_with_metadata_or_insert("_geo_list.lng"))
+                .ok_or(UserError::AttributeLimitReached)?;
+
+            for [lat, lng] in points {
+                facet_fn(lat_fid, lat_meta, perm_json_p::Depth::OnBaseKey, &lat.into())?;
+                facet_fn(lng_fid, lng_meta, perm_json_p::Depth::OnBaseKey, &lng.into())?;
+            }
         }
     }
 

--- a/crates/milli/src/update/new/extract/faceted/facet_document.rs
+++ b/crates/milli/src/update/new/extract/faceted/facet_document.rs
@@ -130,9 +130,7 @@ pub fn extract_geo_list_document<'doc>(
     facet_fn: &mut impl FnMut(FieldId, Metadata, perm_json_p::Depth, &Value) -> Result<()>,
 ) -> Result<()> {
     if let Some(geo_list_value) = document.geo_list_field()? {
-        if let Some(points) =
-            extract_geo_list_coordinates(external_document_id, geo_list_value)?
-        {
+        if let Some(points) = extract_geo_list_coordinates(external_document_id, geo_list_value)? {
             let ((lat_fid, lat_meta), (lng_fid, lng_meta)) = field_id_map
                 .id_with_metadata_or_insert("_geo_list.lat")
                 .zip(field_id_map.id_with_metadata_or_insert("_geo_list.lng"))

--- a/crates/milli/src/update/new/extract/geo/mod.rs
+++ b/crates/milli/src/update/new/extract/geo/mod.rs
@@ -9,7 +9,7 @@ use heed::RoTxn;
 use serde_json::value::RawValue;
 use serde_json::Value;
 
-use crate::error::GeoError;
+use crate::error::{GeoError, GeoListError};
 use crate::update::new::document::{Document, DocumentContext};
 use crate::update::new::indexer::document_changes::Extractor;
 use crate::update::new::ref_cell_ext::RefCellExt as _;
@@ -30,7 +30,7 @@ impl GeoExtractor {
         index: &Index,
         grenad_parameters: GrenadParameters,
     ) -> Result<Option<Self>> {
-        if index.is_geo_enabled(rtxn)? {
+        if index.is_geo_enabled(rtxn)? || index.is_geo_list_enabled(rtxn)? {
             Ok(Some(GeoExtractor { grenad_parameters }))
         } else {
             Ok(None)
@@ -186,6 +186,21 @@ impl<'extractor> Extractor<'extractor> for GeoExtractor {
                             None => data_ref.removed.push(geopoint),
                         }
                     }
+
+                    // Also remove _geo_list points
+                    let current_geo_list = current
+                        .geo_list_field()?
+                        .map(|gl| extract_geo_list_coordinates(external_id, gl))
+                        .transpose()?;
+                    if let Some(points) = current_geo_list.flatten() {
+                        for lat_lng in points {
+                            let geopoint = ExtractedGeoPoint { docid, lat_lng };
+                            match &mut data_ref.spilled_removed {
+                                Some(file) => file.write_all(bytes_of(&geopoint))?,
+                                None => data_ref.removed.push(geopoint),
+                            }
+                        }
+                    }
                 }
                 DocumentChange::Update(update) => {
                     let current = update.current(rtxn, index, db_fields_ids_map)?;
@@ -204,9 +219,6 @@ impl<'extractor> Extractor<'extractor> for GeoExtractor {
                         .transpose()?;
 
                     if current_geo != updated_geo {
-                        // If the current and new geo points are different it means that
-                        // we need to replace the current by the new point and therefore
-                        // delete the current point from the RTree.
                         if let Some(lat_lng) = current_geo.flatten() {
                             let geopoint = ExtractedGeoPoint { docid, lat_lng };
                             match &mut data_ref.spilled_removed {
@@ -220,6 +232,38 @@ impl<'extractor> Extractor<'extractor> for GeoExtractor {
                             match &mut data_ref.spilled_inserted {
                                 Some(file) => file.write_all(bytes_of(&geopoint))?,
                                 None => data_ref.inserted.push(geopoint),
+                            }
+                        }
+                    }
+
+                    // Handle _geo_list update
+                    let current_geo_list = current
+                        .geo_list_field()?
+                        .map(|gl| extract_geo_list_coordinates(external_id, gl))
+                        .transpose()?;
+                    let updated_geo_list = update
+                        .merged(rtxn, index, db_fields_ids_map)?
+                        .geo_list_field()?
+                        .map(|gl| extract_geo_list_coordinates(external_id, gl))
+                        .transpose()?;
+
+                    if current_geo_list != updated_geo_list {
+                        if let Some(points) = current_geo_list.flatten() {
+                            for lat_lng in points {
+                                let geopoint = ExtractedGeoPoint { docid, lat_lng };
+                                match &mut data_ref.spilled_removed {
+                                    Some(file) => file.write_all(bytes_of(&geopoint))?,
+                                    None => data_ref.removed.push(geopoint),
+                                }
+                            }
+                        }
+                        if let Some(points) = updated_geo_list.flatten() {
+                            for lat_lng in points {
+                                let geopoint = ExtractedGeoPoint { docid, lat_lng };
+                                match &mut data_ref.spilled_inserted {
+                                    Some(file) => file.write_all(bytes_of(&geopoint))?,
+                                    None => data_ref.inserted.push(geopoint),
+                                }
                             }
                         }
                     }
@@ -239,6 +283,22 @@ impl<'extractor> Extractor<'extractor> for GeoExtractor {
                         match &mut data_ref.spilled_inserted {
                             Some(file) => file.write_all(bytes_of(&geopoint))?,
                             None => data_ref.inserted.push(geopoint),
+                        }
+                    }
+
+                    // Also insert _geo_list points
+                    let inserted_geo_list = insertion
+                        .inserted()
+                        .geo_list_field()?
+                        .map(|gl| extract_geo_list_coordinates(external_id, gl))
+                        .transpose()?;
+                    if let Some(points) = inserted_geo_list.flatten() {
+                        for lat_lng in points {
+                            let geopoint = ExtractedGeoPoint { docid, lat_lng };
+                            match &mut data_ref.spilled_inserted {
+                                Some(file) => file.write_all(bytes_of(&geopoint))?,
+                                None => data_ref.inserted.push(geopoint),
+                            }
                         }
                     }
                 }
@@ -314,6 +374,106 @@ pub fn extract_geo_coordinates(
             document_id: Value::from(external_id),
             lat,
             lng,
+        })
+        .into()),
+    }
+}
+
+/// Extracts and validates an array of `{lat, lng}` objects from a `_geo_list` field.
+///
+/// Returns `Ok(None)` if the value is `null`, `Ok(Some(vec))` for a valid non-empty array.
+pub fn extract_geo_list_coordinates(
+    external_id: &str,
+    raw_value: &RawValue,
+) -> Result<Option<Vec<[f64; 2]>>> {
+    let value: Value =
+        serde_json::from_str(raw_value.get()).map_err(InternalError::SerdeJson)?;
+
+    match value {
+        Value::Null => Ok(None),
+        Value::Array(arr) => {
+            if arr.is_empty() {
+                return Err(Box::new(GeoListError::EmptyArray {
+                    document_id: Value::from(external_id),
+                })
+                .into());
+            }
+
+            let mut points = Vec::with_capacity(arr.len());
+            for element in arr {
+                let obj = match element {
+                    Value::Object(obj) => obj,
+                    other => {
+                        return Err(Box::new(GeoListError::ElementNotAnObject {
+                            document_id: Value::from(external_id),
+                            value: other,
+                        })
+                        .into());
+                    }
+                };
+
+                let lat = obj.get("lat");
+                let lng = obj.get("lng");
+
+                let [lat_val, lng_val] = match (lat, lng) {
+                    (Some(lat), Some(lng)) => [lat.clone(), lng.clone()],
+                    (Some(_), None) => {
+                        return Err(Box::new(GeoListError::ElementMissingLongitude {
+                            document_id: Value::from(external_id),
+                        })
+                        .into());
+                    }
+                    (None, Some(_)) => {
+                        return Err(Box::new(GeoListError::ElementMissingLatitude {
+                            document_id: Value::from(external_id),
+                        })
+                        .into());
+                    }
+                    (None, None) => {
+                        return Err(Box::new(
+                            GeoListError::ElementMissingLatitudeAndLongitude {
+                                document_id: Value::from(external_id),
+                            },
+                        )
+                        .into());
+                    }
+                };
+
+                match (
+                    extract_finite_float_from_value(lat_val),
+                    extract_finite_float_from_value(lng_val),
+                ) {
+                    (Ok(lat), Ok(lng)) => points.push([lat, lng]),
+                    (Ok(_), Err(value)) => {
+                        return Err(Box::new(GeoListError::ElementBadLongitude {
+                            document_id: Value::from(external_id),
+                            value,
+                        })
+                        .into());
+                    }
+                    (Err(value), Ok(_)) => {
+                        return Err(Box::new(GeoListError::ElementBadLatitude {
+                            document_id: Value::from(external_id),
+                            value,
+                        })
+                        .into());
+                    }
+                    (Err(lat), Err(lng)) => {
+                        return Err(Box::new(GeoListError::ElementBadLatitudeAndLongitude {
+                            document_id: Value::from(external_id),
+                            lat,
+                            lng,
+                        })
+                        .into());
+                    }
+                }
+            }
+
+            Ok(Some(points))
+        }
+        other => Err(Box::new(GeoListError::NotAnArray {
+            document_id: Value::from(external_id),
+            value: other,
         })
         .into()),
     }

--- a/crates/milli/src/update/new/extract/geo/mod.rs
+++ b/crates/milli/src/update/new/extract/geo/mod.rs
@@ -386,8 +386,7 @@ pub fn extract_geo_list_coordinates(
     external_id: &str,
     raw_value: &RawValue,
 ) -> Result<Option<Vec<[f64; 2]>>> {
-    let value: Value =
-        serde_json::from_str(raw_value.get()).map_err(InternalError::SerdeJson)?;
+    let value: Value = serde_json::from_str(raw_value.get()).map_err(InternalError::SerdeJson)?;
 
     match value {
         Value::Null => Ok(None),
@@ -430,11 +429,9 @@ pub fn extract_geo_list_coordinates(
                         .into());
                     }
                     (None, None) => {
-                        return Err(Box::new(
-                            GeoListError::ElementMissingLatitudeAndLongitude {
-                                document_id: Value::from(external_id),
-                            },
-                        )
+                        return Err(Box::new(GeoListError::ElementMissingLatitudeAndLongitude {
+                            document_id: Value::from(external_id),
+                        })
                         .into());
                     }
                 };

--- a/crates/milli/src/update/new/indexer/mod.rs
+++ b/crates/milli/src/update/new/indexer/mod.rs
@@ -824,8 +824,8 @@ pub fn rebuild_geo_rtree(index: &Index, wtxn: &mut RwTxn<'_>) -> Result<()> {
 
         if let Some(fid) = geo_fid {
             if let Some(value) = doc.get(fid) {
-                let raw_value: &RawValue = serde_json::from_slice(value)
-                    .map_err(crate::InternalError::SerdeJson)?;
+                let raw_value: &RawValue =
+                    serde_json::from_slice(value).map_err(crate::InternalError::SerdeJson)?;
                 if let Some(point) = extract_geo_coordinates("", raw_value)? {
                     let xyz = lat_lng_to_xyz(&point);
                     rtree.insert(GeoPoint::new(xyz, (docid, point)));
@@ -836,8 +836,8 @@ pub fn rebuild_geo_rtree(index: &Index, wtxn: &mut RwTxn<'_>) -> Result<()> {
 
         if let Some(fid) = geo_list_fid {
             if let Some(value) = doc.get(fid) {
-                let raw_value: &RawValue = serde_json::from_slice(value)
-                    .map_err(crate::InternalError::SerdeJson)?;
+                let raw_value: &RawValue =
+                    serde_json::from_slice(value).map_err(crate::InternalError::SerdeJson)?;
                 if let Some(points) = extract_geo_list_coordinates("", raw_value)? {
                     for point in points {
                         let xyz = lat_lng_to_xyz(&point);

--- a/crates/milli/src/update/new/merger.rs
+++ b/crates/milli/src/update/new/merger.rs
@@ -54,7 +54,8 @@ where
 
     // Only remove docids from faceted if they were removed but not re-inserted
     // (a document can have both _geo and _geo_list, so a docid may still have points)
-    faceted -= &removed_docids - &inserted_docids;
+    let only_removed = &removed_docids - &inserted_docids;
+    faceted -= only_removed;
     faceted |= &inserted_docids;
 
     let mut file = tempfile::tempfile()?;

--- a/crates/openapi-generator/src/main.rs
+++ b/crates/openapi-generator/src/main.rs
@@ -810,8 +810,9 @@ fn check_body_schema_in_file(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use serde_json::json;
+
+    use super::*;
 
     #[test]
     fn test_normalize_path() {

--- a/external-crates/async-openai-macros/src/lib.rs
+++ b/external-crates/async-openai-macros/src/lib.rs
@@ -1,11 +1,10 @@
 use proc_macro::TokenStream;
 use quote::{quote, ToTokens};
+use syn::parse::{Parse, ParseStream};
+use syn::punctuated::Punctuated;
+use syn::token::Comma;
 use syn::{
-    parse::{Parse, ParseStream},
-    parse_macro_input,
-    punctuated::Punctuated,
-    token::Comma,
-    FnArg, GenericParam, Generics, ItemFn, Pat, PatType, TypeParam, WhereClause,
+    parse_macro_input, FnArg, GenericParam, Generics, ItemFn, Pat, PatType, TypeParam, WhereClause,
 };
 
 // Parse attribute arguments like #[byot(T0: Display + Debug, T1: Clone, R: Serialize)]

--- a/external-crates/async-openai/src/chat.rs
+++ b/external-crates/async-openai/src/chat.rs
@@ -1,11 +1,9 @@
-use crate::{
-    config::Config,
-    error::OpenAIError,
-    types::{
-        ChatCompletionResponseStream, CreateChatCompletionRequest, CreateChatCompletionResponse,
-    },
-    Client,
+use crate::config::Config;
+use crate::error::OpenAIError;
+use crate::types::{
+    ChatCompletionResponseStream, CreateChatCompletionRequest, CreateChatCompletionResponse,
 };
+use crate::Client;
 
 /// Given a list of messages comprising a conversation, the model will return a response.
 ///

--- a/external-crates/async-openai/src/completion.rs
+++ b/external-crates/async-openai/src/completion.rs
@@ -1,9 +1,7 @@
-use crate::{
-    client::Client,
-    config::Config,
-    error::OpenAIError,
-    types::{CompletionResponseStream, CreateCompletionRequest, CreateCompletionResponse},
-};
+use crate::client::Client;
+use crate::config::Config;
+use crate::error::OpenAIError;
+use crate::types::{CompletionResponseStream, CreateCompletionRequest, CreateCompletionResponse};
 
 /// Given a prompt, the model will return one or more predicted completions,
 /// and can also return the probabilities of alternative tokens at each position.

--- a/external-crates/async-openai/src/types/assistant.rs
+++ b/external-crates/async-openai/src/types/assistant.rs
@@ -3,9 +3,8 @@ use std::collections::HashMap;
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 
-use crate::error::OpenAIError;
-
 use super::{FunctionName, FunctionObject, ResponseFormat};
+use crate::error::OpenAIError;
 
 #[derive(Clone, Serialize, Debug, Deserialize, PartialEq, Default)]
 pub struct AssistantToolCodeInterpreterResources {

--- a/external-crates/async-openai/src/types/assistant_stream.rs
+++ b/external-crates/async-openai/src/types/assistant_stream.rs
@@ -1,13 +1,13 @@
-use std::{pin::Pin, time::Duration};
+use std::pin::Pin;
+use std::time::Duration;
 
 use futures::Stream;
 use serde::Deserialize;
 
-use crate::error::{map_deserialization_error, ApiError, OpenAIError};
-
 use super::{
     MessageDeltaObject, MessageObject, RunObject, RunStepDeltaObject, RunStepObject, ThreadObject,
 };
+use crate::error::{map_deserialization_error, ApiError, OpenAIError};
 
 /// Represents an event emitted when streaming a Run.
 ///

--- a/external-crates/async-openai/src/types/chat.rs
+++ b/external-crates/async-openai/src/types/chat.rs
@@ -1,4 +1,5 @@
-use std::{collections::HashMap, pin::Pin};
+use std::collections::HashMap;
+use std::pin::Pin;
 
 use derive_builder::Builder;
 use futures::Stream;

--- a/external-crates/async-openai/src/types/completion.rs
+++ b/external-crates/async-openai/src/types/completion.rs
@@ -1,12 +1,12 @@
-use std::{collections::HashMap, pin::Pin};
+use std::collections::HashMap;
+use std::pin::Pin;
 
 use derive_builder::Builder;
 use futures::Stream;
 use serde::{Deserialize, Serialize};
 
-use crate::error::OpenAIError;
-
 use super::{ChatCompletionStreamOptions, Choice, CompletionUsage, Prompt, Stop};
+use crate::error::OpenAIError;
 
 #[derive(Clone, Serialize, Deserialize, Default, Debug, Builder, PartialEq)]
 #[builder(name = "CreateCompletionRequestArgs")]

--- a/external-crates/async-openai/src/types/file.rs
+++ b/external-crates/async-openai/src/types/file.rs
@@ -1,9 +1,8 @@
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 
-use crate::error::OpenAIError;
-
 use super::InputSource;
+use crate::error::OpenAIError;
 
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct FileInput {

--- a/external-crates/async-openai/src/types/image.rs
+++ b/external-crates/async-openai/src/types/image.rs
@@ -1,9 +1,8 @@
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 
-use crate::error::OpenAIError;
-
 use super::InputSource;
+use crate::error::OpenAIError;
 
 #[derive(Default, Debug, Serialize, Deserialize, Clone, Copy, PartialEq)]
 pub enum ImageSize {

--- a/external-crates/async-openai/src/types/invites.rs
+++ b/external-crates/async-openai/src/types/invites.rs
@@ -1,8 +1,8 @@
-use crate::types::OpenAIError;
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 
 use super::OrganizationRole;
+use crate::types::OpenAIError;
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq)]
 #[serde(rename_all = "lowercase")]

--- a/external-crates/async-openai/src/types/message.rs
+++ b/external-crates/async-openai/src/types/message.rs
@@ -3,9 +3,8 @@ use std::collections::HashMap;
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 
-use crate::error::OpenAIError;
-
 use super::{ImageDetail, ImageUrl};
+use crate::error::OpenAIError;
 
 #[derive(Clone, Serialize, Debug, Deserialize, PartialEq, Default)]
 #[serde(rename_all = "lowercase")]

--- a/external-crates/async-openai/src/types/project_users.rs
+++ b/external-crates/async-openai/src/types/project_users.rs
@@ -1,6 +1,7 @@
-use crate::types::OpenAIError;
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
+
+use crate::types::OpenAIError;
 
 /// Represents an individual user in a project.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]

--- a/external-crates/async-openai/src/types/projects.rs
+++ b/external-crates/async-openai/src/types/projects.rs
@@ -1,6 +1,7 @@
-use crate::types::OpenAIError;
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
+
+use crate::types::OpenAIError;
 
 /// `active` or `archived`
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq)]

--- a/external-crates/async-openai/src/types/realtime/client_event.rs
+++ b/external-crates/async-openai/src/types/realtime/client_event.rs
@@ -1,7 +1,8 @@
 use serde::{Deserialize, Serialize};
 use tokio_tungstenite::tungstenite::Message;
 
-use super::{item::Item, session_resource::SessionResource};
+use super::item::Item;
+use super::session_resource::SessionResource;
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct SessionUpdateEvent {

--- a/external-crates/async-openai/src/types/realtime/server_event.rs
+++ b/external-crates/async-openai/src/types/realtime/server_event.rs
@@ -1,9 +1,12 @@
 use serde::{Deserialize, Serialize};
 
-use super::{
-    content_part::ContentPart, conversation::Conversation, error::RealtimeAPIError, item::Item,
-    rate_limit::RateLimit, response_resource::ResponseResource, session_resource::SessionResource,
-};
+use super::content_part::ContentPart;
+use super::conversation::Conversation;
+use super::error::RealtimeAPIError;
+use super::item::Item;
+use super::rate_limit::RateLimit;
+use super::response_resource::ResponseResource;
+use super::session_resource::SessionResource;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ErrorEvent {

--- a/external-crates/async-openai/src/types/run.rs
+++ b/external-crates/async-openai/src/types/run.rs
@@ -3,12 +3,12 @@ use std::collections::HashMap;
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 
-use crate::{error::OpenAIError, types::FunctionCall};
-
 use super::{
     AssistantTools, AssistantsApiResponseFormatOption, AssistantsApiToolChoiceOption,
     CreateMessageRequest,
 };
+use crate::error::OpenAIError;
+use crate::types::FunctionCall;
 
 /// Represents an execution run on a [thread](https://platform.openai.com/docs/api-reference/threads).
 #[derive(Clone, Serialize, Debug, Deserialize, PartialEq)]

--- a/external-crates/async-openai/src/types/thread.rs
+++ b/external-crates/async-openai/src/types/thread.rs
@@ -3,13 +3,12 @@ use std::collections::HashMap;
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 
-use crate::error::OpenAIError;
-
 use super::{
     AssistantToolResources, AssistantTools, AssistantsApiResponseFormatOption,
     AssistantsApiToolChoiceOption, CreateAssistantToolResources, CreateMessageRequest,
     TruncationObject,
 };
+use crate::error::OpenAIError;
 
 /// Represents a thread that contains [messages](https://platform.openai.com/docs/api-reference/messages).
 #[derive(Clone, Serialize, Debug, Deserialize, PartialEq)]

--- a/external-crates/async-openai/src/types/upload.rs
+++ b/external-crates/async-openai/src/types/upload.rs
@@ -1,8 +1,8 @@
-use crate::error::OpenAIError;
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 
 use super::{InputSource, OpenAIFile};
+use crate::error::OpenAIError;
 
 /// Request to create an upload object that can accept byte chunks in the form of Parts.
 #[derive(Clone, Serialize, Default, Debug, Deserialize, Builder, PartialEq)]

--- a/external-crates/async-openai/src/types/users.rs
+++ b/external-crates/async-openai/src/types/users.rs
@@ -1,8 +1,8 @@
-use crate::types::OpenAIError;
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 
 use super::OrganizationRole;
+use crate::types::OpenAIError;
 
 /// Represents an individual `user` within an organization.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]

--- a/external-crates/async-openai/src/types/vector_store.rs
+++ b/external-crates/async-openai/src/types/vector_store.rs
@@ -3,9 +3,8 @@ use std::collections::HashMap;
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 
-use crate::error::OpenAIError;
-
 use super::StaticChunkingStrategy;
+use crate::error::OpenAIError;
 
 #[derive(Debug, Serialize, Deserialize, Default, Clone, Builder, PartialEq)]
 #[builder(name = "CreateVectorStoreRequestArgs")]

--- a/external-crates/reqwest-eventsource/examples/server.rs
+++ b/external-crates/reqwest-eventsource/examples/server.rs
@@ -1,11 +1,11 @@
+use std::time::SystemTime;
+
 use rocket::http::Status;
-use rocket::request::Outcome;
-use rocket::request::Request;
+use rocket::request::{Outcome, Request};
 use rocket::response::content::RawHtml;
 use rocket::response::stream::{Event, EventStream};
 use rocket::tokio::time::{self, Duration};
 use rocket::{get, launch, routes};
-use std::time::SystemTime;
 
 pub struct LastEventId(pub usize);
 

--- a/external-crates/reqwest-eventsource/src/reqwest_ext.rs
+++ b/external-crates/reqwest-eventsource/src/reqwest_ext.rs
@@ -1,6 +1,7 @@
+use http_client::reqwest::RequestBuilder;
+
 use crate::error::CannotCloneRequestError;
 use crate::event_source::EventSource;
-use http_client::reqwest::RequestBuilder;
 
 /// Provides an easy interface to build an [`EventSource`] from a [`RequestBuilder`]
 pub trait RequestBuilderExt {

--- a/external-crates/reqwest-eventsource/src/retry.rs
+++ b/external-crates/reqwest-eventsource/src/retry.rs
@@ -1,8 +1,8 @@
 //! Helpers to handle connection delays when receiving errors
 
-use crate::error::Error;
 use std::time::Duration;
 
+use crate::error::Error;
 #[cfg(doc)]
 use crate::event_source::{Event, EventSource};
 


### PR DESCRIPTION
## Summary

Adds `_geo_list` as a new reserved field allowing **multiple discrete geo points** per document — e.g., a company with multiple office locations, or a category aggregating all shop locations.

This addresses the use case described in https://github.com/orgs/meilisearch/discussions/508, and specifically fills the **sorting gap** left by the `_geojson` prototype (`prototype-cellulite-1`), which supports filtering but not distance-based sorting.

### What `_geo_list` provides

- **Field format:** `"_geo_list": [{"lat": 48.8, "lng": 2.3}, {"lat": 51.5, "lng": -0.1}, ...]`
- **Filtering:** `_geoRadius` and `_geoBoundingBox` match a document if **any** point in its `_geo_list` is within range
- **Sorting:** `_geoPoint(lat,lng):asc/desc` sorts by the **closest** (or farthest) point per document
- **Results:** `_geoDistance` reflects the minimum distance across both `_geo` and `_geo_list` points
- **Settings:** Add `"_geo_list"` to `filterableAttributes` / `sortableAttributes` (same pattern as `_geo`)

### Architecture

`_geo_list` shares the **same RTree and faceted bitmap** as `_geo`, avoiding infrastructure duplication:
- Multiple RTree entries per docid are structurally valid (`GeoPoint` stores `(DocumentId, [f64; 2])`)
- Sorting uses docid deduplication via `HashSet` in `fill_cache()` — the RTree's nearest-neighbor iterator guarantees the first hit per docid is the closest
- `_geoBoundingBox` uses an RTree-based query for `_geo_list` to avoid false positives from independent lat/lng facet pairing
- A `rebuild_geo_rtree()` function handles the "Documents → Settings" flow, rebuilding the RTree from scratch when geo settings change

## Changes (22 files, +1366 / -68)

1. **Constants, errors, Document trait** — `_geo_list` reserved field, `GeoListError` enum, `geo_list_field()` on Document trait + all implementations
2. **Settings and index methods** — `is_geo_list_*_enabled()`, `has_geo_list()`, `geo_list_fields_ids`, `run_geo_indexing()` in reindex trigger
3. **Extraction pipeline** — `extract_geo_list_coordinates()`, extended `GeoExtractor` to process `_geo_list` for insertions/updates/deletions
4. **Merger** — Fixed bitmap arithmetic for multi-point documents (a docid can appear in both removed and inserted sets)
5. **Facet extraction** — `extract_geo_list_document()` for `_geo_list.lat`/`_geo_list.lng` facet values
6. **Filtering** — `_geoRadius`/`_geoBoundingBox` extended; RTree-based bounding box query for `_geo_list` avoids false positives
7. **Sorting** — Docid deduplication in both ascending and descending RTree paths; `rebuild_geo_rtree()` for settings changes
8. **Search results** — `insert_geo_distance()` extended to consider `_geo_list` points
9. **17 integration tests** covering filtering, sorting, `_geoDistance`, document lifecycle, mixed `_geo`+`_geo_list`, edge cases, and settings changes

## Test plan

- [x] All 22 geo tests pass (17 new + 5 existing)
- [x] `cargo clippy --all-targets -- --deny warnings` clean
- [ ] Full CI suite

## Related

- Discussion: https://github.com/orgs/meilisearch/discussions/508
- GeoJSON prototype: #5758 (supports filtering but not sorting for multi-point documents)

🤖 Generated with [Claude Code](https://claude.ai/code)