### PR TITLE
Add section to CONTRIBUTING.md to bump mini-dashboard version and testing section to right place

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,38 +104,7 @@ To effectively debug snapshot-based hashes, we recommend you export the `MEILI_T
 export MEILI_TEST_FULL_SNAPS=true # add this to your .bashrc, .zshrc, ...
 ```
 
-#### Test troubleshooting
-
-If you get a "Too many open files" error you might want to increase the open file limit using this command:
-
-```bash
-ulimit -Sn 3000
-```
-
-#### Build tools
-
-Meilisearch follows the [cargo xtask](https://github.com/matklad/cargo-xtask) workflow to provide some build tools.
-
-Run `cargo xtask --help` from the root of the repository to find out what is available.
-
-#### Update the openAPI file if the API changed
-
-To update the openAPI file in the code, see [sprint_issue.md](https://github.com/meilisearch/meilisearch/blob/main/.github/ISSUE_TEMPLATE/sprint_issue.md#reminders-when-modifying-the-api).
-
-If you want to generate OpenAPI file manually:
-
-With swagger:
-- Starts Meilisearch with the `swagger` feature flag: `cargo run --features swagger`
-- On a browser, open the following URL: http://localhost:7700/scalar
-- Click the « Download openAPI file »
-
-With the internal crate:
-```bash
-cd crates/openapi-generator
-cargo run --release -- --pretty
-```
-
-### Testing the documentation locally
+#### Testing the documentation locally
 
 You can run the [documentation](https://github.com/meilisearch/documentation) site locally to preview how the API reference renders.
 
@@ -163,6 +132,52 @@ npx mint dev
 ```
 
 The local docs site will be available (the URL is shown in the terminal).
+
+#### Test troubleshooting
+
+If you get a "Too many open files" error you might want to increase the open file limit using this command:
+
+```bash
+ulimit -Sn 3000
+```
+
+### Build tools
+
+Meilisearch follows the [cargo xtask](https://github.com/matklad/cargo-xtask) workflow to provide some build tools.
+
+Run `cargo xtask --help` from the root of the repository to find out what is available.
+
+### Update the openAPI file if the API changed
+
+To update the openAPI file in the code, see [sprint_issue.md](https://github.com/meilisearch/meilisearch/blob/main/.github/ISSUE_TEMPLATE/sprint_issue.md#reminders-when-modifying-the-api).
+
+If you want to generate OpenAPI file manually:
+
+With swagger:
+- Starts Meilisearch with the `swagger` feature flag: `cargo run --features swagger`
+- On a browser, open the following URL: http://localhost:7700/scalar
+- Click the « Download openAPI file »
+
+With the internal crate:
+```bash
+cd crates/openapi-generator
+cargo run --release -- --pretty
+```
+
+### Update the mini-dashboard (local interface)
+
+To update the [mini-dashboard](https://github.com/meilisearch/mini-dashboard) (the local web interface served by Meilisearch):
+
+1. Download the `build.zip` of the mini-dashboard attached to the [release](https://github.com/meilisearch/mini-dashboard/releases) you want to use.
+
+2. Compute the SHA-1 checksum of the downloaded file:
+```bash
+shasum -a 1 ~/Downloads/build.zip
+```
+
+3. In `crates/meilisearch/Cargo.toml`, update the `[package.metadata.mini-dashboard]` section with the new `assets-url` (pointing to the mini-dashboard release URL) and the `sha1` checksum.
+
+See [this example PR](https://github.com/meilisearch/meilisearch/pull/6091/changes) for a concrete example of the changes to apply.
 
 ### Logging
 


### PR DESCRIPTION
## Related issue

Fixes https://linear.app/meilisearch/issue/ENGPROD-2374/add-guide-in-contributingmd-to-update-mini-dashboard

## Generative AI tools

- [ ] This PR does not use generative AI tooling
- [X] This PR uses generative AI tooling and respect the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - to generate the docs

## Requirements

⚠️ Ensure the following requirements before merging ⚠️
- [ ] Automated tests have been added.
- [ ] If some tests cannot be automated, manual rigorous tests should be applied.
- [ ] ⚠️ If there is any change in the DB:
    - [ ] Test that any impacted DB still works as expected after using `--experimental-dumpless-upgrade` on a DB created with the last released Meilisearch
    - [ ] Test that during the upgrade, **search is still available** (artificially make the upgrade longer if needed)
    - [ ] Set the `db change` label.
- [ ] If necessary, the feature have been tested in the Cloud production environment (with [prototypes](./documentation/prototypes.md)) and the Cloud UI is ready.
- [ ] If necessary, the [documentation](https://github.com/meilisearch/documentation) related to the implemented feature in the PR is ready.
- [ ] If necessary, the [integrations](https://github.com/meilisearch/integration-guides) related to the implemented feature in the PR are ready.
