### PR TITLE
Try the latest version of LMDB for nested read txn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3137,8 +3137,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "heed"
 version = "0.22.1-nested-rtxns-7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4679efe3143dcb1b7d82023d532c42445f840bd5156efb4d5fb1a2258f06cbc"
+source = "git+https://github.com/meilisearch/heed?branch=allow-nested-rtxn-from-wtxn#1da4f76d7c42377f270632b8c79089990ee43107"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",
@@ -3155,14 +3154,12 @@ dependencies = [
 [[package]]
 name = "heed-traits"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3130048d404c57ce5a1ac61a903696e8fcde7e8c2991e9fcfc1f27c3ef74ff"
+source = "git+https://github.com/meilisearch/heed?branch=allow-nested-rtxn-from-wtxn#1da4f76d7c42377f270632b8c79089990ee43107"
 
 [[package]]
 name = "heed-types"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c255bdf46e07fb840d120a36dcc81f385140d7191c76a7391672675c01a55d"
+source = "git+https://github.com/meilisearch/heed?branch=allow-nested-rtxn-from-wtxn#1da4f76d7c42377f270632b8c79089990ee43107"
 dependencies = [
  "bincode 1.3.3",
  "byteorder",
@@ -4238,8 +4235,7 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 [[package]]
 name = "lmdb-master-sys"
 version = "0.2.6-nested-rtxns-6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e113d9bf240f974fbe7fd516cbfd8c422e925c0655495501c7237548425493d0"
+source = "git+https://github.com/meilisearch/heed?branch=allow-nested-rtxn-from-wtxn#1da4f76d7c42377f270632b8c79089990ee43107"
 dependencies = [
  "cc",
  "doxygen-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,3 +64,6 @@ opt-level = 3
 opt-level = 3
 [profile.dev.package.gemm-f16]
 opt-level = 3
+
+[patch.crates-io]
+heed = { git = "https://github.com/meilisearch/heed", branch = "allow-nested-rtxn-from-wtxn" }


### PR DESCRIPTION
This PR is mostly to run the CI tests on the new LMDB version with support for nested read transactions.

This version is a bit better than the LMDB fork we are currently using because it has been cleaned up by Howard Chu (maintainer of LMDB). It is much more reliable than what I did previously (we had only one memory leak). I plan to make this version of LMDB the version heed is provided with in the future.