### PR TITLE
Fix typo: occured to occurred

### DIFF
--- a/crates/milli/src/thread_pool_no_abort.rs
+++ b/crates/milli/src/thread_pool_no_abort.rs
@@ -59,7 +59,7 @@ impl ThreadPoolNoAbort {
 }
 
 #[derive(Error, Debug)]
-#[error("A panic occured. Read the logs to find more information about it")]
+#[error("A panic occurred. Read the logs to find more information about it")]
 pub struct PanicCatched;
 
 #[derive(Default)]


### PR DESCRIPTION
Corrects spelling in error message where 'occured' should be 'occurred' in crates/milli/src/thread_pool_no_abort.rs