### PR TITLE
Fix mismatch between request and response in list indexes example

### DIFF
--- a/crates/meilisearch/src/routes/indexes/mod.rs
+++ b/crates/meilisearch/src/routes/indexes/mod.rs
@@ -105,7 +105,7 @@ pub struct ListIndexes {
     #[deserr(default, error = DeserrQueryParamError<InvalidIndexOffset>)]
     pub offset: Param<usize>,
     /// The number of indexes to retrieve.
-    #[param(required = false, value_type = Option<usize>, default = 20, example = 1)]
+    #[param(required = false, value_type = Option<usize>, default = 20, example = 3)]
     #[deserr(default = Param(PAGINATION_DEFAULT_LIMIT), error = DeserrQueryParamError<InvalidIndexLimit>)]
     pub limit: Param<usize>,
 }
@@ -133,11 +133,23 @@ impl ListIndexes {
                         "primaryKey": "movie_id",
                         "createdAt": "2019-11-20T09:40:33.711324Z",
                         "updatedAt": "2019-11-20T09:40:33.711324Z"
+                    },
+                    {
+                        "uid": "books",
+                        "primaryKey": "book_id",
+                        "createdAt": "2019-11-20T09:40:33.711324Z",
+                        "updatedAt": "2019-11-20T09:40:33.711324Z"
+                    },
+                    {
+                        "uid": "clothes",
+                        "primaryKey": "clothes_id",
+                        "createdAt": "2019-11-20T09:40:33.711324Z",
+                        "updatedAt": "2019-11-20T09:40:33.711324Z"
                     }
                 ],
-                "limit": 1,
+                "limit": 3,
                 "offset": 0,
-                "total": 1
+                "total": 3
             }
         )),
         (status = 401, description = "The authorization header is missing.", body = ResponseError, content_type = "application/json", example = json!(

--- a/crates/meilisearch/src/routes/indexes/mod.rs
+++ b/crates/meilisearch/src/routes/indexes/mod.rs
@@ -101,7 +101,7 @@ pub struct ListIndexes {
     #[deserr(default, error = DeserrQueryParamError<InvalidIndexOffset>)]
     pub offset: Param<usize>,
     /// The number of indexes to retrieve.
-    #[param(required = false, value_type = Option<usize>, default = 20, example = 1)]
+    #[param(required = false, value_type = Option<usize>, default = 20, example = 3)]
     #[deserr(default = Param(PAGINATION_DEFAULT_LIMIT), error = DeserrQueryParamError<InvalidIndexLimit>)]
     pub limit: Param<usize>,
 }
@@ -129,11 +129,23 @@ impl ListIndexes {
                         "primaryKey": "movie_id",
                         "createdAt": "2019-11-20T09:40:33.711324Z",
                         "updatedAt": "2019-11-20T09:40:33.711324Z"
+                    },
+                    {
+                        "uid": "books",
+                        "primaryKey": "book_id",
+                        "createdAt": "2019-11-20T09:40:33.711324Z",
+                        "updatedAt": "2019-11-20T09:40:33.711324Z"
+                    },
+                    {
+                        "uid": "clothes",
+                        "primaryKey": "clothes_id",
+                        "createdAt": "2019-11-20T09:40:33.711324Z",
+                        "updatedAt": "2019-11-20T09:40:33.711324Z"
                     }
                 ],
-                "limit": 1,
+                "limit": 3,
                 "offset": 0,
-                "total": 1
+                "total": 3
             }
         )),
         (status = 401, description = "The authorization header is missing.", body = ResponseError, content_type = "application/json", example = json!(


### PR DESCRIPTION
## Related issue

Fixes #...

## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respect the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - *list of used tools and what they were used for*

## Requirements

⚠️ Ensure the following requirements before merging ⚠️
- [ ] Automated tests have been added.
- [x] If some tests cannot be automated, manual rigorous tests should be applied.
- [ ] ⚠️ If there is any change in the DB:
    - [ ] Test that any impacted DB still works as expected after using `--experimental-dumpless-upgrade` on a DB created with the last released Meilisearch
    - [ ] Test that during the upgrade, **search is still available** (artificially make the upgrade longer if needed)
    - [ ] Set the `db change` label.
- [ ] If necessary, the feature have been tested in the Cloud production environment (with [prototypes](./documentation/prototypes.md)) and the Cloud UI is ready.
- [ ] If necessary, the [documentation](https://github.com/meilisearch/documentation) related to the implemented feature in the PR is ready.
- [ ] If necessary, the [integrations](https://github.com/meilisearch/integration-guides) related to the implemented feature in the PR are ready.



Closes #6293

This PR fixes an inconsistency in the list indexes API example where the request uses `limit: 3` but the response example shows `"limit": 1`.

The response example has been updated to `"limit": 3` so that it correctly reflects the request and pagination behavior.