### PR TITLE
Fix the `WordDelta::added_or_deleted_words` function

### DIFF
--- a/crates/milli/src/update/new/indexer/word_delta.rs
+++ b/crates/milli/src/update/new/indexer/word_delta.rs
@@ -24,7 +24,7 @@ impl WordDelta {
     }
 
     pub fn added_or_deleted_words(&self) -> impl Iterator<Item = Either<&str, &str>> + '_ {
-        itertools::merge_join_by(self.added.iter(), self.modified.iter(), |a, b| a.cmp(b))
+        itertools::merge_join_by(self.added.iter(), self.deleted.iter(), |a, b| a.cmp(b))
             .filter_map(|eob| match eob {
                 EitherOrBoth::Both(_, _) => None,
                 EitherOrBoth::Left(added) => Some(Either::Left(added.as_str())),


### PR DESCRIPTION
This PR fixes #6349 and fixes #6324. I made a mistake in #6279: I used the `modified` words instead of the `deleted` ones when diffing the words to add and remove from the FST.

The bug was that `Either::Right` values were registered as `DelAdd::Deletion`, which meant that modified words were removed from the FST rather than being kept and updated.

## Generative AI tools

- [ ] This PR does not use generative AI tooling
- [x] This PR uses generative AI tooling and respects the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - I used Claude's Opus 4.6 to investigate my PR #6279 (I fetched the diff myself by appending `.diff` at the end of the URL).
    - I fixed the typo myself