### PR TITLE
Add environment variable to configure max open indexes

### DIFF
--- a/crates/meilisearch/src/analytics/segment_analytics.rs
+++ b/crates/meilisearch/src/analytics/segment_analytics.rs
@@ -261,6 +261,7 @@ impl Infos {
             experimental_limit_batched_tasks_total_size,
             experimental_embedding_cache_entries,
             experimental_no_snapshot_compaction,
+            experimental_max_open_indexes: _,
             experimental_allowed_ip_networks,
             http_addr,
             master_key: _,

--- a/crates/meilisearch/src/lib.rs
+++ b/crates/meilisearch/src/lib.rs
@@ -275,7 +275,7 @@ pub fn setup_meilisearch(
             |size| size.as_u64(),
         ),
         index_growth_amount: byte_unit::Byte::from_str("10GiB").unwrap().as_u64() as usize,
-        index_count: DEFAULT_INDEX_COUNT,
+        index_count: opt.experimental_max_open_indexes.unwrap_or(DEFAULT_INDEX_COUNT),
         instance_features: opt.to_instance_features(),
         auto_upgrade: opt.experimental_dumpless_upgrade,
         embedding_cache_cap: opt.experimental_embedding_cache_entries,

--- a/crates/meilisearch/src/option.rs
+++ b/crates/meilisearch/src/option.rs
@@ -70,6 +70,7 @@ const MEILI_EXPERIMENTAL_LIMIT_BATCHED_TASKS_TOTAL_SIZE: &str =
 const MEILI_EXPERIMENTAL_EMBEDDING_CACHE_ENTRIES: &str =
     "MEILI_EXPERIMENTAL_EMBEDDING_CACHE_ENTRIES";
 const MEILI_EXPERIMENTAL_NO_SNAPSHOT_COMPACTION: &str = "MEILI_EXPERIMENTAL_NO_SNAPSHOT_COMPACTION";
+const MEILI_EXPERIMENTAL_MAX_OPEN_INDEXES: &str = "MEILI_EXPERIMENTAL_MAX_OPEN_INDEXES";
 const MEILI_EXPERIMENTAL_NO_EDITION_2024_FOR_DUMPS: &str =
     "MEILI_EXPERIMENTAL_NO_EDITION_2024_FOR_DUMPS";
 const MEILI_EXPERIMENTAL_PERSONALIZATION_API_KEY: &str =
@@ -492,6 +493,14 @@ pub struct Opt {
     #[serde(default = "default_embedding_cache_entries")]
     pub experimental_embedding_cache_entries: usize,
 
+    /// Experimentally configures the maximum number of indexes that can be concurrently opened in memory.
+    ///
+    /// Defaults to 20 on Unix and 4 on Windows when not specified. Increasing this value is useful
+    /// for instances with thousands of indexes that are rarely queried, avoiding constant reopening.
+    #[clap(long, env = MEILI_EXPERIMENTAL_MAX_OPEN_INDEXES)]
+    #[serde(default)]
+    pub experimental_max_open_indexes: Option<usize>,
+
     /// Experimental no snapshot compaction feature.
     ///
     /// When enabled, Meilisearch will not compact snapshots during creation.
@@ -623,6 +632,7 @@ impl Opt {
             experimental_limit_batched_tasks_total_size,
             experimental_embedding_cache_entries,
             experimental_no_snapshot_compaction,
+            experimental_max_open_indexes,
             experimental_personalization_api_key,
             experimental_allowed_ip_networks,
             s3_snapshot_options,
@@ -724,6 +734,12 @@ impl Opt {
             MEILI_EXPERIMENTAL_EMBEDDING_CACHE_ENTRIES,
             experimental_embedding_cache_entries.to_string(),
         );
+        if let Some(max_open_indexes) = experimental_max_open_indexes {
+            export_to_env_if_not_present(
+                MEILI_EXPERIMENTAL_MAX_OPEN_INDEXES,
+                max_open_indexes.to_string(),
+            );
+        }
         export_to_env_if_not_present(
             MEILI_EXPERIMENTAL_NO_SNAPSHOT_COMPACTION,
             experimental_no_snapshot_compaction.to_string(),


### PR DESCRIPTION
## Summary

Add `MEILI_EXPERIMENTAL_MAX_OPEN_INDEXES` environment variable (and `--experimental-max-open-indexes` CLI flag) to allow users to configure the maximum number of indexes that can be concurrently opened in memory.

Fixes #6241

## Changes

- Add `MEILI_EXPERIMENTAL_MAX_OPEN_INDEXES` constant and `experimental_max_open_indexes: Option<usize>` field to `Opt` struct
- Pass the configured value to `IndexSchedulerOptions.index_count`, falling back to `DEFAULT_INDEX_COUNT` (20 on Unix, 4 on Windows) when not set
- Export the env var for child processes when specified

## Test plan

- `cargo check --all` passes
- When env var is not set, behavior is identical to current (default 20/4)
- When set (e.g., `MEILI_EXPERIMENTAL_MAX_OPEN_INDEXES=50`), the LRU cache uses the configured limit

## AI disclosure

AI tooling (Claude) was used to assist with code generation. All changes have been reviewed and tested.