### PR TITLE
Download datasets by using an access and secret key

### DIFF
--- a/.github/workflows/benchmarks-manual.yml
+++ b/.github/workflows/benchmarks-manual.yml
@@ -42,6 +42,9 @@ jobs:
 
       # Run benchmarks
       - name: Run benchmarks - Dataset ${BENCH_NAME} - Branch ${{ steps.current_branch.outputs.name }} - Commit ${{ steps.commit_sha.outputs.short }}
+        env:
+          S3_ACCESS_KEY: ${{ secrets.DO_SPACES_ACCESS_KEY }}
+          S3_SECRET_KEY: ${{ secrets.DO_SPACES_SECRET_KEY }}
         run: |
           cd crates/benchmarks
           cargo bench --bench ${BENCH_NAME} -- --save-baseline ${{ steps.file.outputs.basename }}

--- a/.github/workflows/benchmarks-manual.yml
+++ b/.github/workflows/benchmarks-manual.yml
@@ -43,11 +43,17 @@ jobs:
       # Run benchmarks
       - name: Run benchmarks - Dataset ${BENCH_NAME} - Branch ${{ steps.current_branch.outputs.name }} - Commit ${{ steps.commit_sha.outputs.short }}
         env:
+          MILLI_BENCH_DATASETS_PATH: "target/benchmarks-datasets"
           S3_ACCESS_KEY: ${{ secrets.DO_SPACES_ACCESS_KEY }}
           S3_SECRET_KEY: ${{ secrets.DO_SPACES_SECRET_KEY }}
         run: |
           cd crates/benchmarks
           cargo bench --bench ${BENCH_NAME} -- --save-baseline ${{ steps.file.outputs.basename }}
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2.8.0
+        with:
+          directory: target/benchmarks-datasets
 
       # Generate critcmp files
       - name: Install critcmp

--- a/.github/workflows/benchmarks-pr.yml
+++ b/.github/workflows/benchmarks-pr.yml
@@ -88,11 +88,17 @@ jobs:
       # Run benchmarks
       - name: Run benchmarks - Dataset ${{ steps.command.outputs.command-arguments }} - Branch ${{ steps.current_branch.outputs.name }} - Commit ${{ steps.commit_sha.outputs.short }}
         env:
+          MILLI_BENCH_DATASETS_PATH: "target/benchmarks-datasets"
           S3_ACCESS_KEY: ${{ secrets.DO_SPACES_ACCESS_KEY }}
           S3_SECRET_KEY: ${{ secrets.DO_SPACES_SECRET_KEY }}
         run: |
           cd crates/benchmarks
           cargo bench --bench ${{ steps.command.outputs.command-arguments }} -- --save-baseline ${{ steps.file.outputs.basename }}
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2.8.0
+        with:
+          directory: target/benchmarks-datasets
 
       # Generate critcmp files
       - name: Install critcmp

--- a/.github/workflows/benchmarks-pr.yml
+++ b/.github/workflows/benchmarks-pr.yml
@@ -87,6 +87,9 @@ jobs:
 
       # Run benchmarks
       - name: Run benchmarks - Dataset ${{ steps.command.outputs.command-arguments }} - Branch ${{ steps.current_branch.outputs.name }} - Commit ${{ steps.commit_sha.outputs.short }}
+        env:
+          S3_ACCESS_KEY: ${{ secrets.DO_SPACES_ACCESS_KEY }}
+          S3_SECRET_KEY: ${{ secrets.DO_SPACES_SECRET_KEY }}
         run: |
           cd crates/benchmarks
           cargo bench --bench ${{ steps.command.outputs.command-arguments }} -- --save-baseline ${{ steps.file.outputs.basename }}

--- a/.github/workflows/benchmarks-push-indexing.yml
+++ b/.github/workflows/benchmarks-push-indexing.yml
@@ -41,11 +41,17 @@ jobs:
       # Run benchmarks
       - name: Run benchmarks - Dataset ${BENCH_NAME} - Branch ${{ steps.current_branch.outputs.name }} - Commit ${{ steps.commit_sha.outputs.short }}
         env:
+          MILLI_BENCH_DATASETS_PATH: "target/benchmarks-datasets"
           S3_ACCESS_KEY: ${{ secrets.DO_SPACES_ACCESS_KEY }}
           S3_SECRET_KEY: ${{ secrets.DO_SPACES_SECRET_KEY }}
         run: |
           cd crates/benchmarks
           cargo bench --bench ${BENCH_NAME} -- --save-baseline ${{ steps.file.outputs.basename }}
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2.8.0
+        with:
+          directory: target/benchmarks-datasets
 
       # Generate critcmp files
       - name: Install critcmp

--- a/.github/workflows/benchmarks-push-indexing.yml
+++ b/.github/workflows/benchmarks-push-indexing.yml
@@ -40,6 +40,9 @@ jobs:
 
       # Run benchmarks
       - name: Run benchmarks - Dataset ${BENCH_NAME} - Branch ${{ steps.current_branch.outputs.name }} - Commit ${{ steps.commit_sha.outputs.short }}
+        env:
+          S3_ACCESS_KEY: ${{ secrets.DO_SPACES_ACCESS_KEY }}
+          S3_SECRET_KEY: ${{ secrets.DO_SPACES_SECRET_KEY }}
         run: |
           cd crates/benchmarks
           cargo bench --bench ${BENCH_NAME} -- --save-baseline ${{ steps.file.outputs.basename }}

--- a/.github/workflows/benchmarks-push-search-geo.yml
+++ b/.github/workflows/benchmarks-push-search-geo.yml
@@ -40,11 +40,17 @@ jobs:
       # Run benchmarks
       - name: Run benchmarks - Dataset ${BENCH_NAME} - Branch ${{ steps.current_branch.outputs.name }} - Commit ${{ steps.commit_sha.outputs.short }}
         env:
+          MILLI_BENCH_DATASETS_PATH: "target/benchmarks-datasets"
           S3_ACCESS_KEY: ${{ secrets.DO_SPACES_ACCESS_KEY }}
           S3_SECRET_KEY: ${{ secrets.DO_SPACES_SECRET_KEY }}
         run: |
           cd crates/benchmarks
           cargo bench --bench ${BENCH_NAME} -- --save-baseline ${{ steps.file.outputs.basename }}
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2.8.0
+        with:
+          directory: target/benchmarks-datasets
 
       # Generate critcmp files
       - name: Install critcmp

--- a/.github/workflows/benchmarks-push-search-geo.yml
+++ b/.github/workflows/benchmarks-push-search-geo.yml
@@ -39,6 +39,9 @@ jobs:
 
       # Run benchmarks
       - name: Run benchmarks - Dataset ${BENCH_NAME} - Branch ${{ steps.current_branch.outputs.name }} - Commit ${{ steps.commit_sha.outputs.short }}
+        env:
+          S3_ACCESS_KEY: ${{ secrets.DO_SPACES_ACCESS_KEY }}
+          S3_SECRET_KEY: ${{ secrets.DO_SPACES_SECRET_KEY }}
         run: |
           cd crates/benchmarks
           cargo bench --bench ${BENCH_NAME} -- --save-baseline ${{ steps.file.outputs.basename }}

--- a/.github/workflows/benchmarks-push-search-songs.yml
+++ b/.github/workflows/benchmarks-push-search-songs.yml
@@ -40,11 +40,17 @@ jobs:
       # Run benchmarks
       - name: Run benchmarks - Dataset ${BENCH_NAME} - Branch ${{ steps.current_branch.outputs.name }} - Commit ${{ steps.commit_sha.outputs.short }}
         env:
+          MILLI_BENCH_DATASETS_PATH: "target/benchmarks-datasets"
           S3_ACCESS_KEY: ${{ secrets.DO_SPACES_ACCESS_KEY }}
           S3_SECRET_KEY: ${{ secrets.DO_SPACES_SECRET_KEY }}
         run: |
           cd crates/benchmarks
           cargo bench --bench ${BENCH_NAME} -- --save-baseline ${{ steps.file.outputs.basename }}
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2.8.0
+        with:
+          directory: target/benchmarks-datasets
 
       # Generate critcmp files
       - name: Install critcmp

--- a/.github/workflows/benchmarks-push-search-songs.yml
+++ b/.github/workflows/benchmarks-push-search-songs.yml
@@ -39,6 +39,9 @@ jobs:
 
       # Run benchmarks
       - name: Run benchmarks - Dataset ${BENCH_NAME} - Branch ${{ steps.current_branch.outputs.name }} - Commit ${{ steps.commit_sha.outputs.short }}
+        env:
+          S3_ACCESS_KEY: ${{ secrets.DO_SPACES_ACCESS_KEY }}
+          S3_SECRET_KEY: ${{ secrets.DO_SPACES_SECRET_KEY }}
         run: |
           cd crates/benchmarks
           cargo bench --bench ${BENCH_NAME} -- --save-baseline ${{ steps.file.outputs.basename }}

--- a/.github/workflows/benchmarks-push-search-wiki.yml
+++ b/.github/workflows/benchmarks-push-search-wiki.yml
@@ -40,11 +40,17 @@ jobs:
       # Run benchmarks
       - name: Run benchmarks - Dataset ${BENCH_NAME} - Branch ${{ steps.current_branch.outputs.name }} - Commit ${{ steps.commit_sha.outputs.short }}
         env:
+          MILLI_BENCH_DATASETS_PATH: "target/benchmarks-datasets"
           S3_ACCESS_KEY: ${{ secrets.DO_SPACES_ACCESS_KEY }}
           S3_SECRET_KEY: ${{ secrets.DO_SPACES_SECRET_KEY }}
         run: |
           cd crates/benchmarks
           cargo bench --bench ${BENCH_NAME} -- --save-baseline ${{ steps.file.outputs.basename }}
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2.8.0
+        with:
+          directory: target/benchmarks-datasets
 
       # Generate critcmp files
       - name: Install critcmp

--- a/.github/workflows/benchmarks-push-search-wiki.yml
+++ b/.github/workflows/benchmarks-push-search-wiki.yml
@@ -39,6 +39,9 @@ jobs:
 
       # Run benchmarks
       - name: Run benchmarks - Dataset ${BENCH_NAME} - Branch ${{ steps.current_branch.outputs.name }} - Commit ${{ steps.commit_sha.outputs.short }}
+        env:
+          S3_ACCESS_KEY: ${{ secrets.DO_SPACES_ACCESS_KEY }}
+          S3_SECRET_KEY: ${{ secrets.DO_SPACES_SECRET_KEY }}
         run: |
           cd crates/benchmarks
           cargo bench --bench ${BENCH_NAME} -- --save-baseline ${{ steps.file.outputs.basename }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .idea/
 .vscode/
 /target
+/crates/benchmarks/target
+/crates/benchmarks/Cargo.lock
 **/*.csv
 **/*.json_lines
 **/*.rs.bk

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,29 +628,6 @@ version = "0.5.1"
 source = "git+https://github.com/meilisearch/bbqueue#e8af4a4bccc8eb36b2b0442c4a9c5cb839d1cea2"
 
 [[package]]
-name = "benchmarks"
-version = "1.37.0"
-dependencies = [
- "anyhow",
- "bumpalo",
- "bytes",
- "convert_case 0.9.0",
- "criterion",
- "csv",
- "flate2",
- "http-client",
- "memmap2",
- "milli",
- "mimalloc",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "reqwest",
- "roaring 0.10.12",
- "serde_json",
- "tempfile",
-]
-
-[[package]]
 name = "big_s"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ members = [
     "crates/filter-parser",
     "crates/flatten-serde-json",
     "crates/json-depth-checker",
-    "crates/benchmarks",
     "crates/fuzzers",
     "crates/tracing-trace",
     "crates/xtask",
@@ -24,6 +23,7 @@ members = [
     "external-crates/async-openai",
     "external-crates/async-openai-macros",
 ]
+exclude = ["crates/benchmarks"]
 
 [workspace.package]
 version = "1.37.0"

--- a/crates/benchmarks/Cargo.toml
+++ b/crates/benchmarks/Cargo.toml
@@ -1,14 +1,8 @@
 [package]
 name = "benchmarks"
 publish = false
-
-version.workspace = true
-authors.workspace = true
-description.workspace = true
-homepage.workspace = true
-readme.workspace = true
-edition.workspace = true
-license.workspace = true
+edition = "2021"
+license = "MIT"
 
 [dependencies]
 anyhow = "1.0.100"
@@ -36,6 +30,7 @@ reqwest = { version = "0.12.24", features = [
     "blocking",
     "rustls-tls",
 ], default-features = false }
+rusty-s3 = "0.8.1"
 
 [features]
 default = ["milli/all-tokenizations"]

--- a/crates/benchmarks/build.rs
+++ b/crates/benchmarks/build.rs
@@ -1,14 +1,18 @@
 use std::fs::File;
 use std::io::{Cursor, Read, Seek, Write};
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 use std::{env, fs};
 
 use bytes::Bytes;
 use convert_case::{Case, Casing};
 use flate2::read::GzDecoder;
-use reqwest::IntoUrl;
+use rusty_s3::S3Action as _;
+use rusty_s3::{Bucket, Credentials, UrlStyle};
 
-const BASE_URL: &str = "https://milli-benchmarks.fra1.digitaloceanspaces.com/datasets";
+const BUCKET_REGION: &str = "fra1";
+const BUCKET_NAME: &str = "milli-benchmarks";
+const ENDPOINT: &str = "https://fra1.digitaloceanspaces.com";
 
 const DATASET_SONGS: (&str, &str) = ("smol-songs", "csv");
 const DATASET_SONGS_1_2: (&str, &str) = ("smol-songs-1_2", "csv");
@@ -49,6 +53,17 @@ const BASE_DATASETS_PATH_KEY: &str = "MILLI_BENCH_DATASETS_PATH";
 fn main() -> anyhow::Result<()> {
     let out_dir = PathBuf::from(env::var(BASE_DATASETS_PATH_KEY).unwrap_or(env::var("OUT_DIR")?));
 
+    // setting up a bucket
+    let endpoint = ENDPOINT.parse().expect("endpoint is a valid Url");
+    let path_style = UrlStyle::VirtualHost;
+    let bucket = Bucket::new(endpoint, path_style, BUCKET_NAME, BUCKET_REGION)
+        .expect("Url has a valid scheme and host");
+
+    // setting up the credentials
+    let key = env::var("S3_ACCESS_KEY").expect("S3_ACCESS_KEY is set and a valid String");
+    let secret = env::var("S3_SECRET_KEY").expect("S3_SECRET_KEY is set and a valid String");
+    let credentials = Credentials::new(key, secret);
+
     let benches_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR")?).join("benches");
     let mut manifest_paths_file = File::create(benches_dir.join("datasets_paths.rs"))?;
     write!(
@@ -78,10 +93,10 @@ fn main() -> anyhow::Result<()> {
             );
             continue;
         }
-        let url = format!("{}/{}.{}.gz", BASE_URL, dataset, extension);
-        eprintln!("downloading: {}", url);
-        let bytes = retry(|| download_dataset(url.clone()), 10)?;
-        eprintln!("{} downloaded successfully", url);
+        let object = format!("datasets/{dataset}.{extension}.gz");
+        eprintln!("downloading: {object}");
+        let bytes = retry(|| download_object(&bucket, &credentials, &object), 10)?;
+        eprintln!("{object} downloaded successfully");
         eprintln!("uncompressing in {}", out_file.display());
         uncompress_in_file(bytes, &out_file)?;
     }
@@ -98,7 +113,15 @@ fn retry<Ok, Err>(fun: impl Fn() -> Result<Ok, Err>, times: usize) -> Result<Ok,
     fun()
 }
 
-fn download_dataset<U: IntoUrl>(url: U) -> anyhow::Result<Cursor<Bytes>> {
+fn download_object(
+    bucket: &Bucket,
+    credentials: &Credentials,
+    object: &str,
+) -> anyhow::Result<Cursor<Bytes>> {
+    let presigned_url_duration = Duration::from_secs(60 * 60);
+    let action = bucket.get_object(Some(&credentials), object);
+    let url = action.sign(presigned_url_duration);
+
     let bytes =
         reqwest::blocking::Client::builder().timeout(None).build()?.get(url).send()?.bytes()?;
     Ok(Cursor::new(bytes))


### PR DESCRIPTION
This PR updates the CIs to use access and secret keys to download the dataset files used in the different benchmark CIs. It excludes the benchmarks crate from the workspace members to avoid having an *env var missing* error.

EDIT: After a brief talk we may want to delete these benchmarks are we are no longer using them and now rely on workload based benchmarks.

## To do
- [x] Add the S3 access keys into 1Password.
- [ ] Update the README to specify that we need S3 access keys from our private 1Password wallet. Under the name "S3 DigitalOcean benchmarks datasets".
- [ ] Put back the benchmarks crate as a workspace member. Right now it is generating a whole target folder to compile Meilisearch + benchmarks from scratch.