### PR TITLE
Add `X-Accel-Buffering: no` for `/logs/stream` route

### DIFF
--- a/crates/meilisearch/src/routes/logs.rs
+++ b/crates/meilisearch/src/routes/logs.rs
@@ -5,6 +5,7 @@ use std::pin::Pin;
 use std::str::FromStr;
 use std::sync::Arc;
 
+use actix_http::header::{HeaderName, HeaderValue};
 use actix_web::web::{Bytes, Data};
 use actix_web::{web, HttpResponse};
 use deserr::actix_web::AwebJson;
@@ -335,7 +336,12 @@ pub async fn get_logs(
     .unwrap();
 
     if let Some(stream) = stream {
-        Ok(HttpResponse::Ok().streaming(stream))
+        let mut resp = HttpResponse::Ok().streaming(stream);
+
+        resp.headers_mut()
+            .insert(HeaderName::from_static("x-accel-buffering"), HeaderValue::from_static("no"));
+
+        Ok(resp)
     } else {
         Err(MeilisearchHttpError::AlreadyUsedLogRoute.into())
     }


### PR DESCRIPTION
## Related issue

Fixes https://linear.app/meilisearch/issue/ENGPROD-2400/tell-reverse-proxies-to-not-buffer-streaming-responses-from-logsstream

Like #6228, we need to add this header to improve our cloud integration

## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respect the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - *list of used tools and what they were used for*

## Requirements

⚠️ Ensure the following requirements before merging ⚠️
- [ ] Automated tests have been added.
- [x] If some tests cannot be automated, manual rigorous tests should be applied.
- [ ] ⚠️ If there is any change in the DB:
    - [ ] Test that any impacted DB still works as expected after using `--experimental-dumpless-upgrade` on a DB created with the last released Meilisearch
    - [ ] Test that during the upgrade, **search is still available** (artificially make the upgrade longer if needed)
    - [ ] Set the `db change` label.
- [ ] If necessary, the feature have been tested in the Cloud production environment (with [prototypes](./documentation/prototypes.md)) and the Cloud UI is ready.
- [ ] If necessary, the [documentation](https://github.com/meilisearch/documentation) related to the implemented feature in the PR is ready.
- [ ] If necessary, the [integrations](https://github.com/meilisearch/integration-guides) related to the implemented feature in the PR are ready.
