### PR TITLE
Restore globbing functionality in the bench pr workflow

### DIFF
--- a/.github/workflows/bench-manual.yml
+++ b/.github/workflows/bench-manual.yml
@@ -24,4 +24,4 @@ jobs:
 
       - name: Run benchmarks - workload ${WORKLOAD_NAME} - branch ${{ github.ref }} - commit ${{ github.sha }}
         run: |
-          cargo xtask bench --api-key "${{ secrets.BENCHMARK_API_KEY }}" --dashboard-url "${{ vars.BENCHMARK_DASHBOARD_URL }}" --reason "Manual [Run #${{ github.run_id }}](https://github.com/meilisearch/meilisearch/actions/runs/${{ github.run_id }})" -- "${WORKLOAD_NAME}"
+          cargo xtask bench --api-key "${{ secrets.BENCHMARK_API_KEY }}" --dashboard-url "${{ vars.BENCHMARK_DASHBOARD_URL }}" --reason "Manual [Run #${{ github.run_id }}](https://github.com/meilisearch/meilisearch/actions/runs/${{ github.run_id }})" -- ${WORKLOAD_NAME}

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -75,7 +75,7 @@ jobs:
           cargo xtask bench --api-key "${{ secrets.BENCHMARK_API_KEY }}" \
              --dashboard-url "${{ vars.BENCHMARK_DASHBOARD_URL }}" \
              --reason "[Comment](${{ github.event.comment.html_url }}) on [#${{ github.event.issue.number }}](${{ github.event.issue.html_url }})" \
-             -- "$BENCH_ARGS" > benchlinks.txt
+             -- $BENCH_ARGS > benchlinks.txt
 
       - name: Send comment in PR
         run: |

--- a/.github/workflows/benchmarks-pr.yml
+++ b/.github/workflows/benchmarks-pr.yml
@@ -96,7 +96,7 @@ jobs:
           BASELINE_NAME: ${{ steps.file.outputs.basename }}
         run: |
           cd crates/benchmarks
-          cargo bench --bench "$BENCH_DATASET" -- --save-baseline "$BASELINE_NAME"
+          cargo bench --bench $BENCH_DATASET -- --save-baseline "$BASELINE_NAME"
 
       # Generate critcmp files
       - name: Install critcmp


### PR DESCRIPTION
Fixes a regression from #6308, where the globbing functionality was broken and made it hard to benchmark multiple workflow files simultaneously.

## Generative AI tools

- [ ] This PR does not use generative AI tooling
- [x] This PR uses generative AI tooling and respects the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - I asked Claude to [investigate this PR](https://github.com/meilisearch/meilisearch/pull/6308) to restore the globbing behavior.