### PR TITLE
fix: respect user-configured baseUrl over source default in chat config

### DIFF
--- a/crates/meilisearch/src/routes/chats/config.rs
+++ b/crates/meilisearch/src/routes/chats/config.rs
@@ -25,7 +25,7 @@ impl Config {
                     config = config.with_api_key(api_key);
                 }
                 let base_url = chat_settings.base_url.as_deref();
-                if let Some(base_url) = chat_settings.source.base_url().or(base_url) {
+                if let Some(base_url) = base_url.or(chat_settings.source.base_url()) {
                     config = config.with_api_base(base_url);
                 }
                 Self::OpenAiCompatible(config)


### PR DESCRIPTION
## Summary

The `baseUrl` in chat workspace settings was being ignored for OpenAI and Mistral sources. The `.or()` precedence in `Config::new()` was inverted — the source's built-in default URL always took priority over the user-configured URL.

Fixes #6056

## Changes
- Swapped `.or()` operand order so user-configured `base_url` takes precedence over `source.base_url()` default

## Root cause

In `config.rs` line 28:
```rust
// Before: source default wins, user config ignored
chat_settings.source.base_url().or(base_url)

// After: user config wins, source default as fallback
base_url.or(chat_settings.source.base_url())
```

For OpenAI, `source.base_url()` returns `Some("https://api.openai.com/v1/")`, so `.or()` never used the user's custom URL.

## Test plan
- `cargo check -p meilisearch` passes
- Verified logic: when `base_url` is `Some(custom_url)`, the custom URL is now used; when `None`, the source default is used as fallback

> This PR was made with the help of AI (Claude). As required by the Meilisearch contributing guidelines, this is disclosed.