### PR TITLE
Replace boolean by PatternMatch for searchable

### DIFF
--- a/crates/meilisearch/src/routes/indexes/fields.rs
+++ b/crates/meilisearch/src/routes/indexes/fields.rs
@@ -57,15 +57,15 @@ impl<'a> Field<'a> {
 
         Field {
             name,
-            displayed: FieldDisplayConfig { enabled: metadata.displayed },
+            displayed: FieldDisplayConfig { enabled: metadata.displayed == PatternMatch::Match },
             searchable: FieldSearchConfig {
                 enabled: metadata.is_searchable() == PatternMatch::Match,
             },
-            sortable: FieldSortableConfig { enabled: metadata.sortable },
-            distinct: FieldDistinctConfig { enabled: metadata.distinct },
+            sortable: FieldSortableConfig { enabled: metadata.sortable == PatternMatch::Match },
+            distinct: FieldDistinctConfig { enabled: metadata.distinct == PatternMatch::Match },
             ranking_rule: FieldRankingRuleConfig {
-                enabled: metadata.is_asc_desc(),
-                order: metadata.asc_desc,
+                enabled: metadata.is_asc_desc() == PatternMatch::Match,
+                order: metadata.asc_desc.1,
             },
             filterable: FieldFilterableConfig {
                 enabled: is_filterable,

--- a/crates/meilisearch/src/routes/indexes/fields.rs
+++ b/crates/meilisearch/src/routes/indexes/fields.rs
@@ -58,7 +58,9 @@ impl<'a> Field<'a> {
         Field {
             name,
             displayed: FieldDisplayConfig { enabled: metadata.displayed },
-            searchable: FieldSearchConfig { enabled: metadata.searchable.is_some() },
+            searchable: FieldSearchConfig {
+                enabled: metadata.is_searchable() == PatternMatch::Match,
+            },
             sortable: FieldSortableConfig { enabled: metadata.sortable },
             distinct: FieldDistinctConfig { enabled: metadata.distinct },
             ranking_rule: FieldRankingRuleConfig {

--- a/crates/meilisearch/tests/common/mod.rs
+++ b/crates/meilisearch/tests/common/mod.rs
@@ -534,6 +534,13 @@ pub async fn shared_index_with_geo_documents() -> &'static Index<'static, Shared
 
             let (response, _code) = index
                 ._update_settings(
+                    json!({"filterableAttributes": ["_geo", "type"], "sortableAttributes": ["_geo"]}),
+                )
+                .await;
+            server.wait_task(response.uid()).await.succeeded();
+
+            let (response, _code) = index
+                ._update_settings(
                     json!({"filterableAttributes": ["_geo"], "sortableAttributes": ["_geo"]}),
                 )
                 .await;
@@ -554,6 +561,10 @@ pub async fn shared_index_geojson_documents() -> &'static Index<'static, Shared>
             let lille = serde_json::from_str::<serde_json::Value>(countries).unwrap();
             let (response, _code) =
                 index._add_documents(Value(lille), Some("name"), None, false).await;
+            server.wait_task(response.uid()).await.succeeded();
+
+            let (response, _code) =
+                index._update_settings(json!({"filterableAttributes": ["_geojson", "name"]})).await;
             server.wait_task(response.uid()).await.succeeded();
 
             let (response, _code) =

--- a/crates/meilisearch/tests/index/snapshots/integration__index__fields__fields_after_uploading_recipe_and_settings-4.snap
+++ b/crates/meilisearch/tests/index/snapshots/integration__index__fields__fields_after_uploading_recipe_and_settings-4.snap
@@ -123,7 +123,7 @@ expression: "(code.as_u16(), resp)"
       {
         "name": "cuisine.is_authentic",
         "displayed": {
-          "enabled": false
+          "enabled": true
         },
         "searchable": {
           "enabled": false
@@ -151,7 +151,7 @@ expression: "(code.as_u16(), resp)"
       {
         "name": "cuisine.region",
         "displayed": {
-          "enabled": false
+          "enabled": true
         },
         "searchable": {
           "enabled": true
@@ -179,7 +179,7 @@ expression: "(code.as_u16(), resp)"
       {
         "name": "cuisine.type",
         "displayed": {
-          "enabled": false
+          "enabled": true
         },
         "searchable": {
           "enabled": true
@@ -599,7 +599,7 @@ expression: "(code.as_u16(), resp)"
       {
         "name": "nutrition.calories",
         "displayed": {
-          "enabled": false
+          "enabled": true
         },
         "searchable": {
           "enabled": false
@@ -627,7 +627,7 @@ expression: "(code.as_u16(), resp)"
       {
         "name": "nutrition.carbs",
         "displayed": {
-          "enabled": false
+          "enabled": true
         },
         "searchable": {
           "enabled": false
@@ -655,7 +655,7 @@ expression: "(code.as_u16(), resp)"
       {
         "name": "nutrition.fat",
         "displayed": {
-          "enabled": false
+          "enabled": true
         },
         "searchable": {
           "enabled": false
@@ -683,7 +683,7 @@ expression: "(code.as_u16(), resp)"
       {
         "name": "nutrition.protein",
         "displayed": {
-          "enabled": false
+          "enabled": true
         },
         "searchable": {
           "enabled": false

--- a/crates/milli/src/attribute_patterns.rs
+++ b/crates/milli/src/attribute_patterns.rs
@@ -114,6 +114,31 @@ pub fn match_field_legacy(pattern: &str, field: &str) -> PatternMatch {
     }
 }
 
+/// Match a field against a set of patterns using the legacy behavior.
+///
+/// A field matches a set of patterns if it is a parent of one of the patterns or if it matches one of the patterns.
+///
+/// # Arguments
+///
+/// * `patterns` - The set of patterns to match against.
+/// * `field` - The field to match against the patterns.
+pub fn field_match_any_patterns_legacy<'a, I, P>(patterns: I, field: &str) -> PatternMatch
+where
+    I: IntoIterator<Item = P>,
+    P: AsRef<str>,
+{
+    let mut selection = PatternMatch::NoMatch;
+    for pattern in patterns {
+        match match_field_legacy(pattern.as_ref(), field) {
+            PatternMatch::Match => return PatternMatch::Match,
+            PatternMatch::Parent => selection = PatternMatch::Parent,
+            PatternMatch::NoMatch => (),
+        }
+    }
+
+    selection
+}
+
 /// Match a field against a distinct field.
 pub fn match_distinct_field(distinct_field: Option<&str>, field: &str) -> PatternMatch {
     if let Some(distinct_field) = distinct_field {

--- a/crates/milli/src/attribute_patterns.rs
+++ b/crates/milli/src/attribute_patterns.rs
@@ -122,7 +122,7 @@ pub fn match_field_legacy(pattern: &str, field: &str) -> PatternMatch {
 ///
 /// * `patterns` - The set of patterns to match against.
 /// * `field` - The field to match against the patterns.
-pub fn field_match_any_patterns_legacy<'a, I, P>(patterns: I, field: &str) -> PatternMatch
+pub fn field_match_any_patterns_legacy<I, P>(patterns: I, field: &str) -> PatternMatch
 where
     I: IntoIterator<Item = P>,
     P: AsRef<str>,

--- a/crates/milli/src/fields_ids_map/metadata.rs
+++ b/crates/milli/src/fields_ids_map/metadata.rs
@@ -18,7 +18,7 @@ use crate::{
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Metadata {
     /// The weight as defined in the FieldidsWeightsMap of the searchable attribute if it is searchable.
-    pub searchable: Option<Weight>,
+    pub searchable: (PatternMatch, Option<Weight>),
     /// The field is part of the exact attributes.
     pub exact: bool,
     /// The field is part of the sortable attributes.
@@ -187,12 +187,16 @@ impl Metadata {
         self.sortable
     }
 
-    pub fn is_searchable(&self) -> bool {
-        self.searchable.is_some()
+    pub fn is_searchable(&self) -> PatternMatch {
+        let (pattern_match, _) = self.searchable;
+
+        pattern_match
     }
 
     pub fn searchable_weight(&self) -> Option<Weight> {
-        self.searchable
+        let (_, weight) = self.searchable;
+
+        weight
     }
 
     pub fn is_distinct(&self) -> bool {
@@ -323,7 +327,7 @@ impl MetadataBuilder {
         if is_faceted_by(field, RESERVED_VECTORS_FIELD_NAME) {
             // Vectors fields are not searchable, filterable, distinct or asc_desc
             return Metadata {
-                searchable: None,
+                searchable: (PatternMatch::NoMatch, None),
                 exact: false,
                 sortable: false,
                 distinct: false,
@@ -353,7 +357,7 @@ impl MetadataBuilder {
         if match_field_legacy(RESERVED_GEO_FIELD_NAME, field) == PatternMatch::Match {
             // Geo fields are not searchable, distinct or asc_desc
             return Metadata {
-                searchable: None,
+                searchable: (PatternMatch::NoMatch, None),
                 exact: false,
                 sortable,
                 distinct: false,
@@ -369,7 +373,7 @@ impl MetadataBuilder {
         if match_field_legacy(RESERVED_GEOJSON_FIELD_NAME, field) == PatternMatch::Match {
             debug_assert!(!sortable, "geojson fields should not be sortable");
             return Metadata {
-                searchable: None,
+                searchable: (PatternMatch::NoMatch, None),
                 exact: false,
                 sortable,
                 distinct: false,
@@ -388,9 +392,12 @@ impl MetadataBuilder {
             Some(attributes) => attributes
                 .iter()
                 .enumerate()
-                .find(|(_i, pattern)| is_faceted_by(field, pattern))
-                .map(|(i, _)| i as u16),
-            None => Some(0),
+                .find_map(|(i, pattern)| match match_field_legacy(pattern, field) {
+                    PatternMatch::Match => Some((PatternMatch::Match, Some(i as u16))),
+                    pattern_match => Some((pattern_match, None)),
+                })
+                .unwrap_or((PatternMatch::NoMatch, None)),
+            None => (PatternMatch::Match, Some(0)),
         };
 
         let exact = self.exact_searchable_attributes.iter().any(|attr| is_faceted_by(field, attr));

--- a/crates/milli/src/fields_ids_map/metadata.rs
+++ b/crates/milli/src/fields_ids_map/metadata.rs
@@ -5,7 +5,9 @@ use charabia::Language;
 use heed::RoTxn;
 
 use super::FieldsIdsMap;
-use crate::attribute_patterns::{match_field_legacy, PatternMatch};
+use crate::attribute_patterns::{
+    field_match_any_patterns_legacy, match_distinct_field, match_field_legacy, PatternMatch,
+};
 use crate::constants::{
     RESERVED_GEOJSON_FIELD_NAME, RESERVED_GEO_FIELD_NAME, RESERVED_VECTORS_FIELD_NAME,
 };
@@ -20,23 +22,23 @@ pub struct Metadata {
     /// The weight as defined in the FieldidsWeightsMap of the searchable attribute if it is searchable.
     pub searchable: (PatternMatch, Option<Weight>),
     /// The field is part of the exact attributes.
-    pub exact: bool,
+    pub exact: PatternMatch,
     /// The field is part of the sortable attributes.
-    pub sortable: bool,
+    pub sortable: PatternMatch,
     /// The field is defined as the distinct attribute.
-    pub distinct: bool,
+    pub distinct: PatternMatch,
     /// The field has been defined as asc/desc in the ranking rules.
-    pub asc_desc: Option<FieldSortOrder>,
+    pub asc_desc: (PatternMatch, Option<FieldSortOrder>),
     /// The field is a geo field (`_geo`, `_geo.lat`, `_geo.lng`).
-    pub geo: bool,
+    pub geo: PatternMatch,
     /// The field is a geo json field (`_geojson`).
-    pub geo_json: bool,
+    pub geo_json: PatternMatch,
     /// The field is defined as a field that can be displayed.
-    pub displayed: bool,
+    pub displayed: PatternMatch,
     /// The id of the localized attributes rule if the field is localized.
     pub localized_attributes_rule_id: Option<NonZeroU16>,
     /// The id of the filterable attributes rule if the field is filterable.
-    pub filterable_attributes_rule_id: Option<NonZeroU16>,
+    pub filterable_attributes_rule_id: (PatternMatch, Option<NonZeroU16>),
     /// How that field will be sorted by.
     pub sort_by: OrderBy,
 }
@@ -159,7 +161,7 @@ impl Metadata {
         &self,
         rules: &'rules [FilterableAttributesRule],
     ) -> Option<(usize, &'rules FilterableAttributesRule)> {
-        let filterable_attributes_rule_id = self.filterable_attributes_rule_id?.get();
+        let filterable_attributes_rule_id = self.filterable_attributes_rule_id.1?.get();
         let rule_id = (filterable_attributes_rule_id - 1) as usize;
         let rule = rules.get(rule_id).unwrap();
         Some((rule_id, rule))
@@ -183,7 +185,7 @@ impl Metadata {
             .unwrap_or_else(|| (None, FilterableAttributesFeatures::no_features()))
     }
 
-    pub fn is_sortable(&self) -> bool {
+    pub fn is_sortable(&self) -> PatternMatch {
         self.sortable
     }
 
@@ -199,36 +201,58 @@ impl Metadata {
         weight
     }
 
-    pub fn is_distinct(&self) -> bool {
+    pub fn is_distinct(&self) -> PatternMatch {
         self.distinct
     }
 
-    pub fn is_asc_desc(&self) -> bool {
-        self.asc_desc.is_some()
+    pub fn is_asc_desc(&self) -> PatternMatch {
+        let (pattern_match, _) = self.asc_desc;
+
+        pattern_match
     }
 
-    pub fn is_geo(&self) -> bool {
+    pub fn is_geo(&self) -> PatternMatch {
         self.geo
     }
 
-    /// Returns `true` if the field is part of the facet databases. (sortable, distinct, asc_desc, filterable or facet searchable)
-    pub fn is_faceted(&self, rules: &[FilterableAttributesRule]) -> bool {
-        if self.is_distinct() || self.is_sortable() || self.is_asc_desc() {
-            return true;
+    /// Returns the pattern match if the field is part of the facet databases. (sortable, distinct, asc_desc, filterable or facet searchable)
+    pub fn is_faceted(&self, rules: &[FilterableAttributesRule]) -> PatternMatch {
+        let mut pattern_match = PatternMatch::NoMatch;
+        match self.distinct {
+            PatternMatch::Match => return PatternMatch::Match,
+            PatternMatch::Parent => pattern_match = PatternMatch::Parent,
+            PatternMatch::NoMatch => (),
+        }
+        match self.sortable {
+            PatternMatch::Match => return PatternMatch::Match,
+            PatternMatch::Parent => pattern_match = PatternMatch::Parent,
+            PatternMatch::NoMatch => (),
+        }
+        match self.asc_desc.0 {
+            PatternMatch::Match => return PatternMatch::Match,
+            PatternMatch::Parent => pattern_match = PatternMatch::Parent,
+            PatternMatch::NoMatch => (),
+        }
+        match self.filterable_attributes_rule_id {
+            (PatternMatch::Match, _) => {
+                let features = self.filterable_attributes_features(rules);
+                if features.is_filterable() || features.is_facet_searchable() {
+                    return PatternMatch::Match;
+                }
+            }
+            (PatternMatch::Parent, _) => pattern_match = PatternMatch::Parent,
+            (PatternMatch::NoMatch, _) => (),
         }
 
-        let features = self.filterable_attributes_features(rules);
-        if features.is_filterable() || features.is_facet_searchable() {
-            return true;
-        }
-
-        false
+        pattern_match
     }
 
     pub fn require_facet_level_database(&self, rules: &[FilterableAttributesRule]) -> bool {
         let features = self.filterable_attributes_features(rules);
 
-        self.is_sortable() || self.is_asc_desc() || features.is_filterable_comparison()
+        self.is_sortable() == PatternMatch::Match
+            || self.is_asc_desc() == PatternMatch::Match
+            || features.is_filterable_comparison()
     }
 }
 
@@ -328,42 +352,51 @@ impl MetadataBuilder {
             // Vectors fields are not searchable, filterable, distinct or asc_desc
             return Metadata {
                 searchable: (PatternMatch::NoMatch, None),
-                exact: false,
-                sortable: false,
-                distinct: false,
-                asc_desc: None,
-                geo: false,
-                geo_json: false,
+                exact: PatternMatch::NoMatch,
+                sortable: PatternMatch::NoMatch,
+                distinct: PatternMatch::NoMatch,
+                asc_desc: (PatternMatch::NoMatch, None),
+                geo: PatternMatch::NoMatch,
+                geo_json: PatternMatch::NoMatch,
                 localized_attributes_rule_id: None,
-                filterable_attributes_rule_id: None,
+                filterable_attributes_rule_id: (PatternMatch::NoMatch, None),
                 displayed: self.is_field_displayed(field),
                 sort_by: OrderBy::default(),
             };
         }
 
         // A field is sortable if it is faceted by a sortable attribute
-        let sortable = self
-            .sortable_attributes
-            .iter()
-            .any(|pattern| match_field_legacy(pattern, field) == PatternMatch::Match);
+        let sortable = field_match_any_patterns_legacy(&self.sortable_attributes, field);
 
+        let mut matching_filterable = PatternMatch::NoMatch;
         let filterable_attributes_rule_id = self
             .filterable_attributes
             .iter()
-            .position(|attribute| attribute.match_str(field) == PatternMatch::Match)
+            .position(|attribute| match attribute.match_str(field) {
+                PatternMatch::Match => {
+                    matching_filterable = PatternMatch::Match;
+                    true
+                }
+                PatternMatch::Parent => {
+                    matching_filterable = PatternMatch::Parent;
+                    false
+                }
+                PatternMatch::NoMatch => false,
+            })
             // saturating_add(1): make `id` `NonZero`
             .map(|id| NonZeroU16::new(id.saturating_add(1).try_into().unwrap()).unwrap());
+        let filterable_attributes_rule_id = (matching_filterable, filterable_attributes_rule_id);
 
         if match_field_legacy(RESERVED_GEO_FIELD_NAME, field) == PatternMatch::Match {
             // Geo fields are not searchable, distinct or asc_desc
             return Metadata {
                 searchable: (PatternMatch::NoMatch, None),
-                exact: false,
+                exact: PatternMatch::NoMatch,
                 sortable,
-                distinct: false,
-                asc_desc: None,
-                geo: true,
-                geo_json: false,
+                distinct: PatternMatch::NoMatch,
+                asc_desc: (PatternMatch::NoMatch, None),
+                geo: PatternMatch::Match,
+                geo_json: PatternMatch::NoMatch,
                 localized_attributes_rule_id: None,
                 filterable_attributes_rule_id,
                 displayed: self.is_field_displayed(field),
@@ -371,15 +404,15 @@ impl MetadataBuilder {
             };
         }
         if match_field_legacy(RESERVED_GEOJSON_FIELD_NAME, field) == PatternMatch::Match {
-            debug_assert!(!sortable, "geojson fields should not be sortable");
+            debug_assert!(sortable != PatternMatch::Match, "geojson fields should not be sortable");
             return Metadata {
                 searchable: (PatternMatch::NoMatch, None),
-                exact: false,
+                exact: PatternMatch::NoMatch,
                 sortable,
-                distinct: false,
-                asc_desc: None,
-                geo: false,
-                geo_json: true,
+                distinct: PatternMatch::NoMatch,
+                asc_desc: (PatternMatch::NoMatch, None),
+                geo: PatternMatch::NoMatch,
+                geo_json: PatternMatch::Match,
                 localized_attributes_rule_id: None,
                 filterable_attributes_rule_id,
                 displayed: self.is_field_displayed(field),
@@ -400,11 +433,21 @@ impl MetadataBuilder {
             None => (PatternMatch::Match, Some(0)),
         };
 
-        let exact = self.exact_searchable_attributes.iter().any(|attr| is_faceted_by(field, attr));
+        let exact = field_match_any_patterns_legacy(&self.exact_searchable_attributes, field);
 
-        let distinct =
-            self.distinct_attribute.as_ref().is_some_and(|distinct_field| field == distinct_field);
-        let asc_desc = self.asc_desc_attributes.get(field).copied();
+        let distinct = match_distinct_field(self.distinct_attribute.as_deref(), field);
+        let asc_desc = match field_match_any_patterns_legacy(self.asc_desc_attributes.keys(), field)
+        {
+            PatternMatch::Match => {
+                // If the field matches an asc_desc attribute, return the order
+                match self.asc_desc_attributes.get(field) {
+                    Some(&order) => (PatternMatch::Match, Some(order)),
+                    None => (PatternMatch::NoMatch, None),
+                }
+            }
+            PatternMatch::Parent => (PatternMatch::Parent, None),
+            PatternMatch::NoMatch => (PatternMatch::NoMatch, None),
+        };
 
         let localized_attributes_rule_id = self
             .localized_attributes
@@ -420,8 +463,8 @@ impl MetadataBuilder {
             sortable,
             distinct,
             asc_desc,
-            geo: false,
-            geo_json: false,
+            geo: PatternMatch::NoMatch,
+            geo_json: PatternMatch::NoMatch,
             localized_attributes_rule_id,
             filterable_attributes_rule_id,
             displayed: self.is_field_displayed(field),
@@ -429,8 +472,11 @@ impl MetadataBuilder {
         }
     }
 
-    fn is_field_displayed(&self, field: &str) -> bool {
-        self.displayed_attributes.as_ref().map(|attrs| attrs.contains(field)).unwrap_or(true)
+    fn is_field_displayed(&self, field: &str) -> PatternMatch {
+        match self.displayed_attributes.as_ref() {
+            Some(attrs) => field_match_any_patterns_legacy(attrs, field),
+            None => PatternMatch::Match,
+        }
     }
 
     pub fn searchable_attributes(&self) -> Option<&[String]> {

--- a/crates/milli/src/fields_ids_map/metadata.rs
+++ b/crates/milli/src/fields_ids_map/metadata.rs
@@ -215,6 +215,17 @@ impl Metadata {
         self.geo
     }
 
+    pub fn is_geo_enabled(&self) -> bool {
+        self.geo == PatternMatch::Match
+            && (self.sortable == PatternMatch::Match
+                || self.filterable_attributes_rule_id.0 == PatternMatch::Match)
+    }
+
+    pub fn is_geojson_enabled(&self) -> bool {
+        self.geo_json == PatternMatch::Match
+            && self.filterable_attributes_rule_id.0 == PatternMatch::Match
+    }
+
     /// Returns the pattern match if the field is part of the facet databases. (sortable, distinct, asc_desc, filterable or facet searchable)
     pub fn is_faceted(&self, rules: &[FilterableAttributesRule]) -> PatternMatch {
         let mut pattern_match = PatternMatch::NoMatch;

--- a/crates/milli/src/fields_ids_map/metadata.rs
+++ b/crates/milli/src/fields_ids_map/metadata.rs
@@ -239,6 +239,10 @@ impl Metadata {
                 if features.is_filterable() || features.is_facet_searchable() {
                     return PatternMatch::Match;
                 }
+                // If the field is not filterable or facet searchable,
+                // it may be a parent field of a filterable or facet searchable field.
+                // This case can happen when a field is added to the filterable attributes with every features deactivated.
+                pattern_match = PatternMatch::Parent;
             }
             (PatternMatch::Parent, _) => pattern_match = PatternMatch::Parent,
             (PatternMatch::NoMatch, _) => (),
@@ -422,14 +426,24 @@ impl MetadataBuilder {
 
         let searchable = match &self.searchable_attributes {
             // A field is searchable if it is faceted by a searchable attribute
-            Some(attributes) => attributes
-                .iter()
-                .enumerate()
-                .find_map(|(i, pattern)| match match_field_legacy(pattern, field) {
-                    PatternMatch::Match => Some((PatternMatch::Match, Some(i as u16))),
-                    pattern_match => Some((pattern_match, None)),
-                })
-                .unwrap_or((PatternMatch::NoMatch, None)),
+            Some(attributes) => {
+                let mut matching_searchable = PatternMatch::NoMatch;
+                let weight =
+                    attributes.iter().enumerate().find_map(
+                        |(i, pattern)| match match_field_legacy(pattern, field) {
+                            PatternMatch::Match => {
+                                matching_searchable = PatternMatch::Match;
+                                Some(i as u16)
+                            }
+                            PatternMatch::Parent => {
+                                matching_searchable = PatternMatch::Parent;
+                                None
+                            }
+                            PatternMatch::NoMatch => None,
+                        },
+                    );
+                (matching_searchable, weight)
+            }
             None => (PatternMatch::Match, Some(0)),
         };
 

--- a/crates/milli/src/prompt/fields.rs
+++ b/crates/milli/src/prompt/fields.rs
@@ -8,7 +8,7 @@ use liquid::model::{
 use liquid::{ObjectView, ValueView};
 
 use crate::fields_ids_map::metadata::{FieldIdMapWithMetadata, Metadata};
-use crate::GlobalFieldsIdsMap;
+use crate::{GlobalFieldsIdsMap, PatternMatch};
 
 #[derive(Debug, Clone, Copy)]
 pub struct FieldValue<'a, D: ObjectView> {
@@ -68,8 +68,8 @@ impl<'a, D: ObjectView> FieldValue<'a, D> {
 
     pub fn is_searchable(&self) -> &bool {
         match self.metadata.is_searchable() {
-            true => &true,
-            false => &false,
+            PatternMatch::Match => &true,
+            _ => &false,
         }
     }
 

--- a/crates/milli/src/update/index_documents/extract/extract_docid_word_positions.rs
+++ b/crates/milli/src/update/index_documents/extract/extract_docid_word_positions.rs
@@ -12,7 +12,7 @@ use super::helpers::{create_sorter, sorter_into_reader, GrenadParameters, KeepLa
 use crate::error::{InternalError, SerializationError};
 use crate::update::del_add::{del_add_from_two_obkvs, DelAdd, KvReaderDelAdd};
 use crate::update::settings::{InnerIndexSettings, InnerIndexSettingsDiff};
-use crate::{FieldId, Result, MAX_POSITION_PER_ATTRIBUTE, MAX_WORD_LENGTH};
+use crate::{FieldId, PatternMatch, Result, MAX_POSITION_PER_ATTRIBUTE, MAX_WORD_LENGTH};
 
 /// Extracts the word and positions where this word appear and
 /// prefixes it by the document id.
@@ -162,7 +162,7 @@ fn searchable_fields_changed(
             // "_vectors": { "manual": [1, 2, 3]} -> "_vectors.manual" is not registered.
             continue;
         };
-        if metadata.is_searchable() {
+        if metadata.is_searchable() == PatternMatch::Match {
             let del_add = KvReaderDelAdd::from_slice(field_bytes);
             match (del_add.get(DelAdd::Deletion), del_add.get(DelAdd::Addition)) {
                 // if both fields are None, check the next field.
@@ -217,7 +217,7 @@ fn tokens_from_document<'a>(
             continue;
         };
         // if field is searchable.
-        if metadata.is_searchable() {
+        if metadata.is_searchable() == PatternMatch::Match {
             // extract deletion or addition only.
             if let Some(field_bytes) = KvReaderDelAdd::from_slice(field_bytes).get(del_add) {
                 // parse json.

--- a/crates/milli/src/update/index_documents/extract/extract_facet_string_docids.rs
+++ b/crates/milli/src/update/index_documents/extract/extract_facet_string_docids.rs
@@ -17,7 +17,7 @@ use crate::update::index_documents::helpers::{
     MergeDeladdBtreesetString, MergeDeladdCboRoaringBitmaps,
 };
 use crate::update::settings::{InnerIndexSettings, InnerIndexSettingsDiff};
-use crate::{FieldId, Result, MAX_FACET_VALUE_LENGTH};
+use crate::{FieldId, PatternMatch, Result, MAX_FACET_VALUE_LENGTH};
 
 /// Extracts the facet string and the documents ids where this facet string appear.
 ///
@@ -91,7 +91,7 @@ fn extract_facet_string_docids_document_update<R: io::Read + io::Seek>(
             unreachable!("metadata not found for field_id: {}", field_id)
         };
 
-        if !metadata.is_faceted(&settings.filterable_attributes_rules) {
+        if metadata.is_faceted(&settings.filterable_attributes_rules) != PatternMatch::Match {
             continue;
         }
 

--- a/crates/milli/src/update/new/extract/faceted/extract_facets.rs
+++ b/crates/milli/src/update/new/extract/faceted/extract_facets.rs
@@ -32,9 +32,8 @@ use crate::update::new::{DocumentChange, DocumentIdentifiers};
 use crate::update::settings::SettingsDelta;
 use crate::update::GrenadParameters;
 use crate::{
-    DocumentId, FieldId, FieldIdMapMissingEntry, FilterFeatures, FilterableAttributesFeatures,
-    FilterableAttributesRule, GlobalFieldsIdsMap, InternalError, PatternMatch, Result, UserError,
-    MAX_FACET_VALUE_LENGTH,
+    DocumentId, FieldId, FieldIdMapMissingEntry, FilterableAttributesRule, GlobalFieldsIdsMap,
+    InternalError, PatternMatch, Result, UserError, MAX_FACET_VALUE_LENGTH,
 };
 
 pub struct FacetedExtractorData<'a, 'b> {
@@ -300,7 +299,7 @@ impl FacetedDocidsExtractor {
         value: &Value,
     ) -> Result<()> {
         // if the field is not faceted, do nothing
-        if !meta.is_faceted(filterable_attributes) {
+        if meta.is_faceted(filterable_attributes) != PatternMatch::Match {
             return Ok(());
         }
 
@@ -645,69 +644,30 @@ impl FacetedDocidsExtractor {
             current_document,
             // TODO extract into another function
             |field_name| {
-                let Some((field_id, metadata)) = old_fields_ids_map.id_with_metadata(field_name)
-                else {
-                    return PatternMatch::NoMatch;
+                let old_faceted = match old_fields_ids_map.id_with_metadata(field_name) {
+                    Some((_, metadata)) => metadata.is_faceted(old_filterable_rules),
+                    None => PatternMatch::NoMatch,
                 };
 
-                let FilterableAttributesFeatures { facet_search: old_facet_search, filter } =
-                    metadata.filterable_attributes_features(old_filterable_rules);
-                let FilterFeatures { equality: old_equality, comparison: old_comparison } = filter;
-                let old_asc_desc = metadata.asc_desc.is_some();
-                let old_sortable = metadata.sortable;
-                let old_distinct = metadata.distinct;
-
-                let new_facet_search;
-                let new_equality;
-                let new_comparison;
-                let new_asc_desc;
-                let new_sortable;
-                let new_distinct;
-                // TODO do not duplicate this logic and put it in a function
-                //      for delete_old_fid_from_facet_databases to use it
-                match new_fields_ids_map.metadata(field_id) {
-                    Some(metadata) => {
-                        let FilterableAttributesFeatures { facet_search, filter } =
-                            metadata.filterable_attributes_features(new_filterable_rules);
-                        let FilterFeatures { equality, comparison } = filter;
-                        new_facet_search = facet_search;
-                        new_equality = equality;
-                        new_comparison = comparison;
-                        new_asc_desc = metadata.asc_desc.is_some();
-                        new_sortable = metadata.sortable;
-                        new_distinct = metadata.distinct;
-                    }
-                    None => {
-                        // This will trigger a clean deletion from everywhere
-                        new_facet_search = false;
-                        new_equality = false;
-                        new_comparison = false;
-                        new_asc_desc = false;
-                        new_sortable = false;
-                        new_distinct = false;
-                    }
+                let new_faceted = match new_fields_ids_map.id_with_metadata(field_name) {
+                    Some((_, metadata)) => metadata.is_faceted(new_filterable_rules),
+                    None => PatternMatch::NoMatch,
                 };
 
-                let is_old_faceted = old_equality
-                    || old_comparison
-                    || old_facet_search
-                    || old_asc_desc
-                    || old_sortable
-                    || old_distinct;
-
-                let is_new_faceted = new_equality
-                    || new_comparison
-                    || new_facet_search
-                    || new_asc_desc
-                    || new_sortable
-                    || new_distinct;
-
-                if !is_old_faceted && is_new_faceted {
-                    PatternMatch::Match
-                } else {
-                    // We force the system to go down the rabbit hole
-                    // and avoid an early break if we return NoMatch
-                    PatternMatch::Parent
+                match (old_faceted, new_faceted) {
+                    // If the field became faceted, return Match
+                    (PatternMatch::NoMatch, PatternMatch::Match)
+                    | (PatternMatch::Parent, PatternMatch::Match) => PatternMatch::Match,
+                    // If the field is no longer faceted, return NoMatch
+                    (PatternMatch::NoMatch, PatternMatch::NoMatch)
+                    | (PatternMatch::Match, PatternMatch::NoMatch)
+                    | (PatternMatch::Parent, PatternMatch::NoMatch) => PatternMatch::NoMatch,
+                    // If the field became a parent field, return Parent
+                    (PatternMatch::NoMatch, PatternMatch::Parent)
+                    | (PatternMatch::Match, PatternMatch::Parent) => PatternMatch::Parent,
+                    // If the field is still faceted or parent, return Parent because it can be a parent field of a new faceted field
+                    (PatternMatch::Match, PatternMatch::Match)
+                    | (PatternMatch::Parent, PatternMatch::Parent) => PatternMatch::Parent,
                 }
             },
             &mut |name| {

--- a/crates/milli/src/update/new/extract/searchable/extract_word_docids.rs
+++ b/crates/milli/src/update/new/extract/searchable/extract_word_docids.rs
@@ -12,7 +12,6 @@ use crate::fields_ids_map::metadata::Metadata;
 use crate::update::new::document::DocumentContext;
 use crate::update::new::extract::cache::BalancedCaches;
 use crate::update::new::extract::perm_json_p::contained_in;
-use crate::update::new::extract::searchable::has_searchable_children;
 use crate::update::new::indexer::document_changes::{
     extract, DocumentChanges, Extractor, IndexingContext,
 };
@@ -363,7 +362,7 @@ impl WordDocidsExtractors {
                 return Err(UserError::AttributeLimitReached.into());
             };
 
-            let pattern_match = if meta.is_searchable() {
+            let pattern_match = if meta.is_searchable() == PatternMatch::Match {
                 PatternMatch::Match
             } else {
                 // TODO: should be a match on the field_name using `match_field_legacy` function,
@@ -540,8 +539,6 @@ impl WordDocidsExtractors {
 
         let new_fields_ids_map = settings_delta.new_fields_ids_map();
         let old_fields_ids_map = context.index.fields_ids_map_with_metadata(&context.rtxn)?;
-        let old_searchable = settings_delta.old_searchable_attributes().as_ref();
-        let new_searchable = settings_delta.new_searchable_attributes().as_ref();
 
         let current_document = document.current(
             &context.rtxn,
@@ -585,11 +582,23 @@ impl WordDocidsExtractors {
                         ActionToOperate::ReindexAllFields
                     }
                     // At least one field is removed from the searchable fields => ReindexAllFields
-                    (Metadata { searchable: Some(_), .. }, Metadata { searchable: None, .. }) => {
-                        ActionToOperate::ReindexAllFields
-                    }
+                    (
+                        Metadata { searchable: (PatternMatch::Match, _), .. },
+                        Metadata { searchable: (PatternMatch::NoMatch, _), .. },
+                    )
+                    | (
+                        Metadata { searchable: (PatternMatch::Match, _), .. },
+                        Metadata { searchable: (PatternMatch::Parent, _), .. },
+                    ) => ActionToOperate::ReindexAllFields,
                     // At least one field is added in the searchable fields => IndexAddedFields
-                    (Metadata { searchable: None, .. }, Metadata { searchable: Some(_), .. }) => {
+                    (
+                        Metadata { searchable: (PatternMatch::NoMatch, _), .. },
+                        Metadata { searchable: (PatternMatch::Match, _), .. },
+                    )
+                    | (
+                        Metadata { searchable: (PatternMatch::Parent, _), .. },
+                        Metadata { searchable: (PatternMatch::Match, _), .. },
+                    ) => {
                         // We can safely overwrite the action, because we early return when action is ReindexAllFields.
                         ActionToOperate::IndexAddedFields
                     }
@@ -614,30 +623,29 @@ impl WordDocidsExtractors {
             let old_field_metadata = old_fields_ids_map.metadata(field_id).unwrap();
             let new_field_metadata = new_fields_ids_map.metadata(field_id).unwrap();
 
+            let was_matching_searchable = old_field_metadata.is_searchable();
+            let is_matching_searchable = new_field_metadata.is_searchable();
+
             let pattern_match = match action {
                 ActionToOperate::ReindexAllFields => {
-                    if old_field_metadata.is_searchable() || new_field_metadata.is_searchable() {
-                        PatternMatch::Match
-                    // If any old or new field is searchable then we need to iterate over all fields
-                    // else if any field matches we need to iterate over all fields
-                    } else if has_searchable_children(
-                        field_name,
-                        old_searchable.zip(new_searchable).map(|(old, new)| old.iter().chain(new)),
-                    ) {
-                        PatternMatch::Parent
-                    } else {
-                        PatternMatch::NoMatch
+                    match (was_matching_searchable, is_matching_searchable) {
+                        // If any old or new field is searchable then we need to iterate over all fields
+                        (PatternMatch::Match, _) | (_, PatternMatch::Match) => PatternMatch::Match,
+                        // else if any child matches we need to iterate over all fields
+                        (PatternMatch::Parent, _) | (_, PatternMatch::Parent) => {
+                            PatternMatch::Parent
+                        }
+                        _ => PatternMatch::NoMatch,
                     }
                 }
                 ActionToOperate::IndexAddedFields => {
-                    // Was not searchable but now is
-                    if !old_field_metadata.is_searchable() && new_field_metadata.is_searchable() {
-                        PatternMatch::Match
-                    // If the field is now a parent of a searchable field
-                    } else if has_searchable_children(field_name, new_searchable) {
-                        PatternMatch::Parent
-                    } else {
-                        PatternMatch::NoMatch
+                    match (was_matching_searchable, is_matching_searchable) {
+                        // Was not searchable but now is
+                        (PatternMatch::NoMatch, PatternMatch::Match)
+                        | (PatternMatch::Parent, PatternMatch::Match) => PatternMatch::Match,
+                        // If the field is now a parent of a searchable field
+                        (_, PatternMatch::Parent) => PatternMatch::Parent,
+                        _ => PatternMatch::NoMatch,
                     }
                 }
                 ActionToOperate::SkipDocument => unreachable!(),
@@ -654,8 +662,12 @@ impl WordDocidsExtractors {
 
             match (old_field_metadata, new_field_metadata) {
                 (
-                    Metadata { searchable: Some(_), exact: old_exact, .. },
-                    Metadata { searchable: None, .. },
+                    Metadata { searchable: (PatternMatch::Match, _), exact: old_exact, .. },
+                    Metadata { searchable: (PatternMatch::NoMatch, _), .. },
+                )
+                | (
+                    Metadata { searchable: (PatternMatch::Match, _), exact: old_exact, .. },
+                    Metadata { searchable: (PatternMatch::Parent, _), .. },
                 ) => cached_sorter.insert_del_u32(
                     field_id,
                     pos,
@@ -667,8 +679,12 @@ impl WordDocidsExtractors {
                     doc_alloc,
                 ),
                 (
-                    Metadata { searchable: None, .. },
-                    Metadata { searchable: Some(_), exact: new_exact, .. },
+                    Metadata { searchable: (PatternMatch::NoMatch, _), .. },
+                    Metadata { searchable: (PatternMatch::Match, _), exact: new_exact, .. },
+                )
+                | (
+                    Metadata { searchable: (PatternMatch::Parent, _), .. },
+                    Metadata { searchable: (PatternMatch::Match, _), exact: new_exact, .. },
                 ) => cached_sorter.insert_add_u32(
                     field_id,
                     pos,
@@ -678,7 +694,10 @@ impl WordDocidsExtractors {
                     document.docid(),
                     doc_alloc,
                 ),
-                (Metadata { searchable: None, .. }, Metadata { searchable: None, .. }) => {
+                (
+                    Metadata { searchable: (PatternMatch::NoMatch, _), .. },
+                    Metadata { searchable: (PatternMatch::NoMatch, _), .. },
+                ) => {
                     unreachable!()
                 }
                 (Metadata { exact: old_exact, .. }, Metadata { exact: new_exact, .. }) => {

--- a/crates/milli/src/update/new/extract/searchable/extract_word_docids.rs
+++ b/crates/milli/src/update/new/extract/searchable/extract_word_docids.rs
@@ -672,7 +672,7 @@ impl WordDocidsExtractors {
                     field_id,
                     pos,
                     word,
-                    old_exact || old_disabled_typos_terms.is_exact(word),
+                    old_exact == PatternMatch::Match || old_disabled_typos_terms.is_exact(word),
                     // We deleted the field globally
                     FieldDbExtraction::Skip,
                     document.docid(),
@@ -689,7 +689,7 @@ impl WordDocidsExtractors {
                     field_id,
                     pos,
                     word,
-                    new_exact || new_disabled_typos_terms.is_exact(word),
+                    new_exact == PatternMatch::Match || new_disabled_typos_terms.is_exact(word),
                     FieldDbExtraction::Extract,
                     document.docid(),
                     doc_alloc,
@@ -705,7 +705,7 @@ impl WordDocidsExtractors {
                         field_id,
                         pos,
                         word,
-                        old_exact || old_disabled_typos_terms.is_exact(word),
+                        old_exact == PatternMatch::Match || old_disabled_typos_terms.is_exact(word),
                         // The field has already been extracted
                         FieldDbExtraction::Skip,
                         document.docid(),
@@ -715,7 +715,7 @@ impl WordDocidsExtractors {
                         field_id,
                         pos,
                         word,
-                        new_exact || new_disabled_typos_terms.is_exact(word),
+                        new_exact == PatternMatch::Match || new_disabled_typos_terms.is_exact(word),
                         // The field has already been extracted
                         FieldDbExtraction::Skip,
                         document.docid(),

--- a/crates/milli/src/update/new/extract/searchable/extract_word_pair_proximity_docids.rs
+++ b/crates/milli/src/update/new/extract/searchable/extract_word_pair_proximity_docids.rs
@@ -353,13 +353,14 @@ impl WordPairProximityDocidsExtractor {
                     action = match (old_field_metadata, new_field_metadata) {
                         // At least one field is removed or added from the searchable fields
                         (
-                            Metadata { searchable: Some(_), .. },
-                            Metadata { searchable: None, .. },
-                        )
-                        | (
-                            Metadata { searchable: None, .. },
-                            Metadata { searchable: Some(_), .. },
-                        ) => ActionToOperate::ReindexAllFields,
+                            Metadata { searchable: (was_matching, _), .. },
+                            Metadata { searchable: (is_matching, _), .. },
+                        ) if was_matching != is_matching
+                            && (was_matching == PatternMatch::Match
+                                || is_matching == PatternMatch::Match) =>
+                        {
+                            ActionToOperate::ReindexAllFields
+                        }
                         _ => action,
                     };
 
@@ -494,7 +495,7 @@ fn process_document_tokens<'doc>(
     let mut should_tokenize = |field_name: &str| {
         let (field_id, meta) = field_id_and_metadata(field_name)?;
 
-        let pattern_match = if meta.is_searchable() {
+        let pattern_match = if meta.is_searchable() == PatternMatch::Match {
             PatternMatch::Match
         } else {
             // TODO: should be a match on the field_name using `match_field_legacy` function,

--- a/crates/milli/src/update/new/extract/searchable/mod.rs
+++ b/crates/milli/src/update/new/extract/searchable/mod.rs
@@ -27,17 +27,3 @@ pub fn match_searchable_field(
 
     selection
 }
-
-/// return `true` if the provided `field_name` is a parent of at least one of the fields contained in `searchable`,
-/// or if `searchable` is `None`.
-fn has_searchable_children<I, A>(field_name: &str, searchable: Option<I>) -> bool
-where
-    I: IntoIterator<Item = A>,
-    A: AsRef<str>,
-{
-    searchable.is_none_or(|fields| {
-        fields
-            .into_iter()
-            .any(|attr| match_field_legacy(attr.as_ref(), field_name) == PatternMatch::Parent)
-    })
-}

--- a/crates/milli/src/update/new/indexer/extract.rs
+++ b/crates/milli/src/update/new/indexer/extract.rs
@@ -28,7 +28,9 @@ use crate::update::new::{merge_and_send_docids, merge_and_send_facet_docids, Fac
 use crate::update::settings::SettingsDelta;
 use crate::vector::db::{EmbedderInfo, IndexEmbeddingConfig};
 use crate::vector::RuntimeEmbedders;
-use crate::{Index, InternalError, Result, ThreadPoolNoAbort, ThreadPoolNoAbortBuilder};
+use crate::{
+    Index, InternalError, PatternMatch, Result, ThreadPoolNoAbort, ThreadPoolNoAbortBuilder,
+};
 
 #[allow(clippy::too_many_arguments)]
 pub(super) fn extract_all<'pl, 'extractor, DC, MSP>(
@@ -632,7 +634,7 @@ where
         let enabled_sortable_geo = settings_delta
             .new_fields_ids_map()
             .id_with_metadata(RESERVED_GEO_FIELD_NAME)
-            .is_some_and(|(_id, meta)| meta.is_sortable());
+            .is_some_and(|(_id, meta)| meta.is_sortable() == PatternMatch::Match);
 
         if !enabled_filterable_geo && !enabled_sortable_geo {
             break 'geo;

--- a/crates/milli/src/update/new/indexer/extract.rs
+++ b/crates/milli/src/update/new/indexer/extract.rs
@@ -13,7 +13,7 @@ use super::super::thread_local::{FullySend, ThreadLocal};
 use super::super::FacetFieldIdsDelta;
 use super::document_changes::{extract, DocumentChanges, IndexingContext};
 use super::settings_changes::settings_change_extract;
-use crate::constants::RESERVED_GEO_FIELD_NAME;
+use crate::constants::{RESERVED_GEOJSON_FIELD_NAME, RESERVED_GEO_FIELD_NAME};
 use crate::documents::{FieldIdMapper, PrimaryKey};
 use crate::progress::{EmbedderStats, MergingWordCache};
 use crate::proximity::ProximityPrecision;
@@ -28,9 +28,7 @@ use crate::update::new::{merge_and_send_docids, merge_and_send_facet_docids, Fac
 use crate::update::settings::SettingsDelta;
 use crate::vector::db::{EmbedderInfo, IndexEmbeddingConfig};
 use crate::vector::RuntimeEmbedders;
-use crate::{
-    Index, InternalError, PatternMatch, Result, ThreadPoolNoAbort, ThreadPoolNoAbortBuilder,
-};
+use crate::{Index, InternalError, Result, ThreadPoolNoAbort, ThreadPoolNoAbortBuilder};
 
 #[allow(clippy::too_many_arguments)]
 pub(super) fn extract_all<'pl, 'extractor, DC, MSP>(
@@ -628,15 +626,16 @@ where
     }
 
     'geo: {
-        let enabled_filterable_geo =
-            !settings_delta.old_filterable_rules().iter().any(|rule| rule.has_geo())
-                && settings_delta.new_filterable_rules().iter().any(|rule| rule.has_geo());
-        let enabled_sortable_geo = settings_delta
+        let old_enabled_geo = settings_delta
+            .old_fields_ids_map()
+            .id_with_metadata(RESERVED_GEO_FIELD_NAME)
+            .is_some_and(|(_id, meta)| meta.is_geo_enabled());
+        let new_enabled_geo = settings_delta
             .new_fields_ids_map()
             .id_with_metadata(RESERVED_GEO_FIELD_NAME)
-            .is_some_and(|(_id, meta)| meta.is_sortable() == PatternMatch::Match);
+            .is_some_and(|(_id, meta)| meta.is_geo_enabled());
 
-        if !enabled_filterable_geo && !enabled_sortable_geo {
+        if old_enabled_geo || !new_enabled_geo {
             break 'geo;
         }
 
@@ -662,11 +661,16 @@ where
     }
 
     'cellulite: {
-        let enabled_filterable_geojson =
-            !settings_delta.old_filterable_rules().iter().any(|rule| rule.has_geojson())
-                && settings_delta.new_filterable_rules().iter().any(|rule| rule.has_geojson());
+        let old_enabled_geojson = settings_delta
+            .old_fields_ids_map()
+            .id_with_metadata(RESERVED_GEOJSON_FIELD_NAME)
+            .is_some_and(|(_id, meta)| meta.is_geojson_enabled());
+        let new_enabled_geojson = settings_delta
+            .new_fields_ids_map()
+            .id_with_metadata(RESERVED_GEOJSON_FIELD_NAME)
+            .is_some_and(|(_id, meta)| meta.is_geojson_enabled());
 
-        if !enabled_filterable_geojson {
+        if old_enabled_geojson || !new_enabled_geojson {
             break 'cellulite;
         }
 

--- a/crates/milli/src/update/new/indexer/mod.rs
+++ b/crates/milli/src/update/new/indexer/mod.rs
@@ -756,10 +756,10 @@ where
         old_fields_ids_map
             .iter_id_metadata()
             .filter_map(|(id, metadata)| {
-                if metadata.is_searchable()
+                if metadata.is_searchable() == PatternMatch::Match
                     && new_fields_ids_map
                         .metadata(id)
-                        .is_none_or(|metadata| !metadata.is_searchable())
+                        .is_none_or(|metadata| metadata.is_searchable() != PatternMatch::Match)
                 {
                     Some(id)
                 } else {

--- a/crates/milli/src/update/new/indexer/mod.rs
+++ b/crates/milli/src/update/new/indexer/mod.rs
@@ -266,17 +266,7 @@ where
         must_stop_processing,
         progress,
     )?;
-
-    // Clear the cellulite database when the geojson support is removed
-    if settings_delta.new_match_faceted_field(RESERVED_GEOJSON_FIELD_NAME) == PatternMatch::NoMatch
-    {
-        index.cellulite.clear(wtxn)?;
-    }
-
-    // Clear the geo rtree entry when the geo support is removed
-    if settings_delta.new_match_faceted_field(RESERVED_GEO_FIELD_NAME) == PatternMatch::NoMatch {
-        index.delete_geo_rtree(wtxn)?;
-    }
+    delete_old_geo_databases(wtxn, index, settings_delta, must_stop_processing, progress)?;
 
     // Clear word_pair_proximity if byWord to byAttribute
     let old_proximity_precision = settings_delta.old_proximity_precision();
@@ -526,6 +516,47 @@ where
     Ok(())
 }
 
+fn delete_old_geo_databases<SD, MSP>(
+    wtxn: &mut RwTxn<'_>,
+    index: &Index,
+    settings_delta: &SD,
+    must_stop_processing: &MSP,
+    progress: &Progress,
+) -> Result<()>
+where
+    SD: SettingsDelta + Sync,
+    MSP: Fn() -> bool + Sync,
+{
+    let _step = progress.update_progress_scoped(IndexingStep::DeletingFromGeoDatabases);
+
+    let new_fields_ids_map = settings_delta.new_fields_ids_map();
+    let new_filterable_rules = settings_delta.new_filterable_rules();
+
+    let new_geojson_is_faceted =
+        new_fields_ids_map.id_with_metadata(RESERVED_GEOJSON_FIELD_NAME).is_some_and(
+            |(_, metadata)| metadata.is_faceted(new_filterable_rules) == PatternMatch::Match,
+        );
+    // Clear the cellulite database when the geojson support is removed
+    if new_geojson_is_faceted {
+        index.cellulite.clear(wtxn)?;
+    }
+
+    if must_stop_processing() {
+        return Err(Error::InternalError(InternalError::AbortedIndexation));
+    }
+
+    let new_geo_is_faceted =
+        new_fields_ids_map.id_with_metadata(RESERVED_GEO_FIELD_NAME).is_some_and(
+            |(_, metadata)| metadata.is_faceted(new_filterable_rules) == PatternMatch::Match,
+        );
+    // Clear the geo rtree entry when the geo support is removed
+    if new_geo_is_faceted {
+        index.delete_geo_rtree(wtxn)?;
+    }
+
+    Ok(())
+}
+
 pub fn delete_old_fid_from_facet_databases<SD, MSP>(
     wtxn: &mut RwTxn<'_>,
     index: &Index,
@@ -547,70 +578,46 @@ where
     let new_fields_ids_map = settings_delta.new_fields_ids_map();
     let new_filterable_rules = settings_delta.new_filterable_rules();
 
-    for (id, metadata) in old_fields_ids_map.iter_id_metadata() {
-        let FilterableAttributesFeatures { facet_search: old_facet_search, filter } =
-            metadata.filterable_attributes_features(old_filterable_rules);
-        let FilterFeatures { equality: old_equality, comparison: old_comparison } = filter;
-        let old_asc_desc = metadata.asc_desc.is_some();
-        let old_sortable = metadata.sortable;
-        let old_distinct = metadata.distinct;
+    for (id, old_metadata) in old_fields_ids_map.iter_id_metadata() {
+        if old_metadata.is_faceted(old_filterable_rules) != PatternMatch::Match {
+            // This was not faceted, no need to delete it from the facet databases
+            continue;
+        }
 
-        let new_facet_search;
-        let new_equality;
-        let new_comparison;
-        let new_asc_desc;
-        let new_sortable;
-        let new_distinct;
-        match new_fields_ids_map.metadata(id) {
-            Some(metadata) => {
-                let FilterableAttributesFeatures { facet_search, filter } =
-                    metadata.filterable_attributes_features(new_filterable_rules);
-                let FilterFeatures { equality, comparison } = filter;
-                new_facet_search = facet_search;
-                new_equality = equality;
-                new_comparison = comparison;
-                new_asc_desc = metadata.asc_desc.is_some();
-                new_sortable = metadata.sortable;
-                new_distinct = metadata.distinct;
-            }
-            None => {
-                // This will trigger a clean deletion from everywhere
-                new_facet_search = false;
-                new_equality = false;
-                new_comparison = false;
-                new_asc_desc = false;
-                new_sortable = false;
-                new_distinct = false;
-            }
+        let Some(new_metadata) = new_fields_ids_map.metadata(id) else {
+            // This field is no longer in the new fields ids map, delete it from everywhere
+            remove_from_everywhere.insert(id);
+            continue;
         };
 
-        let is_old_faceted = old_equality
-            || old_comparison
-            || old_facet_search
-            || old_asc_desc
-            || old_sortable
-            || old_distinct;
-
-        let is_new_faceted = new_equality
-            || new_comparison
-            || new_facet_search
-            || new_asc_desc
-            || new_sortable
-            || new_distinct;
-
-        if is_old_faceted && !is_new_faceted {
-            // If we delete from everywhere we don't have to check the remaining conditions.
+        if new_metadata.is_faceted(new_filterable_rules) != PatternMatch::Match {
+            // This field is no longer faceted, delete it from everywhere
             remove_from_everywhere.insert(id);
             continue;
         }
 
+        // Check if the field still needs facet search databases
+        let FilterableAttributesFeatures { facet_search: old_facet_search, filter: old_filter } =
+            old_metadata.filterable_attributes_features(old_filterable_rules);
+        let FilterableAttributesFeatures { facet_search: new_facet_search, filter: new_filter } =
+            new_metadata.filterable_attributes_features(new_filterable_rules);
+
         if old_facet_search && !new_facet_search {
-            // Remove only from the facet search
+            // The field is no longer facet searchable, delete it from the facet search databases
             remove_from_facet_search.insert(id);
         }
 
+        // Check if the field still needs facet level databases
+        let FilterFeatures { equality: _, comparison: old_comparison } = old_filter;
+        let old_asc_desc = old_metadata.is_asc_desc() == PatternMatch::Match;
+        let old_sortable = old_metadata.is_sortable() == PatternMatch::Match;
         let is_old_comparison = old_sortable || old_asc_desc || old_comparison;
+
+        let FilterFeatures { equality: _, comparison: new_comparison } = new_filter;
+        let new_asc_desc = new_metadata.is_asc_desc() == PatternMatch::Match;
+        let new_sortable = new_metadata.is_sortable() == PatternMatch::Match;
         let is_new_comparison = new_sortable || new_asc_desc || new_comparison;
+
         if is_old_comparison && !is_new_comparison {
             // Remove the comparison levels from the facets.
             remove_comparison_levels_only.insert(id);

--- a/crates/milli/src/update/new/indexer/mod.rs
+++ b/crates/milli/src/update/new/indexer/mod.rs
@@ -529,15 +529,13 @@ where
 {
     let _step = progress.update_progress_scoped(IndexingStep::DeletingFromGeoDatabases);
 
-    let new_fields_ids_map = settings_delta.new_fields_ids_map();
-    let new_filterable_rules = settings_delta.new_filterable_rules();
+    let new_enabled_geojson = settings_delta
+        .new_fields_ids_map()
+        .id_with_metadata(RESERVED_GEOJSON_FIELD_NAME)
+        .is_some_and(|(_id, meta)| meta.is_geojson_enabled());
 
-    let new_geojson_is_faceted =
-        new_fields_ids_map.id_with_metadata(RESERVED_GEOJSON_FIELD_NAME).is_some_and(
-            |(_, metadata)| metadata.is_faceted(new_filterable_rules) == PatternMatch::Match,
-        );
     // Clear the cellulite database when the geojson support is removed
-    if !new_geojson_is_faceted {
+    if !new_enabled_geojson {
         index.cellulite.clear(wtxn)?;
     }
 
@@ -545,12 +543,13 @@ where
         return Err(Error::InternalError(InternalError::AbortedIndexation));
     }
 
-    let new_geo_is_faceted =
-        new_fields_ids_map.id_with_metadata(RESERVED_GEO_FIELD_NAME).is_some_and(
-            |(_, metadata)| metadata.is_faceted(new_filterable_rules) == PatternMatch::Match,
-        );
+    let new_enabled_geo = settings_delta
+        .new_fields_ids_map()
+        .id_with_metadata(RESERVED_GEO_FIELD_NAME)
+        .is_some_and(|(_id, meta)| meta.is_geo_enabled());
+
     // Clear the geo rtree entry when the geo support is removed
-    if !new_geo_is_faceted {
+    if !new_enabled_geo {
         index.delete_geo_rtree(wtxn)?;
     }
 

--- a/crates/milli/src/update/new/indexer/mod.rs
+++ b/crates/milli/src/update/new/indexer/mod.rs
@@ -537,7 +537,7 @@ where
             |(_, metadata)| metadata.is_faceted(new_filterable_rules) == PatternMatch::Match,
         );
     // Clear the cellulite database when the geojson support is removed
-    if new_geojson_is_faceted {
+    if !new_geojson_is_faceted {
         index.cellulite.clear(wtxn)?;
     }
 
@@ -550,7 +550,7 @@ where
             |(_, metadata)| metadata.is_faceted(new_filterable_rules) == PatternMatch::Match,
         );
     // Clear the geo rtree entry when the geo support is removed
-    if new_geo_is_faceted {
+    if !new_geo_is_faceted {
         index.delete_geo_rtree(wtxn)?;
     }
 

--- a/crates/milli/src/update/new/steps.rs
+++ b/crates/milli/src/update/new/steps.rs
@@ -19,6 +19,7 @@ make_enum_progress! {
         DeletingFromAllFilters,
         DeletingFromFacetsOnly,
         DeletingFromComparisonsOnly,
+        DeletingFromGeoDatabases,
         WaitingForDatabaseWrites,
         WaitingForExtractors,
         PostProcessingFacets,

--- a/crates/milli/src/update/settings.rs
+++ b/crates/milli/src/update/settings.rs
@@ -1970,7 +1970,9 @@ impl InnerIndexSettingsDiff {
         settings
             .fields_ids_map
             .iter_id_metadata()
-            .filter(|(_, metadata)| metadata.is_faceted(&settings.filterable_attributes_rules))
+            .filter(|(_, metadata)| {
+                metadata.is_faceted(&settings.filterable_attributes_rules) == PatternMatch::Match
+            })
             .map(|(id, _)| id)
             .collect()
     }
@@ -1978,10 +1980,10 @@ impl InnerIndexSettingsDiff {
     pub fn facet_fids_changed(&self) -> bool {
         for eob in merge_join_by(
             self.old.fields_ids_map.iter().filter(|(_, _, metadata)| {
-                metadata.is_faceted(&self.old.filterable_attributes_rules)
+                metadata.is_faceted(&self.old.filterable_attributes_rules) == PatternMatch::Match
             }),
             self.new.fields_ids_map.iter().filter(|(_, _, metadata)| {
-                metadata.is_faceted(&self.new.filterable_attributes_rules)
+                metadata.is_faceted(&self.new.filterable_attributes_rules) == PatternMatch::Match
             }),
             |(old_fid, _, _), (new_fid, _, _)| old_fid.cmp(new_fid),
         ) {
@@ -2644,9 +2646,6 @@ pub trait SettingsDelta {
     fn old_fields_ids_map(&self) -> &FieldIdMapWithMetadata;
     fn new_fields_ids_map(&self) -> &FieldIdMapWithMetadata;
 
-    fn old_searchable_attributes(&self) -> &Option<Vec<String>>;
-    fn new_searchable_attributes(&self) -> &Option<Vec<String>>;
-
     fn old_disabled_typos_terms(&self) -> &DisabledTyposTerms;
     fn new_disabled_typos_terms(&self) -> &DisabledTyposTerms;
 
@@ -2655,9 +2654,6 @@ pub trait SettingsDelta {
 
     fn old_filterable_rules(&self) -> &[FilterableAttributesRule];
     fn new_filterable_rules(&self) -> &[FilterableAttributesRule];
-
-    fn old_match_faceted_field(&self, field_name: &str) -> PatternMatch;
-    fn new_match_faceted_field(&self, field_name: &str) -> PatternMatch;
 
     fn old_geo_fields_ids(&self) -> Option<(FieldId, FieldId)>;
     fn new_geo_fields_ids(&self) -> Option<(FieldId, FieldId)>;
@@ -2691,13 +2687,6 @@ impl SettingsDelta for InnerIndexSettingsDiff {
         &self.new.fields_ids_map
     }
 
-    fn old_searchable_attributes(&self) -> &Option<Vec<String>> {
-        &self.old.user_defined_searchable_attributes
-    }
-    fn new_searchable_attributes(&self) -> &Option<Vec<String>> {
-        &self.new.user_defined_searchable_attributes
-    }
-
     fn old_disabled_typos_terms(&self) -> &DisabledTyposTerms {
         &self.old.disabled_typos_terms
     }
@@ -2717,13 +2706,6 @@ impl SettingsDelta for InnerIndexSettingsDiff {
     }
     fn new_filterable_rules(&self) -> &[FilterableAttributesRule] {
         &self.new.filterable_attributes_rules
-    }
-
-    fn old_match_faceted_field(&self, field_name: &str) -> PatternMatch {
-        self.old.match_faceted_field(field_name)
-    }
-    fn new_match_faceted_field(&self, field_name: &str) -> PatternMatch {
-        self.new.match_faceted_field(field_name)
     }
 
     fn old_geo_fields_ids(&self) -> Option<(FieldId, FieldId)> {

--- a/crates/milli/src/update/upgrade/v1_32.rs
+++ b/crates/milli/src/update/upgrade/v1_32.rs
@@ -14,7 +14,9 @@ use crate::heed_codec::StrBEU16Codec;
 use crate::progress::Progress;
 use crate::update::new::steps::SettingsIndexerStep;
 use crate::vector::VectorStore;
-use crate::{make_enum_progress, Error, Index, InternalError, MustStopProcessing, Result};
+use crate::{
+    make_enum_progress, Error, Index, InternalError, MustStopProcessing, PatternMatch, Result,
+};
 
 pub(super) struct CleanupFidBasedDatabases();
 
@@ -43,7 +45,13 @@ impl UpgradeIndex for CleanupFidBasedDatabases {
         let fid_map = index.fields_ids_map_with_metadata(wtxn)?;
         let fids_to_delete: BTreeSet<_> = fid_map
             .iter()
-            .filter_map(|(id, _, metadata)| if !metadata.is_searchable() { Some(id) } else { None })
+            .filter_map(|(id, _, metadata)| {
+                if metadata.is_searchable() != PatternMatch::Match {
+                    Some(id)
+                } else {
+                    None
+                }
+            })
             .collect();
 
         if !fids_to_delete.is_empty() {


### PR DESCRIPTION
## Related issue

Change the Metadata structure to allow identifying if a field:
- match a feature
- doesn't match a feature
- is a parent field of a field matching the feature

This allows us to better explore the nested document without having to match the fields agaisnt the settings everywhere.

Diff:
```rust
pub struct Metadata {
    // old
    pub searchable: Option<Weight>,
    // new
    pub searchable: (PatternMatch, Option<Weight>),

    // old
    pub exact: bool,
    // new
    pub exact: PatternMatch,

    // old
    pub sortable: bool,
    // new
    pub sortable: PatternMatch,

    // old
    pub distinct: bool,
    // new
    pub distinct: PatternMatch,

    // old
    pub asc_desc: Option<FieldSortOrder>,
    // new
    pub asc_desc: (PatternMatch, Option<FieldSortOrder>),

    // old
    pub geo: bool,
    // new
    pub geo: PatternMatch,

    // old
    pub geo_json: bool,
    // new
    pub geo_json: PatternMatch,

    // old
    pub displayed: bool,
    // new
    pub displayed: PatternMatch,

    pub localized_attributes_rule_id: Option<NonZeroU16>,

    // old
    pub filterable_attributes_rule_id: Option<NonZeroU16>,
    // new
    pub filterable_attributes_rule_id: (PatternMatch, Option<NonZeroU16>),

    pub sort_by: OrderBy,
}
```

## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respect the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - *list of used tools and what they were used for*
