### PR TITLE
`useNetwork`: Pick local instance if it owns the shard

### DIFF
--- a/crates/meilisearch/src/search/federated/network/enterprise_edition.rs
+++ b/crates/meilisearch/src/search/federated/network/enterprise_edition.rs
@@ -32,18 +32,30 @@ pub fn partition_shards(
 
 pub(super) fn remote_for_shard(network: Network) -> BTreeMap<String, String> {
     let mut rng = rand::thread_rng();
+    let local = network.local;
 
     let remote_for_shard = {
         network
             .shards
             .into_iter()
             .filter_map(move |(shard_name, shard)| {
-                let Some(remote_for_shard) = shard.remotes.into_iter().choose(&mut rng) else {
-                    tracing::warn!("No remote for shard {shard_name}");
-                    return None;
+                let shard_name = shard_name.escape_default().collect();
+
+                let remote_for_shard = match &local {
+                    // pick the local instance if it owns the shard
+                    Some(local) if shard.remotes.contains(local) => local.clone(),
+                    // otherwise pick a random other remote
+                    _ => {
+                        let Some(remote_for_shard) = shard.remotes.into_iter().choose(&mut rng)
+                        else {
+                            tracing::warn!("No remote for shard {shard_name}");
+                            return None;
+                        };
+                        remote_for_shard
+                    }
                 };
 
-                Some((shard_name.escape_default().collect(), remote_for_shard))
+                Some((shard_name, remote_for_shard))
             })
             .collect()
     };


### PR DESCRIPTION
# Changelog

To prevent unnecessary network activity, when deciding which remote to ask for a shard in a search over the network, Meilisearch will now always pick the local instance if it owns the shard.

## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respect the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - *list of used tools and what they were used for*

