### PR TITLE
Use the latest version of heed with nested rtxns support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,9 +444,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arroy"
-version = "0.6.4-nested-rtxns"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb8b6b34d9d83e3b837cb7f72a439dbd2293b102393c084af5e5b097212e1532"
+checksum = "699ea33fc45fb11de023c86d7d4dfe7dda934cfa81838d6bc637e2587f0e5d6d"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -1116,9 +1116,9 @@ dependencies = [
 
 [[package]]
 name = "cellulite"
-version = "0.3.1-nested-rtxns-2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f22d721963ead1a144f10cb8b53dc9469e760723b069123c7c7bc675c7354270"
+checksum = "ea10acbe37fc6de810cb2d03171f25161437582aa6184f0755cd5a8a448dec0e"
 dependencies = [
  "crossbeam",
  "geo",
@@ -3043,9 +3043,9 @@ dependencies = [
 
 [[package]]
 name = "hannoy"
-version = "0.1.7-nested-rtxns"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "887aa70bc3aecc9b5c4652752820e3b37a1fb95d62520efbd18acd377cc26e95"
+checksum = "202cc875f1cff075e50f71e3b2415b549f31709be4f9a1de29dfb3920038cdb2"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -3136,9 +3136,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "heed"
-version = "0.22.1-nested-rtxns-7"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4679efe3143dcb1b7d82023d532c42445f840bd5156efb4d5fb1a2258f06cbc"
+checksum = "ad82d6598ccf1dac15c8b758a1bd282b755b6776be600429176757190a1b0202"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",
@@ -4237,9 +4237,9 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lmdb-master-sys"
-version = "0.2.6-nested-rtxns-6"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e113d9bf240f974fbe7fd516cbfd8c422e925c0655495501c7237548425493d0"
+checksum = "aaeb9bd22e73bd1babffff614994b341e9b2008de7bb73bf1f7e9154f1978f8b"
 dependencies = [
  "cc",
  "doxygen-rs",

--- a/crates/milli/Cargo.toml
+++ b/crates/milli/Cargo.toml
@@ -19,7 +19,7 @@ bstr = "1.12.1"
 bytemuck = { version = "1.24.0", features = ["extern_crate_alloc"] }
 byteorder = "1.5.0"
 charabia = { version = "0.9.9", default-features = false }
-cellulite = "0.3.1-nested-rtxns-2"
+cellulite = "0.3.1"
 concat-arrays = "0.1.2"
 convert_case = "0.9.0"
 crossbeam-channel = "0.5.15"
@@ -36,7 +36,7 @@ grenad = { version = "0.5.0", default-features = false, features = [
     "rayon",
     "tempfile",
 ] }
-heed = { version = "0.22.1-nested-rtxns-6", default-features = false, features = [
+heed = { version = "0.22.1", default-features = false, features = [
     "serde-json",
     "serde-bincode",
 ] }
@@ -93,8 +93,8 @@ rhai = { version = "1.23.6", features = [
     "no_time",
     "sync",
 ] }
-arroy = "0.6.4-nested-rtxns"
-hannoy = { version = "0.1.7-nested-rtxns", features = ["arroy"] }
+arroy = "0.6.4"
+hannoy = { version = "0.1.3", features = ["arroy"] }
 rand = "0.8.5"
 tracing = "0.1.41"
 url = "2.5.7"


### PR DESCRIPTION
This PR bumps the versions of crates that use heed to [the latest version, v0.22.1](https://github.com/meilisearch/heed/releases/tag/v0.22.1). This version finally stabilized a long-standing piece of work we were doing with Howard Chu: nested read transactions. We no longer have to rely on unstable pre-releases, but rather on a clean, stable version of LMDB (still a fork, but a better one).

## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respects the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - *list of used tools and what they were used for*