### PR TITLE
chore: remove verbose debug log on list documents

### DIFF
--- a/crates/meilisearch/src/routes/indexes/documents.rs
+++ b/crates/meilisearch/src/routes/indexes/documents.rs
@@ -750,7 +750,6 @@ fn documents_by_query(
 
     let ret = PaginationView::new(offset, limit, total as usize, documents);
 
-    debug!(returns = ?ret, "Get documents");
     Ok(HttpResponse::Ok().json(ret))
 }
 


### PR DESCRIPTION
This PR remove verbose debug log on list documents with GET.
