### PR TITLE
Normalize before filter

### DIFF
--- a/crates/meilisearch/tests/search/filters.rs
+++ b/crates/meilisearch/tests/search/filters.rs
@@ -1170,3 +1170,53 @@ async fn vector_filter_regenerate() {
     }
     "###);
 }
+
+#[actix_rt::test]
+async fn issue_6335() {
+    test_settings_documents_indexing_swapping_and_search(
+        &NESTED_DOCUMENTS,
+        &json!({"filterableAttributes": [{"attributePatterns": ["cattos"],
+        "features": {
+                  "facetSearch": false,
+                  "filter": {"equality": true, "comparison": true}
+        }}]}),
+        &json!({
+            "filter": "cattos < pestiféré"
+        }),
+        |response, code| {
+            snapshot!(code, @"200 OK");
+            snapshot!(json_string!(response["hits"]), @r#"
+            [
+              {
+                "id": 750,
+                "father": "romain",
+                "mother": "michelle",
+                "cattos": [
+                  "enigma"
+                ]
+              },
+              {
+                "id": 951,
+                "father": "jean-baptiste",
+                "mother": "sophie",
+                "doggos": [
+                  {
+                    "name": "turbo",
+                    "age": 5
+                  },
+                  {
+                    "name": "fast",
+                    "age": 6
+                  }
+                ],
+                "cattos": [
+                  "moumoute",
+                  "gomez"
+                ]
+              }
+            ]
+            "#);
+        },
+    )
+    .await;
+}

--- a/crates/milli/src/search/facet/filter/index_filter.rs
+++ b/crates/milli/src/search/facet/filter/index_filter.rs
@@ -83,6 +83,8 @@ impl<'a> IndexFilter<'a> {
     ) -> Result<RoaringBitmap> {
         let numbers_db = index.facet_id_f64_docids;
         let strings_db = index.facet_id_string_docids;
+        let left_normalized_value;
+        let right_normalized_value;
 
         // Make sure we always bound the ranges with the field id and the level,
         // as the facets values are all in the same database and prefixed by the
@@ -124,25 +126,29 @@ impl<'a> IndexFilter<'a> {
             Condition::GreaterThan(val) => {
                 let number = val.parse_finite_float().ok();
                 let number_bounds = number.map(|number| (Excluded(number), Included(f64::MAX)));
-                let str_bounds = (Excluded(val.fragment()), Unbounded);
+                left_normalized_value = crate::normalize_facet(val.fragment());
+                let str_bounds = (Excluded(left_normalized_value.as_str()), Unbounded);
                 (number_bounds, str_bounds)
             }
             Condition::GreaterThanOrEqual(val) => {
                 let number = val.parse_finite_float().ok();
                 let number_bounds = number.map(|number| (Included(number), Included(f64::MAX)));
-                let str_bounds = (Included(val.fragment()), Unbounded);
+                left_normalized_value = crate::normalize_facet(val.fragment());
+                let str_bounds = (Included(left_normalized_value.as_str()), Unbounded);
                 (number_bounds, str_bounds)
             }
             Condition::LowerThan(val) => {
                 let number = val.parse_finite_float().ok();
                 let number_bounds = number.map(|number| (Included(f64::MIN), Excluded(number)));
-                let str_bounds = (Unbounded, Excluded(val.fragment()));
+                left_normalized_value = crate::normalize_facet(val.fragment());
+                let str_bounds = (Unbounded, Excluded(left_normalized_value.as_str()));
                 (number_bounds, str_bounds)
             }
             Condition::LowerThanOrEqual(val) => {
                 let number = val.parse_finite_float().ok();
                 let number_bounds = number.map(|number| (Included(f64::MIN), Included(number)));
-                let str_bounds = (Unbounded, Included(val.fragment()));
+                left_normalized_value = crate::normalize_facet(val.fragment());
+                let str_bounds = (Unbounded, Included(left_normalized_value.as_str()));
                 (number_bounds, str_bounds)
             }
             Condition::Between { from, to } => {
@@ -151,7 +157,12 @@ impl<'a> IndexFilter<'a> {
 
                 let number_bounds =
                     from_number.zip(to_number).map(|(from, to)| (Included(from), Included(to)));
-                let str_bounds = (Included(from.fragment()), Included(to.fragment()));
+                left_normalized_value = crate::normalize_facet(from.fragment());
+                right_normalized_value = crate::normalize_facet(to.fragment());
+                let str_bounds = (
+                    Included(left_normalized_value.as_str()),
+                    Included(right_normalized_value.as_str()),
+                );
                 (number_bounds, str_bounds)
             }
             Condition::Null => {


### PR DESCRIPTION
## Related issue

Fixes #6335 

# Changelog

Fixes a bug where string facet values appearing in `<, <=, >, >=` and `IN` filters where not normalized before comparison to facet values.

This would cause some values in document (e.g. `2026-01-01T00:00:00`) to appear to be higher than their filter counterpart, due to being normalized (e.g. like `2026-01-01t00:00:00`). 

Thanks to @njaard for [reporting the issue](https://github.com/meilisearch/meilisearch/issues/6335) :heart: 

# Implementation

- Normalize before passing the value to facet range search
- Add test that fails before the fix and passes after the fix.

Maintainability note: Such bugs could be prevented in the future by reifying "(hyper)normalized" values as dedicated types rather than using Strings and manually maintaining their invariants. Had the bounds accepted a `NormalizedStr<'a>` instead of a `&'a str`, the bug would not have been written in the first place.

## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respect the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - *list of used tools and what they were used for*
