### PR TITLE
Fix legacy indexer issues

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -158,6 +158,33 @@ jobs:
           command: test
           args: --locked -p meilisearch --features test-ollama ollama
 
+  test-legacy-indexer:
+    name: Test legacy settings indexer
+    runs-on: ubuntu-22.04
+    env:
+      MEILI_EXPERIMENTAL_NO_EDITION_2024_FOR_SETTINGS: "true"
+    steps:
+      - uses: actions/checkout@v5
+      - name: check free space before
+        run: df -h
+      - name: Clean space as per https://github.com/actions/virtual-environments/issues/709
+        run: |
+          sudo rm -rf "/opt/ghc" || true
+          sudo rm -rf "/usr/share/dotnet" || true
+          sudo rm -rf "/usr/local/lib/android" || true
+          sudo rm -rf "/usr/local/share/boost" || true
+      - name: check free space after
+        run: df -h
+      - name: Setup test with Rust stable
+        uses: dtolnay/rust-toolchain@1.91.1
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2.8.0
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --locked --all
+
   test-disabled-tokenization:
     name: Test disabled tokenization
     runs-on: ubuntu-22.04

--- a/crates/index-scheduler/src/scheduler/process_index_operation.rs
+++ b/crates/index-scheduler/src/scheduler/process_index_operation.rs
@@ -379,7 +379,7 @@ impl IndexScheduler {
                             let filter = match Filter::from_json(filter_expr) {
                                 Ok(filter) => filter,
                                 Err(err) => {
-                                    // theorically, this should be catched by deserr before reaching the index-scheduler and cannot happens
+                                    // theorically, this should be caught by deserr before reaching the index-scheduler and cannot happens
                                     task.status = Status::Failed;
                                     task.error = Some(
                                         Error::from_milli(err, Some(index_uid.clone())).into(),

--- a/crates/index-scheduler/src/scheduler/test_failure.rs
+++ b/crates/index-scheduler/src/scheduler/test_failure.rs
@@ -185,7 +185,7 @@ fn fail_in_process_batch_for_document_deletion() {
             false,
         )
         .unwrap();
-    // This one should not be catched by Meilisearch but it's still nice to handle it because if one day we break the filters it could happens
+    // This one should not be caught by Meilisearch but it's still nice to handle it because if one day we break the filters it could happens
     index_scheduler
         .register(
             KindWithContent::DocumentDeletionByFilter {

--- a/crates/meilisearch/src/option.rs
+++ b/crates/meilisearch/src/option.rs
@@ -1275,7 +1275,7 @@ where
     T: AsRef<OsStr>,
 {
     if let Err(VarError::NotPresent) = std::env::var(key) {
-        std::env::set_var(key, value);
+        unsafe { std::env::set_var(key, value) };
     }
 }
 

--- a/crates/meilisearch/tests/common/server.rs
+++ b/crates/meilisearch/tests/common/server.rs
@@ -546,7 +546,11 @@ pub fn default_settings(dir: impl AsRef<Path>) -> Opt {
             skip_index_budget: true,
             // Having 2 threads makes the tests way faster
             max_indexing_threads: MaxThreads::from_str("2").unwrap(),
-            experimental_no_edition_2024_for_settings: false,
+            experimental_no_edition_2024_for_settings: std::env::var_os(
+                "MEILI_EXPERIMENTAL_NO_EDITION_2024_FOR_SETTINGS",
+            )
+            .map(|x| FromStr::from_str(&x.into_string().unwrap()).unwrap())
+            .unwrap_or(false),
             experimental_no_edition_2024_for_dumps: false,
         },
         experimental_enable_metrics: false,

--- a/crates/meilisearch/tests/common/server.rs
+++ b/crates/meilisearch/tests/common/server.rs
@@ -43,9 +43,9 @@ impl Server<Owned> {
         let dir = TempDir::new().unwrap();
 
         if cfg!(windows) {
-            std::env::set_var("TMP", TEST_TEMP_DIR.path());
+            unsafe { std::env::set_var("TMP", TEST_TEMP_DIR.path()) };
         } else {
-            std::env::set_var("TMPDIR", TEST_TEMP_DIR.path());
+            unsafe { std::env::set_var("TMPDIR", TEST_TEMP_DIR.path()) };
         }
 
         let options = default_settings(dir.path());
@@ -58,9 +58,9 @@ impl Server<Owned> {
 
     pub async fn new_auth_with_options(mut options: Opt, dir: TempDir) -> Self {
         if cfg!(windows) {
-            std::env::set_var("TMP", TEST_TEMP_DIR.path());
+            unsafe { std::env::set_var("TMP", TEST_TEMP_DIR.path()) };
         } else {
-            std::env::set_var("TMPDIR", TEST_TEMP_DIR.path());
+            unsafe { std::env::set_var("TMPDIR", TEST_TEMP_DIR.path()) };
         }
 
         options.master_key = Some("MASTER_KEY".to_string());
@@ -251,9 +251,9 @@ impl Server<Shared> {
         let dir = TempDir::new().unwrap();
 
         if cfg!(windows) {
-            std::env::set_var("TMP", TEST_TEMP_DIR.path());
+            unsafe { std::env::set_var("TMP", TEST_TEMP_DIR.path()) };
         } else {
-            std::env::set_var("TMPDIR", TEST_TEMP_DIR.path());
+            unsafe { std::env::set_var("TMPDIR", TEST_TEMP_DIR.path()) };
         }
 
         let options = default_settings(dir.path());

--- a/crates/milli/src/error.rs
+++ b/crates/milli/src/error.rs
@@ -12,7 +12,7 @@ use thiserror::Error;
 
 use crate::constants::{RESERVED_GEOJSON_FIELD_NAME, RESERVED_GEO_FIELD_NAME};
 use crate::documents::{self, DocumentsBatchCursorError};
-use crate::thread_pool_no_abort::PanicCatched;
+use crate::thread_pool_no_abort::CaughtPanic;
 use crate::vector::settings::EmbeddingSettings;
 use crate::{CriterionError, DocumentId, FieldId, Object, SortError};
 
@@ -63,7 +63,7 @@ pub enum InternalError {
     #[error(transparent)]
     RayonThreadPool(#[from] ThreadPoolBuildError),
     #[error(transparent)]
-    PanicInThreadPool(#[from] PanicCatched),
+    PanicInThreadPool(#[from] CaughtPanic),
     #[error(transparent)]
     SerdeJson(#[from] serde_json::Error),
     #[error(transparent)]

--- a/crates/milli/src/lib.rs
+++ b/crates/milli/src/lib.rs
@@ -57,7 +57,7 @@ pub use search::new::{
     VisualSearchLogger,
 };
 use serde_json::Value;
-pub use thread_pool_no_abort::{PanicCatched, ThreadPoolNoAbort, ThreadPoolNoAbortBuilder};
+pub use thread_pool_no_abort::{CaughtPanic, ThreadPoolNoAbort, ThreadPoolNoAbortBuilder};
 pub use {arroy, cellulite, charabia as tokenizer, hannoy, heed, rhai};
 
 pub use self::asc_desc::{AscDesc, AscDescError, Member, SortError};

--- a/crates/milli/src/thread_pool_no_abort.rs
+++ b/crates/milli/src/thread_pool_no_abort.rs
@@ -11,12 +11,12 @@ pub struct ThreadPoolNoAbort {
     thread_pool: ThreadPool,
     /// The number of active operations.
     active_operations: AtomicUsize,
-    /// Set to true if the thread pool catched a panic.
-    pool_catched_panic: Arc<AtomicBool>,
+    /// Set to true if the thread pool caught a panic.
+    pool_caught_panic: Arc<AtomicBool>,
 }
 
 impl ThreadPoolNoAbort {
-    pub fn install<OP, R>(&self, op: OP) -> Result<R, PanicCatched>
+    pub fn install<OP, R>(&self, op: OP) -> Result<R, CaughtPanic>
     where
         OP: FnOnce() -> R + Send,
         R: Send,
@@ -24,15 +24,15 @@ impl ThreadPoolNoAbort {
         self.active_operations.fetch_add(1, Ordering::Relaxed);
         let output = self.thread_pool.install(op);
         self.active_operations.fetch_sub(1, Ordering::Relaxed);
-        // While reseting the pool panic catcher we return an error if we catched one.
-        if self.pool_catched_panic.swap(false, Ordering::SeqCst) {
-            Err(PanicCatched)
+        // While reseting the pool panic catcher we return an error if we caught one.
+        if self.pool_caught_panic.swap(false, Ordering::SeqCst) {
+            Err(CaughtPanic)
         } else {
             Ok(output)
         }
     }
 
-    pub fn broadcast<OP, R>(&self, op: OP) -> Result<Vec<R>, PanicCatched>
+    pub fn broadcast<OP, R>(&self, op: OP) -> Result<Vec<R>, CaughtPanic>
     where
         OP: Fn(BroadcastContext<'_>) -> R + Sync,
         R: Send,
@@ -40,9 +40,9 @@ impl ThreadPoolNoAbort {
         self.active_operations.fetch_add(1, Ordering::Relaxed);
         let output = self.thread_pool.broadcast(op);
         self.active_operations.fetch_sub(1, Ordering::Relaxed);
-        // While reseting the pool panic catcher we return an error if we catched one.
-        if self.pool_catched_panic.swap(false, Ordering::SeqCst) {
-            Err(PanicCatched)
+        // While reseting the pool panic catcher we return an error if we caught one.
+        if self.pool_caught_panic.swap(false, Ordering::SeqCst) {
+            Err(CaughtPanic)
         } else {
             Ok(output)
         }
@@ -59,8 +59,8 @@ impl ThreadPoolNoAbort {
 }
 
 #[derive(Error, Debug)]
-#[error("A panic occured. Read the logs to find more information about it")]
-pub struct PanicCatched;
+#[error("A panic occurred. Read the logs to find more information about it")]
+pub struct CaughtPanic;
 
 #[derive(Default)]
 pub struct ThreadPoolNoAbortBuilder(ThreadPoolBuilder);
@@ -88,15 +88,15 @@ impl ThreadPoolNoAbortBuilder {
     }
 
     pub fn build(mut self) -> Result<ThreadPoolNoAbort, rayon::ThreadPoolBuildError> {
-        let pool_catched_panic = Arc::new(AtomicBool::new(false));
+        let pool_caught_panic = Arc::new(AtomicBool::new(false));
         self.0 = self.0.panic_handler({
-            let catched_panic = pool_catched_panic.clone();
-            move |_result| catched_panic.store(true, Ordering::SeqCst)
+            let caught_panic = pool_caught_panic.clone();
+            move |_result| caught_panic.store(true, Ordering::SeqCst)
         });
         Ok(ThreadPoolNoAbort {
             thread_pool: self.0.build()?,
             active_operations: AtomicUsize::new(0),
-            pool_catched_panic,
+            pool_caught_panic,
         })
     }
 }

--- a/crates/milli/src/update/index_documents/extract/extract_vector_points.rs
+++ b/crates/milli/src/update/index_documents/extract/extract_vector_points.rs
@@ -1217,18 +1217,29 @@ struct WriteGrenadOnEmbed<'a> {
 }
 
 impl WriteGrenadOnEmbed<'_> {
+    /// Adds a (docid, extractor_id) pair, indicating they have no associated embedding.
+    ///
+    /// # Panics
+    ///
+    /// if the (docid, extractor_id) pair is not greater than all previously sent pairs.
     pub fn push_response(&mut self, docid: DocumentId, extractor_id: u8) {
         self.waiting_responses.push_back((docid, extractor_id));
     }
 
+    /// Write any outstanding `waiting_responses`.
     pub fn finish(mut self) -> Result<grenad::Reader<BufReader<File>>> {
-        for (docid, extractor_id) in self.waiting_responses {
-            self.scratch.clear();
-            self.scratch.write_u32::<BigEndian>(docid).unwrap();
-            self.scratch.write_u8(extractor_id).unwrap();
-            self.vector_writer.insert(&self.scratch, []).unwrap();
+        for (docid, extractor_id) in std::mem::take(&mut self.waiting_responses) {
+            self.write(docid, extractor_id, None);
         }
         writer_into_reader(self.vector_writer)
+    }
+
+    fn write(&mut self, docid: u32, extractor_id: u8, embedding: Option<&[f32]>) {
+        self.scratch.clear();
+        self.scratch.write_u32::<BigEndian>(docid).unwrap();
+        self.scratch.write_u8(extractor_id).unwrap();
+        let embedding = if let Some(embedding) = embedding { embedding } else { &[] };
+        self.vector_writer.insert(&self.scratch, cast_slice(embedding)).unwrap();
     }
 }
 
@@ -1241,22 +1252,15 @@ impl<'doc> OnEmbed<'doc> for WriteGrenadOnEmbed<'_> {
         let (docid, extractor_id) = (response.metadata.docid, response.metadata.extractor_id);
         while let Some(waiting_response) = self.waiting_responses.pop_front() {
             if (docid, extractor_id) > waiting_response {
-                self.scratch.clear();
-                self.scratch.write_u32::<BigEndian>(docid).unwrap();
-                self.scratch.write_u8(extractor_id).unwrap();
-                self.vector_writer.insert(&self.scratch, []).unwrap();
+                let (docid, extractor_id) = waiting_response;
+                self.write(docid, extractor_id, None);
             } else {
                 self.waiting_responses.push_front(waiting_response);
                 break;
             }
         }
 
-        if let Some(embedding) = response.embedding {
-            self.scratch.clear();
-            self.scratch.write_u32::<BigEndian>(docid).unwrap();
-            self.scratch.write_u8(extractor_id).unwrap();
-            self.vector_writer.insert(&self.scratch, cast_slice(embedding.as_slice())).unwrap();
-        }
+        self.write(docid, extractor_id, response.embedding.as_deref());
     }
 
     fn process_embedding_error(

--- a/crates/milli/src/update/index_documents/extract/extract_vector_points.rs
+++ b/crates/milli/src/update/index_documents/extract/extract_vector_points.rs
@@ -415,12 +415,12 @@ pub fn extract_vector_points<R: io::Read + io::Seek>(
         // lazily get it when needed
         let document_id = || -> Value { from_utf8(external_id_bytes).unwrap().into() };
 
-        let regenerate_for_embedders = embedder_info
+        let dont_regenerate_for_embedders = embedder_info
             .iter()
-            .filter(|&(_, infos)| infos.embedding_status.must_regenerate(docid))
+            .filter(|&(_, infos)| !infos.embedding_status.must_regenerate(docid))
             .map(|(name, _)| name.clone());
         let mut parsed_vectors = ParsedVectorsDiff::new(
-            regenerate_for_embedders,
+            dont_regenerate_for_embedders,
             obkv,
             old_vectors_fid,
             new_vectors_fid,

--- a/crates/milli/src/update/index_documents/mod.rs
+++ b/crates/milli/src/update/index_documents/mod.rs
@@ -500,19 +500,12 @@ where
         // we should insert it in `dimension`
         let backend = self.index.get_vector_store(self.wtxn)?.unwrap_or_default();
         for (name, action) in settings_diff.embedding_config_updates.iter() {
-            if action.is_being_quantized && !dimension.contains_key(name.as_str()) {
-                let index = self.index.embedding_configs().embedder_id(self.wtxn, name)?.ok_or(
-                    InternalError::DatabaseMissingEntry {
-                        db_name: "embedder_category_id",
-                        key: None,
-                    },
-                )?;
-                let reader =
-                    VectorStore::new(backend, self.index.vector_store, index, action.was_quantized);
-                let Some(dim) = reader.dimensions(self.wtxn)? else {
+            let must_rebuild = action.is_being_quantized || action.remove_fragments().is_some();
+            if must_rebuild && !dimension.contains_key(name.as_str()) {
+                let Some(runtime_embedder) = settings_diff.new.runtime_embedders.get(name) else {
                     continue;
                 };
-                dimension.insert(name.to_string(), dim);
+                dimension.insert(name.to_string(), runtime_embedder.embedder.dimensions());
             }
         }
 

--- a/crates/milli/src/update/settings.rs
+++ b/crates/milli/src/update/settings.rs
@@ -14,7 +14,7 @@ use super::chat::ChatSearchParams;
 use super::del_add::{DelAdd, DelAddOperation};
 use super::index_documents::{IndexDocumentsConfig, Transform};
 use super::{ChatSettings, IndexerConfig};
-use crate::attribute_patterns::PatternMatch;
+use crate::attribute_patterns::{match_field_legacy, PatternMatch};
 use crate::constants::{RESERVED_GEOJSON_FIELD_NAME, RESERVED_GEO_FIELD_NAME};
 use crate::criterion::Criterion;
 use crate::disabled_typos_terms::DisabledTyposTerms;
@@ -1935,10 +1935,13 @@ impl InnerIndexSettingsDiff {
             Some(DelAddOperation::DeletionAndAddition)
         } else if let Some(only_additional_fields) = &self.only_additional_fields {
             let additional_field = self.new.fields_ids_map.name(id).unwrap();
-            if only_additional_fields.contains(additional_field) {
-                Some(DelAddOperation::Addition)
-            } else {
+            if only_additional_fields
+                .iter()
+                .all(|f| match_field_legacy(f, additional_field) == PatternMatch::NoMatch)
+            {
                 None
+            } else {
+                Some(DelAddOperation::Addition)
             }
         } else if self.cache_user_defined_searchables {
             Some(DelAddOperation::DeletionAndAddition)

--- a/crates/milli/src/vector/error.rs
+++ b/crates/milli/src/vector/error.rs
@@ -10,7 +10,7 @@ use crate::error::FaultSource;
 use crate::update::new::vector_document::VectorDocument;
 use crate::vector::embedder::composite::MAX_COMPOSITE_DISTANCE;
 use crate::vector::embedder::rest::ConfigurationSource;
-use crate::{FieldDistribution, PanicCatched};
+use crate::{CaughtPanic, FieldDistribution};
 
 #[derive(Debug, thiserror::Error)]
 #[error("Error while generating embeddings: {inner}")]
@@ -101,7 +101,7 @@ pub enum EmbedErrorKind {
     #[error("no embedding was produced")]
     MissingEmbedding,
     #[error(transparent)]
-    PanicInThreadPool(#[from] PanicCatched),
+    PanicInThreadPool(#[from] CaughtPanic),
     #[error("`media` requested but the configuration doesn't have source `rest`")]
     RestMediaNotARest,
     #[error("`media` requested, and the configuration has source `rest`, but the configuration doesn't have `searchFragments`.")]

--- a/crates/milli/src/vector/parsed_vectors.rs
+++ b/crates/milli/src/vector/parsed_vectors.rs
@@ -374,7 +374,7 @@ pub struct ParsedVectorsDiff {
 
 impl ParsedVectorsDiff {
     pub fn new(
-        regenerate_for_embedders: impl Iterator<Item = String>,
+        dont_regenerate_for_embedders: impl Iterator<Item = String>,
         documents_diff: &KvReader<FieldId>,
         old_vectors_fid: Option<FieldId>,
         new_vectors_fid: Option<FieldId>,
@@ -395,8 +395,8 @@ impl ParsedVectorsDiff {
             }
         }
         .flatten().map_or(BTreeMap::default(), |del| del.into_iter().map(|(name, vec)| (name, VectorState::Inline(vec))).collect());
-        for name in regenerate_for_embedders {
-            old.entry(name).or_insert(VectorState::Generated);
+        for name in dont_regenerate_for_embedders {
+            old.entry(name).or_insert(VectorState::Manual);
         }
 
         let new = 'new: {


### PR DESCRIPTION
## Changelog

- Fix issues when using the legacy settings indexer:
  - When using the experimental feature "multimodal", removing a fragment would cause an internal error in subsequent search requests
  - When using the experimental feature "multimodal", modifying fragments would sometimes cause an internal error at indexing time
  - `regenerate: false` would be ignored when modifying embedder settings
  - Index a nested field declared as searchable even if its parents are not declared as searchable
- Add new CI run that tests the stable settings indexer

## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respect the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - *list of used tools and what they were used for*
