### PR TITLE
rest: disable tcp connection pooling

### DIFF
--- a/crates/milli/src/vector/embedder/rest.rs
+++ b/crates/milli/src/vector/embedder/rest.rs
@@ -194,8 +194,8 @@ impl Embedder {
         let config = http_client::ureq::config::Config::builder()
             .prepare(|config| {
                 config
-                    .max_idle_connections(REQUEST_PARALLELISM * 2)
-                    .max_idle_connections_per_host(REQUEST_PARALLELISM * 2)
+                    .max_idle_connections(0)
+                    .max_idle_connections_per_host(0)
                     .timeout_global(Some(std::time::Duration::from_secs(timeout)))
                     // important in ureq 3: to be able to retrieve the response for HTTP 400
                     .http_status_as_error(false)


### PR DESCRIPTION
prototype: [prototype-v1.35.0-disable-tcp-pooling.0](https://github.com/meilisearch/meilisearch/actions/runs/22571462111)

## Changelog

We disabled the reuse of idle connections with ureq because it was poorly interacting with the OpenAI and VoyageAI APIs. We now see much better throughput without a very low or even nonexistent error rate.