### PR TITLE
Add internal db sizes to index stats

### DIFF
--- a/crates/index-scheduler/src/index_mapper/mod.rs
+++ b/crates/index-scheduler/src/index_mapper/mod.rs
@@ -113,6 +113,13 @@ pub struct IndexStats {
     /// are not returned to the disk after a deletion, this number is typically larger than
     /// `used_database_size` that only includes the size of the used pages.
     pub database_size: u64,
+
+    /// Size of all the internal databases for the index, ordered by decreasing size.
+    ///
+    /// Database names can change from version to version.
+    #[serde(default)] // backward compatibility
+    pub internal_database_sizes: Vec<(String, u64)>,
+
     /// Number of embeddings in the index.
     /// Option: retrocompatible with the stats of the pre-v1.13.0 versions of meilisearch
     pub number_of_embeddings: Option<u64>,
@@ -144,11 +151,23 @@ impl IndexStats {
     /// - rtxn: a RO transaction for the index, obtained from `Index::read_txn()`.
     pub fn new(index: &Index, rtxn: &RoTxn) -> milli::Result<Self> {
         let vector_store_stats = index.vector_store_stats(rtxn)?;
+        let mut db_size = index.database_sizes(rtxn)?;
+        db_size.sort_by(|_, left, _, right| left.cmp(right).reverse());
+        let internal_database_sizes = db_size
+            .into_iter()
+            .take_while(|(_, size)| *size != 0)
+            .map(|(dbname, size)| {
+                use convert_case::{Case, Casing as _};
+
+                (dbname.to_case(Case::Camel), size as u64)
+            })
+            .collect();
         Ok(IndexStats {
             number_of_embeddings: Some(vector_store_stats.number_of_embeddings),
             number_of_embedded_documents: Some(vector_store_stats.documents.len()),
             documents_database_stats: index.documents_stats(rtxn)?.unwrap_or_default(),
             number_of_documents: None,
+            internal_database_sizes,
             database_size: index.on_disk_size()?,
             used_database_size: index.used_size()?,
             primary_key: index.primary_key(rtxn)?.map(|s| s.to_string()),

--- a/crates/index-scheduler/src/lib.rs
+++ b/crates/index-scheduler/src/lib.rs
@@ -1337,8 +1337,10 @@ pub struct IndexStats {
     /// Whether this index is currently performing indexation, according to the scheduler.
     pub is_indexing: bool,
     /// Internal stats computed from the index.
-    pub inner_stats: index_mapper::IndexStats,
+    pub inner_stats: InnerIndexStats,
 }
+
+pub use index_mapper::IndexStats as InnerIndexStats;
 
 /// These structure are not meant to be exposed to the end user, if needed, use the meilisearch-types::webhooks structure instead.
 /// /!\ Everytime you deserialize this structure you should fill the cli_webhook later on with the `with_cli` method. /!\

--- a/crates/index-scheduler/src/scheduler/test.rs
+++ b/crates/index-scheduler/src/scheduler/test.rs
@@ -1024,7 +1024,7 @@ fn create_and_list_index() {
 
     index_scheduler.index("kefir").unwrap();
     let list = index_scheduler.paginated_indexes_stats(&AuthFilter::default(), 0, 20).unwrap();
-    snapshot!(json_string!(list, { "[1][0][1].created_at" => "[date]", "[1][0][1].updated_at" => "[date]", "[1][0][1].used_database_size" => "[bytes]", "[1][0][1].database_size" => "[bytes]" }), @r###"
+    snapshot!(json_string!(list, { "[1][0][1].created_at" => "[date]", "[1][0][1].updated_at" => "[date]", "[1][0][1].used_database_size" => "[bytes]", "[1][0][1].database_size" => "[bytes]", "[1][0][1].internal_database_sizes" => "[bytes]" }), @r###"
     [
       1,
       [
@@ -1037,6 +1037,7 @@ fn create_and_list_index() {
               "totalValueSize": 0
             },
             "database_size": "[bytes]",
+            "internal_database_sizes": "[bytes]",
             "number_of_embeddings": 0,
             "number_of_embedded_documents": 0,
             "used_database_size": "[bytes]",

--- a/crates/meilisearch-types/src/error.rs
+++ b/crates/meilisearch-types/src/error.rs
@@ -353,6 +353,8 @@ InvalidSettingsSynonyms                        , InvalidRequest       , BAD_REQU
 InvalidSettingsTypoTolerance                   , InvalidRequest       , BAD_REQUEST ;
 InvalidSettingsLocalizedAttributes             , InvalidRequest       , BAD_REQUEST ;
 InvalidState                                   , Internal             , INTERNAL_SERVER_ERROR ;
+InvalidStatsShowInternalDatabaseSizes          , InvalidRequest       , BAD_REQUEST ;
+InvalidStatsSizeFormat                         , InvalidRequest       , BAD_REQUEST ;
 InvalidStoreFile                               , Internal             , INTERNAL_SERVER_ERROR ;
 InvalidSwapDuplicateIndexFound                 , InvalidRequest       , BAD_REQUEST ;
 InvalidSwapIndexes                             , InvalidRequest       , BAD_REQUEST ;

--- a/crates/meilisearch/src/analytics/segment_analytics.rs
+++ b/crates/meilisearch/src/analytics/segment_analytics.rs
@@ -10,6 +10,7 @@ use actix_web::HttpRequest;
 use byte_unit::Byte;
 use index_scheduler::IndexScheduler;
 use meilisearch_auth::{AuthController, AuthFilter};
+use meilisearch_types::deserr::query_params::Param;
 use meilisearch_types::features::RuntimeTogglableFeatures;
 use meilisearch_types::InstanceUid;
 use once_cell::sync::Lazy;
@@ -27,6 +28,7 @@ use super::{config_user_id_path, Aggregate, MEILISEARCH_CONFIG_PATH};
 use crate::option::{
     default_http_addr, IndexerOpts, LogMode, MaxMemory, MaxThreads, ScheduleSnapshot,
 };
+use crate::routes::indexes::GetIndexStatsParams;
 use crate::routes::{create_all_stats, Stats};
 use crate::Opt;
 
@@ -488,6 +490,7 @@ impl Segment {
             index_scheduler.clone().into(),
             auth_controller.into(),
             &AuthFilter::default(),
+            GetIndexStatsParams { show_internal_database_sizes: Param(false), size_format: None },
         ) {
             // Replace the version number with the prototype name if any.
             let version = build_info::DescribeResult::from_build()

--- a/crates/meilisearch/src/routes/indexes/mod.rs
+++ b/crates/meilisearch/src/routes/indexes/mod.rs
@@ -551,6 +551,40 @@ pub async fn delete_index(
     Ok(HttpResponse::Accepted().json(task))
 }
 
+#[derive(Serialize, Debug, ToSchema)]
+#[serde(untagged, rename_all = "camelCase")]
+#[schema(rename_all = "camelCase")]
+pub enum Size {
+    /// Size as an integer, in bytes
+    Raw(u64),
+    /// Size as a human-readable string with an appropriate unit.
+    Human(String),
+}
+
+impl From<Size> for serde_json::Value {
+    fn from(value: Size) -> Self {
+        match value {
+            Size::Raw(bytes) => serde_json::Value::Number(serde_json::Number::from(bytes)),
+            Size::Human(human) => serde_json::Value::String(human),
+        }
+    }
+}
+
+impl Size {
+    pub fn new(bytes: u64, format: SizeFormat) -> Self {
+        use byte_unit::Byte;
+        use byte_unit::UnitType::Binary;
+
+        match format {
+            SizeFormat::Human => {
+                let size = Byte::from_u64(bytes as u64).get_appropriate_unit(Binary);
+                Self::Human(format!("{size:#.2}"))
+            }
+            SizeFormat::Raw => Self::Raw(bytes),
+        }
+    }
+}
+
 /// Stats of an `Index`, as known to the `stats` route.
 #[derive(Serialize, Debug, ToSchema)]
 #[serde(rename_all = "camelCase")]
@@ -559,11 +593,17 @@ pub struct IndexStats {
     /// Number of documents in the index
     pub number_of_documents: u64,
     /// Size of the documents database, in bytes.
-    pub raw_document_db_size: u64,
+    pub raw_document_db_size: Size,
     /// Average size of a document in the documents database.
-    pub avg_document_size: u64,
+    pub avg_document_size: Size,
     /// Whether or not the index is currently ingesting document
     pub is_indexing: bool,
+    /// Size of all the internal databases for the index.
+    ///
+    /// Database names can change from version to version.
+    #[serde(skip_serializing_if = "serde_json::Map::is_empty")]
+    // serde_json::Map<String, Size> is not Serialize, so we convert the Size to a serde_json::Value
+    pub internal_database_sizes: serde_json::Map<String, serde_json::Value>,
     /// Number of embeddings in the index
     #[serde(skip_serializing_if = "Option::is_none")]
     pub number_of_embeddings: Option<u64>,
@@ -576,19 +616,59 @@ pub struct IndexStats {
     pub field_distribution: FieldDistribution,
 }
 
-impl From<index_scheduler::IndexStats> for IndexStats {
-    fn from(stats: index_scheduler::IndexStats) -> Self {
-        IndexStats {
-            number_of_documents: stats
-                .inner_stats
-                .number_of_documents
-                .unwrap_or(stats.inner_stats.documents_database_stats.number_of_entries()),
-            raw_document_db_size: stats.inner_stats.documents_database_stats.total_size(),
-            avg_document_size: stats.inner_stats.documents_database_stats.average_value_size(),
-            is_indexing: stats.is_indexing,
-            number_of_embeddings: stats.inner_stats.number_of_embeddings,
-            number_of_embedded_documents: stats.inner_stats.number_of_embedded_documents,
-            field_distribution: stats.inner_stats.field_distribution,
+#[derive(Copy, Clone, Debug, Serialize, Deserr, ToSchema)]
+#[serde(rename_all = "camelCase")]
+#[deserr(rename_all = camelCase)]
+#[schema(rename_all = "camelCase")]
+pub enum SizeFormat {
+    /// Format sizes as a human-readable string with an appropriate unit.
+    Human,
+    /// Format sizes as a number of bytes.
+    Raw,
+}
+
+impl IndexStats {
+    pub fn from_db_index_stats(
+        db_index_stats: index_scheduler::IndexStats,
+        format: SizeFormat,
+        with_internal_database_sizes: bool,
+    ) -> Self {
+        let index_scheduler::IndexStats {
+            is_indexing,
+            inner_stats:
+                index_scheduler::InnerIndexStats {
+                    documents_database_stats,
+                    number_of_documents,
+                    database_size: _,
+                    internal_database_sizes,
+                    number_of_embeddings,
+                    number_of_embedded_documents,
+                    used_database_size: _,
+                    primary_key: _,
+                    field_distribution,
+                    created_at: _,
+                    updated_at: _,
+                },
+        } = db_index_stats;
+
+        Self {
+            number_of_documents: number_of_documents
+                .unwrap_or(documents_database_stats.number_of_entries()),
+            raw_document_db_size: Size::new(documents_database_stats.total_size(), format),
+            avg_document_size: Size::new(documents_database_stats.average_value_size(), format),
+            internal_database_sizes: if with_internal_database_sizes {
+                let internal_database_sizes = internal_database_sizes
+                    .into_iter()
+                    .map(|(dbname, size)| (dbname, Size::new(size, format).into()))
+                    .collect();
+                internal_database_sizes
+            } else {
+                Default::default()
+            },
+            is_indexing,
+            number_of_embeddings,
+            number_of_embedded_documents,
+            field_distribution,
         }
     }
 }
@@ -634,11 +714,40 @@ impl From<index_scheduler::IndexStats> for IndexStats {
 )]
 pub async fn get_index_stats(
     index_scheduler: GuardedData<ActionPolicy<{ actions::STATS_GET }>, Data<IndexScheduler>>,
+    params: AwebQueryParameter<GetIndexStatsParams, DeserrQueryParamError>,
     index_uid: web::Path<String>,
 ) -> Result<HttpResponse, ResponseError> {
     let index_uid = IndexUid::try_from(index_uid.into_inner())?;
-    let stats = IndexStats::from(index_scheduler.index_stats(&index_uid)?);
+
+    let GetIndexStatsParams {
+        show_internal_database_sizes: Param(show_internal_database_sizes),
+        size_format,
+    } = params.into_inner();
+
+    let stats = IndexStats::from_db_index_stats(
+        index_scheduler.index_stats(&index_uid)?,
+        size_format.unwrap_or(SizeFormat::Raw), // default to `raw` for backcompat.
+        show_internal_database_sizes,
+    );
 
     debug!(returns = ?stats, "Get index stats");
     Ok(HttpResponse::Ok().json(stats))
+}
+
+#[derive(Debug, Deserr, IntoParams)]
+#[deserr(error = DeserrQueryParamError, rename_all = camelCase, deny_unknown_fields)]
+#[into_params(rename_all = "camelCase", parameter_in = Query)]
+pub struct GetIndexStatsParams {
+    /// If `true`, adds `internalDatabaseSizes` to the response.
+    #[deserr(default, error = DeserrQueryParamError<InvalidStatsShowInternalDatabaseSizes>)]
+    #[param(required = false, value_type = bool, example = false)]
+    pub show_internal_database_sizes: Param<bool>,
+
+    /// Specify how to format the sizes:
+    ///
+    /// - `"raw"`: format sizes as a number of bytes
+    /// - `"human"`: format sizes as a human-readable string with an appropriate unit.
+    #[deserr(default, error = DeserrQueryParamError<InvalidStatsSizeFormat>)]
+    #[param(required = false, example = "human")]
+    pub size_format: Option<SizeFormat>,
 }

--- a/crates/meilisearch/src/routes/indexes/mod.rs
+++ b/crates/meilisearch/src/routes/indexes/mod.rs
@@ -577,7 +577,7 @@ impl Size {
 
         match format {
             SizeFormat::Human => {
-                let size = Byte::from_u64(bytes as u64).get_appropriate_unit(Binary);
+                let size = Byte::from_u64(bytes).get_appropriate_unit(Binary);
                 Self::Human(format!("{size:#.2}"))
             }
             SizeFormat::Raw => Self::Raw(bytes),
@@ -657,11 +657,10 @@ impl IndexStats {
             raw_document_db_size: Size::new(documents_database_stats.total_size(), format),
             avg_document_size: Size::new(documents_database_stats.average_value_size(), format),
             internal_database_sizes: if with_internal_database_sizes {
-                let internal_database_sizes = internal_database_sizes
+                internal_database_sizes
                     .into_iter()
                     .map(|(dbname, size)| (dbname, Size::new(size, format).into()))
-                    .collect();
-                internal_database_sizes
+                    .collect()
             } else {
                 Default::default()
             },

--- a/crates/meilisearch/src/routes/indexes/mod.rs
+++ b/crates/meilisearch/src/routes/indexes/mod.rs
@@ -602,6 +602,7 @@ pub struct IndexStats {
     ///
     /// Database names can change from version to version.
     #[serde(skip_serializing_if = "serde_json::Map::is_empty")]
+    #[schema(value_type = HashMap<String, Size>)]
     // serde_json::Map<String, Size> is not Serialize, so we convert the Size to a serde_json::Value
     pub internal_database_sizes: serde_json::Map<String, serde_json::Value>,
     /// Number of embeddings in the index
@@ -677,7 +678,7 @@ impl IndexStats {
 /// Return statistics for a single index: document count, database size, indexing status, and field distribution.
 #[routes::path(
     security(("Bearer" = ["stats.get", "stats.*", "*"])),
-    params(("index_uid" = String, example = "movies", description = "Unique identifier of the index.", nullable = false)),
+    params(("index_uid" = String, example = "movies", description = "Unique identifier of the index.", nullable = false), GetIndexStatsParams),
     responses(
         (status = OK, description = "The stats of the index.", body = IndexStats, content_type = "application/json", example = json!(
             {
@@ -744,7 +745,7 @@ pub struct GetIndexStatsParams {
 
     /// Specify how to format the sizes:
     ///
-    /// - `"raw"`: format sizes as a number of bytes
+    /// - `"raw"` (default): format sizes as a number of bytes
     /// - `"human"`: format sizes as a human-readable string with an appropriate unit.
     #[deserr(default, error = DeserrQueryParamError<InvalidStatsSizeFormat>)]
     #[param(required = false, example = "human")]

--- a/crates/meilisearch/src/routes/metrics.rs
+++ b/crates/meilisearch/src/routes/metrics.rs
@@ -2,6 +2,7 @@ use actix_web::web::{self, Data};
 use actix_web::HttpResponse;
 use index_scheduler::{IndexScheduler, Query};
 use meilisearch_auth::AuthController;
+use meilisearch_types::deserr::query_params::Param;
 use meilisearch_types::error::ResponseError;
 use meilisearch_types::keys::actions;
 use meilisearch_types::milli::progress::ProgressStepView;
@@ -12,6 +13,7 @@ use time::OffsetDateTime;
 use crate::extractors::authentication::policies::ActionPolicy;
 use crate::extractors::authentication::{AuthenticationError, GuardedData};
 use crate::routes::create_all_stats;
+use crate::routes::indexes::{GetIndexStatsParams, SizeFormat};
 use crate::search_queue::SearchQueue;
 
 #[routes::routes(
@@ -131,10 +133,28 @@ pub async fn get_metrics(
         return Err(error);
     }
 
-    let response = create_all_stats((*index_scheduler).clone(), auth_controller, auth_filters)?;
+    let response = create_all_stats(
+        (*index_scheduler).clone(),
+        auth_controller,
+        auth_filters,
+        GetIndexStatsParams {
+            show_internal_database_sizes: Param(false),
+            size_format: Some(SizeFormat::Raw),
+        },
+    )?;
 
-    crate::metrics::MEILISEARCH_DB_SIZE_BYTES.set(response.database_size as i64);
-    crate::metrics::MEILISEARCH_USED_DB_SIZE_BYTES.set(response.used_database_size as i64);
+    let database_size = match response.database_size {
+        crate::routes::indexes::Size::Raw(bytes) => bytes as i64,
+        crate::routes::indexes::Size::Human(_) => 0,
+    };
+
+    let used_database_size = match response.used_database_size {
+        crate::routes::indexes::Size::Raw(bytes) => bytes as i64,
+        crate::routes::indexes::Size::Human(_) => 0,
+    };
+
+    crate::metrics::MEILISEARCH_DB_SIZE_BYTES.set(database_size as i64);
+    crate::metrics::MEILISEARCH_USED_DB_SIZE_BYTES.set(used_database_size as i64);
     crate::metrics::MEILISEARCH_INDEX_COUNT.set(response.indexes.len() as i64);
 
     crate::metrics::MEILISEARCH_SEARCH_QUEUE_SIZE.set(search_queue.capacity() as i64);

--- a/crates/meilisearch/src/routes/mod.rs
+++ b/crates/meilisearch/src/routes/mod.rs
@@ -419,9 +419,9 @@ pub async fn running() -> HttpResponse {
 #[serde(rename_all = "camelCase")]
 pub struct Stats {
     /// Total disk space used by the database in bytes
-    pub database_size: u64,
+    pub database_size: Size,
     /// Actual size of the data in the database in bytes
-    pub used_database_size: u64,
+    pub used_database_size: Size,
     /// Date of the last update in RFC 3339 format. Null if no update has been
     /// processed
     #[serde(serialize_with = "time::serde::rfc3339::option::serialize")]
@@ -471,10 +471,13 @@ pub struct Stats {
 async fn get_stats(
     index_scheduler: GuardedData<ActionPolicy<{ actions::STATS_GET }>, Data<IndexScheduler>>,
     auth_controller: GuardedData<ActionPolicy<{ actions::STATS_GET }>, Data<AuthController>>,
+    params: AwebQueryParameter<GetIndexStatsParams, DeserrQueryParamError>,
 ) -> Result<HttpResponse, ResponseError> {
     let filters = index_scheduler.filters();
+    let params = params.into_inner();
 
-    let stats = create_all_stats((*index_scheduler).clone(), (*auth_controller).clone(), filters)?;
+    let stats =
+        create_all_stats((*index_scheduler).clone(), (*auth_controller).clone(), filters, params)?;
 
     debug!(returns = ?stats, "Get stats");
     Ok(HttpResponse::Ok().json(stats))

--- a/crates/meilisearch/src/routes/mod.rs
+++ b/crates/meilisearch/src/routes/mod.rs
@@ -2,11 +2,14 @@ use std::collections::BTreeMap;
 
 use actix_web::web::Data;
 use actix_web::{web, HttpRequest, HttpResponse};
+use deserr::actix_web::AwebQueryParameter;
 use export::Export;
 use index_scheduler::IndexScheduler;
 use meilisearch_auth::AuthController;
 use meilisearch_types::batch_view::BatchView;
 use meilisearch_types::batches::BatchStats;
+use meilisearch_types::deserr::query_params::Param;
+use meilisearch_types::deserr::DeserrQueryParamError;
 use meilisearch_types::error::{Code, ErrorType, ResponseError};
 use meilisearch_types::index_uid::IndexUid;
 use meilisearch_types::keys::CreateApiKey;
@@ -37,7 +40,9 @@ use crate::milli::progress::{ProgressStepView, ProgressView};
 use crate::routes::batches::AllBatches;
 use crate::routes::features::RuntimeTogglableFeatures;
 use crate::routes::indexes::documents::{DocumentDeletionByFilter, DocumentEditionByFunction};
-use crate::routes::indexes::{IndexView, ListFields, ListFieldsFilter};
+use crate::routes::indexes::{
+    GetIndexStatsParams, IndexView, ListFields, ListFieldsFilter, Size, SizeFormat,
+};
 use crate::routes::multi_search::SearchResults;
 use crate::routes::network::{Network, Remote, Shard};
 use crate::routes::swap_indexes::SwapIndexesPayload;
@@ -479,11 +484,15 @@ pub fn create_all_stats(
     index_scheduler: Data<IndexScheduler>,
     auth_controller: Data<AuthController>,
     filters: &meilisearch_auth::AuthFilter,
+    params: GetIndexStatsParams,
 ) -> Result<Stats, ResponseError> {
     let mut last_task: Option<OffsetDateTime> = None;
     let mut indexes = BTreeMap::new();
     let mut database_size = 0;
     let mut used_database_size = 0;
+
+    let size_format = params.size_format.unwrap_or(SizeFormat::Raw); // default to `raw` for backcompat.
+    let Param(show_internal_database_sizes) = params.show_internal_database_sizes;
 
     for index_uid in index_scheduler.index_names()? {
         // Accumulate the size of all indexes, even unauthorized ones, so
@@ -500,13 +509,19 @@ pub fn create_all_stats(
         last_task = last_task.map_or(Some(stats.inner_stats.updated_at), |last| {
             Some(last.max(stats.inner_stats.updated_at))
         });
-        indexes.insert(index_uid.to_string(), stats.into());
+        indexes.insert(
+            index_uid.to_string(),
+            IndexStats::from_db_index_stats(stats, size_format, show_internal_database_sizes),
+        );
     }
 
     database_size += index_scheduler.size()?;
     used_database_size += index_scheduler.used_size()?;
     database_size += auth_controller.size()?;
     used_database_size += auth_controller.used_size()?;
+
+    let database_size = Size::new(database_size, size_format);
+    let used_database_size = Size::new(used_database_size, size_format);
 
     let stats = Stats { database_size, used_database_size, last_update: last_task, indexes };
     Ok(stats)

--- a/crates/meilisearch/src/routes/mod.rs
+++ b/crates/meilisearch/src/routes/mod.rs
@@ -119,7 +119,7 @@ mod webhooks;
         url = "http://localhost:7700",
         description = "Local server.",
     )),
-    components(schemas(PaginationView<KeyView>, PaginationView<IndexView>, IndexView, DocumentDeletionByFilter, AllBatches, BatchStats, ProgressStepView, ProgressView, BatchView, RuntimeTogglableFeatures, SwapIndexesPayload, DocumentEditionByFunction, MergeFacets, FederationOptions, SearchQueryWithIndex, Federation, FederatedSearch, FederatedSearchResult, SearchResults, SearchResultWithIndex, SimilarQuery, SimilarResult, PaginationView<serde_json::Value>, BrowseQuery, UpdateIndexRequest, IndexUid, IndexCreateRequest, KeyView, Action, CreateApiKey, UpdateStderrLogs, LogMode, GetLogs, IndexStats, Stats, HealthStatus, HealthResponse, VersionResponse, Code, ErrorType, AllTasks, TaskView, Status, DetailsView, ResponseError, Settings<Unchecked>, Settings<Checked>, TypoSettings, MinWordSizeTyposSetting, FacetingSettings, PaginationSettings, SummarizedTaskView, Kind, Network, Remote, Shard, FilterableAttributesRule, FilterableAttributesPatterns, AttributePatterns, FilterableAttributesFeatures, FilterFeatures, Export, WebhookSettings, WebhookResults, WebhookWithMetadataRedactedAuthorization, meilisearch_types::milli::vector::VectorStoreBackend, ListFields, ListFieldsFilter))
+    components(schemas(PaginationView<KeyView>, PaginationView<IndexView>, IndexView, DocumentDeletionByFilter, AllBatches, BatchStats, ProgressStepView, ProgressView, BatchView, RuntimeTogglableFeatures, SwapIndexesPayload, DocumentEditionByFunction, MergeFacets, FederationOptions, SearchQueryWithIndex, Federation, FederatedSearch, FederatedSearchResult, SearchResults, SearchResultWithIndex, SimilarQuery, SimilarResult, PaginationView<serde_json::Value>, BrowseQuery, UpdateIndexRequest, IndexUid, IndexCreateRequest, KeyView, Action, CreateApiKey, UpdateStderrLogs, LogMode, GetLogs, IndexStats, Stats, HealthStatus, HealthResponse, VersionResponse, Code, ErrorType, AllTasks, TaskView, Status, DetailsView, ResponseError, Settings<Unchecked>, Settings<Checked>, TypoSettings, MinWordSizeTyposSetting, FacetingSettings, PaginationSettings, SummarizedTaskView, Kind, Network, Remote, Shard, FilterableAttributesRule, FilterableAttributesPatterns, AttributePatterns, FilterableAttributesFeatures, FilterFeatures, Export, WebhookSettings, WebhookResults, WebhookWithMetadataRedactedAuthorization, meilisearch_types::milli::vector::VectorStoreBackend, ListFields, ListFieldsFilter, SizeFormat))
 )]
 pub struct MeilisearchApi;
 
@@ -437,6 +437,7 @@ pub struct Stats {
 #[routes::path(
     override_tag = "Stats",
     security(("Bearer" = ["stats.get", "stats.*", "*"])),
+    params(GetIndexStatsParams),
     responses(
         (status = 200, description = "The stats of the instance.", body = Stats, content_type = "application/json", example = json!(
             {


### PR DESCRIPTION
## Changelog

Adds two new query parameters to `GET /indexes/{indexUid}/stats` and `GET /stats`:
- `showInternalDatabaseSizes`: boolean, optional, defaults to `false`. When present, the index stat objects in responses of the stat routes now contain an additional `internalDatabaseSizes` key, whose value  is a dictionary of the internal database names and their current size in the index, like in the stats object of a batch.
- `sizeFormat`: `human` or `raw`: optional, defaults to `raw`. When present and set to `human`, then all database sizes in responses of the stat routes will be returned as a string containing an appropriate unit (MiB, GiB, etc). When missing or set to `raw`, then the current behavior of expressing the size in bytes as a number is retained.

Note for integrations: The keys in `internalDatabaseSizes` are subject to change and should not be exposed as a strongly typed object. This is the same as the existing `internalDatabaseSizes` in batch stats.

<details>

<summary>

Adding `showInternalDatabaseSizes` to an index stats 

</summary>

```jsonc
// curl -X GET "http://localhost:7700/indexes/movies/stats?showInternalDatabaseSizes=true"
{
  "numberOfDocuments": 31944,
  "rawDocumentDbSize": 20594688,
  "avgDocumentSize": 636,
  "isIndexing": false,
  "internalDatabaseSizes": {
    "wordPairProximityDocids": 100827136,
    "documents": 20594688,
    "wordPositionDocids": 18694144,
    "wordFidDocids": 10715136,
    "wordPrefixPositionDocids": 10256384,
    "wordDocids": 9453568,
    "wordPrefixFidDocids": 4603904,
    "wordPrefixDocids": 3424256,
    "main": 1425408,
    "externalDocumentsIds": 999424,
    "fieldIdWordCountDocids": 245760,
    "exactWordPrefixDocids": 16384,
    "celluliteMetadata": 16384
  },
  "numberOfEmbeddings": 0,
  "numberOfEmbeddedDocuments": 0,
  "fieldDistribution": {
    "genres": 31944,
    "id": 31944,
    "overview": 31944,
    "poster": 31944,
    "release_date": 31944,
    "title": 31944
  }
}
```

</details>

<details>

<summary> 

Adding `showInternalDatabaseSizes` and `sizeFormat=human` to global stats 

</summary>

```jsonc
// curl -X GET "http://localhost:7700/stats?showInternalDatabaseSizes=true&sizeFormat=human"
{
  "databaseSize": "351.38 MiB",
  "usedDatabaseSize": "350.64 MiB",
  "lastUpdate": "2026-04-16T13:07:02.74243Z",
  "indexes": {
    "comics": {
      "numberOfDocuments": 31944,
      "rawDocumentDbSize": "23.14 MiB",
      "avgDocumentSize": "751 B",
      "isIndexing": false,
      "internalDatabaseSizes": {
        "wordPairProximityDocids": "98.06 MiB",
        "documents": "23.14 MiB",
        "wordPositionDocids": "17.22 MiB",
        "wordFidDocids": "10.36 MiB",
        "wordPrefixPositionDocids": "9.47 MiB",
        "wordDocids": "8.97 MiB",
        "wordPrefixFidDocids": "4.36 MiB",
        "wordPrefixDocids": "3.27 MiB",
        "main": "1.36 MiB",
        "externalDocumentsIds": "944 KiB",
        "fieldIdWordCountDocids": "240 KiB",
        "exactWordPrefixDocids": "16 KiB",
        "celluliteMetadata": "16 KiB"
      },
      "numberOfEmbeddings": 0,
      "numberOfEmbeddedDocuments": 0,
      "fieldDistribution": {
        "genres": 31944,
        "id": 31944,
        "overview": 31944,
        "poster": 31944,
        "release_date": 31944,
        "title": 31944
      }
    },
    "movies": {
      "numberOfDocuments": 31944,
      "rawDocumentDbSize": "19.64 MiB",
      "avgDocumentSize": "636 B",
      "isIndexing": false,
      "internalDatabaseSizes": {
        "wordPairProximityDocids": "96.16 MiB",
        "documents": "19.64 MiB",
        "wordPositionDocids": "17.83 MiB",
        "wordFidDocids": "10.22 MiB",
        "wordPrefixPositionDocids": "9.78 MiB",
        "wordDocids": "9.02 MiB",
        "wordPrefixFidDocids": "4.39 MiB",
        "wordPrefixDocids": "3.27 MiB",
        "main": "1.36 MiB",
        "externalDocumentsIds": "976 KiB",
        "fieldIdWordCountDocids": "240 KiB",
        "exactWordPrefixDocids": "16 KiB",
        "celluliteMetadata": "16 KiB"
      },
      "numberOfEmbeddings": 0,
      "numberOfEmbeddedDocuments": 0,
      "fieldDistribution": {
        "genres": 31944,
        "id": 31944,
        "overview": 31944,
        "poster": 31944,
        "release_date": 31944,
        "title": 31944
      }
    }
  }
}
```

</details>

<details>

<summary> 

The call without any parameters is the same as in previous versions.

</summary>

```jsonc
// curl -X GET "http://localhost:7700/stats"
{
  "databaseSize": 368443392,
  "usedDatabaseSize": 367673344,
  "lastUpdate": "2026-04-16T13:07:02.74243Z",
  "indexes": {
    "comics": {
      "numberOfDocuments": 31944,
      "rawDocumentDbSize": 24264704,
      "avgDocumentSize": 751,
      "isIndexing": false,
      "numberOfEmbeddings": 0,
      "numberOfEmbeddedDocuments": 0,
      "fieldDistribution": {
        "genres": 31944,
        "id": 31944,
        "overview": 31944,
        "poster": 31944,
        "release_date": 31944,
        "title": 31944
      }
    },
    "movies": {
      "numberOfDocuments": 31944,
      "rawDocumentDbSize": 20594688,
      "avgDocumentSize": 636,
      "isIndexing": false,
      "numberOfEmbeddings": 0,
      "numberOfEmbeddedDocuments": 0,
      "fieldDistribution": {
        "genres": 31944,
        "id": 31944,
        "overview": 31944,
        "poster": 31944,
        "release_date": 31944,
        "title": 31944
      }
    }
  }
}
```

</details>


## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respect the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - *list of used tools and what they were used for*
