### PR TITLE
Introduce a feature to offload indexes to an S3 storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2444,9 +2444,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2459,9 +2459,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2469,15 +2469,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2486,15 +2486,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2514,15 +2514,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
@@ -2532,9 +2532,9 @@ checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2544,7 +2544,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -3611,6 +3610,7 @@ dependencies = [
  "enum-iterator",
  "file-store",
  "flate2",
+ "futures",
  "hashbrown 0.15.5",
  "http-client",
  "indexmap",

--- a/crates/index-scheduler/Cargo.toml
+++ b/crates/index-scheduler/Cargo.toml
@@ -24,6 +24,7 @@ dump = { path = "../dump" }
 enum-iterator = "2.3.0"
 file-store = { path = "../file-store" }
 flate2 = "1.1.5"
+futures = "0.3.32"
 hashbrown = "0.15.5"
 http-client = { path = "../http-client" }
 indexmap = "2.12.0"

--- a/crates/index-scheduler/src/index_mapper/enterprise_edition.rs
+++ b/crates/index-scheduler/src/index_mapper/enterprise_edition.rs
@@ -1,0 +1,76 @@
+use std::io::{self, ErrorKind};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::fs::{create_dir_all, metadata};
+use tokio::sync::mpsc::Receiver;
+use tracing::warn;
+use uuid::Uuid;
+
+// TODO not sure I want to use it this way
+use super::index_map::IndexTransferRequest;
+
+/// It's 10 MB/s 🐌
+fn fake_transfer_speed(size: u64) -> Duration {
+    Duration::from_secs(size / (10 * 1024 * 1024))
+}
+
+async fn download_index(
+    indexes_folder: &Path,
+    fake_s3_folder: &Path,
+    uuid: Uuid,
+) -> Result<(), io::Error> {
+    let index_path = indexes_folder.join(uuid.to_string());
+    let index_path_in_s3 = fake_s3_folder.join(uuid.to_string());
+    let index_size = metadata(index_path_in_s3.join("data.ms")).await?.len();
+    let download_duration = fake_transfer_speed(index_size);
+    tokio::time::sleep(download_duration).await;
+    tokio::fs::rename(index_path_in_s3, index_path).await?;
+    Ok(())
+}
+
+async fn upload_index(
+    indexes_folder: &Path,
+    fake_s3_folder: &Path,
+    uuid: Uuid,
+) -> Result<(), io::Error> {
+    let index_path = indexes_folder.join(uuid.to_string());
+    let index_path_in_s3 = fake_s3_folder.join(uuid.to_string());
+    let index_size = metadata(index_path.join("data.ms")).await?.len();
+    let upload_duration = fake_transfer_speed(index_size);
+    tokio::time::sleep(upload_duration).await;
+    tokio::fs::rename(index_path, index_path_in_s3).await?;
+    Ok(())
+}
+
+pub async fn process_index_transfers(
+    indexes: PathBuf,
+    mut transfer_receiver: Receiver<IndexTransferRequest>,
+) {
+    // Create the folder that fakes S3
+    // TODO remove this once we actually upload to S3
+    let fake_s3 = indexes.join("this-is-s3");
+    if let Err(e) = create_dir_all(&fake_s3).await {
+        if e.kind() != ErrorKind::AlreadyExists {
+            panic!("Failed to create fake S3 folder: {e}");
+        }
+    }
+
+    while let Some(request) = transfer_receiver.recv().await {
+        match request {
+            IndexTransferRequest::Download { uuid, answer } => {
+                let result = download_index(&indexes, &fake_s3, uuid).await.map_err(Arc::new);
+                if answer.send(result).is_err() {
+                    warn!("Couldn't send the download status of index {uuid}: channel closed");
+                }
+            }
+            IndexTransferRequest::Upload { uuid, answer } => {
+                let result = upload_index(&indexes, &fake_s3, uuid).await.map_err(Arc::new);
+                if answer.send(result).is_err() {
+                    warn!("Couldn't send the upload status of index {uuid}: channel closed");
+                }
+            }
+        }
+    }
+}

--- a/crates/index-scheduler/src/index_mapper/index_map.rs
+++ b/crates/index-scheduler/src/index_mapper/index_map.rs
@@ -18,6 +18,9 @@ use uuid::Uuid;
 use super::IndexStatus::{self, Available, BeingDeleted, Closing, Missing};
 use crate::clamp_to_page_size;
 use crate::lru::{InsertionOutcome, LruMap};
+
+type IndexTransferCompletion = Shared<oneshot::Receiver<Result<(), Arc<io::Error>>>>;
+
 /// Keep an internally consistent view of the open indexes in memory.
 ///
 /// This view is made of an LRU cache that will evict the least frequently used indexes when new indexes are opened.
@@ -46,7 +49,7 @@ pub struct IndexMap {
     /// Note that opening it after the upload has completed will block until the **download** completes.
     ///
     /// One must wait for the download to complete before opening an index that is being downloaded.
-    transferring: HashMap<Uuid, Shared<oneshot::Receiver<Result<(), Arc<io::Error>>>>>,
+    transferring: HashMap<Uuid, IndexTransferCompletion>,
 
     /// A monotonically increasing generation number, used to differentiate between multiple successive index closing requests.
     ///
@@ -65,8 +68,8 @@ pub struct IndexMap {
 
 #[derive(Clone)]
 pub enum TransferState {
-    Downloading(Shared<oneshot::Receiver<Result<(), Arc<io::Error>>>>),
-    Uploading(Shared<oneshot::Receiver<Result<(), Arc<io::Error>>>>),
+    Downloading(IndexTransferCompletion),
+    Uploading(IndexTransferCompletion),
 }
 
 #[derive(Clone)]
@@ -208,6 +211,8 @@ impl IndexMap {
 
     /// Attempts to create a new index that wasn't existing before.
     ///
+    /// None is returned if the index is being transferred.
+    ///
     /// # Status table
     ///
     /// | Previous Status | New Status |
@@ -225,12 +230,35 @@ impl IndexMap {
         enable_mdb_writemap: bool,
         map_size: usize,
         create_or_open: CreateOrOpen,
-    ) -> Result<Index> {
+    ) -> Result<Option<Index>> {
         if !matches!(self.get_unavailable(uuid).await, Missing) {
+            // The index could be in the transferring state, right?
             panic!("Attempt to open an index that was unavailable");
         }
-        let index =
-            create_or_open_index(path, date, enable_mdb_writemap, map_size, create_or_open)?;
+
+        let index = match create_or_open {
+            CreateOrOpen::Open => {
+                // 1. check if the index exists
+                // 2. if it does, open it;
+                // 3. if not, register a download task and wait for it to complete
+                //    Warning: we must NOT wait for the download to complete here
+                //    or we will block the entire index management system.
+                //    We *MUST* rather return immediately an async task that the
+                //    caller can await on. We can return an Either<Index, Shared<OneShot>>.
+                // 4. Once the download is complete, open the index
+                // 5. insert it in the available map
+                let (sender, receiver) = oneshot::channel();
+                todo!("Do the download");
+                let receiver = receiver.shared();
+                todo!("do not insert another transferring job if one is already in progress");
+                self.transferring.insert(*uuid, receiver.clone());
+                return Ok(None);
+            }
+            create_or_open @ CreateOrOpen::Create { .. } => {
+                create_or_open_index(path, date, enable_mdb_writemap, map_size, create_or_open)?
+            }
+        };
+
         match self.available.insert(*uuid, index.clone()) {
             InsertionOutcome::InsertedNew => (),
             InsertionOutcome::Evicted(evicted_uuid, evicted_index) => {
@@ -240,7 +268,8 @@ impl IndexMap {
                 panic!("Attempt to open an index that was already opened")
             }
         }
-        Ok(index)
+
+        Ok(Some(index))
     }
 
     /// Increases the current generation. See documentation for this field.

--- a/crates/index-scheduler/src/index_mapper/index_map.rs
+++ b/crates/index-scheduler/src/index_mapper/index_map.rs
@@ -39,6 +39,7 @@ pub struct IndexMap {
     unavailable: LruMap<Uuid, ClosingIndex>,
     /// A set of indexes that have been deleted.
     deleting: HashSet<Uuid>,
+
     /// The set of indexes that are currently being uploaded and downloaded.
     ///
     /// One must wait for the upload to complete before opening an index that is being uploaded.
@@ -60,6 +61,12 @@ pub struct IndexMap {
     /// closing request was made, so the reader that "lost the race" has the old generation and will need to wait again for the index
     /// to close.
     generation: usize,
+}
+
+#[derive(Clone)]
+pub enum TransferState {
+    Downloading(Shared<oneshot::Receiver<Result<(), Arc<io::Error>>>>),
+    Uploading(Shared<oneshot::Receiver<Result<(), Arc<io::Error>>>>),
 }
 
 #[derive(Clone)]
@@ -113,8 +120,8 @@ impl ReopenableIndex {
     /// | Closing         | Available or Closing depending on generation |
     /// | Available       | Available                                    |
     ///
-    pub fn reopen(self, map: &mut IndexMap, path: &Path) -> Result<()> {
-        if let Closing(reopen) = map.get(&self.uuid) {
+    pub async fn reopen(self, map: &mut IndexMap, path: &Path) -> Result<()> {
+        if let Closing(reopen) = map.get(&self.uuid).await {
             if reopen.generation != self.generation {
                 return Ok(());
             }
@@ -126,7 +133,8 @@ impl ReopenableIndex {
                 self.enable_mdb_writemap,
                 self.map_size,
                 CreateOrOpen::Open,
-            )?;
+            )
+            .await?;
         }
         Ok(())
     }
@@ -144,8 +152,8 @@ impl ReopenableIndex {
     /// | BeingDeleted    | BeingDeleted                               |
     /// | Closing         | Missing or Closing depending on generation |
     /// | Available       | Available                                  |
-    pub fn close(self, map: &mut IndexMap) {
-        if let Closing(reopen) = map.get(&self.uuid) {
+    pub async fn close(self, map: &mut IndexMap) {
+        if let Closing(reopen) = map.get(&self.uuid).await {
             if reopen.generation != self.generation {
                 return;
             }
@@ -180,19 +188,21 @@ impl IndexMap {
     /// Gets the current status of an index in the map.
     ///
     /// If the index is available it can be accessed from the returned status.
-    pub fn get(&self, uuid: &Uuid) -> IndexStatus {
-        self.available
-            .get(uuid)
-            .map(|index| Available(index.clone()))
-            .unwrap_or_else(|| self.get_unavailable(uuid))
+    pub async fn get(&self, uuid: &Uuid) -> IndexStatus {
+        match self.available.get(uuid) {
+            Some(index) => Available(index.clone()),
+            None => self.get_unavailable(uuid).await,
+        }
     }
 
-    fn get_unavailable(&self, uuid: &Uuid) -> IndexStatus {
-        // TBD I think we need to use get_mut on the LRU map here
+    async fn get_unavailable(&self, uuid: &Uuid) -> IndexStatus {
         match self.unavailable.get(uuid) {
             Some(reopen) => Closing(reopen.clone()),
             None if self.deleting.get(uuid).is_some() => BeingDeleted,
-            None => Missing,
+            None => match self.transferring.get(uuid) {
+                Some(_) => todo!(),
+                None => Missing,
+            },
         }
     }
 
@@ -207,7 +217,7 @@ impl IndexMap {
     /// | Closing         | panics     |
     /// | Available       | panics     |
     ///
-    pub fn create(
+    pub async fn create(
         &mut self,
         uuid: &Uuid,
         path: &Path,
@@ -216,7 +226,7 @@ impl IndexMap {
         map_size: usize,
         create_or_open: CreateOrOpen,
     ) -> Result<Index> {
-        if !matches!(self.get_unavailable(uuid), Missing) {
+        if !matches!(self.get_unavailable(uuid).await, Missing) {
             panic!("Attempt to open an index that was unavailable");
         }
         let index =
@@ -346,6 +356,47 @@ impl IndexMap {
             "Attempt to finish deletion of an index that was being closed"
         );
     }
+
+    /// Finishes the download of an index that is being transferred
+    /// and do not insert it anywhere. The caller will receive Missing
+    /// and will open the freshly downloaded index.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the index is not being transferred or the transfer a
+    /// copy of an `Arc` error is kept alive.
+    pub async fn end_downloading(&mut self, uuid: &Uuid) -> Result<(), io::Error> {
+        assert!(
+            self.available.get(uuid).is_none(),
+            "Attempt to finish the download of an available index"
+        );
+        match self.transferring.remove(uuid) {
+            Some(task) => {
+                // safety: we must be the last ones to get this error
+                task.await.unwrap().map_err(|err| Arc::into_inner(err).unwrap())
+            }
+            None => {
+                panic!("Attempt to finish the download of an index that is not being transferred")
+            }
+        }
+    }
+
+    // TBD we could probably merge this with `end_downloading`
+    pub async fn end_uploading(&mut self, uuid: &Uuid) -> Result<(), io::Error> {
+        assert!(
+            self.available.get(uuid).is_none(),
+            "Attempt to finish the download of an available index"
+        );
+        match self.transferring.remove(uuid) {
+            Some(task) => {
+                // safety: we must be the last ones to get this error
+                task.await.unwrap().map_err(|err| Arc::into_inner(err).unwrap())
+            }
+            None => {
+                panic!("Attempt to finish the download of an index that is not being transferred")
+            }
+        }
+    }
 }
 
 /// Create or open an index in the specified path.
@@ -413,15 +464,15 @@ mod tests {
         assert_eq!(state.is_some(), is_closing);
     }
 
-    #[test]
-    fn evict_indexes() {
+    #[tokio::test]
+    async fn evict_indexes() {
         let (mapper, env, _handle) = IndexMapper::test();
         let mut uuids = vec![];
         // LRU cap + 1
         for i in 0..(5 + 1) {
             let index_name = format!("index-{i}");
             let wtxn = env.write_txn().unwrap();
-            mapper.create_index(wtxn, &index_name, None, None).unwrap();
+            mapper.create_index(wtxn, &index_name, None, None).await.unwrap();
             let txn = env.read_txn().unwrap();
             uuids.push(mapper.index_mapping.get(&txn, &index_name).unwrap().unwrap());
         }
@@ -430,26 +481,29 @@ mod tests {
 
         // get back the evicted index
         let wtxn = env.write_txn().unwrap();
-        mapper.create_index(wtxn, "index-0", None, None).unwrap();
+        mapper.create_index(wtxn, "index-0", None, None).await.unwrap();
 
         // Least recently used is now index-1
         check_first_unavailable(&mapper, uuids[1], true);
     }
 
-    #[test]
-    fn resize_index() {
+    #[tokio::test]
+    async fn resize_index() {
         let (mapper, env, _handle) = IndexMapper::test();
-        let index = mapper.create_index(env.write_txn().unwrap(), "index", None, None).unwrap();
+        let index =
+            mapper.create_index(env.write_txn().unwrap(), "index", None, None).await.unwrap();
         assert_index_size(index, mapper.index_base_map_size);
 
         mapper.resize_index(&env.read_txn().unwrap(), "index").unwrap();
 
-        let index = mapper.create_index(env.write_txn().unwrap(), "index", None, None).unwrap();
+        let index =
+            mapper.create_index(env.write_txn().unwrap(), "index", None, None).await.unwrap();
         assert_index_size(index, mapper.index_base_map_size + mapper.index_growth_amount);
 
         mapper.resize_index(&env.read_txn().unwrap(), "index").unwrap();
 
-        let index = mapper.create_index(env.write_txn().unwrap(), "index", None, None).unwrap();
+        let index =
+            mapper.create_index(env.write_txn().unwrap(), "index", None, None).await.unwrap();
         assert_index_size(index, mapper.index_base_map_size + mapper.index_growth_amount * 2);
     }
 

--- a/crates/index-scheduler/src/index_mapper/index_map.rs
+++ b/crates/index-scheduler/src/index_mapper/index_map.rs
@@ -1,9 +1,15 @@
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::env::VarError;
+use std::io;
 use std::path::Path;
 use std::str::FromStr;
+use std::sync::Arc;
 use std::time::Duration;
 
+use futures::channel::oneshot;
+use futures::future::Shared;
+use futures::FutureExt;
+use hashbrown::HashSet;
 use meilisearch_types::heed::{EnvClosingEvent, EnvFlags, EnvOpenOptions};
 use meilisearch_types::milli::{CreateOrOpen, Index, Result};
 use time::OffsetDateTime;
@@ -30,7 +36,16 @@ pub struct IndexMap {
     /// or because they are being closed.
     ///
     /// If they are being deleted, the UUID points to `None`.
-    unavailable: BTreeMap<Uuid, Option<ClosingIndex>>,
+    unavailable: LruMap<Uuid, ClosingIndex>,
+    /// A set of indexes that have been deleted.
+    deleting: HashSet<Uuid>,
+    /// The set of indexes that are currently being uploaded and downloaded.
+    ///
+    /// One must wait for the upload to complete before opening an index that is being uploaded.
+    /// Note that opening it after the upload has completed will block until the **download** completes.
+    ///
+    /// One must wait for the download to complete before opening an index that is being downloaded.
+    transferring: HashMap<Uuid, Shared<oneshot::Receiver<Result<(), Arc<io::Error>>>>>,
 
     /// A monotonically increasing generation number, used to differentiate between multiple successive index closing requests.
     ///
@@ -140,8 +155,26 @@ impl ReopenableIndex {
 }
 
 impl IndexMap {
-    pub fn new(cap: usize) -> IndexMap {
-        Self { unavailable: Default::default(), available: LruMap::new(cap), generation: 0 }
+    /// Creates a new `IndexMap` with the specified number of opened and on-disk indexes.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if `on_disk_cap` is smaller than `opened_cap`.
+    pub fn new(opened_cap: usize, on_disk_cap: usize) -> IndexMap {
+        let unavailable = match on_disk_cap.checked_sub(opened_cap) {
+            Some(unavailable) => unavailable,
+            None => panic!(
+                "on-disk capacity ({on_disk_cap}) must be greater than or equal to opened capacity ({opened_cap})"
+            ),
+        };
+
+        Self {
+            available: LruMap::new(opened_cap),
+            unavailable: LruMap::new(unavailable),
+            deleting: HashSet::default(),
+            transferring: HashMap::default(),
+            generation: 0,
+        }
     }
 
     /// Gets the current status of an index in the map.
@@ -155,9 +188,10 @@ impl IndexMap {
     }
 
     fn get_unavailable(&self, uuid: &Uuid) -> IndexStatus {
+        // TBD I think we need to use get_mut on the LRU map here
         match self.unavailable.get(uuid) {
-            Some(Some(reopen)) => Closing(reopen.clone()),
-            Some(None) => BeingDeleted,
+            Some(reopen) => Closing(reopen.clone()),
+            None if self.deleting.get(uuid).is_some() => BeingDeleted,
             None => Missing,
         }
     }
@@ -245,10 +279,20 @@ impl IndexMap {
         let map_size = index.map_size() + map_size_growth;
         let closing_event = index.prepare_for_closing();
         let generation = self.next_generation();
-        self.unavailable.insert(
-            uuid,
-            Some(ClosingIndex { uuid, closing_event, enable_mdb_writemap, map_size, generation }),
-        );
+        let closing_index =
+            ClosingIndex { uuid, closing_event, enable_mdb_writemap, map_size, generation };
+        match self.unavailable.insert(uuid, closing_index) {
+            InsertionOutcome::InsertedNew => (),
+            InsertionOutcome::Evicted(evicted_uuid, evicted_closing_index) => {
+                let (sender, receiver) = oneshot::channel();
+                // What should we do about the index being closed?
+                // Should I give the closing_event to the uploader?
+                // I think I don't care about the closing_event, right?
+                todo!("upload the index and delete it once the upload is successful");
+                self.transferring.insert(evicted_uuid, receiver.shared());
+            }
+            InsertionOutcome::Replaced(_) => unreachable!(),
+        }
     }
 
     /// Attempts to delete and index.
@@ -268,12 +312,12 @@ impl IndexMap {
         uuid: &Uuid,
     ) -> std::result::Result<Option<EnvClosingEvent>, Option<ClosingIndex>> {
         if let Some(index) = self.available.remove(uuid) {
-            self.unavailable.insert(*uuid, None);
+            self.deleting.insert(*uuid);
             return Ok(Some(index.prepare_for_closing()));
         }
         match self.unavailable.remove(uuid) {
-            Some(Some(reopen)) => Err(Some(reopen)),
-            Some(None) => Err(None),
+            Some(reopen) => Err(Some(reopen)),
+            None if self.deleting.contains(uuid) => Err(None),
             None => Ok(None),
         }
     }
@@ -295,9 +339,10 @@ impl IndexMap {
             self.available.get(uuid).is_none(),
             "Attempt to finish deletion of an index that was not being deleted"
         );
+        self.deleting.remove(uuid);
         // Do not panic if the index was Missing or BeingDeleted
         assert!(
-            !matches!(self.unavailable.remove(uuid), Some(Some(_))),
+            !matches!(self.unavailable.remove(uuid), Some(_)),
             "Attempt to finish deletion of an index that was being closed"
         );
     }
@@ -347,6 +392,7 @@ mod tests {
     use uuid::Uuid;
 
     use super::super::IndexMapper;
+    use crate::index_mapper::index_map::ClosingIndex;
     use crate::test_utils::IndexSchedulerHandle;
     use crate::utils::clamp_to_page_size;
     use crate::IndexScheduler;
@@ -360,7 +406,9 @@ mod tests {
 
     fn check_first_unavailable(mapper: &IndexMapper, expected_uuid: Uuid, is_closing: bool) {
         let index_map = mapper.index_map.read().unwrap();
-        let (uuid, state) = index_map.unavailable.first_key_value().unwrap();
+        // let (uuid, state) = index_map.unavailable.first_key_value().unwrap();
+        let (uuid, state): (&Uuid, Option<ClosingIndex>) =
+            todo!("check the first key value another way with the LRU");
         assert_eq!(uuid, &expected_uuid);
         assert_eq!(state.is_some(), is_closing);
     }

--- a/crates/index-scheduler/src/index_mapper/index_map.rs
+++ b/crates/index-scheduler/src/index_mapper/index_map.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
 use std::env::VarError;
-use std::io;
-use std::path::Path;
+use std::io::{self, ErrorKind};
+use std::ops::Not as _;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -13,6 +14,10 @@ use hashbrown::HashSet;
 use meilisearch_types::heed::{EnvClosingEvent, EnvFlags, EnvOpenOptions};
 use meilisearch_types::milli::{CreateOrOpen, Index, Result};
 use time::OffsetDateTime;
+use tokio::runtime;
+use tokio::sync::mpsc::Receiver;
+use tokio::task::JoinHandle;
+use tracing::warn;
 use uuid::Uuid;
 
 use super::IndexStatus::{self, Available, BeingDeleted, Closing, Missing};
@@ -20,6 +25,7 @@ use crate::clamp_to_page_size;
 use crate::lru::{InsertionOutcome, LruMap};
 
 type IndexTransferCompletion = Shared<oneshot::Receiver<Result<(), Arc<io::Error>>>>;
+type IndexTransferCompletionNotifier = oneshot::Sender<Result<(), Arc<io::Error>>>;
 
 /// Keep an internally consistent view of the open indexes in memory.
 ///
@@ -51,6 +57,9 @@ pub struct IndexMap {
     /// One must wait for the download to complete before opening an index that is being downloaded.
     transferring: HashMap<Uuid, IndexTransferCompletion>,
 
+    /// The channel used to send index transfer requests to the transfer task.
+    transfer_sender: Option<tokio::sync::mpsc::Sender<IndexTransferRequest>>,
+
     /// A monotonically increasing generation number, used to differentiate between multiple successive index closing requests.
     ///
     /// Because multiple readers could be waiting on an index to close, the following could theoretically happen:
@@ -64,6 +73,15 @@ pub struct IndexMap {
     /// closing request was made, so the reader that "lost the race" has the old generation and will need to wait again for the index
     /// to close.
     generation: usize,
+}
+
+/// The request sent to the transfer task to download or upload an index.
+#[derive(Debug)]
+pub enum IndexTransferRequest {
+    /// Request to download an index to S3.
+    Download { uuid: Uuid, answer: IndexTransferCompletionNotifier },
+    /// Request to upload an index to S3.
+    Upload { uuid: Uuid, answer: IndexTransferCompletionNotifier },
 }
 
 #[derive(Clone)]
@@ -130,7 +148,7 @@ impl ReopenableIndex {
             }
             map.unavailable.remove(&self.uuid);
             map.create(
-                &self.uuid,
+                self.uuid,
                 path,
                 None,
                 self.enable_mdb_writemap,
@@ -168,10 +186,18 @@ impl ReopenableIndex {
 impl IndexMap {
     /// Creates a new `IndexMap` with the specified number of opened and on-disk indexes.
     ///
+    /// If `runtime` is `None`, the transfer task will not be spawned and index offloading
+    /// will not be supported.
+    ///
     /// ## Panics
     ///
     /// Panics if `on_disk_cap` is smaller than `opened_cap`.
-    pub fn new(opened_cap: usize, on_disk_cap: usize) -> IndexMap {
+    pub fn new(
+        opened_cap: usize,
+        on_disk_cap: usize,
+        runtime: Option<runtime::Handle>,
+        indexes_folder: PathBuf,
+    ) -> IndexMap {
         let unavailable = match on_disk_cap.checked_sub(opened_cap) {
             Some(unavailable) => unavailable,
             None => panic!(
@@ -179,11 +205,22 @@ impl IndexMap {
             ),
         };
 
+        let transfer_sender = match runtime {
+            Some(runtime) => {
+                // TODO why limiting to 10?
+                let (transfer_sender, transfer_receiver) = tokio::sync::mpsc::channel(10);
+                runtime.spawn(process_index_transfers(indexes_folder, transfer_receiver));
+                Some(transfer_sender)
+            }
+            None => None,
+        };
+
         Self {
             available: LruMap::new(opened_cap),
             unavailable: LruMap::new(unavailable),
             deleting: HashSet::default(),
             transferring: HashMap::default(),
+            transfer_sender,
             generation: 0,
         }
     }
@@ -211,7 +248,7 @@ impl IndexMap {
 
     /// Attempts to create a new index that wasn't existing before.
     ///
-    /// None is returned if the index is being transferred.
+    /// None is returned if the index is being downloaded.
     ///
     /// # Status table
     ///
@@ -224,42 +261,54 @@ impl IndexMap {
     ///
     pub async fn create(
         &mut self,
-        uuid: &Uuid,
+        uuid: Uuid,
         path: &Path,
         date: Option<(OffsetDateTime, OffsetDateTime)>,
         enable_mdb_writemap: bool,
         map_size: usize,
         create_or_open: CreateOrOpen,
     ) -> Result<Option<Index>> {
-        if !matches!(self.get_unavailable(uuid).await, Missing) {
-            // The index could be in the transferring state, right?
+        if !matches!(self.get_unavailable(&uuid).await, Missing) {
             panic!("Attempt to open an index that was unavailable");
         }
 
         let index = match create_or_open {
             CreateOrOpen::Open => {
-                // 1. check if the index exists
-                // 2. if it does, open it;
-                // 3. if not, register a download task and wait for it to complete
-                //    Warning: we must NOT wait for the download to complete here
-                //    or we will block the entire index management system.
-                //    We *MUST* rather return immediately an async task that the
-                //    caller can await on. We can return an Either<Index, Shared<OneShot>>.
-                // 4. Once the download is complete, open the index
-                // 5. insert it in the available map
-                let (sender, receiver) = oneshot::channel();
-                todo!("Do the download");
-                let receiver = receiver.shared();
-                todo!("do not insert another transferring job if one is already in progress");
-                self.transferring.insert(*uuid, receiver.clone());
-                return Ok(None);
+                match self.transfer_sender.as_ref() {
+                    Some(transfer_sender) if path.try_exists()?.not() => {
+                        // if index is not on disk, register a download task and wait for
+                        // it to complete Warning: we must NOT wait for the download to
+                        // complete here or we will block the entire index management system.
+                        // We *MUST* return immediately and make the caller to find out
+                        // that the index is being downloaded and wait for it to complete.
+                        let (answer, receiver) = oneshot::channel();
+                        // TODO do not unwrap
+                        transfer_sender
+                            .send(IndexTransferRequest::Download { uuid, answer })
+                            .await
+                            .unwrap();
+                        if self.transferring.insert(uuid, receiver.shared()).is_some() {
+                            panic!(
+                                "Attempt to download an index that was already being transfered"
+                            );
+                        }
+                        return Ok(None);
+                    }
+                    _ => create_or_open_index(
+                        path,
+                        date,
+                        enable_mdb_writemap,
+                        map_size,
+                        create_or_open,
+                    )?,
+                }
             }
             create_or_open @ CreateOrOpen::Create { .. } => {
                 create_or_open_index(path, date, enable_mdb_writemap, map_size, create_or_open)?
             }
         };
 
-        match self.available.insert(*uuid, index.clone()) {
+        match self.available.insert(uuid, index.clone()) {
             InsertionOutcome::InsertedNew => (),
             InsertionOutcome::Evicted(evicted_uuid, evicted_index) => {
                 self.close(evicted_uuid, evicted_index, enable_mdb_writemap, 0);
@@ -323,12 +372,21 @@ impl IndexMap {
         match self.unavailable.insert(uuid, closing_index) {
             InsertionOutcome::InsertedNew => (),
             InsertionOutcome::Evicted(evicted_uuid, evicted_closing_index) => {
-                let (sender, receiver) = oneshot::channel();
-                // What should we do about the index being closed?
-                // Should I give the closing_event to the uploader?
-                // I think I don't care about the closing_event, right?
-                todo!("upload the index and delete it once the upload is successful");
-                self.transferring.insert(evicted_uuid, receiver.shared());
+                // In case of no runtime, we simply keep the index on disk but
+                // don't store it in the transferring map nor run the transfer task.
+                // This way, next time the index is needed, we can simply load it from disk.
+                if let Some(transfer_sender) = self.transfer_sender.as_ref() {
+                    // What should we do about the index being closed?
+                    // Should I give the closing_event to the uploader?
+                    // I think I don't care about the closing_event, right?
+                    let (answer, receiver) = oneshot::channel();
+                    // TODO We would probably prefer using the async `send` instead
+                    transfer_sender
+                        .blocking_send(IndexTransferRequest::Upload { uuid: evicted_uuid, answer })
+                        // TODO do not unwrap here
+                        .unwrap();
+                    self.transferring.insert(evicted_uuid, receiver.shared());
+                }
             }
             InsertionOutcome::Replaced(_) => unreachable!(),
         }
@@ -401,6 +459,73 @@ impl IndexMap {
                 task.await.unwrap().map_err(|err| Arc::into_inner(err).unwrap())
             }
             None => Ok(()),
+        }
+    }
+}
+
+// TODO move this the a `enterprise_edition` module.
+async fn process_index_transfers(
+    indexes: PathBuf,
+    mut transfer_receiver: Receiver<IndexTransferRequest>,
+) {
+    use tokio::fs::{create_dir_all, metadata};
+
+    /// It's 10 MB/s 🐌
+    fn fake_transfer_speed(size: u64) -> Duration {
+        Duration::from_secs(size / (10 * 1024 * 1024))
+    }
+
+    async fn download_index(
+        indexes_folder: &Path,
+        fake_s3_folder: &Path,
+        uuid: Uuid,
+    ) -> Result<(), io::Error> {
+        let index_path = indexes_folder.join(uuid.to_string());
+        let index_path_in_s3 = fake_s3_folder.join(uuid.to_string());
+        let index_size = metadata(index_path_in_s3.join("data.ms")).await?.len();
+        let download_duration = fake_transfer_speed(index_size);
+        tokio::time::sleep(download_duration).await;
+        tokio::fs::rename(index_path_in_s3, index_path).await?;
+        Ok(())
+    }
+
+    async fn upload_index(
+        indexes_folder: &Path,
+        fake_s3_folder: &Path,
+        uuid: Uuid,
+    ) -> Result<(), io::Error> {
+        let index_path = indexes_folder.join(uuid.to_string());
+        let index_path_in_s3 = fake_s3_folder.join(uuid.to_string());
+        let index_size = metadata(index_path.join("data.ms")).await?.len();
+        let upload_duration = fake_transfer_speed(index_size);
+        tokio::time::sleep(upload_duration).await;
+        tokio::fs::rename(index_path, index_path_in_s3).await?;
+        Ok(())
+    }
+
+    // Create the folder that fakes S3
+    // TODO remove this once we actually upload to S3
+    let fake_s3 = indexes.join("this-is-s3");
+    if let Err(e) = create_dir_all(&fake_s3).await {
+        if e.kind() != ErrorKind::AlreadyExists {
+            panic!("Failed to create fake S3 folder: {e}");
+        }
+    }
+
+    while let Some(request) = transfer_receiver.recv().await {
+        match request {
+            IndexTransferRequest::Download { uuid, answer } => {
+                let result = download_index(&indexes, &fake_s3, uuid).await.map_err(Arc::new);
+                if answer.send(result).is_err() {
+                    warn!("Couldn't send the download status of index {uuid}: channel closed");
+                }
+            }
+            IndexTransferRequest::Upload { uuid, answer } => {
+                let result = upload_index(&indexes, &fake_s3, uuid).await.map_err(Arc::new);
+                if answer.send(result).is_err() {
+                    warn!("Couldn't send the upload status of index {uuid}: channel closed");
+                }
+            }
         }
     }
 }

--- a/crates/index-scheduler/src/index_mapper/index_map.rs
+++ b/crates/index-scheduler/src/index_mapper/index_map.rs
@@ -386,7 +386,7 @@ impl IndexMap {
         );
     }
 
-    /// Finishes the download of an index that is being transferred
+    /// Finishes the download and upload of an index that is being transferred
     /// and do not insert it anywhere. The caller will receive Missing
     /// and will open the freshly downloaded index.
     ///
@@ -394,36 +394,13 @@ impl IndexMap {
     ///
     /// Panics if the index is not being transferred or the transfer a
     /// copy of an `Arc` error is kept alive.
-    pub async fn end_downloading(&mut self, uuid: &Uuid) -> Result<(), io::Error> {
-        assert!(
-            self.available.get(uuid).is_none(),
-            "Attempt to finish the download of an available index"
-        );
+    pub async fn end_transferring(&mut self, uuid: &Uuid) -> Result<(), io::Error> {
         match self.transferring.remove(uuid) {
             Some(task) => {
                 // safety: we must be the last ones to get this error
                 task.await.unwrap().map_err(|err| Arc::into_inner(err).unwrap())
             }
-            None => {
-                panic!("Attempt to finish the download of an index that is not being transferred")
-            }
-        }
-    }
-
-    // TBD we could probably merge this with `end_downloading`
-    pub async fn end_uploading(&mut self, uuid: &Uuid) -> Result<(), io::Error> {
-        assert!(
-            self.available.get(uuid).is_none(),
-            "Attempt to finish the download of an available index"
-        );
-        match self.transferring.remove(uuid) {
-            Some(task) => {
-                // safety: we must be the last ones to get this error
-                task.await.unwrap().map_err(|err| Arc::into_inner(err).unwrap())
-            }
-            None => {
-                panic!("Attempt to finish the download of an index that is not being transferred")
-            }
+            None => Ok(()),
         }
     }
 }

--- a/crates/index-scheduler/src/index_mapper/index_map.rs
+++ b/crates/index-scheduler/src/index_mapper/index_map.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::env::VarError;
-use std::io::{self, ErrorKind};
+use std::io;
 use std::ops::Not as _;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -15,10 +15,10 @@ use meilisearch_types::heed::{EnvClosingEvent, EnvFlags, EnvOpenOptions};
 use meilisearch_types::milli::{CreateOrOpen, Index, Result};
 use time::OffsetDateTime;
 use tokio::runtime;
-use tokio::sync::mpsc::Receiver;
-use tokio::task::JoinHandle;
-use tracing::warn;
 use uuid::Uuid;
+
+#[cfg(feature = "enterprise")]
+pub use super::enterprise_edition::process_index_transfers;
 
 use super::IndexStatus::{self, Available, BeingDeleted, Closing, Missing};
 use crate::clamp_to_page_size;
@@ -206,11 +206,17 @@ impl IndexMap {
         };
 
         let transfer_sender = match runtime {
+            #[cfg(feature = "enterprise")]
             Some(runtime) => {
                 // TODO why limiting to 10?
                 let (transfer_sender, transfer_receiver) = tokio::sync::mpsc::channel(10);
                 runtime.spawn(process_index_transfers(indexes_folder, transfer_receiver));
                 Some(transfer_sender)
+            }
+            #[cfg(not(feature = "enterprise"))]
+            Some(_) => {
+                let _ = indexes_folder;
+                None
             }
             None => None,
         };
@@ -463,73 +469,6 @@ impl IndexMap {
     }
 }
 
-// TODO move this the a `enterprise_edition` module.
-async fn process_index_transfers(
-    indexes: PathBuf,
-    mut transfer_receiver: Receiver<IndexTransferRequest>,
-) {
-    use tokio::fs::{create_dir_all, metadata};
-
-    /// It's 10 MB/s 🐌
-    fn fake_transfer_speed(size: u64) -> Duration {
-        Duration::from_secs(size / (10 * 1024 * 1024))
-    }
-
-    async fn download_index(
-        indexes_folder: &Path,
-        fake_s3_folder: &Path,
-        uuid: Uuid,
-    ) -> Result<(), io::Error> {
-        let index_path = indexes_folder.join(uuid.to_string());
-        let index_path_in_s3 = fake_s3_folder.join(uuid.to_string());
-        let index_size = metadata(index_path_in_s3.join("data.ms")).await?.len();
-        let download_duration = fake_transfer_speed(index_size);
-        tokio::time::sleep(download_duration).await;
-        tokio::fs::rename(index_path_in_s3, index_path).await?;
-        Ok(())
-    }
-
-    async fn upload_index(
-        indexes_folder: &Path,
-        fake_s3_folder: &Path,
-        uuid: Uuid,
-    ) -> Result<(), io::Error> {
-        let index_path = indexes_folder.join(uuid.to_string());
-        let index_path_in_s3 = fake_s3_folder.join(uuid.to_string());
-        let index_size = metadata(index_path.join("data.ms")).await?.len();
-        let upload_duration = fake_transfer_speed(index_size);
-        tokio::time::sleep(upload_duration).await;
-        tokio::fs::rename(index_path, index_path_in_s3).await?;
-        Ok(())
-    }
-
-    // Create the folder that fakes S3
-    // TODO remove this once we actually upload to S3
-    let fake_s3 = indexes.join("this-is-s3");
-    if let Err(e) = create_dir_all(&fake_s3).await {
-        if e.kind() != ErrorKind::AlreadyExists {
-            panic!("Failed to create fake S3 folder: {e}");
-        }
-    }
-
-    while let Some(request) = transfer_receiver.recv().await {
-        match request {
-            IndexTransferRequest::Download { uuid, answer } => {
-                let result = download_index(&indexes, &fake_s3, uuid).await.map_err(Arc::new);
-                if answer.send(result).is_err() {
-                    warn!("Couldn't send the download status of index {uuid}: channel closed");
-                }
-            }
-            IndexTransferRequest::Upload { uuid, answer } => {
-                let result = upload_index(&indexes, &fake_s3, uuid).await.map_err(Arc::new);
-                if answer.send(result).is_err() {
-                    warn!("Couldn't send the upload status of index {uuid}: channel closed");
-                }
-            }
-        }
-    }
-}
-
 /// Create or open an index in the specified path.
 /// The path *must* exist or an error will be thrown.
 fn create_or_open_index(
@@ -574,7 +513,6 @@ mod tests {
     use uuid::Uuid;
 
     use super::super::IndexMapper;
-    use crate::index_mapper::index_map::ClosingIndex;
     use crate::test_utils::IndexSchedulerHandle;
     use crate::utils::clamp_to_page_size;
     use crate::IndexScheduler;
@@ -586,13 +524,10 @@ mod tests {
         }
     }
 
-    fn check_first_unavailable(mapper: &IndexMapper, expected_uuid: Uuid, is_closing: bool) {
+    fn check_first_unavailable(mapper: &IndexMapper, expected_uuid: Uuid) {
         let index_map = mapper.index_map.read().unwrap();
-        // let (uuid, state) = index_map.unavailable.first_key_value().unwrap();
-        let (uuid, state): (&Uuid, Option<ClosingIndex>) =
-            todo!("check the first key value another way with the LRU");
+        let (uuid, _state) = index_map.unavailable.first_key_value().unwrap();
         assert_eq!(uuid, &expected_uuid);
-        assert_eq!(state.is_some(), is_closing);
     }
 
     #[tokio::test]
@@ -608,14 +543,14 @@ mod tests {
             uuids.push(mapper.index_mapping.get(&txn, &index_name).unwrap().unwrap());
         }
         // index-0 was evicted
-        check_first_unavailable(&mapper, uuids[0], true);
+        check_first_unavailable(&mapper, uuids[0]);
 
         // get back the evicted index
         let wtxn = env.write_txn().unwrap();
         mapper.create_index(wtxn, "index-0", None, None).await.unwrap();
 
         // Least recently used is now index-1
-        check_first_unavailable(&mapper, uuids[1], true);
+        check_first_unavailable(&mapper, uuids[1]);
     }
 
     #[tokio::test]

--- a/crates/index-scheduler/src/index_mapper/mod.rs
+++ b/crates/index-scheduler/src/index_mapper/mod.rs
@@ -94,6 +94,9 @@ pub enum IndexStatus {
     /// Temporarily do not insert the index in the index map as it is currently being resized/evicted from the map.
     Closing(index_map::ClosingIndex),
     /// You can use the index without worrying about anything.
+    ///
+    /// If the index is being transferred (uploaded or downloaded),
+    /// it will be available after an await.
     Available(Index),
 }
 
@@ -171,7 +174,10 @@ impl IndexMapper {
         budget: IndexBudget,
     ) -> Result<Self> {
         Ok(Self {
-            index_map: Arc::new(RwLock::new(IndexMap::new(budget.index_count))),
+            index_map: Arc::new(RwLock::new(IndexMap::new(
+                2, // TBD available capacity
+                4, // TBD on-disk capacity
+            ))),
             index_mapping: env.create_database(wtxn, Some(db_name::INDEX_MAPPING))?,
             index_stats: env.create_database(wtxn, Some(db_name::INDEX_STATS))?,
             base_path: options.indexes_path.clone(),

--- a/crates/index-scheduler/src/index_mapper/mod.rs
+++ b/crates/index-scheduler/src/index_mapper/mod.rs
@@ -215,7 +215,7 @@ impl IndexMapper {
                 // Error if the UUIDv4 somehow already exists in the map, since it should be fresh.
                 // This is very unlikely to happen in practice.
                 // TODO: it would be better to lazily create the index. But we need an Index::open function for milli.
-                let index = self
+                let index = match self
                     .index_map
                     .write()
                     .unwrap()
@@ -228,7 +228,12 @@ impl IndexMapper {
                         CreateOrOpen::Create { shards },
                     )
                     .await
-                    .map_err(|e| Error::from_milli(e, Some(uuid.to_string())))?;
+                    .map_err(|e| Error::from_milli(e, Some(uuid.to_string())))?
+                {
+                    Some(index) => index,
+                    None => unreachable!("Index doesn't exist so must not be downloaded"),
+                };
+
                 let index_rtxn = index.read_txn()?;
                 let stats = crate::index_mapper::IndexStats::new(&index, &index_rtxn)
                     .map_err(|e| Error::from_milli(e, Some(name.to_string())))?;
@@ -461,7 +466,7 @@ impl IndexMapper {
                         Missing => {
                             let index_path = self.index_path(uuid);
 
-                            break index_map
+                            match index_map
                                 .create(
                                     &uuid,
                                     &index_path,
@@ -471,15 +476,15 @@ impl IndexMapper {
                                     CreateOrOpen::Open,
                                 )
                                 .await
-                                .map_err(|e| Error::from_milli(e, Some(uuid.to_string())))?;
-                        }
-                        Transferring(_) => {
-                            // awaiting the download/upload will be handled in the next loop operation
-                            continue;
+                                .map_err(|e| Error::from_milli(e, Some(uuid.to_string())))?
+                            {
+                                Some(index) => break index,
+                                None => continue,
+                            }
                         }
                         Available(index) => break index,
-                        Closing(_) => {
-                            // the reopening will be handled in the next loop operation
+                        Closing(_) | Transferring(_) => {
+                            // awaiting the download/upload or reopening will be handled in the next loop operation
                             continue;
                         }
                         BeingDeleted => return Err(Error::IndexNotFound(name.to_string())),

--- a/crates/index-scheduler/src/index_mapper/mod.rs
+++ b/crates/index-scheduler/src/index_mapper/mod.rs
@@ -15,8 +15,8 @@ use time::OffsetDateTime;
 use tracing::error;
 use uuid::Uuid;
 
-use self::index_map::IndexMap;
-use self::IndexStatus::{Available, BeingDeleted, Closing, Missing};
+use self::index_map::{IndexMap, TransferState};
+use self::IndexStatus::{Available, BeingDeleted, Closing, Missing, Transferring};
 use crate::uuid_codec::UuidCodec;
 use crate::{Error, IndexBudget, IndexSchedulerOptions, Result};
 
@@ -93,10 +93,11 @@ pub enum IndexStatus {
     BeingDeleted,
     /// Temporarily do not insert the index in the index map as it is currently being resized/evicted from the map.
     Closing(index_map::ClosingIndex),
-    /// You can use the index without worrying about anything.
+    /// The index is currently being downloaded from or uploaded to the S3 bucket.
     ///
-    /// If the index is being transferred (uploaded or downloaded),
-    /// it will be available after an await.
+    /// Await the future and call either `end_download` or `end_upload` depending on the state.
+    Transferring(TransferState),
+    /// You can use the index without worrying about anything.
     Available(Index),
 }
 
@@ -190,15 +191,16 @@ impl IndexMapper {
     }
 
     /// Get or create the index.
-    pub fn create_index(
+    pub async fn create_index(
         &self,
-        mut wtxn: RwTxn,
+        mut wtxn: RwTxn<'_>,
         name: &str,
         date: Option<(OffsetDateTime, OffsetDateTime)>,
         shards: Option<Shards>,
     ) -> Result<Index> {
-        match self.index(&wtxn, name) {
+        match self.index(&wtxn, name).await {
             Ok(index) => {
+                // TBD don't block here
                 wtxn.commit()?;
                 Ok(index)
             }
@@ -207,6 +209,7 @@ impl IndexMapper {
                 self.index_mapping.put(&mut wtxn, name, &uuid)?;
 
                 let index_path = self.index_path(uuid);
+                // TBD don't block here
                 fs::create_dir_all(&index_path)?;
 
                 // Error if the UUIDv4 somehow already exists in the map, since it should be fresh.
@@ -224,6 +227,7 @@ impl IndexMapper {
                         self.index_base_map_size,
                         CreateOrOpen::Create { shards },
                     )
+                    .await
                     .map_err(|e| Error::from_milli(e, Some(uuid.to_string())))?;
                 let index_rtxn = index.read_txn()?;
                 let stats = crate::index_mapper::IndexStats::new(&index, &index_rtxn)
@@ -231,6 +235,7 @@ impl IndexMapper {
                 self.store_stats_of(&mut wtxn, name, &stats)?;
                 drop(index_rtxn);
 
+                // TBD don't block here
                 wtxn.commit()?;
 
                 Ok(index)
@@ -375,7 +380,7 @@ impl IndexMapper {
     }
 
     /// Return an index, may open it if it wasn't already opened.
-    pub fn index(&self, rtxn: &RoTxn, name: &str) -> Result<Index> {
+    pub async fn index(&self, rtxn: &RoTxn<'_>, name: &str) -> Result<Index> {
         if let Some((current_name, current_index)) =
             self.currently_updating_index.read().unwrap().as_ref()
         {
@@ -410,12 +415,13 @@ impl IndexMapper {
             }
 
             // we get the index here to drop the lock before entering the match
-            let index = self.index_map.read().unwrap().get(&uuid);
+            let index = self.index_map.read().unwrap().get(&uuid).await;
 
             match index {
                 Available(index) => break index,
                 Closing(reopen) => {
                     // Avoiding deadlocks: no lock taken while doing this operation.
+                    // TBD we must not wait timeout directly like that on the async runtime
                     let reopen = if let Some(reopen) = reopen.wait_timeout(Duration::from_secs(6)) {
                         reopen
                     } else {
@@ -425,8 +431,23 @@ impl IndexMapper {
                     // take the lock to reopen the environment.
                     reopen
                         .reopen(&mut self.index_map.write().unwrap(), &index_path)
+                        .await
                         .map_err(|e| Error::from_milli(e, Some(uuid.to_string())))?;
                     continue;
+                }
+                Transferring(TransferState::Downloading(task)) => {
+                    // safety: we must ignore the error as it is extracted
+                    //         from an Arc in the end_downloading method
+                    let _ = task.await;
+                    // TBD correctly manage the error
+                    self.index_map.write().unwrap().end_downloading(&uuid).await.unwrap();
+                }
+                Transferring(TransferState::Uploading(task)) => {
+                    // safety: we must ignore the error as it is extracted
+                    //         from an Arc in the end_uploading method
+                    let _ = task.await;
+                    // TBD correctly manage the error
+                    self.index_map.write().unwrap().end_uploading(&uuid).await.unwrap();
                 }
                 BeingDeleted => return Err(Error::IndexNotFound(name.to_string())),
                 // since we're lazy, it's possible that the index has not been opened yet.
@@ -436,7 +457,7 @@ impl IndexMapper {
                     // that someone already opened the index (eg if two searches happen
                     // at the same time), thus before opening it we check a second time
                     // if it's not already there.
-                    match index_map.get(&uuid) {
+                    match index_map.get(&uuid).await {
                         Missing => {
                             let index_path = self.index_path(uuid);
 
@@ -449,7 +470,12 @@ impl IndexMapper {
                                     self.index_base_map_size,
                                     CreateOrOpen::Open,
                                 )
+                                .await
                                 .map_err(|e| Error::from_milli(e, Some(uuid.to_string())))?;
+                        }
+                        Transferring(_) => {
+                            // awaiting the download/upload will be handled in the next loop operation
+                            continue;
                         }
                         Available(index) => break index,
                         Closing(_) => {
@@ -473,9 +499,9 @@ impl IndexMapper {
         self.base_path.join(uuid.to_string())
     }
 
-    pub fn rollback_index(
+    pub async fn rollback_index(
         &self,
-        rtxn: &RoTxn,
+        rtxn: &RoTxn<'_>,
         name: &str,
         to: (u32, u32, u32),
     ) -> Result<RollbackOutcome> {
@@ -492,14 +518,14 @@ impl IndexMapper {
         let mut index_map = self.index_map.write().unwrap();
 
         'close_index: loop {
-            match index_map.get(&uuid) {
+            match index_map.get(&uuid).await {
                 Available(_) => {
                     index_map.close_for_resize(&uuid, self.enable_mdb_writemap, 0);
                     // index should now be `Closing`; try again
                     continue;
                 }
                 // index already closed
-                Missing => break 'close_index,
+                Missing | Transferring(_) => break 'close_index,
                 // closing requested by this thread or another one; wait for closing to complete, then exit
                 Closing(closing_index) => {
                     if closing_index.wait_timeout(Duration::from_secs(100)).is_none() {
@@ -514,6 +540,7 @@ impl IndexMapper {
         }
 
         let index_path = self.index_path(uuid);
+        // TBD don't block in here
         Index::rollback(milli::heed::EnvOpenOptions::new().read_txn_without_tls(), index_path, to)
             .map_err(|err| crate::Error::from_milli(err, Some(name.to_string())))
     }
@@ -525,21 +552,26 @@ impl IndexMapper {
     ///
     /// Since `f` is allowed to return a result, and `Index` is cloneable, it is still possible to wrongly build e.g. a vector of
     /// all the indexes, but this function makes it harder and so less likely to do accidentally.
-    pub fn try_for_each_index<U, V>(
+    pub async fn try_for_each_index<U, V>(
         &self,
-        rtxn: &RoTxn,
+        rtxn: &RoTxn<'_>,
         mut f: impl FnMut(&str, &Index) -> Result<U>,
     ) -> Result<V>
     where
         V: FromIterator<U>,
     {
-        self.index_mapping
-            .iter(rtxn)?
-            .map(|res| {
-                res.map_err(Error::from)
-                    .and_then(|(name, _)| self.index(rtxn, name).and_then(|index| f(name, &index)))
-            })
-            .collect()
+        let mut tmp = Vec::new();
+        for result in self.index_mapping.iter(rtxn)? {
+            match result {
+                Ok((name, _)) => {
+                    let index = self.index(rtxn, name).await?;
+                    // TBD not a big fan as `f` will block
+                    tmp.push(f(name, &index)?);
+                }
+                Err(err) => return Err(err.into()),
+            }
+        }
+        Ok(tmp.into_iter().collect::<V>())
     }
 
     /// Return the name of all indexes without opening them.
@@ -586,7 +618,7 @@ impl IndexMapper {
     /// If available in the cache, they are directly returned.
     /// Otherwise, the `Index` is opened to compute the stats on the fly (the result is not cached).
     /// The stats for an index are cached after each `Index` update.
-    pub fn stats_of(&self, rtxn: &RoTxn, index_uid: &str) -> Result<IndexStats> {
+    pub async fn stats_of(&self, rtxn: &RoTxn<'_>, index_uid: &str) -> Result<IndexStats> {
         let uuid = self
             .index_mapping
             .get(rtxn, index_uid)?
@@ -595,7 +627,7 @@ impl IndexMapper {
         match self.index_stats.get(rtxn, &uuid)? {
             Some(stats) => Ok(stats),
             None => {
-                let index = self.index(rtxn, index_uid)?;
+                let index = self.index(rtxn, index_uid).await?;
                 let index_rtxn = index.read_txn()?;
                 IndexStats::new(&index, &index_rtxn)
                     .map_err(|e| Error::from_milli(e, Some(uuid.to_string())))

--- a/crates/index-scheduler/src/index_mapper/mod.rs
+++ b/crates/index-scheduler/src/index_mapper/mod.rs
@@ -12,6 +12,7 @@ use meilisearch_types::milli::update::IndexerConfig;
 use meilisearch_types::milli::{self, CreateOrOpen, FieldDistribution, Index};
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
+use tokio::runtime::{Handle, Runtime};
 use tracing::error;
 use uuid::Uuid;
 
@@ -173,11 +174,14 @@ impl IndexMapper {
         wtxn: &mut RwTxn,
         options: &IndexSchedulerOptions,
         budget: IndexBudget,
+        runtime: Option<Handle>,
     ) -> Result<Self> {
         Ok(Self {
             index_map: Arc::new(RwLock::new(IndexMap::new(
                 2, // TBD available capacity
-                4, // TBD on-disk capacity
+                4, // TBD on-disk capacity,
+                runtime,
+                options.indexes_path.clone(),
             ))),
             index_mapping: env.create_database(wtxn, Some(db_name::INDEX_MAPPING))?,
             index_stats: env.create_database(wtxn, Some(db_name::INDEX_STATS))?,
@@ -220,7 +224,7 @@ impl IndexMapper {
                     .write()
                     .unwrap()
                     .create(
-                        &uuid,
+                        uuid,
                         &index_path,
                         date,
                         self.enable_mdb_writemap,
@@ -231,7 +235,9 @@ impl IndexMapper {
                     .map_err(|e| Error::from_milli(e, Some(uuid.to_string())))?
                 {
                     Some(index) => index,
-                    None => unreachable!("Index doesn't exist so must not be downloaded"),
+                    None => unreachable!(
+                        "Attempt to download a non-existent index while it must be created"
+                    ),
                 };
 
                 let index_rtxn = index.read_txn()?;
@@ -465,10 +471,9 @@ impl IndexMapper {
                     match index_map.get(&uuid).await {
                         Missing => {
                             let index_path = self.index_path(uuid);
-
                             match index_map
                                 .create(
-                                    &uuid,
+                                    uuid,
                                     &index_path,
                                     None,
                                     self.enable_mdb_writemap,

--- a/crates/index-scheduler/src/index_mapper/mod.rs
+++ b/crates/index-scheduler/src/index_mapper/mod.rs
@@ -12,7 +12,7 @@ use meilisearch_types::milli::update::IndexerConfig;
 use meilisearch_types::milli::{self, CreateOrOpen, FieldDistribution, Index};
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
-use tokio::runtime::{Handle, Runtime};
+use tokio::runtime::Handle;
 use tracing::error;
 use uuid::Uuid;
 
@@ -22,6 +22,9 @@ use crate::uuid_codec::UuidCodec;
 use crate::{Error, IndexBudget, IndexSchedulerOptions, Result};
 
 mod index_map;
+
+#[cfg(feature = "enterprise")]
+mod enterprise_edition;
 
 /// The number of database used by index mapper
 const NUMBER_OF_DATABASES: u32 = 2;

--- a/crates/index-scheduler/src/index_mapper/mod.rs
+++ b/crates/index-scheduler/src/index_mapper/mod.rs
@@ -445,14 +445,14 @@ impl IndexMapper {
                     //         from an Arc in the end_downloading method
                     let _ = task.await;
                     // TBD correctly manage the error
-                    self.index_map.write().unwrap().end_downloading(&uuid).await.unwrap();
+                    self.index_map.write().unwrap().end_transferring(&uuid).await.unwrap();
                 }
                 Transferring(TransferState::Uploading(task)) => {
                     // safety: we must ignore the error as it is extracted
                     //         from an Arc in the end_uploading method
                     let _ = task.await;
                     // TBD correctly manage the error
-                    self.index_map.write().unwrap().end_uploading(&uuid).await.unwrap();
+                    self.index_map.write().unwrap().end_transferring(&uuid).await.unwrap();
                 }
                 BeingDeleted => return Err(Error::IndexNotFound(name.to_string())),
                 // since we're lazy, it's possible that the index has not been opened yet.

--- a/crates/index-scheduler/src/lib.rs
+++ b/crates/index-scheduler/src/lib.rs
@@ -346,7 +346,7 @@ impl IndexScheduler {
         let dynamic_search_rules =
             dynamic_search_rules::DynamicSearchRulesStore::new(&env, &mut wtxn)?;
         let queue = Queue::new(&env, &mut wtxn, &options)?;
-        let index_mapper = IndexMapper::new(&env, &mut wtxn, &options, budget)?;
+        let index_mapper = IndexMapper::new(&env, &mut wtxn, &options, budget, runtime.clone())?;
         let chat_settings = env.create_database(&mut wtxn, Some(db_name::CHAT_SETTINGS))?;
 
         let persisted = env.create_database(&mut wtxn, Some(db_name::PERSISTED))?;

--- a/crates/index-scheduler/src/lib.rs
+++ b/crates/index-scheduler/src/lib.rs
@@ -572,9 +572,9 @@ impl IndexScheduler {
     /// Some configurations also can't reasonably open multiple indexes at once.
     /// If you need to fetch information from or perform an action on all indexes,
     /// see the `try_for_each_index` function.
-    pub fn index(&self, name: &str) -> Result<Index> {
+    pub async fn index(&self, name: &str) -> Result<Index> {
         let rtxn = self.env.read_txn()?;
-        self.index_mapper.index(&rtxn, name)
+        self.index_mapper.index(&rtxn, name).await
     }
 
     /// Return the boolean referring if index exists.
@@ -599,12 +599,15 @@ impl IndexScheduler {
     ///
     /// If many indexes exist, this operation can take time to complete (in the order of seconds for a 1000 of indexes) as it needs to open
     /// all the indexes.
-    pub fn try_for_each_index<U, V>(&self, f: impl FnMut(&str, &Index) -> Result<U>) -> Result<V>
+    pub async fn try_for_each_index<U, V>(
+        &self,
+        f: impl FnMut(&str, &Index) -> Result<U>,
+    ) -> Result<V>
     where
         V: FromIterator<U>,
     {
         let rtxn = self.env.read_txn()?;
-        self.index_mapper.try_for_each_index(&rtxn, f)
+        self.index_mapper.try_for_each_index(&rtxn, f).await
     }
 
     /// Returns the total number of indexes available for the specified filter.
@@ -1008,20 +1011,20 @@ impl IndexScheduler {
     }
 
     /// Create a new index without any associated task.
-    pub fn create_raw_index(
+    pub async fn create_raw_index(
         &self,
         name: &str,
         date: Option<(OffsetDateTime, OffsetDateTime)>,
         shards: Option<Shards>,
     ) -> Result<Index> {
         let wtxn = self.env.write_txn()?;
-        let index = self.index_mapper.create_index(wtxn, name, date, shards)?;
+        let index = self.index_mapper.create_index(wtxn, name, date, shards).await?;
         Ok(index)
     }
 
-    pub fn refresh_index_stats(&self, name: &str) -> Result<()> {
+    pub async fn refresh_index_stats(&self, name: &str) -> Result<()> {
         let mut mapper_wtxn = self.env.write_txn()?;
-        let index = self.index_mapper.index(&mapper_wtxn, name)?;
+        let index = self.index_mapper.index(&mapper_wtxn, name).await?;
         let index_rtxn = index.read_txn()?;
 
         let stats = crate::index_mapper::IndexStats::new(&index, &index_rtxn)
@@ -1124,10 +1127,10 @@ impl IndexScheduler {
         });
     }
 
-    pub fn index_stats(&self, index_uid: &str) -> Result<IndexStats> {
+    pub async fn index_stats(&self, index_uid: &str) -> Result<IndexStats> {
         let is_indexing = self.is_index_processing(index_uid)?;
         let rtxn = self.read_txn()?;
-        let index_stats = self.index_mapper.stats_of(&rtxn, index_uid)?;
+        let index_stats = self.index_mapper.stats_of(&rtxn, index_uid).await?;
 
         Ok(IndexStats { is_indexing, inner_stats: index_stats })
     }

--- a/crates/index-scheduler/src/lru.rs
+++ b/crates/index-scheduler/src/lru.rs
@@ -190,6 +190,14 @@ where
         }
         None
     }
+
+    #[cfg(test)]
+    pub fn first_key_value(&self) -> Option<(&K, &V)>
+    where
+        K: Ord,
+    {
+        self.0.data.iter().min_by_key(|(_, (k, _))| k).map(|(_, (k, v))| (k, v))
+    }
 }
 
 /// The result of an insertion in a LRU map.

--- a/crates/meilisearch/src/routes/indexes/search.rs
+++ b/crates/meilisearch/src/routes/indexes/search.rs
@@ -632,7 +632,7 @@ pub(crate) async fn search(
 
         (search_result, deadline)
     } else {
-        let index = index_scheduler.index(&index_uid).map_err(|err| match &err {
+        let index = index_scheduler.index(&index_uid).await.map_err(|err| match &err {
             index_scheduler::Error::IndexNotFound(_) => {
                 let mut err = ResponseError::from(err);
                 err.code = index_not_found_http_code;


### PR DESCRIPTION
This PR introduces a feature that keeps a small number of indexes on disk and offloads those that exceed the limit. This is not correlated to the current number of loaded (opened) indexes. There is a maximum of 18 open indexes simultaneously, and we plan to have a higher limit for the number of local indexes (like 50-100).

EDIT: following comment may be a bit outdated. We now have the available, unavailable, deleting and transfered fields in the `IndexMap`. The unavailable become an Lru and deleting is a simple HashSet.

### Notes About the Current Implementation

I have modified the `IndexMapper` structure to accept an async tokio runtime handle. This handle is used to fire asynchronous operations for uploading and downloading indexes. It seems the runtime is optional when creating the `IndexScheduler` (from which I obtain the runtime handle). Adding a runtime to the `IndexMapper` is probably only beneficial to the offloading system, which is an enterprise edition feature and shouldn't contaminate community-edition code. I suppose it's not very complex to make the `IndexMapper` accept a runtime handle, though...

I have introduced a new `closed` field in the `IndexMap` struct to track the indexes I need to upload when there are too many on disk, especially those I need to offload when the time comes. It's basically an LRU, but for indexes that aren't in my opened/available list. I don't yet have a good idea of how to behave when the engine starts, and we see that there are more indexes on disk than the `closed` capacity. The easiest solution would be to scan the on-disk indexes and upload extra indexes that must not be kept on disk (bonus: delete any potential unknown ones). Scanning disk indexes would scale well, since the number of indexes is small enough and defaults to 100. As to how we define the extra indexes to upload, it's hard to know. I can insert them into my LRU, which will cause the earliest-inserted UUIDs to be uploaded, depending on [the order they are returned by the directory scan](https://doc.rust-lang.org/stable/std/fs/fn.read_dir.html).

Another issue I have with the `closed` structure is that it doesn't account for open indexes and is essentially a mirror of the unavailable index list. A better approach would be to have two LRUs: one to track opened indexes and another to track unavailable ones. Both already exist, but the latter is not an LRU. By converting it into one, we can track which one must be uploaded. However, it also means that once we insert a fresh index into the unavailable ones and pop one, we need to track the upload status somewhere, and it cannot be tracked from the unavailable list, since it is already full at that point. We can introduce a new `uploading` list of indexes to track the status of their upload, and ensure _we are not downloading_ an index that is being uploaded, instead keeping it inaccessible (?) while it is uploading. By keeping the index in the "indexes" folder, we keep it in a valid state for a future startup: if the engine restarts, the indexes remain available, and we do not download a potentially outdated version from the S3 bucket. Once the upload is successful, we immediately delete the index from disk. Next time the upload task is pulled, and the task is successful, we remove the entry from the `uploading` set.

A better approach for the **index downloader and uploader is to have a single async task** dedicated to downloading that accepts tasks via an async channel. Network tasks would notify of completion via a one-shot channel, i.e., [`Shared<oneshot::Receiver>`](https://docs.rs/futures/latest/futures/future/trait.FutureExt.html#method.shared). On the other end, the unavailable set of indexes could wait for the upload/download completion by using the other end of the one-shot channel. By doing that, we factorize a lot and drastically reduce the download and upload weights of indexes. Upload is done [asynchronously and in parallel](https://github.com/meilisearch/meilisearch/blob/bb968aaf0d2981a615d8e748d13c930b3cbc76c7/crates/index-scheduler/src/scheduler/enterprise_edition/s3.rs#L374-L566) (with a maximum in-flight parts), and could even be prioritized depending on the main network tasks channel. Another advantage of this approach is the control we have over the memory used for uploading and downloading indexes, as we can limit the number of tasks processing simultaneously to one upload and one download. I see one limitation to this approach: a `Shared<oneshot::Receiver>` requires `F::Output: Clone` and `io::Error` is not, I could [try using an `Arc<io::Error>`, maybe](https://doc.rust-lang.org/stable/std/sync/struct.Arc.html#impl-Error-for-Arc%3CT%3E).

About the function signature of the different **IndexMapper methods. I would like them to be async**. It changes many calls to this method, but it's definitely a better approach. First, because opening an index can take time ([like a lot](https://github.com/meilisearch/meilisearch/blob/bb968aaf0d2981a615d8e748d13c930b3cbc76c7/crates/index-scheduler/src/index_mapper/mod.rs#L413-L417)), we mostly call `IndexMapper::index` in async contexts. That's really bad for an async HTTP runtime. Right now, we are already doing a lot of work using loops, mutexes, and locks. We may have to switch to using async mutexes. I just have some doubts about the way we will use these async methods in our non-async tests. It's feasible, but a lot of changes.

Note that to be able to make those methods async, the `RoTxn` and `RwTxn` must be able to jump over `.await` point. This applies only to `Send` types. [`RoTxn<WithoutTls>` is `Send`](https://docs.rs/heed/latest/heed/struct.RoTxn.html#impl-Send-for-RoTxn%3C'_,+WithoutTls%3E), and `RwTxn` wraps an `RoTxn<WithoutTls>`, [so it is also `Send`](https://docs.rs/heed/latest/heed/struct.RwTxn.html#impl-Send-for-RwTxn%3C'p%3E).

```rust
impl IndexMapper {
  // This method tries to block_on the task that downloads the index.
  // Once the download is complete, the index is marked as missing (among the opened ones),
  // the loop continues, opens the index, and returns it.
  pub async fn index(&self, rtxn: &RoTxn, name: &str) -> Result<Index>;

  // Calling `index` internally so it's inherently async.
  pub async fn create_index(
      &self,
      wtxn: RwTxn,
      name: &str,
      date: Option<(OffsetDateTime, OffsetDateTime)>,
      shards: Option<Shards>,
  ) -> Result<Index>;

  // Doing a loop and sleeping for 6s a couple of times to wait for the index to close.
  // Would be better if it were spawning a blocking task to wait for closing.
  pub async fn delete_index(&self, wtxn: RwTxn, name: &str) -> Result<()>;

  // Calls close_for_resize, which calls IndexMap::close, which should probably be async
  pub async fn resize_index(&self, rtxn: &RoTxn, name: &str) -> Result<()>;

  // Calls close_for_resize, which calls IndexMap::close, which should probably be async
  pub async fn close_index(&self, rtxn: &RoTxn, name: &str) -> Result<()>;

  // Calls close_for_resize, which calls IndexMap::close, which should probably be async
  pub async fn rollback_index(
      &self,
      rtxn: &RoTxn,
      name: &str,
      to: (u32, u32, u32),
  ) -> Result<RollbackOutcome>;

  // What should this method do?
  // A simple loop in an async context with basic .await on the different indexes?
  //  I probably need to switch the FnMut into an AsyncFnMut.
  // Right now, the loop tries to download and offload all indexes.
  pub async fn try_for_each_index<U, V>(
        &self,
        rtxn: &RoTxn,
        f: impl FnMut(&str, &Index) -> Result<U>,
    ) -> Result<V>
    where
        V: FromIterator<U>;
}

impl IndexMap {
  // The method currently returns an Option<Index> to indicate that the index is being downloaded.
  // I would rather make the user .await for the index to be ready.
  pub async fn create(
        &mut self,
        uuid: &Uuid,
        path: &Path,
        date: Option<(OffsetDateTime, OffsetDateTime)>,
        enable_writemap: bool,
        map_size: usize,
        create_or_open: CreateOrOpen,
    ) -> Result<Index>;

  pub async fn close_for_resize(
      &mut self,
      uuid: &Uuid,
      enable_mdb_writemap: bool,
      map_size_growth: usize,
  );

  // This method will probably .await a download to be ready.
  fn async close(
      &mut self,
      uuid: Uuid,
      index: Index,
      enable_mdb_writemap: bool,
      map_size_growth: usize,
  );

  // This method should probably send a delete request for the index to the S3 bucket and .await for it.
  pub async fn start_deletion(
      &mut self,
      uuid: &Uuid,
  ) -> std::result::Result<Option<EnvClosingEvent>, Option<ClosingIndex>>;
}
```

Note that it is invalid [to `block_on` a future in an async context](https://docs.rs/tokio/latest/tokio/runtime/struct.Handle.html#method.block_on), and guess what? We are always opening indexes in an async context, directly in the HTTP route handler. As I designed the download system via an async task, I had to do the following to make it work, and it's ugly. It's ugly because I am spawning a blocking task (using a dedicated thread) to avoid blocking the async task, and inside... I am using a block_on to wait for an async task to complete...

```rust
// before, it was simple
let index = index_scheduler.index(&index_uid)?;

// right now, it's a bit ugly and not efficient
let index = tokio::task::spawn_blocking({
    let index_scheduler = index_scheduler.clone();
    let index_uid = index_uid.clone();
    move || index_scheduler.index(&index_uid)
})
.await
.unwrap()?;

// in the future, I want something as clean as that
let index = index_scheduler.index(&index_uid).await?;
```

To **avoid TOCTOU and such**, I would prefer opening an index and handling the `NotFound` io error rather than checking whether the path exists. To ensure we do not open a partial index (from a download task), we can download indexes to a dedicated downloads subfolder and persist them after the download completes. I [heard that renaming files is atomic](https://rcrowley.org/2010/01/06/things-unix-can-do-atomically.html) and can only be done when files are on the same device.

I would like to **open an index while it is being uploaded** to avoid having the user wait for something that is already available, but I think that's an optimization we could do later. Enabling this behavior would complicate some specific cases, such as when index A is uploaded and opened simultaneously, and index B is opened, causing index A to be kicked out and uploaded again. I would prefer to keep the code simple for now and avoid this optimization.

### To Do
- [ ] Make this an experimental feature.
- [ ] Make this an enterprise-edition feature.
- [ ] Document how it works on the user-end.
	   We keep an open HTTP connection until the index is loaded and return the time it took to download the offloaded index.
- [ ] Make sure `showPerformanceDetails` accounts for the time it takes to open an index.
- [ ] Use the unavailable list of indexes to make sure not to upload/download indexes multiple times and concurrently.
- [ ] Actually offload to S3. No LMDB compaction, but maybe gzip compression?
	   I am currently faking offloading by moving the index to another directory and sleeping for a while (equivalent to a 10MiB/s network speed).
- [ ] Use an async runtime in a dedicated thread to download and upload indexes.
	    Currently, we are spawning large, complex async tasks to download/upload indexes. We must factorize the logic and keep a single system that pulls downloads/uploads.
- [ ] Think and document how to process snapshots.
	   To check, but right now the snapshot system will load each individual offloaded index, open it, and copy it into the tarball stream to S3. Is it something we want to do?
- [ ] What about sharding? Shouldn't we keep a subset of (full) indexes on each instance instead?

## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respects the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
