### PR TITLE
docs(openapi): align list API keys limit example

### DIFF
--- a/crates/meilisearch/src/routes/api_key.rs
+++ b/crates/meilisearch/src/routes/api_key.rs
@@ -140,7 +140,7 @@ impl ListApiKeys {
                         "updatedAt": "2021-11-12T10:00:00Z"
                     }
                 ],
-                "limit": 20,
+                "limit": 3,
                 "offset": 0,
                 "total": 1
             }


### PR DESCRIPTION
## Summary
- update the `List API keys` OpenAPI response example so its `limit` matches the request sample shown in the API reference

## Why
- addresses #6293 by removing a confusing mismatch between the request and response code samples on the keys API reference page

## Validation
- confirmed the current mismatch on https://www.meilisearch.com/docs/reference/api/keys
- could not run `cargo run -p openapi-generator` locally because this environment does not currently have the Rust toolchain installed