### PR TITLE
Rename some of the search performance traces

### DIFF
--- a/crates/meilisearch/src/routes/chats/chat_completions.rs
+++ b/crates/meilisearch/src/routes/chats/chat_completions.rs
@@ -350,7 +350,7 @@ async fn process_search_request(
     let search_kind =
         search_kind(&query, index_scheduler.get_ref(), index_uid.to_string(), &index)?;
 
-    progress.update_progress(TotalProcessingTimeStep::WaitForPermit);
+    progress.update_progress(TotalProcessingTimeStep::WaitInQueue);
     let permit = search_queue.try_get_search_permit().await?;
     progress.update_progress(TotalProcessingTimeStep::Search);
     let features = index_scheduler.features();

--- a/crates/meilisearch/src/routes/indexes/search.rs
+++ b/crates/meilisearch/src/routes/indexes/search.rs
@@ -546,7 +546,7 @@ pub async fn search_with_url_query(
     let request_uid = Uuid::now_v7();
     debug!(request_uid = ?request_uid, parameters = ?params, "Search get");
     let progress = Progress::default();
-    progress.update_progress(TotalProcessingTimeStep::WaitForPermit);
+    progress.update_progress(TotalProcessingTimeStep::WaitInQueue);
     let permit = search_queue.try_get_search_permit().await?;
     progress.update_progress(TotalProcessingTimeStep::Search);
     let index_uid = IndexUid::try_from(index_uid.into_inner())?;
@@ -749,7 +749,7 @@ pub async fn search_with_post(
     let request_uid = Uuid::now_v7();
 
     let progress = Progress::default();
-    progress.update_progress(TotalProcessingTimeStep::WaitForPermit);
+    progress.update_progress(TotalProcessingTimeStep::WaitInQueue);
     let permit = search_queue.try_get_search_permit().await?;
     progress.update_progress(TotalProcessingTimeStep::Search);
 

--- a/crates/meilisearch/src/routes/multi_search.rs
+++ b/crates/meilisearch/src/routes/multi_search.rs
@@ -151,7 +151,7 @@ pub async fn multi_search_with_post(
     // Since we don't want to process half of the search requests and then get a permit refused
     // we're going to get one permit for the whole duration of the multi-search request.
     let progress = Progress::default();
-    progress.update_progress(TotalProcessingTimeStep::WaitForPermit);
+    progress.update_progress(TotalProcessingTimeStep::WaitInQueue);
     let permit = search_queue.try_get_search_permit().await?;
     progress.update_progress(TotalProcessingTimeStep::Search);
     let request_uid = Uuid::now_v7();

--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -1654,7 +1654,7 @@ pub fn prepare_search<'t>(
             let vector = match query.vector.clone() {
                 Some(vector) => vector,
                 None => {
-                    let _step = progress.update_progress_scoped(SearchStep::Embed);
+                    let _step = progress.update_progress_scoped(SearchStep::EmbedQuery);
                     let span = tracing::trace_span!(target: "search::vector", "embed_one");
                     let _entered = span.enter();
 

--- a/crates/milli/src/search/hybrid.rs
+++ b/crates/milli/src/search/hybrid.rs
@@ -304,7 +304,7 @@ impl Search<'_> {
             Some(vector_query) => vector_query,
             None => {
                 // attempt to embed the vector
-                self.progress.update_progress(SearchStep::Embed);
+                self.progress.update_progress(SearchStep::EmbedQuery);
                 let span = tracing::trace_span!(target: "search::hybrid", "embed_one");
                 let _entered = span.enter();
 

--- a/crates/milli/src/search/new/mod.rs
+++ b/crates/milli/src/search/new/mod.rs
@@ -305,7 +305,7 @@ fn resolve_universe(
     logger: &mut dyn SearchLogger<QueryGraph>,
     progress: &Progress,
 ) -> Result<RoaringBitmap> {
-    let _step = progress.update_progress_scoped(SearchStep::ResolveUniverse);
+    let _step = progress.update_progress_scoped(SearchStep::EvaluateQuery);
     resolve_maximally_reduced_query_graph(
         ctx,
         initial_universe,
@@ -666,7 +666,7 @@ pub fn filtered_universe(
     progress: &Progress,
 ) -> Result<RoaringBitmap> {
     Ok(if let Some(filters) = filters {
-        let _step = progress.update_progress_scoped(SearchStep::Filter);
+        let _step = progress.update_progress_scoped(SearchStep::EvaluateFilter);
         filters.evaluate(txn, index)?
     } else {
         index.documents_ids(txn)?
@@ -713,7 +713,7 @@ pub fn execute_vector_search(
     let placeholder_search_logger: &mut dyn SearchLogger<PlaceholderQuery> =
         &mut placeholder_search_logger;
 
-    let _step = progress.update_progress_scoped(SearchStep::SemanticSearch);
+    let _step = progress.update_progress_scoped(SearchStep::SemanticRanking);
     let BucketSortOutput { docids, scores, all_candidates, degraded } = bucket_sort(
         ctx,
         ranking_rules,
@@ -770,7 +770,7 @@ pub fn execute_search(
     let mut used_negative_operator = false;
     let mut located_query_terms = None;
     let query_terms = if let Some(query) = query {
-        let _step = progress.update_progress_scoped(SearchStep::Tokenize);
+        let _step = progress.update_progress_scoped(SearchStep::TokenizeQuery);
         let span = tracing::trace_span!(target: "search::tokens", "tokenizer_builder");
         let entered = span.enter();
 
@@ -883,7 +883,7 @@ pub fn execute_search(
             progress,
         )?;
 
-        let _step = progress.update_progress_scoped(SearchStep::KeywordSearch);
+        let _step = progress.update_progress_scoped(SearchStep::KeywordRanking);
         bucket_sort(
             ctx,
             ranking_rules,
@@ -903,7 +903,7 @@ pub fn execute_search(
     } else {
         let ranking_rules =
             get_ranking_rules_for_placeholder_search(ctx, sort_criteria, geo_param)?;
-        let _step = progress.update_progress_scoped(SearchStep::PlaceholderSearch);
+        let _step = progress.update_progress_scoped(SearchStep::PlaceholderRanking);
         bucket_sort(
             ctx,
             ranking_rules,

--- a/crates/milli/src/search/steps.rs
+++ b/crates/milli/src/search/steps.rs
@@ -2,13 +2,13 @@ use crate::make_enum_progress;
 
 make_enum_progress! {
     pub enum SearchStep {
-        Tokenize,
-        Embed,
-        Filter,
-        ResolveUniverse,
-        KeywordSearch,
-        PlaceholderSearch,
-        SemanticSearch,
+        TokenizeQuery,
+        EmbedQuery,
+        EvaluateFilter,
+        EvaluateQuery,
+        KeywordRanking,
+        PlaceholderRanking,
+        SemanticRanking,
         Format,
         FacetDistribution,
         Personalization,
@@ -29,7 +29,7 @@ make_enum_progress! {
 
 make_enum_progress! {
     pub enum TotalProcessingTimeStep {
-        WaitForPermit,
+        WaitInQueue,
         Search,
         Similar,
     }


### PR DESCRIPTION
Rename some of the search performance traces to be more self-explanatory:

```
// changed
WaitForPermit -> WaitInQueue
Tokenize -> TokenizeQuery
Embed -> EmbedQuery
Filter -> EvaluateFilter
ResolveUniverse -> EvaluateQuery
KeywordSearch -> KeywordRanking
PlaceholderSearch -> PlaceholderRanking
SemanticSearch -> SemanticRanking

// not changed
Format
FacetDistribution
Personalization
```

## Rational

### `WaitForPermit -> WaitInQueue`

`WaitForPermit` is related to how the code handles the search queue, but we don't really talk about permits to users,  only the search queue. `WaitInQueue` makes more sense from the user POV; however, I was thinking about `WaitForAvailableThread` or `WaitForAnAvailableThread`, longer, but we directly understand the source of the bottleneck.

### `Tokenize -> TokenizeQuery` & `Embed -> EmbedQuery`

Use the same pattern for both terms because they refer to an equivalent process for the different search methods.

### `Filter -> EvaluateFilter` & `ResolveUniverse -> EvaluateQuery`

Use the same pattern for both terms because they refer to an equivalent process, retrieving a set of documents related to a query or a filter.
Moreover, `ResolveUniverse` can only be understood by a Meilisearch developer. `EvaluateQuery` makes more sense from the user POV.

### `KeywordSearch -> KeywordRanking` & `PlaceholderSearch -> PlaceholderRanking` & `SemanticSearch -> SemanticRanking`

Replacing `xxxxSearch` with `xxxxRanking` is more accurate about what the code is doing. Here, we already retrieved the candidates; we rank them now.

