### PR TITLE
fix: correct AttributeLimitReached error message to reflect per-index limit

### DIFF
--- a/crates/meilisearch/tests/documents/add_documents.rs
+++ b/crates/meilisearch/tests/documents/add_documents.rs
@@ -1545,7 +1545,7 @@ async fn error_document_field_limit_reached_in_one_document() {
         "indexedDocuments": 0
       },
       "error": {
-        "message": "A document cannot contain more than 65,535 fields.",
+        "message": "An index cannot contain more than 65,535 unique attribute fields.",
         "code": "max_fields_limit_exceeded",
         "type": "invalid_request",
         "link": "https://docs.meilisearch.com/errors#max_fields_limit_exceeded"
@@ -1628,7 +1628,7 @@ async fn error_document_field_limit_reached_over_multiple_documents() {
         "indexedDocuments": 0
       },
       "error": {
-        "message": "Index `[uuid]`: A document cannot contain more than 65,535 fields.",
+        "message": "Index `[uuid]`: An index cannot contain more than 65,535 unique attribute fields.",
         "code": "max_fields_limit_exceeded",
         "type": "invalid_request",
         "link": "https://docs.meilisearch.com/errors#max_fields_limit_exceeded"

--- a/crates/milli/src/error.rs
+++ b/crates/milli/src/error.rs
@@ -131,7 +131,7 @@ pub enum UserError {
     CelluliteError(#[from] cellulite::Error),
     #[error("Malformed geojson: {0}")]
     MalformedGeojson(serde_json::Error),
-    #[error("A document cannot contain more than 65,535 fields.")]
+    #[error("An index cannot contain more than 65,535 unique attribute fields.")]
     AttributeLimitReached,
     #[error(transparent)]
     CriterionError(#[from] CriterionError),


### PR DESCRIPTION
Updates the `AttributeLimitReached` error message from "A document cannot contain more than 65,535 fields" to "An index cannot contain more than 65,535 unique attribute fields."

The limit applies to unique fields across all documents in an index, not per-document. The original message was misleading users into thinking their individual document had too many fields.

Also updates the corresponding test assertions.

Related: #5508
Closes #6237