### PR TITLE
Throw document template errors when updating the chat settings

### DIFF
--- a/crates/meilisearch-types/src/error.rs
+++ b/crates/meilisearch-types/src/error.rs
@@ -529,6 +529,9 @@ impl ErrorCode for milli::Error {
                 | UserError::TooManyEmbedders(_)
                 | UserError::TooManyFragments(_)
                 | UserError::InvalidPromptForEmbeddings(..) => Code::InvalidSettingsEmbedders,
+                UserError::InvalidChatSettingsDocumentTemplate(_) => {
+                    Code::InvalidChatSettingDocumentTemplate
+                }
                 UserError::NoPrimaryKeyCandidateFound => Code::IndexPrimaryKeyNoCandidateFound,
                 UserError::MultiplePrimaryKeyCandidatesFound { .. } => {
                     Code::IndexPrimaryKeyMultipleCandidatesFound

--- a/crates/meilisearch/src/routes/chats/utils.rs
+++ b/crates/meilisearch/src/routes/chats/utils.rs
@@ -219,7 +219,10 @@ pub fn format_documents<'doc>(
 ) -> Result<Vec<&'doc str>, ResponseError> {
     let ChatConfig { prompt: PromptData { template, max_bytes }, .. } = index.chat_config(rtxn)?;
 
-    let prompt = Prompt::new(template, max_bytes).unwrap();
+    let prompt = Prompt::new(template, max_bytes).map_err(|e| {
+        ResponseError::from_msg(e.to_string(), Code::InvalidChatSettingDocumentTemplate)
+    })?;
+
     let fid_map = index.fields_ids_map(rtxn)?;
     let metadata_builder = MetadataBuilder::from_index(index, rtxn)?;
     let fid_map_with_meta = FieldIdMapWithMetadata::new(fid_map.clone(), metadata_builder);

--- a/crates/milli/src/error.rs
+++ b/crates/milli/src/error.rs
@@ -432,6 +432,8 @@ and can not be more than 511 bytes.", .document_id.to_string()
     DocumentEditionRuntimeError(Box<EvalAltResult>),
     #[error("Document edition runtime error encountered while compiling the function: {0}")]
     DocumentEditionCompilationError(rhai::ParseError),
+    #[error("`.chat.documentTemplate`: Invalid document template: {0}.")]
+    InvalidChatSettingsDocumentTemplate(crate::prompt::error::NewPromptError),
     #[error("`.chat.documentTemplateMaxBytes`: `documentTemplateMaxBytes` cannot be zero")]
     InvalidChatSettingsDocumentTemplateMaxBytes,
     #[error("{0}")]

--- a/crates/milli/src/update/settings.rs
+++ b/crates/milli/src/update/settings.rs
@@ -27,7 +27,7 @@ use crate::index::{
 };
 use crate::order_by_map::OrderByMap;
 use crate::progress::{EmbedderStats, Progress, VariableNameStep};
-use crate::prompt::{default_max_bytes, default_template_text, PromptData};
+use crate::prompt::{default_max_bytes, default_template_text, Prompt, PromptData};
 use crate::proximity::ProximityPrecision;
 use crate::update::index_documents::IndexDocumentsMethod;
 use crate::update::new::indexer::reindex;
@@ -1377,6 +1377,10 @@ impl<'a, 't, 'i> Settings<'a, 't, 'i> {
                         Setting::NotSet => prompt.max_bytes,
                     },
                 };
+
+                // Validate the document template syntax
+                Prompt::new(prompt.template.clone(), prompt.max_bytes)
+                    .map_err(UserError::InvalidChatSettingsDocumentTemplate)?;
 
                 let search_parameters = match new_search_parameters {
                     Setting::Set(sp) => {


### PR DESCRIPTION
The work was originally done in #6251 and fixes #5814, but we received [too much spam from this user](https://github.com/meilisearch/meilisearch/pulls?q=sort:updated-desc+is:pr+author:majiayu000) to review or accept those changes.

### Changelog

We fixed an issue that prevented the engine from explicitly showing the possible document template errors users could encounter when updating the template in the chat settings. The engine now correctly checks for and throws template errors when they are detected.

## Generative AI tools

- [ ] This PR does not use generative AI tooling
- [x] This PR uses generative AI tooling and respects the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - Changes were done in an AI-generated PR, and they looked fine.