### PR TITLE
Add link to documentation on `--experimental-allowed-ip-networks` parameter

### DIFF
--- a/crates/meilisearch/src/routes/network/mod.rs
+++ b/crates/meilisearch/src/routes/network/mod.rs
@@ -93,6 +93,10 @@ async fn get_network(
 #[schema(rename_all = "camelCase")]
 pub struct Remote {
     /// URL of the remote instance
+    ///
+    /// - If the URL of the remote instance is resolving to a non-global IP, make sure that
+    ///   `--experimental-allowed-ip-networks` allows it. For details on how use this parameter,
+    ///   refer to [this documentation](https://www.meilisearch.com/docs/learn/self_hosted/configure_meilisearch_at_launch#allow-requests-to-private-networks).
     #[schema(value_type = Option<String>, example = "http://localhost:7700")]
     #[deserr(default, error = DeserrJsonError<InvalidNetworkUrl>)]
     #[serde(default)]

--- a/crates/milli/src/vector/settings.rs
+++ b/crates/milli/src/vector/settings.rs
@@ -131,7 +131,8 @@ pub struct EmbeddingSettings {
     /// - 🌱 When modified for `openAi``, embeddings are never regenerated
     /// - 🏗️ When modified for `ollama` and `rest`, embeddings are always regenerated
     /// - If targetting URL resolving to a non-global IP (such as `localhost`), make sure that
-    ///   `--experimental-allowed-ip-networks` allows it.
+    ///   `--experimental-allowed-ip-networks` allows it. For details on how use this parameter,
+    ///   refer to [this documentation](https://www.meilisearch.com/docs/learn/self_hosted/configure_meilisearch_at_launch#allow-requests-to-private-networks).
     #[serde(default, skip_serializing_if = "Setting::is_not_set")]
     #[deserr(default)]
     #[schema(value_type = Option<String>, example = json!("http://localhost:11434/api/embeddings"))]
@@ -327,7 +328,8 @@ pub struct SubEmbeddingSettings {
     /// - 🌱 When modified for `openAi``, embeddings are never regenerated
     /// - 🏗️ When modified for `ollama` and `rest`, embeddings are always regenerated
     /// - If targetting URL resolving to a non-global IP (such as `localhost`), make sure that
-    ///   `--experimental-allowed-ip-networks` allows it.
+    ///   `--experimental-allowed-ip-networks` allows it. For details on how use this parameter,
+    ///   refer to [this documentation](https://www.meilisearch.com/docs/learn/self_hosted/configure_meilisearch_at_launch#allow-requests-to-private-networks).
     #[serde(default, skip_serializing_if = "Setting::is_not_set")]
     #[deserr(default)]
     #[schema(value_type = Option<String>, example = json!("http://localhost:11434/api/embeddings"))]


### PR DESCRIPTION
## Related issue

Fixes https://github.com/meilisearch/documentation/issues/3481

Context: https://github.com/meilisearch/documentation/pull/3504#issuecomment-4067774941

The indication of using the `--experimental-allowed-ip-networks` parameter was already present for embedders, I only added the link to provide more details. If you know of other places where this is needed, let me know!

## Generative AI tools

- [X] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respect the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - *list of used tools and what they were used for*

