### PR TITLE
fix: correct AttributeLimitReached error message

### DIFF
--- a/crates/meilisearch/tests/documents/add_documents.rs
+++ b/crates/meilisearch/tests/documents/add_documents.rs
@@ -1545,7 +1545,7 @@ async fn error_document_field_limit_reached_in_one_document() {
         "indexedDocuments": 0
       },
       "error": {
-        "message": "A document cannot contain more than 65,535 fields.",
+        "message": "An index cannot contain more than 65,535 unique attribute fields.",
         "code": "max_fields_limit_exceeded",
         "type": "invalid_request",
         "link": "https://docs.meilisearch.com/errors#max_fields_limit_exceeded"
@@ -1628,7 +1628,7 @@ async fn error_document_field_limit_reached_over_multiple_documents() {
         "indexedDocuments": 0
       },
       "error": {
-        "message": "Index `[uuid]`: A document cannot contain more than 65,535 fields.",
+        "message": "Index `[uuid]`: An index cannot contain more than 65,535 unique attribute fields.",
         "code": "max_fields_limit_exceeded",
         "type": "invalid_request",
         "link": "https://docs.meilisearch.com/errors#max_fields_limit_exceeded"

--- a/crates/milli/src/error.rs
+++ b/crates/milli/src/error.rs
@@ -131,7 +131,7 @@ pub enum UserError {
     CelluliteError(#[from] cellulite::Error),
     #[error("Malformed geojson: {0}")]
     MalformedGeojson(serde_json::Error),
-    #[error("A document cannot contain more than 65,535 fields.")]
+    #[error("An index cannot contain more than 65,535 unique attribute fields.")]
     AttributeLimitReached,
     #[error(transparent)]
     CriterionError(#[from] CriterionError),


### PR DESCRIPTION
The `AttributeLimitReached` error message said "A document cannot contain more than 65,535 fields" but this limit applies to unique attribute fields across the entire index, not per-document. Updated the message and corresponding test snapshots.

Fixes #6237