### PR TITLE
ci: add riscv64 to release binary matrix

### DIFF
--- a/.github/workflows/publish-release-assets.yml
+++ b/.github/workflows/publish-release-assets.yml
@@ -43,7 +43,7 @@ jobs:
       matrix:
         edition: [community, enterprise]
         release:
-          [macos-amd64, macos-aarch64, windows, linux-amd64, linux-aarch64]
+          [macos-amd64, macos-aarch64, windows, linux-amd64, linux-aarch64, linux-riscv64]
         include:
           - edition: "community"
             feature-flag: ""
@@ -76,6 +76,11 @@ jobs:
             binary_path: aarch64-unknown-linux-gnu/release/meilisearch
             asset_name: linux-aarch64
             extra-args: "--target aarch64-unknown-linux-gnu"
+          - release: linux-riscv64
+            os: ubuntu-24.04-riscv
+            binary_path: release/meilisearch
+            asset_name: linux-riscv64
+            extra-args: ""
     needs: check-version
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Adds linux-riscv64 to the release binary matrix using native RISE riscv64 runners (ubuntu-24.04-riscv), following the same pattern as the linux-aarch64 entry.

Builds natively with cargo (no cross-compilation needed since the runner is native riscv64).

RISE runners are provided by the RISE Project (https://riseproject.dev/), free for open source. To enable on this org: install https://github.com/apps/rise-risc-v-runners on this repository. Without it, the job stays queued with no runner.

Build validated: https://github.com/gounthar/meilisearch/actions/runs/23455530481

Closes #6281