### PR TITLE
fix: validate chat document template at settings update time

### DIFF
--- a/crates/meilisearch-types/src/error.rs
+++ b/crates/meilisearch-types/src/error.rs
@@ -517,6 +517,9 @@ impl ErrorCode for milli::Error {
                 | UserError::TooManyEmbedders(_)
                 | UserError::TooManyFragments(_)
                 | UserError::InvalidPromptForEmbeddings(..) => Code::InvalidSettingsEmbedders,
+                UserError::InvalidChatSettingsDocumentTemplate(_) => {
+                    Code::InvalidChatSettingDocumentTemplate
+                }
                 UserError::NoPrimaryKeyCandidateFound => Code::IndexPrimaryKeyNoCandidateFound,
                 UserError::MultiplePrimaryKeyCandidatesFound { .. } => {
                     Code::IndexPrimaryKeyMultipleCandidatesFound

--- a/crates/meilisearch/src/routes/chats/utils.rs
+++ b/crates/meilisearch/src/routes/chats/utils.rs
@@ -219,7 +219,9 @@ pub fn format_documents<'doc>(
 ) -> Result<Vec<&'doc str>, ResponseError> {
     let ChatConfig { prompt: PromptData { template, max_bytes }, .. } = index.chat_config(rtxn)?;
 
-    let prompt = Prompt::new(template, max_bytes).unwrap();
+    let prompt = Prompt::new(template, max_bytes).map_err(|e| {
+        ResponseError::from_msg(e.to_string(), Code::InvalidChatSettingDocumentTemplate)
+    })?;
     let fid_map = index.fields_ids_map(rtxn)?;
     let metadata_builder = MetadataBuilder::from_index(index, rtxn)?;
     let fid_map_with_meta = FieldIdMapWithMetadata::new(fid_map.clone(), metadata_builder);

--- a/crates/milli/src/error.rs
+++ b/crates/milli/src/error.rs
@@ -432,6 +432,8 @@ and can not be more than 511 bytes.", .document_id.to_string()
     DocumentEditionRuntimeError(Box<EvalAltResult>),
     #[error("Document edition runtime error encountered while compiling the function: {0}")]
     DocumentEditionCompilationError(rhai::ParseError),
+    #[error("`.chat.documentTemplate`: Invalid document template: {0}.")]
+    InvalidChatSettingsDocumentTemplate(crate::prompt::error::NewPromptError),
     #[error("`.chat.documentTemplateMaxBytes`: `documentTemplateMaxBytes` cannot be zero")]
     InvalidChatSettingsDocumentTemplateMaxBytes,
     #[error("{0}")]

--- a/crates/milli/src/update/settings.rs
+++ b/crates/milli/src/update/settings.rs
@@ -27,7 +27,7 @@ use crate::index::{
 };
 use crate::order_by_map::OrderByMap;
 use crate::progress::{EmbedderStats, Progress, VariableNameStep};
-use crate::prompt::{default_max_bytes, default_template_text, PromptData};
+use crate::prompt::{default_max_bytes, default_template_text, Prompt, PromptData};
 use crate::proximity::ProximityPrecision;
 use crate::update::index_documents::IndexDocumentsMethod;
 use crate::update::new::indexer::reindex;
@@ -1377,6 +1377,10 @@ impl<'a, 't, 'i> Settings<'a, 't, 'i> {
                         Setting::NotSet => prompt.max_bytes,
                     },
                 };
+
+                // Validate the document template syntax
+                Prompt::new(prompt.template.clone(), prompt.max_bytes)
+                    .map_err(UserError::InvalidChatSettingsDocumentTemplate)?;
 
                 let search_parameters = match new_search_parameters {
                     Setting::Set(sp) => {


### PR DESCRIPTION
## Summary

- Validates Liquid template syntax in `chat.documentTemplate` at settings update time, returning `invalid_chat_setting_document_template` error for malformed templates
- Replaces runtime `.unwrap()` in `format_documents()` with proper error propagation, preventing panics when querying with a previously-accepted invalid template

Fixes #5814

## Changes

- **`crates/milli/src/error.rs`**: Added `InvalidChatSettingsDocumentTemplate(NewPromptError)` variant to `UserError`
- **`crates/milli/src/update/settings.rs`**: Added `Prompt::new()` validation call after building `PromptData` in `update_chat_config()`
- **`crates/meilisearch-types/src/error.rs`**: Mapped new variant to `Code::InvalidChatSettingDocumentTemplate`
- **`crates/meilisearch/src/routes/chats/utils.rs`**: Replaced `.unwrap()` with `.map_err()` for graceful error handling at query time

## Test plan

- [x] `cargo check` passes
- [x] `cargo test -p meilisearch -- chat` — all 5 chat tests pass
- [ ] Manual: POST invalid Liquid template to `/indexes/{uid}/settings` chat settings → expect 400 with `invalid_chat_setting_document_template` error
- [ ] Manual: Verify valid templates still accepted and work at query time

> This PR was written with the help of an AI assistant.