### PR TITLE
Introduce the `RemoteAvailability` struct to support query fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4547,6 +4547,7 @@ dependencies = [
  "meili-snap",
  "memmap2",
  "milli",
+ "papaya",
  "roaring 0.10.12",
  "rustc-hash 2.1.1",
  "serde",
@@ -5151,9 +5152,9 @@ dependencies = [
 
 [[package]]
 name = "papaya"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92dd0b07c53a0a0c764db2ace8c541dc47320dad97c2200c2a637ab9dd2328f"
+checksum = "997ee03cd38c01469a7046643714f0ad28880bcb9e6679ff0666e24817ca19b7"
 dependencies = [
  "equivalent",
  "seize",

--- a/crates/dump/src/lib.rs
+++ b/crates/dump/src/lib.rs
@@ -619,7 +619,7 @@ pub(crate) mod test {
     fn create_test_network() -> Network {
         Network {
             local: Some("myself".to_string()),
-            remotes: maplit::btreemap! {"other".to_string() => Remote { url: "http://test".to_string(), search_api_key: Some("apiKey".to_string()), write_api_key: Some("docApiKey".to_string()) }},
+            remotes: maplit::btreemap! {"other".to_string() => Remote { url: "http://test".to_string(), search_api_key: Some("apiKey".to_string()), write_api_key: Some("docApiKey".to_string()), status: Default::default() }},
             leader: None,
             version: Default::default(),
             shards: maplit::btreemap! {"shard".to_string() => Shard { remotes: maplit::btreeset!["other".to_string()]} },

--- a/crates/index-scheduler/src/features.rs
+++ b/crates/index-scheduler/src/features.rs
@@ -4,6 +4,7 @@ use meilisearch_types::features::{InstanceTogglableFeatures, RuntimeTogglableFea
 use meilisearch_types::heed::types::{SerdeJson, Str};
 use meilisearch_types::heed::{Database, Env, RwTxn, WithoutTls};
 use meilisearch_types::network::Network;
+use meilisearch_types::network::{Network, RemoteAvailability};
 
 use crate::error::FeatureNotEnabledError;
 use crate::Result;
@@ -25,6 +26,7 @@ pub(crate) struct FeatureData {
     persisted: Database<Str, SerdeJson<RuntimeTogglableFeatures>>,
     runtime: Arc<RwLock<RuntimeTogglableFeatures>>,
     network: Arc<RwLock<Network>>,
+    remote_availability: Arc<RemoteAvailability>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -234,6 +236,7 @@ impl FeatureData {
             persisted: runtime_features_db,
             runtime,
             network: Arc::new(RwLock::new(network)),
+            remote_availability: Arc::new(RemoteAvailability::new()),
         })
     }
 
@@ -279,5 +282,8 @@ impl FeatureData {
 
     pub fn network(&self) -> Network {
         Network::clone(&*self.network.read().unwrap())
+
+    pub fn remote_availability(&self) -> &RemoteAvailability {
+        &self.remote_availability
     }
 }

--- a/crates/index-scheduler/src/features.rs
+++ b/crates/index-scheduler/src/features.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, RwLock};
 use meilisearch_types::features::{InstanceTogglableFeatures, RuntimeTogglableFeatures};
 use meilisearch_types::heed::types::{SerdeJson, Str};
 use meilisearch_types::heed::{Database, Env, RwTxn, WithoutTls};
-use meilisearch_types::network::Network;
+use meilisearch_types::network::route::Status;
 use meilisearch_types::network::{Network, RemoteAvailability};
 
 use crate::error::FeatureNotEnabledError;
@@ -281,7 +281,16 @@ impl FeatureData {
     }
 
     pub fn network(&self) -> Network {
-        Network::clone(&*self.network.read().unwrap())
+        let mut network = Network::clone(&*self.network.read().unwrap());
+        for (remote_name, remote) in network.remotes.iter_mut() {
+            remote.status = if self.remote_availability.is_available(remote_name) {
+                Status::Available
+            } else {
+                Status::Unavailable
+            };
+        }
+        network
+    }
 
     pub fn remote_availability(&self) -> &RemoteAvailability {
         &self.remote_availability

--- a/crates/index-scheduler/src/lib.rs
+++ b/crates/index-scheduler/src/lib.rs
@@ -72,6 +72,7 @@ use meilisearch_types::milli::vector::{
 };
 use meilisearch_types::milli::{self, Index};
 use meilisearch_types::network::Network;
+use meilisearch_types::network::{Network, RemoteAvailability};
 use meilisearch_types::task_view::TaskView;
 use meilisearch_types::tasks::network::{
     DbTaskNetwork, NetworkTopologyChange, Origin, TaskNetwork,
@@ -1130,6 +1131,10 @@ impl IndexScheduler {
 
     pub fn features(&self) -> RoFeatures {
         self.features.features()
+    }
+
+    pub fn remote_availability(&self) -> &RemoteAvailability {
+        self.features.remote_availability()
     }
 
     pub fn put_runtime_features(&self, features: RuntimeTogglableFeatures) -> Result<()> {

--- a/crates/index-scheduler/src/lib.rs
+++ b/crates/index-scheduler/src/lib.rs
@@ -71,7 +71,7 @@ use meilisearch_types::milli::vector::{
     Embedder, EmbedderOptions, RuntimeEmbedder, RuntimeEmbedders, RuntimeFragment,
 };
 use meilisearch_types::milli::{self, Index};
-use meilisearch_types::network::Network;
+use meilisearch_types::network::route::Status;
 use meilisearch_types::network::{Network, RemoteAvailability};
 use meilisearch_types::task_view::TaskView;
 use meilisearch_types::tasks::network::{
@@ -928,6 +928,17 @@ impl IndexScheduler {
             self.scheduler.wake_up.signal();
         }
         Ok(())
+    }
+
+    pub fn network_status_change_for_remote(
+        &self,
+        remote_name: String,
+        status: Status,
+    ) -> Result<(), Error> {
+        match status {
+            Status::Available => self.mark_remote_available(&remote_name),
+            Status::Unavailable => self.mark_remote_unavailable_indefinitely(remote_name),
+        }
     }
 
     fn update_network_task<F, O>(

--- a/crates/index-scheduler/src/scheduler/community_edition.rs
+++ b/crates/index-scheduler/src/scheduler/community_edition.rs
@@ -39,6 +39,24 @@ impl IndexScheduler {
         Err(Error::RequiresEnterpriseEdition { action: "processing a network task" })
     }
 
+    pub fn is_remote_available(&self, _remote_name: &str) -> Result<bool> {
+        Err(Error::RequiresEnterpriseEdition { action: "checking the availability of a remote" })
+    }
+
+    pub fn mark_remote_unavailable(&self, _remote_name: String) -> Result<()> {
+        Err(Error::RequiresEnterpriseEdition { action: "marking a remote as unavailable" })
+    }
+
+    pub fn mark_remote_unavailable_indefinitely(&self, _remote_name: String) -> Result<()> {
+        Err(Error::RequiresEnterpriseEdition {
+            action: "marking a remote as unavailable indefinitely",
+        })
+    }
+
+    pub fn mark_remote_available(&self, _remote_name: &str) -> Result<()> {
+        Err(Error::RequiresEnterpriseEdition { action: "marking a remote as available" })
+    }
+
     #[cfg(unix)]
     pub(super) async fn process_snapshot_to_s3(
         &self,

--- a/crates/index-scheduler/src/scheduler/enterprise_edition/network.rs
+++ b/crates/index-scheduler/src/scheduler/enterprise_edition/network.rs
@@ -506,6 +506,25 @@ impl IndexScheduler {
 
         Ok(())
     }
+
+    pub fn is_remote_available(&self, remote_name: &str) -> Result<bool> {
+        Ok(self.remote_availability().is_available(remote_name))
+    }
+
+    pub fn mark_remote_unavailable(&self, remote_name: String) -> Result<()> {
+        self.remote_availability().mark_unavailable(remote_name);
+        Ok(())
+    }
+
+    pub fn mark_remote_unavailable_indefinitely(&self, remote_name: String) -> Result<()> {
+        self.remote_availability().mark_unavailable_indefinitely(remote_name);
+        Ok(())
+    }
+
+    pub fn mark_remote_available(&self, remote_name: &str) -> Result<()> {
+        self.remote_availability().mark_available(remote_name);
+        Ok(())
+    }
 }
 
 fn docids_for_shard<'a>(

--- a/crates/meilisearch-types/Cargo.toml
+++ b/crates/meilisearch-types/Cargo.toml
@@ -28,6 +28,7 @@ fst = "0.4.7"
 itertools = "0.14.0"
 memmap2 = "0.9.9"
 milli = { path = "../milli" }
+papaya = "0.2.4"
 roaring = { version = "0.10.12", features = ["serde"] }
 rustc-hash = "2.1.1"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/crates/meilisearch-types/src/network.rs
+++ b/crates/meilisearch-types/src/network.rs
@@ -1,7 +1,12 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::time::{Duration, Instant};
 
+use papaya::HashMap;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
+
+const BASE_UNAVAILABILITY_DURATION: Duration = Duration::from_secs(30); // 30s
+const MAX_UNAVAILABILITY_DURATION: Duration = Duration::from_mins(5); //   5min
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
 #[serde(rename_all = "camelCase")]
@@ -26,12 +31,96 @@ pub struct Remote {
     pub search_api_key: Option<String>,
     #[serde(default)]
     pub write_api_key: Option<String>,
+    #[serde(skip_deserializing)]
+    pub status: route::Status,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct Shard {
     pub remotes: BTreeSet<String>,
+}
+
+/// Keeps track of the unavailability period for each remote.
+#[derive(Debug)]
+pub struct RemoteAvailability(HashMap<String, Unavailability>);
+
+impl Default for RemoteAvailability {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RemoteAvailability {
+    pub fn new() -> Self {
+        Self(HashMap::default())
+    }
+
+    /// Returns `true` if the remote is available, `false` otherwise.
+    pub fn is_available(&self, remote: &str) -> bool {
+        self.0.pin().get(remote).is_none_or(Unavailability::is_available)
+    }
+
+    /// Marks a remote as unavailable indefinitely, removing any existing unavailability period.
+    pub fn mark_unavailable_indefinitely(&self, remote: String) {
+        self.0.pin().update_or_insert_with(
+            remote,
+            |_| Unavailability::indefinite(),
+            Unavailability::indefinite,
+        );
+    }
+
+    /// Marks a remote as unavailable, extending the existing unavailability period if any.
+    pub fn mark_unavailable(&self, remote: String) {
+        self.0.pin().update_or_insert_with(
+            remote,
+            Unavailability::next_unavailability,
+            Unavailability::default,
+        );
+    }
+
+    /// Marks a remote as available, removing any existing unavailability period.
+    pub fn mark_available(&self, remote: &str) {
+        self.0.pin().remove(remote);
+    }
+}
+
+/// Represents an unavailability period for a remote index
+#[derive(Debug)]
+struct Unavailability {
+    /// From when the unavailability started
+    since: Instant,
+    /// Until when the unavailability ends. None means the unavailability is indefinite.
+    until: Option<Instant>,
+}
+
+impl Unavailability {
+    fn indefinite() -> Self {
+        Self { since: Instant::now(), until: None }
+    }
+
+    fn is_available(&self) -> bool {
+        self.until.is_some_and(|u| Instant::now() > u)
+    }
+
+    fn next_unavailability(&self) -> Self {
+        let Unavailability { since, until } = *self;
+        match until {
+            Some(until) => {
+                let now = Instant::now();
+                let new_duration = ((until - since) * 2).min(MAX_UNAVAILABILITY_DURATION);
+                Self { since: now, until: Some(now + new_duration) }
+            }
+            None => Unavailability { since, until: None },
+        }
+    }
+}
+
+impl Default for Unavailability {
+    fn default() -> Self {
+        let now = Instant::now();
+        Self { since: now, until: Some(now + BASE_UNAVAILABILITY_DURATION) }
+    }
 }
 
 pub mod route {
@@ -80,6 +169,24 @@ pub mod route {
             /// importing their documents.
             successful: bool,
         },
+        /// The specified remote will see it's status change.
+        ///
+        /// Send this message to change the accessiblity of a remote.
+        StatusChangeForRemote {
+            /// Name of the remote whose status will be changed.
+            remote: String,
+            /// The new status for the remote.
+            status: Status,
+        },
+    }
+
+    #[derive(Debug, Default, Serialize, Deserialize, ToSchema, Clone, PartialEq, Eq)]
+    #[serde(rename_all = "camelCase")]
+    #[schema(rename_all = "camelCase")]
+    pub enum Status {
+        #[default]
+        Available,
+        Unavailable,
     }
 
     #[derive(Serialize, Deserialize, ToSchema)]

--- a/crates/meilisearch-types/src/network.rs
+++ b/crates/meilisearch-types/src/network.rs
@@ -57,8 +57,11 @@ impl RemoteAvailability {
     }
 
     /// Returns `true` if the remote is available, `false` otherwise.
+    ///
+    /// Note that this method modifies the internal state by removing
+    /// any expired unavailability periods.
     pub fn is_available(&self, remote: &str) -> bool {
-        self.0.pin().get(remote).is_none_or(Unavailability::is_available)
+        self.0.pin().remove_if(remote, |_, u| Unavailability::is_available(u)).is_ok()
     }
 
     /// Marks a remote as unavailable indefinitely, removing any existing unavailability period.

--- a/crates/meilisearch/src/routes/indexes/search.rs
+++ b/crates/meilisearch/src/routes/indexes/search.rs
@@ -606,10 +606,11 @@ pub(crate) async fn search(
 
     let features = index_scheduler.features();
     let network = index_scheduler.network();
+    let remote_availability = index_scheduler.remote_availability();
 
     let (mut search_result, deadline) = if query.must_use_network(&network, &features)? {
         let mut federation = Federation::default();
-        let queries = Partition::new(network)
+        let queries = Partition::new(network, remote_availability)
             .into_query_partition(&mut federation, &query, None, &index_uid)?
             .collect();
 

--- a/crates/meilisearch/src/routes/network/enterprise_edition.rs
+++ b/crates/meilisearch/src/routes/network/enterprise_edition.rs
@@ -417,6 +417,9 @@ pub async fn post_network_change(
         route::Message::ImportFinishedForRemote { remote, successful } => {
             index_scheduler.network_import_finished_for_remote(remote, successful, payload.origin)
         }
+        route::Message::StatusChangeForRemote { remote, status } => {
+            index_scheduler.network_status_change_for_remote(remote, status)
+        }
     })
     .await
     .map_err(|e| ResponseError::from_msg(e.to_string(), Code::Internal))??;

--- a/crates/meilisearch/src/routes/network/mod.rs
+++ b/crates/meilisearch/src/routes/network/mod.rs
@@ -263,6 +263,7 @@ impl Remote {
                 })?,
             search_api_key: self.search_api_key.set(),
             write_api_key: self.write_api_key.set(),
+            status: route::Status::default(),
         })
     }
 }
@@ -440,6 +441,7 @@ fn merge_networks(
                             url: old_url,
                             search_api_key: old_search_api_key,
                             write_api_key: old_write_api_key,
+                            status: _,
                         } = old;
 
                         let Remote {
@@ -479,6 +481,7 @@ fn merge_networks(
                                 Setting::Reset => None,
                                 Setting::NotSet => old_write_api_key,
                             },
+                            status: Default::default(),
                         };
                         merged_remotes.insert(key, merged);
                     }

--- a/crates/meilisearch/src/search/federated/network.rs
+++ b/crates/meilisearch/src/search/federated/network.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use meilisearch_types::error::ResponseError;
 use meilisearch_types::index_uid::IndexUid;
-use meilisearch_types::network::{Network, Remote};
+use meilisearch_types::network::{Network, Remote, RemoteAvailability};
 
 use crate::search::{Federation, FederationOptions, SearchQuery, SearchQueryWithIndex};
 
@@ -22,9 +22,11 @@ pub enum Partition {
 }
 
 impl Partition {
-    pub fn new(network: Network) -> Self {
+    pub fn new(network: Network, remote_availability: &RemoteAvailability) -> Self {
         if network.leader.is_some() {
-            Partition::ByShard { remote_for_shard: current_edition::remote_for_shard(network) }
+            Partition::ByShard {
+                remote_for_shard: current_edition::remote_for_shard(network, remote_availability),
+            }
         } else {
             Partition::ByRemote { remotes: network.remotes }
         }

--- a/crates/meilisearch/src/search/federated/network/community_edition.rs
+++ b/crates/meilisearch/src/search/federated/network/community_edition.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use meilisearch_types::error::{Code, ResponseError};
-use meilisearch_types::network::Network;
+use meilisearch_types::network::{Network, RemoteAvailability};
 
 use crate::search::SearchQueryWithIndex;
 
@@ -15,6 +15,9 @@ pub fn partition_shards(
     ))
 }
 
-pub(super) fn remote_for_shard(_network: Network) -> BTreeMap<String, String> {
+pub(super) fn remote_for_shard(
+    _network: Network,
+    _remotes_statuses: &RemoteAvailability,
+) -> BTreeMap<String, String> {
     Default::default()
 }

--- a/crates/meilisearch/src/search/federated/network/enterprise_edition.rs
+++ b/crates/meilisearch/src/search/federated/network/enterprise_edition.rs
@@ -6,6 +6,7 @@
 use std::collections::BTreeMap;
 
 use meilisearch_types::milli::SHARD_FIELD;
+use meilisearch_types::network::RemoteAvailability;
 use meilisearch_types::{error::ResponseError, network::Network};
 use rand::seq::IteratorRandom as _;
 
@@ -30,7 +31,10 @@ pub fn partition_shards(
     }))
 }
 
-pub(super) fn remote_for_shard(network: Network) -> BTreeMap<String, String> {
+pub(super) fn remote_for_shard(
+    network: Network,
+    remote_availability: &RemoteAvailability,
+) -> BTreeMap<String, String> {
     let mut rng = rand::thread_rng();
     let local = network.local;
 
@@ -46,7 +50,11 @@ pub(super) fn remote_for_shard(network: Network) -> BTreeMap<String, String> {
                     Some(local) if shard.remotes.contains(local) => local.clone(),
                     // otherwise pick a random other remote
                     _ => {
-                        let Some(remote_for_shard) = shard.remotes.into_iter().choose(&mut rng)
+                        let Some(remote_for_shard) = shard
+                            .remotes
+                            .into_iter()
+                            .filter(|remote| remote_availability.is_available(remote))
+                            .choose(&mut rng)
                         else {
                             tracing::warn!("No remote for shard {shard_name}");
                             return None;

--- a/crates/meilisearch/src/search/federated/perform.rs
+++ b/crates/meilisearch/src/search/federated/perform.rs
@@ -432,10 +432,10 @@ pub async fn perform_federated_search(
     let performance_details =
         federation.show_performance_details.then(|| progress.accumulated_durations());
 
-    if index_scheduler.features().check_network("Track remotes availability").is_ok() {
+    if !network.shards.is_empty() {
         for (remote_name, error) in &remote_errors {
             if error.code.is_server_error() {
-                index_scheduler.mark_remote_unavailable(remote_name.clone())?
+                index_scheduler.mark_remote_unavailable(remote_name.clone())?;
             }
         }
     }

--- a/crates/meilisearch/src/search/federated/perform.rs
+++ b/crates/meilisearch/src/search/federated/perform.rs
@@ -7,25 +7,6 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use std::vec::{IntoIter, Vec};
 
-use super::super::ranking_rules::{self, RankingRules};
-use super::super::{
-    compute_facet_distribution_stats, prepare_search, resolve_pins, AttributesFormat,
-    ComputedFacets, HitMaker, HitsInfo, RetrieveVectors, SearchHit, SearchKind, SearchMetadata,
-    SearchQuery, SearchQueryWithIndex,
-};
-use super::proxy::{proxy_search, ProxySearchError, ProxySearchParams};
-use super::types::{
-    FederatedFacets, FederatedSearchResult, Federation, FederationOptions, MergeFacets, Weight,
-    FEDERATION_HIT, FEDERATION_REMOTE, PINNED_POSITION, WEIGHTED_SCORE_VALUES,
-};
-use super::weighted_scores;
-use crate::error::MeilisearchHttpError;
-use crate::routes::indexes::search::search_kind;
-use crate::search::federated::types::{
-    FEDERATION_EXTRA_DOCUMENT, INDEX_UID, QUERIES_POSITION, WEIGHTED_RANKING_SCORE,
-};
-use crate::search::hydration::{FederatedHydrationFormatter, HydrationContext};
-use crate::search::{parse_filter, NetworkableQuery as _, DEFAULT_SEARCH_LIMIT};
 use actix_http::StatusCode;
 use actix_web::web::Data;
 use index_scheduler::filter::{
@@ -50,6 +31,26 @@ use meilisearch_types::Document;
 use roaring::RoaringBitmap;
 use tokio::task::JoinHandle;
 use uuid::Uuid;
+
+use super::super::ranking_rules::{self, RankingRules};
+use super::super::{
+    compute_facet_distribution_stats, prepare_search, resolve_pins, AttributesFormat,
+    ComputedFacets, HitMaker, HitsInfo, RetrieveVectors, SearchHit, SearchKind, SearchMetadata,
+    SearchQuery, SearchQueryWithIndex,
+};
+use super::proxy::{proxy_search, ProxySearchError, ProxySearchParams};
+use super::types::{
+    FederatedFacets, FederatedSearchResult, Federation, FederationOptions, MergeFacets, Weight,
+    FEDERATION_HIT, FEDERATION_REMOTE, PINNED_POSITION, WEIGHTED_SCORE_VALUES,
+};
+use super::weighted_scores;
+use crate::error::MeilisearchHttpError;
+use crate::routes::indexes::search::search_kind;
+use crate::search::federated::types::{
+    FEDERATION_EXTRA_DOCUMENT, INDEX_UID, QUERIES_POSITION, WEIGHTED_RANKING_SCORE,
+};
+use crate::search::hydration::{FederatedHydrationFormatter, HydrationContext};
+use crate::search::{parse_filter, NetworkableQuery as _, DEFAULT_SEARCH_LIMIT};
 
 #[allow(clippy::too_many_arguments)]
 pub async fn perform_federated_search(
@@ -433,7 +434,7 @@ pub async fn perform_federated_search(
         federation.show_performance_details.then(|| progress.accumulated_durations());
 
     if !network.shards.is_empty() {
-        for (remote_name, error) in &remote_errors {
+        for (remote_name, error) in remote_errors.iter().flatten() {
             if error.code.is_server_error() {
                 index_scheduler.mark_remote_unavailable(remote_name.clone())?;
             }
@@ -990,6 +991,7 @@ impl PartitionedQueries {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn partition(
         &mut self,
         federation: &mut Federation,

--- a/crates/meilisearch/src/search/federated/perform.rs
+++ b/crates/meilisearch/src/search/federated/perform.rs
@@ -44,7 +44,7 @@ use meilisearch_types::milli::{
     self, merge_positioned_hits_into_page, serialize_index_filter_to_filter_string, Deadline,
     DocumentId, FederatingResultsStep, IndexFilter, OrderBy, DEFAULT_VALUES_PER_FACET,
 };
-use meilisearch_types::network::{Network, Remote};
+use meilisearch_types::network::{Network, Remote, RemoteAvailability};
 use meilisearch_types::settings::DEFAULT_PAGINATION_MAX_TOTAL_HITS;
 use meilisearch_types::Document;
 use roaring::RoaringBitmap;
@@ -172,9 +172,13 @@ pub async fn perform_federated_search(
             query_index,
             &network,
             features,
+            index_scheduler.remote_availability(),
         )?
     }
     let federation = federation;
+
+    let remotes_to_query: HashSet<_> =
+        partitioned_queries.remote_queries_by_host.keys().cloned().collect();
 
     // 2. perform queries, merge and make hits index by index
     // 2.1. start remote queries
@@ -430,6 +434,17 @@ pub async fn perform_federated_search(
     let remote_errors = partitioned_queries.has_remote.then_some(remote_errors);
     let performance_details =
         federation.show_performance_details.then(|| progress.accumulated_durations());
+
+    if index_scheduler.features().check_network("Track remotes availability").is_ok() {
+        for remote_name in remotes_to_query {
+            match remote_errors.get(&remote_name) {
+                Some(error) if error.code.is_server_error() => {
+                    index_scheduler.mark_remote_unavailable(remote_name)?
+                }
+                _ => index_scheduler.mark_remote_available(&remote_name)?,
+            }
+        }
+    }
 
     Ok((
         FederatedSearchResult {
@@ -989,6 +1004,7 @@ impl PartitionedQueries {
         query_index: usize,
         network: &Network,
         features: RoFeatures,
+        remote_availability: &RemoteAvailability,
     ) -> Result<(), ResponseError> {
         if let Some(pagination_field) = federated_query.has_pagination() {
             return Err(MeilisearchHttpError::PaginationInFederatedQuery(
@@ -1032,7 +1048,8 @@ impl PartitionedQueries {
 
         let (index_uid, query, federation_options);
         let queries = if federated_query.must_use_network(network, &features)? {
-            let partition = partition.get_or_insert_with(|| super::Partition::new(network.clone()));
+            let partition = partition
+                .get_or_insert_with(|| super::Partition::new(network.clone(), remote_availability));
             (index_uid, query, federation_options) = federated_query.into_index_query_federation();
 
             either::Left(partition.to_query_partition(

--- a/crates/meilisearch/src/search/federated/perform.rs
+++ b/crates/meilisearch/src/search/federated/perform.rs
@@ -177,9 +177,6 @@ pub async fn perform_federated_search(
     }
     let federation = federation;
 
-    let remotes_to_query: HashSet<_> =
-        partitioned_queries.remote_queries_by_host.keys().cloned().collect();
-
     // 2. perform queries, merge and make hits index by index
     // 2.1. start remote queries
     progress.update_progress(FederatingResultsStep::StartRemoteSearch);
@@ -436,12 +433,9 @@ pub async fn perform_federated_search(
         federation.show_performance_details.then(|| progress.accumulated_durations());
 
     if index_scheduler.features().check_network("Track remotes availability").is_ok() {
-        for remote_name in remotes_to_query {
-            match remote_errors.get(&remote_name) {
-                Some(error) if error.code.is_server_error() => {
-                    index_scheduler.mark_remote_unavailable(remote_name)?
-                }
-                _ => index_scheduler.mark_remote_available(&remote_name)?,
+        for (remote_name, error) in &remote_errors {
+            if error.code.is_server_error() {
+                index_scheduler.mark_remote_unavailable(remote_name.clone())?
             }
         }
     }

--- a/crates/meilisearch/tests/network/mod.rs
+++ b/crates/meilisearch/tests/network/mod.rs
@@ -193,7 +193,8 @@ async fn errors_on_param() {
         "kefir": {
           "url": "http://localhost:7700",
           "searchApiKey": null,
-          "writeApiKey": null
+          "writeApiKey": null,
+          "status": "available"
         }
       },
       "shards": {},
@@ -440,12 +441,14 @@ async fn get_and_set_network() {
         "myself": {
           "url": "http://localhost:7700",
           "searchApiKey": null,
-          "writeApiKey": null
+          "writeApiKey": null,
+          "status": "available"
         },
         "thy": {
           "url": "http://localhost:7701",
           "searchApiKey": "foo",
-          "writeApiKey": null
+          "writeApiKey": null,
+          "status": "available"
         }
       },
       "shards": {},
@@ -471,12 +474,14 @@ async fn get_and_set_network() {
         "myself": {
           "url": "http://localhost:7700",
           "searchApiKey": null,
-          "writeApiKey": null
+          "writeApiKey": null,
+          "status": "available"
         },
         "thy": {
           "url": "http://localhost:7701",
           "searchApiKey": "bar",
-          "writeApiKey": null
+          "writeApiKey": null,
+          "status": "available"
         }
       },
       "shards": {},
@@ -503,17 +508,20 @@ async fn get_and_set_network() {
         "myself": {
           "url": "http://localhost:7700",
           "searchApiKey": null,
-          "writeApiKey": null
+          "writeApiKey": null,
+          "status": "available"
         },
         "them": {
           "url": "http://localhost:7702",
           "searchApiKey": "baz",
-          "writeApiKey": null
+          "writeApiKey": null,
+          "status": "available"
         },
         "thy": {
           "url": "http://localhost:7701",
           "searchApiKey": "bar",
-          "writeApiKey": null
+          "writeApiKey": null,
+          "status": "available"
         }
       },
       "shards": {},
@@ -537,12 +545,14 @@ async fn get_and_set_network() {
         "them": {
           "url": "http://localhost:7702",
           "searchApiKey": "baz",
-          "writeApiKey": null
+          "writeApiKey": null,
+          "status": "available"
         },
         "thy": {
           "url": "http://localhost:7701",
           "searchApiKey": "bar",
-          "writeApiKey": null
+          "writeApiKey": null,
+          "status": "available"
         }
       },
       "shards": {},
@@ -562,12 +572,14 @@ async fn get_and_set_network() {
         "them": {
           "url": "http://localhost:7702",
           "searchApiKey": "baz",
-          "writeApiKey": null
+          "writeApiKey": null,
+          "status": "available"
         },
         "thy": {
           "url": "http://localhost:7701",
           "searchApiKey": "bar",
-          "writeApiKey": null
+          "writeApiKey": null,
+          "status": "available"
         }
       },
       "shards": {},
@@ -587,12 +599,14 @@ async fn get_and_set_network() {
         "them": {
           "url": "http://localhost:7702",
           "searchApiKey": "baz",
-          "writeApiKey": null
+          "writeApiKey": null,
+          "status": "available"
         },
         "thy": {
           "url": "http://localhost:7701",
           "searchApiKey": "bar",
-          "writeApiKey": null
+          "writeApiKey": null,
+          "status": "available"
         }
       },
       "shards": {},
@@ -612,12 +626,14 @@ async fn get_and_set_network() {
         "them": {
           "url": "http://localhost:7702",
           "searchApiKey": "baz",
-          "writeApiKey": null
+          "writeApiKey": null,
+          "status": "available"
         },
         "thy": {
           "url": "http://localhost:7701",
           "searchApiKey": "bar",
-          "writeApiKey": null
+          "writeApiKey": null,
+          "status": "available"
         }
       },
       "shards": {},
@@ -637,12 +653,14 @@ async fn get_and_set_network() {
         "them": {
           "url": "http://localhost:7702",
           "searchApiKey": "baz",
-          "writeApiKey": null
+          "writeApiKey": null,
+          "status": "available"
         },
         "thy": {
           "url": "http://localhost:7701",
           "searchApiKey": "bar",
-          "writeApiKey": null
+          "writeApiKey": null,
+          "status": "available"
         }
       },
       "shards": {},
@@ -662,12 +680,14 @@ async fn get_and_set_network() {
         "them": {
           "url": "http://localhost:7702",
           "searchApiKey": "baz",
-          "writeApiKey": null
+          "writeApiKey": null,
+          "status": "available"
         },
         "thy": {
           "url": "http://localhost:7701",
           "searchApiKey": "bar",
-          "writeApiKey": null
+          "writeApiKey": null,
+          "status": "available"
         }
       },
       "shards": {},

--- a/crates/meilisearch/tests/search/multi/proxy.rs
+++ b/crates/meilisearch/tests/search/multi/proxy.rs
@@ -4690,17 +4690,20 @@ async fn remote_auto_sharding() {
         "ms0": {
           "url": "[url]",
           "searchApiKey": null,
-          "writeApiKey": null
+          "writeApiKey": null,
+          "status": "available"
         },
         "ms1": {
           "url": "[url]",
           "searchApiKey": null,
-          "writeApiKey": null
+          "writeApiKey": null,
+          "status": "available"
         },
         "ms2": {
           "url": "[url]",
           "searchApiKey": null,
-          "writeApiKey": null
+          "writeApiKey": null,
+          "status": "available"
         }
       },
       "shards": {
@@ -4734,17 +4737,20 @@ async fn remote_auto_sharding() {
         "ms0": {
           "url": "[url]",
           "searchApiKey": null,
-          "writeApiKey": null
+          "writeApiKey": null,
+          "status": "available"
         },
         "ms1": {
           "url": "[url]",
           "searchApiKey": null,
-          "writeApiKey": null
+          "writeApiKey": null,
+          "status": "available"
         },
         "ms2": {
           "url": "[url]",
           "searchApiKey": null,
-          "writeApiKey": null
+          "writeApiKey": null,
+          "status": "available"
         }
       },
       "shards": {
@@ -4778,17 +4784,20 @@ async fn remote_auto_sharding() {
         "ms0": {
           "url": "[url]",
           "searchApiKey": null,
-          "writeApiKey": null
+          "writeApiKey": null,
+          "status": "available"
         },
         "ms1": {
           "url": "[url]",
           "searchApiKey": null,
-          "writeApiKey": null
+          "writeApiKey": null,
+          "status": "available"
         },
         "ms2": {
           "url": "[url]",
           "searchApiKey": null,
-          "writeApiKey": null
+          "writeApiKey": null,
+          "status": "available"
         }
       },
       "shards": {
@@ -5489,17 +5498,20 @@ async fn remote_auto_sharding_auto_search() {
         "ms0": {
           "url": "[url]",
           "searchApiKey": null,
-          "writeApiKey": null
+          "writeApiKey": null,
+          "status": "available"
         },
         "ms1": {
           "url": "[url]",
           "searchApiKey": null,
-          "writeApiKey": null
+          "writeApiKey": null,
+          "status": "available"
         },
         "ms2": {
           "url": "[url]",
           "searchApiKey": null,
-          "writeApiKey": null
+          "writeApiKey": null,
+          "status": "available"
         }
       },
       "shards": {
@@ -5533,17 +5545,20 @@ async fn remote_auto_sharding_auto_search() {
         "ms0": {
           "url": "[url]",
           "searchApiKey": null,
-          "writeApiKey": null
+          "writeApiKey": null,
+          "status": "available"
         },
         "ms1": {
           "url": "[url]",
           "searchApiKey": null,
-          "writeApiKey": null
+          "writeApiKey": null,
+          "status": "available"
         },
         "ms2": {
           "url": "[url]",
           "searchApiKey": null,
-          "writeApiKey": null
+          "writeApiKey": null,
+          "status": "available"
         }
       },
       "shards": {
@@ -5577,17 +5592,20 @@ async fn remote_auto_sharding_auto_search() {
         "ms0": {
           "url": "[url]",
           "searchApiKey": null,
-          "writeApiKey": null
+          "writeApiKey": null,
+          "status": "available"
         },
         "ms1": {
           "url": "[url]",
           "searchApiKey": null,
-          "writeApiKey": null
+          "writeApiKey": null,
+          "status": "available"
         },
         "ms2": {
           "url": "[url]",
           "searchApiKey": null,
-          "writeApiKey": null
+          "writeApiKey": null,
+          "status": "available"
         }
       },
       "shards": {
@@ -6040,17 +6058,20 @@ async fn remote_auto_sharding_with_custom_metadata() {
         "ms0": {
           "url": "[url]",
           "searchApiKey": null,
-          "writeApiKey": null
+          "writeApiKey": null,
+          "status": "available"
         },
         "ms1": {
           "url": "[url]",
           "searchApiKey": null,
-          "writeApiKey": null
+          "writeApiKey": null,
+          "status": "available"
         },
         "ms2": {
           "url": "[url]",
           "searchApiKey": null,
-          "writeApiKey": null
+          "writeApiKey": null,
+          "status": "available"
         }
       },
       "shards": {
@@ -6084,17 +6105,20 @@ async fn remote_auto_sharding_with_custom_metadata() {
         "ms0": {
           "url": "[url]",
           "searchApiKey": null,
-          "writeApiKey": null
+          "writeApiKey": null,
+          "status": "available"
         },
         "ms1": {
           "url": "[url]",
           "searchApiKey": null,
-          "writeApiKey": null
+          "writeApiKey": null,
+          "status": "available"
         },
         "ms2": {
           "url": "[url]",
           "searchApiKey": null,
-          "writeApiKey": null
+          "writeApiKey": null,
+          "status": "available"
         }
       },
       "shards": {
@@ -6128,17 +6152,20 @@ async fn remote_auto_sharding_with_custom_metadata() {
         "ms0": {
           "url": "[url]",
           "searchApiKey": null,
-          "writeApiKey": null
+          "writeApiKey": null,
+          "status": "available"
         },
         "ms1": {
           "url": "[url]",
           "searchApiKey": null,
-          "writeApiKey": null
+          "writeApiKey": null,
+          "status": "available"
         },
         "ms2": {
           "url": "[url]",
           "searchApiKey": null,
-          "writeApiKey": null
+          "writeApiKey": null,
+          "status": "available"
         }
       },
       "shards": {

--- a/workloads/tests/network.json
+++ b/workloads/tests/network.json
@@ -100,17 +100,9 @@
       "method": "PATCH",
       "body": {
         "inline": {
-          "filterableAttributes": [
-            "genres",
-            "release_date"
-          ],
-          "searchableAttributes": [
-            "title",
-            "overview"
-          ],
-          "sortableAttributes": [
-            "release_date"
-          ]
+          "filterableAttributes": ["genres", "release_date"],
+          "searchableAttributes": ["title", "overview"],
+          "sortableAttributes": ["release_date"]
         }
       },
       "expectedStatus": 202,
@@ -274,17 +266,9 @@
             "batchUid": 0,
             "canceledBy": null,
             "details": {
-              "filterableAttributes": [
-                "genres",
-                "release_date"
-              ],
-              "searchableAttributes": [
-                "title",
-                "overview"
-              ],
-              "sortableAttributes": [
-                "release_date"
-              ]
+              "filterableAttributes": ["genres", "release_date"],
+              "searchableAttributes": ["title", "overview"],
+              "sortableAttributes": ["release_date"]
             },
             "duration": "[duration]",
             "enqueuedAt": "[timestamp]",
@@ -321,26 +305,31 @@
         "remotes": {
           "prod1": {
             "searchApiKey": "foo1",
+            "status": "available",
             "url": "http://localhost:7701",
             "writeApiKey": "bar1"
           },
           "prod2": {
             "searchApiKey": "foo2",
+            "status": "available",
             "url": "http://localhost:7702",
             "writeApiKey": "bar2"
           },
           "prod3": {
             "searchApiKey": "foo3",
+            "status": "available",
             "url": "http://localhost:7703",
             "writeApiKey": "bar3"
           },
           "prod4": {
             "searchApiKey": "foo4",
+            "status": "available",
             "url": "http://localhost:7704",
             "writeApiKey": "bar4"
           },
           "prod5": {
             "searchApiKey": "foo5",
+            "status": "available",
             "url": "http://localhost:7705",
             "writeApiKey": "bar5"
           }
@@ -348,29 +337,19 @@
         "self": "prod1",
         "shards": {
           "prod1": {
-            "remotes": [
-              "prod1"
-            ]
+            "remotes": ["prod1"]
           },
           "prod2": {
-            "remotes": [
-              "prod2"
-            ]
+            "remotes": ["prod2"]
           },
           "prod3": {
-            "remotes": [
-              "prod3"
-            ]
+            "remotes": ["prod3"]
           },
           "prod4": {
-            "remotes": [
-              "prod4"
-            ]
+            "remotes": ["prod4"]
           },
           "prod5": {
-            "remotes": [
-              "prod5"
-            ]
+            "remotes": ["prod5"]
           }
         },
         "version": "00000000-0000-0000-0000-000000000000"


### PR DESCRIPTION
This PR implements a fallback system when using the network feature to prevent unavailable remotes from being queried for a period. We introduced an exponentially increasing unavailability duration, capped at 5 minutes and starting at 30 seconds. This PR also exposes a new /network/control command to mark remotes as available or indefinitely unavailable.

## Changelog

We introduce a new fallback system for the sharding and replication enterprise edition feature, along with a way to determine which remote is available. The engine can avoid machines that are unavailable for a period and resume querying them once they're back online.

The following snippet shows what the /network route looks like now that this PR exposes the remote statuses/availabilities.

```json
"remotes": {
	"prod2": {
	  "url": "http://localhost:7702",
	  "searchApiKey": "mykey",
	  "writeApiKey": "mykey",
	  "status": "available"
	},
	"prod3": {
	  "url": "http://localhost:7703",
	  "searchApiKey": "mykey",
	  "writeApiKey": "mykey",
	  "status": "unavailable"
	}
}
```

## This PR makes forward-compatible changes

*Forward-compatible changes are changes to the database such that databases created in an older version of Meilisearch are still valid in the new version of Meilisearch. They usually represent additive changes, like adding a new optional attribute or setting.*

### Detail the change to the DB format and why it is forward compatible

I added the new `status` field to the Network structure. This structure is serialized to disk. To make it compatible to read the previous version of a Network topology, I made sure [to `skip_deserializing` the `status` field](https://serde.rs/field-attrs.html#skip_deserializing). However, this field is still serialized for inclusion in the HTTP response. Which also means that it is serialized to disk.

- [x] Forward-compatibility: A database created before this PR and using the features touched by this PR was able to be opened by a Meilisearch produced by the code of this PR.
- [ ] Declarative test: add a [declarative test containing a dumpless upgrade](https://github.com/meilisearch/meilisearch/blob/main/TESTING.md#typical-usage)

## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respects the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - *list of used tools and what they were used for*