### PR TITLE
Add support for target index names in the export route

### DIFF
--- a/crates/index-scheduler/src/scheduler/process_export.rs
+++ b/crates/index-scheduler/src/scheduler/process_export.rs
@@ -79,7 +79,9 @@ impl IndexScheduler {
                 indexes.len() as u32,
             ));
 
-            let ExportIndexSettings { filter, override_settings } = export_settings;
+            let ExportIndexSettings { filter, name, override_settings } = export_settings;
+
+            let target_uid = resolve_target_index_name(name.as_deref(), uid);
 
             let index = self.index(uid)?;
             let index_rtxn = index.read_txn()?;
@@ -99,7 +101,7 @@ impl IndexScheduler {
                 must_stop_processing: &must_stop_processing,
             };
             let options = ExportOptions {
-                index_uid: uid,
+                index_uid: &target_uid,
                 payload_size,
                 override_settings: *override_settings,
                 export_mode: ExportMode::ExportRoute,
@@ -678,5 +680,65 @@ pub(super) enum ExportMode<'a> {
     },
 }
 
+/// Resolves the target index name from an optional name template and the source index uid.
+///
+/// - If `name_template` is `None`, returns the source `uid` as-is.
+/// - If `name_template` contains `$name`, replaces all occurrences with the source `uid`.
+/// - If `name_template` does not contain `$name`, returns it as a static name.
+fn resolve_target_index_name(name_template: Option<&str>, uid: &str) -> String {
+    match name_template {
+        Some(template) => template.replace("$name", uid),
+        None => uid.to_string(),
+    }
+}
+
 // progress related
 enum ExportIndex {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_name_none_returns_source_uid() {
+        assert_eq!(resolve_target_index_name(None, "movies"), "movies");
+    }
+
+    #[test]
+    fn resolve_name_static_value() {
+        assert_eq!(resolve_target_index_name(Some("everyone"), "movies"), "everyone");
+    }
+
+    #[test]
+    fn resolve_name_with_dollar_name_variable() {
+        assert_eq!(resolve_target_index_name(Some("backup-$name"), "movies"), "backup-movies");
+    }
+
+    #[test]
+    fn resolve_name_dollar_name_only() {
+        assert_eq!(resolve_target_index_name(Some("$name"), "movies"), "movies");
+    }
+
+    #[test]
+    fn resolve_name_multiple_dollar_name() {
+        assert_eq!(
+            resolve_target_index_name(Some("$name-copy-$name"), "movies"),
+            "movies-copy-movies"
+        );
+    }
+
+    #[test]
+    fn resolve_name_with_wildcard_matched_uid() {
+        // When pattern "super-*" matches "super-toto", uid is "super-toto"
+        assert_eq!(
+            resolve_target_index_name(Some("mega-$name"), "super-toto"),
+            "mega-super-toto"
+        );
+    }
+
+    #[test]
+    fn resolve_name_static_with_wildcard_matched_uid() {
+        // Static name ignores the matched uid
+        assert_eq!(resolve_target_index_name(Some("everyone"), "super-toto"), "everyone");
+    }
+}

--- a/crates/meilisearch-types/src/error.rs
+++ b/crates/meilisearch-types/src/error.rs
@@ -427,6 +427,7 @@ InvalidExportApiKey                            , InvalidRequest       , BAD_REQU
 InvalidExportPayloadSize                       , InvalidRequest       , BAD_REQUEST ;
 InvalidExportIndexesPatterns                   , InvalidRequest       , BAD_REQUEST ;
 InvalidExportIndexFilter                       , InvalidRequest       , BAD_REQUEST ;
+InvalidExportIndexName                         , InvalidRequest       , BAD_REQUEST ;
 InvalidExportIndexOverrideSettings             , InvalidRequest       , BAD_REQUEST ;
 // Experimental features - Chat Completions
 UnimplementedExternalFunctionCalling           , InvalidRequest       , NOT_IMPLEMENTED ;

--- a/crates/meilisearch-types/src/tasks/mod.rs
+++ b/crates/meilisearch-types/src/tasks/mod.rs
@@ -205,6 +205,9 @@ pub struct IndexSwap {
 pub struct ExportIndexSettings {
     /// Filter expression to select documents for export
     pub filter: Option<Value>,
+    /// Target index name template on the destination instance
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
     /// Whether to override settings on the destination index
     pub override_settings: bool,
 }

--- a/crates/meilisearch/src/routes/export.rs
+++ b/crates/meilisearch/src/routes/export.rs
@@ -75,8 +75,8 @@ async fn export(
     let indexes = match indexes {
         Some(indexes) => indexes
             .into_iter()
-            .map(|(pattern, ExportIndexSettings { filter, override_settings })| {
-                (pattern, DbExportIndexSettings { filter, override_settings })
+            .map(|(pattern, ExportIndexSettings { filter, name, override_settings })| {
+                (pattern, DbExportIndexSettings { filter, name, override_settings })
             })
             .collect(),
         None => BTreeMap::from([(
@@ -178,6 +178,13 @@ pub struct ExportIndexSettings {
     #[serde(default)]
     #[deserr(default, error = DeserrJsonError<InvalidExportIndexFilter>)]
     pub filter: Option<Value>,
+    /// Target index name on the destination instance.
+    /// Use `$name` to reference the source index name dynamically.
+    /// If omitted, the source index name is used.
+    #[schema(value_type = Option<String>, example = json!("backup-$name"))]
+    #[serde(default)]
+    #[deserr(default, error = DeserrJsonError<InvalidExportIndexName>)]
+    pub name: Option<String>,
     /// Whether to override settings on the destination index
     #[schema(value_type = Option<bool>, example = json!(true))]
     #[serde(default)]

--- a/crates/meilisearch/src/routes/export_analytics.rs
+++ b/crates/meilisearch/src/routes/export_analytics.rs
@@ -10,6 +10,7 @@ pub struct ExportAnalytics {
     sum_exports_meilisearch_cloud: usize,
     sum_index_patterns: usize,
     sum_patterns_with_filter: usize,
+    sum_patterns_with_name: usize,
     sum_patterns_with_override_settings: usize,
     payload_sizes: Vec<u64>,
 }
@@ -29,6 +30,9 @@ impl ExportAnalytics {
         let patterns_with_filter_count = indexes.as_ref().map_or(0, |indexes| {
             indexes.values().filter(|settings| settings.filter.is_some()).count()
         });
+        let patterns_with_name_count = indexes.as_ref().map_or(0, |indexes| {
+            indexes.values().filter(|settings| settings.name.is_some()).count()
+        });
         let patterns_with_override_settings_count = indexes.as_ref().map_or(0, |indexes| {
             indexes.values().filter(|settings| settings.override_settings).count()
         });
@@ -45,6 +49,7 @@ impl ExportAnalytics {
             sum_exports_meilisearch_cloud: is_meilisearch_cloud as usize,
             sum_index_patterns: index_patterns_count,
             sum_patterns_with_filter: patterns_with_filter_count,
+            sum_patterns_with_name: patterns_with_name_count,
             sum_patterns_with_override_settings: patterns_with_override_settings_count,
             payload_sizes,
         }
@@ -62,6 +67,7 @@ impl Aggregate for ExportAnalytics {
         self.sum_exports_meilisearch_cloud += other.sum_exports_meilisearch_cloud;
         self.sum_index_patterns += other.sum_index_patterns;
         self.sum_patterns_with_filter += other.sum_patterns_with_filter;
+        self.sum_patterns_with_name += other.sum_patterns_with_name;
         self.sum_patterns_with_override_settings += other.sum_patterns_with_override_settings;
         self.payload_sizes.extend(other.payload_sizes);
         self
@@ -92,6 +98,12 @@ impl Aggregate for ExportAnalytics {
             Some(self.sum_patterns_with_filter as f64 / self.total_received as f64)
         };
 
+        let avg_patterns_with_name = if self.total_received == 0 {
+            None
+        } else {
+            Some(self.sum_patterns_with_name as f64 / self.total_received as f64)
+        };
+
         let avg_patterns_with_override_settings = if self.total_received == 0 {
             None
         } else {
@@ -104,6 +116,7 @@ impl Aggregate for ExportAnalytics {
             "avg_exports_meilisearch_cloud": avg_exports_meilisearch_cloud,
             "avg_index_patterns": avg_index_patterns,
             "avg_patterns_with_filter": avg_patterns_with_filter,
+            "avg_patterns_with_name": avg_patterns_with_name,
             "avg_patterns_with_override_settings": avg_patterns_with_override_settings,
             "avg_payload_size": avg_payload_size,
         })


### PR DESCRIPTION
## Summary

Add a `name` field to the export index settings that allows users to specify a custom target index name on the destination instance. The `$name` variable references the source index name dynamically. If omitted, the source index name is used (current behavior).

Fixes #6049

## Changes

- Add `name: Option<String>` field to both route-level and DB-level `ExportIndexSettings`
- Add `InvalidExportIndexName` error code for deserialization errors
- Add `resolve_target_index_name()` that handles `$name` variable substitution
- Use resolved target name in all export URL constructions
- Add analytics tracking for `name` field usage
- Add 7 unit tests covering all name resolution scenarios including wildcard interactions

## Examples

```json
// Dynamic name with $name variable
{ "indexes": { "super-*": { "name": "mega-$name" } } }
// "super-toto" exports as "mega-super-toto"

// Static name (no $name)
{ "indexes": { "movies": { "name": "backup-movies" } } }

// Omitted (default: uses source index name)
{ "indexes": { "movies": {} } }
```

## Test plan

- 7 unit tests for `resolve_target_index_name` covering:
  - `None` template returns source uid
  - Static name without `$name`
  - Template with `$name` substitution
  - `$name` as the entire template
  - Multiple `$name` occurrences
  - Wildcard-matched uid with dynamic name
  - Wildcard-matched uid with static name
- `cargo check --all` passes
- `cargo test -p index-scheduler -- process_export::tests` passes (7/7)

## AI disclosure

AI tooling (Claude) was used to assist with code generation. All changes have been reviewed and tested.