### PR TITLE
Add `X-Accel-Buffering: no` on SSE responses

### DIFF
--- a/crates/meilisearch/src/routes/chats/chat_completions.rs
+++ b/crates/meilisearch/src/routes/chats/chat_completions.rs
@@ -542,6 +542,13 @@ async fn non_streamed_chat(
     Ok(HttpResponse::Ok().json(response))
 }
 
+fn sse_chat_response(rx: tokio::sync::mpsc::Receiver<Event>) -> impl Responder {
+    Sse::from_infallible_receiver(rx)
+        .with_retry_duration(Duration::from_secs(10))
+        .customize()
+        .insert_header(("X-Accel-Buffering", "no"))
+}
+
 async fn streamed_chat(
     index_scheduler: GuardedData<ActionPolicy<{ actions::CHAT_COMPLETIONS }>, Data<IndexScheduler>>,
     auth_ctrl: web::Data<AuthController>,
@@ -630,7 +637,7 @@ async fn streamed_chat(
     aggregate.succeed(start_time.elapsed());
     analytics.publish(aggregate, &req);
 
-    Ok(Sse::from_infallible_receiver(rx).with_retry_duration(Duration::from_secs(10)))
+    Ok(sse_chat_response(rx))
 }
 
 /// Updates the chat completion with the new messages, streams the LLM tokens,


### PR DESCRIPTION
## Related issue

Fixes https://linear.app/meilisearch/issue/ENGPROD-2335/kong-proxy-buffering-prevents-sse-streaming-on-chatcompletions

## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respect the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - *list of used tools and what they were used for*

## Requirements

⚠️ Ensure the following requirements before merging ⚠️
- [ ] Automated tests have been added.
- [ ] If some tests cannot be automated, manual rigorous tests should be applied.
- [ ] ⚠️ If there is any change in the DB:
    - [ ] Test that any impacted DB still works as expected after using `--experimental-dumpless-upgrade` on a DB created with the last released Meilisearch
    - [ ] Test that during the upgrade, **search is still available** (artificially make the upgrade longer if needed)
    - [ ] Set the `db change` label.
- [ ] If necessary, the feature have been tested in the Cloud production environment (with [prototypes](./documentation/prototypes.md)) and the Cloud UI is ready.
- [ ] If necessary, the [documentation](https://github.com/meilisearch/documentation) related to the implemented feature in the PR is ready.
- [ ] If necessary, the [integrations](https://github.com/meilisearch/integration-guides) related to the implemented feature in the PR are ready.
