### PR TITLE
Improve error message for max_fields_limit_exceeded

### DIFF
--- a/crates/meilisearch/tests/documents/add_documents.rs
+++ b/crates/meilisearch/tests/documents/add_documents.rs
@@ -1545,7 +1545,7 @@ async fn error_document_field_limit_reached_in_one_document() {
         "indexedDocuments": 0
       },
       "error": {
-        "message": "A document cannot contain more than 65,535 fields.",
+        "message": "The index has reached its maximum number of unique fields across all documents. A single index cannot have more than 65,535 unique fields.",
         "code": "max_fields_limit_exceeded",
         "type": "invalid_request",
         "link": "https://docs.meilisearch.com/errors#max_fields_limit_exceeded"
@@ -1628,7 +1628,7 @@ async fn error_document_field_limit_reached_over_multiple_documents() {
         "indexedDocuments": 0
       },
       "error": {
-        "message": "Index `[uuid]`: A document cannot contain more than 65,535 fields.",
+        "message": "Index `[uuid]`: The index has reached its maximum number of unique fields across all documents. A single index cannot have more than 65,535 unique fields.",
         "code": "max_fields_limit_exceeded",
         "type": "invalid_request",
         "link": "https://docs.meilisearch.com/errors#max_fields_limit_exceeded"

--- a/crates/milli/src/error.rs
+++ b/crates/milli/src/error.rs
@@ -131,7 +131,7 @@ pub enum UserError {
     CelluliteError(#[from] cellulite::Error),
     #[error("Malformed geojson: {0}")]
     MalformedGeojson(serde_json::Error),
-    #[error("A document cannot contain more than 65,535 fields.")]
+    #[error("The index has reached its maximum number of unique fields across all documents. A single index cannot have more than 65,535 unique fields.")]
     AttributeLimitReached,
     #[error(transparent)]
     CriterionError(#[from] CriterionError),


### PR DESCRIPTION
Fixes #5508

## Summary

The error message for `max_fields_limit_exceeded` was misleading. It incorrectly stated "A document cannot contain more than 65,535 fields" when the actual limit is on the total number of unique fields across ALL documents in an index, not per-document.

This PR updates the error message to accurately reflect the actual behavior.

## Changes

- Updated the error message in `crates/milli/src/error.rs` from "A document cannot contain more than 65,535 fields." to "The index has reached its maximum number of unique fields across all documents. A single index cannot have more than 65,535 unique fields."
- Updated test expectations in `crates/meilisearch/tests/documents/add_documents.rs` to match the new message

## Testing

Existing tests have been updated to verify the new error message is returned correctly.

## Generative AI tools

- [x] This PR uses generative AI tooling and respect the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - Claude Code was used to understand the codebase and make the code changes

## Requirements

- [x] Automated tests have been added. (Existing tests updated)
- [x] If some tests cannot be automated, manual rigorous tests should be applied. (N/A - existing tests cover this)
- [x] If there is any change in the DB: (N/A - no DB changes)
- [x] If necessary, the feature have been tested in the Cloud production environment (N/A)
- [x] If necessary, the documentation related to the implemented feature in the PR is ready. (The error message is self-documenting)
- [x] If necessary, the integrations related to the implemented feature in the PR are ready. (N/A)

```
crates/meilisearch/tests/documents/add_documents.rs | 4 ++--
crates/milli/src/error.rs                           | 2 +-
2 files changed, 3 insertions(+), 3 deletions(-)
```