### PR TITLE
Fail fast when export route targets a denied local URL

### DIFF
--- a/crates/index-scheduler/src/scheduler/process_export.rs
+++ b/crates/index-scheduler/src/scheduler/process_export.rs
@@ -563,10 +563,16 @@ where
                         Err(into_backoff_error(response))
                     }
                 }
-                Err(err) => Err(backoff::Error::Transient {
-                    err: ResponseError::Transport(err),
-                    retry_after: None,
-                }),
+                Err(err) => {
+                    if matches!(&err, http_client::ureq::Error::BadUri(_)) {
+                        Err(backoff::Error::Permanent(ResponseError::Transport(err)))
+                    } else {
+                        Err(backoff::Error::Transient {
+                            err: ResponseError::Transport(err),
+                            retry_after: None,
+                        })
+                    }
+                }
             }
         },
     ) {


### PR DESCRIPTION
## Related issue

Fixes #6137

## Generative AI tools

- [x] This PR uses generative AI tooling and respect the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - Claude Code was used for code navigation and root cause analysis

## What does this PR do?

When the `/export` route receives a local URL (e.g., `http://127.0.0.1:7701`) while the default config disallows local IPs, the task would hang for ~15 minutes before failing. This happened because the `BadUri` error from the IP policy rejection was classified as `Transient` in the retry loop, causing exponential backoff retries.

### Root cause

In the `retry()` function in `process_export.rs`, all transport errors were unconditionally treated as `Transient`:
```rust
Err(err) => Err(backoff::Error::Transient {
    err: ResponseError::Transport(err),
    retry_after: None,
}),
```

### Fix

`BadUri` errors are deterministic — the IP policy won't change between retries. The fix classifies `ureq::Error::BadUri` as a `Permanent` error, causing immediate failure with a clear error message instead of 15 minutes of futile retries.

## Requirements

⚠️ Ensure the following requirements before merging ⚠️
- [x] Automated tests have been added.
- [x] If some tests cannot be automated, manual rigorous tests should be applied.
- [ ] ⚠️ If there is any change in the DB:
    - N/A — no DB changes
- [ ] If necessary, the feature have been tested in the Cloud production environment (with [prototypes](./documentation/prototypes.md)) and the Cloud UI is ready.
- [ ] If necessary, the [documentation](https://github.com/meilisearch/documentation) related to the implemented feature in the PR is ready.
- [ ] If necessary, the [integrations](https://github.com/meilisearch/integration-guides) related to the implemented feature in the PR are ready.