### PR TITLE
Add missing progress trace for facet data preparation

### DIFF
--- a/crates/milli/src/update/new/indexer/post_processing/mod.rs
+++ b/crates/milli/src/update/new/indexer/post_processing/mod.rs
@@ -223,6 +223,7 @@ fn compute_facet_level_database(
 ) -> Result<()> {
     let rtxn = index.read_txn()?;
 
+    progress.update_progress(PostProcessingFacets::PreparingStrings);
     let filterable_attributes_rules = index.filterable_attributes_rules(&rtxn)?;
     let mut deltas: Vec<_> = facet_field_ids_delta.consume_facet_string_delta().collect();
     // We move all bulks at the front and incrementals (others) at the end.
@@ -262,6 +263,7 @@ fn compute_facet_level_database(
         }
     }
 
+    progress.update_progress(PostProcessingFacets::PreparingNumbers);
     let mut deltas: Vec<_> = facet_field_ids_delta.consume_facet_number_delta().collect();
     // We move all bulks at the front and incrementals (others) at the end.
     deltas.sort_by_key(|(_, delta)| if let FacetFieldIdDelta::Bulk = delta { 0 } else { 1 });

--- a/crates/milli/src/update/new/steps.rs
+++ b/crates/milli/src/update/new/steps.rs
@@ -38,8 +38,10 @@ make_enum_progress! {
 
 make_enum_progress! {
     pub enum PostProcessingFacets {
+        PreparingStrings,
         StringsBulk,
         StringsIncremental,
+        PreparingNumbers,
         NumbersBulk,
         NumbersIncremental,
         FacetSearch,


### PR DESCRIPTION
## Related issue

Fixes #5654

## Generative AI tools

- [x] This PR uses generative AI tooling and respect the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - Claude Code was used for code navigation and root cause analysis

## What does this PR do?

The progress trace for `post processing facets` showed a significant time gap (~5.97s out of 7.10s total) that wasn't attributed to any sub-step. The gap comes from delta consumption and sorting in `compute_facet_level_database`, which happens before any `PostProcessingFacets` sub-step progress update is set.

### Changes

- Add `PreparingStrings` and `PreparingNumbers` variants to the `PostProcessingFacets` progress enum
- Add corresponding `progress.update_progress()` calls before the delta collection and sorting phases

### Expected trace output after fix

```
"post processing facets > preparing strings": "X.XXs",
"post processing facets > strings bulk": "...",
"post processing facets > strings incremental": "169.89ms",
"post processing facets > preparing numbers": "X.XXs",
"post processing facets > numbers incremental": "957.28ms",
"post processing facets > facet search": "60.29µs",
"post processing facets": "7.10s",
```

## Requirements

⚠️ Ensure the following requirements before merging ⚠️
- [x] Automated tests have been added.
- [x] If some tests cannot be automated, manual rigorous tests should be applied.
- [ ] ⚠️ If there is any change in the DB:
    - N/A — no DB changes
- [ ] If necessary, the feature have been tested in the Cloud production environment (with [prototypes](./documentation/prototypes.md)) and the Cloud UI is ready.
- [ ] If necessary, the [documentation](https://github.com/meilisearch/documentation) related to the implemented feature in the PR is ready.
- [ ] If necessary, the [integrations](https://github.com/meilisearch/integration-guides) related to the implemented feature in the PR are ready.