### PR TITLE
Make the health route return a 500 when the task compaction succeeded

### DIFF
--- a/crates/meilisearch/src/routes/mod.rs
+++ b/crates/meilisearch/src/routes/mod.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::sync::atomic::Ordering;
 
 use actix_web::web::Data;
 use actix_web::{web, HttpRequest, HttpResponse};
@@ -578,6 +579,7 @@ struct HealthResponse {
 enum HealthStatus {
     #[default]
     Available,
+    MustRestart,
 }
 
 /// Get health
@@ -599,6 +601,11 @@ pub async fn get_health(
     auth_controller: Data<AuthController>,
     search_queue: Data<SearchQueue>,
 ) -> Result<HttpResponse, ResponseError> {
+    if tasks::compact::COMPACTION_SUCCESSFUL.load(Ordering::Relaxed) {
+        return Ok(HttpResponse::InternalServerError()
+            .json(HealthResponse { status: HealthStatus::MustRestart }));
+    }
+
     search_queue.health().unwrap();
     index_scheduler.health().unwrap();
     auth_controller.health().unwrap();

--- a/crates/meilisearch/src/routes/tasks/compact.rs
+++ b/crates/meilisearch/src/routes/tasks/compact.rs
@@ -1,5 +1,6 @@
 use std::fs::File;
 use std::io::{Seek, SeekFrom};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use actix_web::web::{self, Data};
@@ -17,6 +18,10 @@ use utoipa::ToSchema;
 
 use super::ActionPolicy;
 use crate::extractors::authentication::GuardedData;
+
+/// This boolean is used to indicate whether compaction
+/// has been successful and the server must be restarted.
+pub static COMPACTION_SUCCESSFUL: AtomicBool = AtomicBool::new(false);
 
 #[routes::routes(
     routes("/tasks/compact" => [post(compact_task_queue)]),
@@ -122,8 +127,10 @@ pub async fn compact_task_queue(
             Err(e) => {
                 HttpResponse::InternalServerError().json(report_task_queue_compaction_failure(e))
             }
-
-            Ok(summary) => HttpResponse::Ok().json(summary),
+            Ok(summary) => {
+                COMPACTION_SUCCESSFUL.store(true, Ordering::Relaxed);
+                HttpResponse::Ok().json(summary)
+            }
         }
     } else {
         HttpResponse::InternalServerError()

--- a/workloads/tests/task_queue_compaction.json
+++ b/workloads/tests/task_queue_compaction.json
@@ -58,6 +58,14 @@
       }
     },
     {
+      "route": "health",
+      "method": "GET",
+      "expectedStatus": 500,
+      "expectedResponse": {
+        "status": "mustRestart"
+      }
+    },
+    {
       "binary": {
         "source": "build"
       }


### PR DESCRIPTION
This PR changes the `/health` status to a `mustRestart` status when the server must restart, and specifically after a successful compaction has finished. The main benefit is that the Cloud will automatically restart the user instance after a successful task queue compaction.

## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respects the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - *list of used tools and what they were used for*