### PR TITLE
fix: propagate error from format_facet_distributions instead of unwrap

### DIFF
--- a/crates/meilisearch/src/routes/chats/chat_completions.rs
+++ b/crates/meilisearch/src/routes/chats/chat_completions.rs
@@ -246,7 +246,8 @@ fn setup_search_tool(
         let index_description = chat_config.description;
         let _ = writeln!(&mut function_description, "\n\n - {name}: {index_description}\n");
         index_uids.push(name.to_string());
-        let facet_distributions = format_facet_distributions(index, &rtxn, 10).unwrap(); // TODO do not unwrap
+        let facet_distributions = format_facet_distributions(index, &rtxn, 10)
+            .map_err(|e| index_scheduler::Error::from_milli(e, Some(name.to_string())))?;
         let _ = writeln!(&mut filter_description, "\n## Facet distributions of the {name} index");
         let _ = writeln!(&mut filter_description, "{facet_distributions}");
 


### PR DESCRIPTION
Replaces `.unwrap()` with proper error propagation (`.map_err()` + `?`) for the `format_facet_distributions` call in the chat completions handler. The existing code had a `TODO` comment noting this should not unwrap.

The `milli::Error` is converted to `index_scheduler::Error` via `Error::from_milli`, following the same pattern used throughout the codebase for this conversion. This attaches the index name for better diagnostics.

This prevents a potential panic if the index has corrupt or missing facet data.

Closes #6235