### PR TITLE
fix: clamp map_size to page boundary in index_budget

### DIFF
--- a/crates/index-scheduler/src/lib.rs
+++ b/crates/index-scheduler/src/lib.rs
@@ -441,7 +441,7 @@ impl IndexScheduler {
         let mut index_count = budget / base_map_size;
         if index_count < 2 {
             // take a bit less than half than the budget to make sure we can always afford to open an index
-            let map_size = (budget * 2) / 5;
+            let map_size = clamp_to_page_size((budget * 2) / 5);
             // single index of max budget
             tracing::debug!("1 index of {map_size}B can be opened simultaneously.");
             return IndexBudget { map_size, index_count: 1, task_db_size };


### PR DESCRIPTION
Wraps the `map_size` computation in the `index_count < 2` branch of `index_budget()` with `clamp_to_page_size()`, matching what the other two branches already do.

Without this, the computed map size may not be page-aligned, which causes heed to reject it on Windows (where the page size is 4096 bytes).

Related: #6051
Closes #6233