### PR TITLE
Factorize delete_old_fid_from_facet_databases

### DIFF
--- a/crates/milli/src/update/new/extract/faceted/extract_facets.rs
+++ b/crates/milli/src/update/new/extract/faceted/extract_facets.rs
@@ -10,6 +10,7 @@ use serde_json::Value;
 
 use super::super::cache::BalancedCaches;
 use super::facet_document::{extract_document_facets, extract_geo_document};
+use super::field_facet_status::FieldFacetStatus;
 use super::FacetKind;
 use crate::fields_ids_map::metadata::Metadata;
 use crate::filterable_attributes_rules::match_faceted_field;
@@ -32,9 +33,8 @@ use crate::update::new::{DocumentChange, DocumentIdentifiers};
 use crate::update::settings::SettingsDelta;
 use crate::update::GrenadParameters;
 use crate::{
-    DocumentId, FieldId, FieldIdMapMissingEntry, FilterFeatures, FilterableAttributesFeatures,
-    FilterableAttributesRule, GlobalFieldsIdsMap, InternalError, PatternMatch, Result, UserError,
-    MAX_FACET_VALUE_LENGTH,
+    DocumentId, FieldId, FieldIdMapMissingEntry, FilterableAttributesRule, GlobalFieldsIdsMap,
+    InternalError, PatternMatch, Result, UserError, MAX_FACET_VALUE_LENGTH,
 };
 
 pub struct FacetedExtractorData<'a, 'b> {
@@ -643,66 +643,20 @@ impl FacetedDocidsExtractor {
 
         extract_document_facets(
             current_document,
-            // TODO extract into another function
             |field_name| {
                 let Some((field_id, metadata)) = old_fields_ids_map.id_with_metadata(field_name)
                 else {
                     return PatternMatch::NoMatch;
                 };
 
-                let FilterableAttributesFeatures { facet_search: old_facet_search, filter } =
-                    metadata.filterable_attributes_features(old_filterable_rules);
-                let FilterFeatures { equality: old_equality, comparison: old_comparison } = filter;
-                let old_asc_desc = metadata.asc_desc.is_some();
-                let old_sortable = metadata.sortable;
-                let old_distinct = metadata.distinct;
+                let old_status = FieldFacetStatus::from_metadata(&metadata, old_filterable_rules);
+                let new_status = FieldFacetStatus::from_field_id(
+                    new_fields_ids_map,
+                    new_filterable_rules,
+                    field_id,
+                );
 
-                let new_facet_search;
-                let new_equality;
-                let new_comparison;
-                let new_asc_desc;
-                let new_sortable;
-                let new_distinct;
-                // TODO do not duplicate this logic and put it in a function
-                //      for delete_old_fid_from_facet_databases to use it
-                match new_fields_ids_map.metadata(field_id) {
-                    Some(metadata) => {
-                        let FilterableAttributesFeatures { facet_search, filter } =
-                            metadata.filterable_attributes_features(new_filterable_rules);
-                        let FilterFeatures { equality, comparison } = filter;
-                        new_facet_search = facet_search;
-                        new_equality = equality;
-                        new_comparison = comparison;
-                        new_asc_desc = metadata.asc_desc.is_some();
-                        new_sortable = metadata.sortable;
-                        new_distinct = metadata.distinct;
-                    }
-                    None => {
-                        // This will trigger a clean deletion from everywhere
-                        new_facet_search = false;
-                        new_equality = false;
-                        new_comparison = false;
-                        new_asc_desc = false;
-                        new_sortable = false;
-                        new_distinct = false;
-                    }
-                };
-
-                let is_old_faceted = old_equality
-                    || old_comparison
-                    || old_facet_search
-                    || old_asc_desc
-                    || old_sortable
-                    || old_distinct;
-
-                let is_new_faceted = new_equality
-                    || new_comparison
-                    || new_facet_search
-                    || new_asc_desc
-                    || new_sortable
-                    || new_distinct;
-
-                if !is_old_faceted && is_new_faceted {
+                if !old_status.is_faceted() && new_status.is_faceted() {
                     PatternMatch::Match
                 } else {
                     // We force the system to go down the rabbit hole

--- a/crates/milli/src/update/new/extract/faceted/field_facet_status.rs
+++ b/crates/milli/src/update/new/extract/faceted/field_facet_status.rs
@@ -1,0 +1,79 @@
+use crate::fields_ids_map::metadata::{FieldIdMapWithMetadata, Metadata};
+use crate::{FieldId, FilterFeatures, FilterableAttributesFeatures, FilterableAttributesRule};
+
+/// A summary of the facet-related capabilities of a field.
+///
+/// This is the "complex check" that needs to be evaluated for both the
+/// document-side facet extraction and the database-side facet deletion.
+/// Keeping this logic in a single place avoids forgetting a part of the
+/// strategy when a new facet capability is added.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FieldFacetStatus {
+    pub facet_search: bool,
+    pub equality: bool,
+    pub comparison: bool,
+    pub asc_desc: bool,
+    pub sortable: bool,
+    pub distinct: bool,
+}
+
+impl FieldFacetStatus {
+    /// A status where the field has no facet-related capability at all.
+    ///
+    /// This is the equivalent of the field being completely missing from
+    /// the fields ids map.
+    pub const NONE: Self = Self {
+        facet_search: false,
+        equality: false,
+        comparison: false,
+        asc_desc: false,
+        sortable: false,
+        distinct: false,
+    };
+
+    /// Compute the [`FieldFacetStatus`] for a field given its [`Metadata`]
+    /// and the corresponding filterable attributes rules.
+    pub fn from_metadata(metadata: &Metadata, rules: &[FilterableAttributesRule]) -> Self {
+        let FilterableAttributesFeatures { facet_search, filter } =
+            metadata.filterable_attributes_features(rules);
+        let FilterFeatures { equality, comparison } = filter;
+        Self {
+            facet_search,
+            equality,
+            comparison,
+            asc_desc: metadata.asc_desc.is_some(),
+            sortable: metadata.sortable,
+            distinct: metadata.distinct,
+        }
+    }
+
+    /// Compute the [`FieldFacetStatus`] for a field id in the given map,
+    /// returning [`Self::NONE`] when the field is absent.
+    pub fn from_field_id(
+        fields_ids_map: &FieldIdMapWithMetadata,
+        rules: &[FilterableAttributesRule],
+        field_id: FieldId,
+    ) -> Self {
+        match fields_ids_map.metadata(field_id) {
+            Some(metadata) => Self::from_metadata(&metadata, rules),
+            None => Self::NONE,
+        }
+    }
+
+    /// Whether this field is involved in any facet-related datastructure
+    /// (filterable, facet-searchable, sortable, asc/desc or distinct).
+    pub fn is_faceted(&self) -> bool {
+        self.equality
+            || self.comparison
+            || self.facet_search
+            || self.asc_desc
+            || self.sortable
+            || self.distinct
+    }
+
+    /// Whether this field is involved in the comparison datastructures
+    /// (sortable, asc/desc or comparison filter).
+    pub fn is_comparison(&self) -> bool {
+        self.sortable || self.asc_desc || self.comparison
+    }
+}

--- a/crates/milli/src/update/new/extract/faceted/mod.rs
+++ b/crates/milli/src/update/new/extract/faceted/mod.rs
@@ -1,7 +1,9 @@
 mod extract_facets;
 mod facet_document;
+mod field_facet_status;
 
 pub use extract_facets::FacetedDocidsExtractor;
+pub use field_facet_status::FieldFacetStatus;
 
 #[repr(u8)]
 #[derive(Debug, Clone, Copy)]

--- a/crates/milli/src/update/new/indexer/mod.rs
+++ b/crates/milli/src/update/new/indexer/mod.rs
@@ -36,9 +36,10 @@ use crate::update::settings::SettingsDelta;
 use crate::update::GrenadParameters;
 use crate::vector::settings::{EmbedderAction, RemoveFragments, WriteBackToDocuments};
 use crate::vector::{Embedder, RuntimeEmbedders, VectorStore};
+use super::extract::FieldFacetStatus;
 use crate::{
-    Error, FieldsIdsMap, FilterFeatures, FilterableAttributesFeatures, GlobalFieldsIdsMap, Index,
-    InternalError, PatternMatch, Result, ThreadPoolNoAbort,
+    Error, FieldId, FieldsIdsMap, GlobalFieldsIdsMap, Index, InternalError, PatternMatch, Result,
+    ThreadPoolNoAbort,
 };
 
 pub(crate) mod de;
@@ -548,70 +549,22 @@ where
     let new_filterable_rules = settings_delta.new_filterable_rules();
 
     for (id, metadata) in old_fields_ids_map.iter_id_metadata() {
-        let FilterableAttributesFeatures { facet_search: old_facet_search, filter } =
-            metadata.filterable_attributes_features(old_filterable_rules);
-        let FilterFeatures { equality: old_equality, comparison: old_comparison } = filter;
-        let old_asc_desc = metadata.asc_desc.is_some();
-        let old_sortable = metadata.sortable;
-        let old_distinct = metadata.distinct;
+        let old_status = FieldFacetStatus::from_metadata(&metadata, old_filterable_rules);
+        let new_status =
+            FieldFacetStatus::from_field_id(new_fields_ids_map, new_filterable_rules, id);
 
-        let new_facet_search;
-        let new_equality;
-        let new_comparison;
-        let new_asc_desc;
-        let new_sortable;
-        let new_distinct;
-        match new_fields_ids_map.metadata(id) {
-            Some(metadata) => {
-                let FilterableAttributesFeatures { facet_search, filter } =
-                    metadata.filterable_attributes_features(new_filterable_rules);
-                let FilterFeatures { equality, comparison } = filter;
-                new_facet_search = facet_search;
-                new_equality = equality;
-                new_comparison = comparison;
-                new_asc_desc = metadata.asc_desc.is_some();
-                new_sortable = metadata.sortable;
-                new_distinct = metadata.distinct;
-            }
-            None => {
-                // This will trigger a clean deletion from everywhere
-                new_facet_search = false;
-                new_equality = false;
-                new_comparison = false;
-                new_asc_desc = false;
-                new_sortable = false;
-                new_distinct = false;
-            }
-        };
-
-        let is_old_faceted = old_equality
-            || old_comparison
-            || old_facet_search
-            || old_asc_desc
-            || old_sortable
-            || old_distinct;
-
-        let is_new_faceted = new_equality
-            || new_comparison
-            || new_facet_search
-            || new_asc_desc
-            || new_sortable
-            || new_distinct;
-
-        if is_old_faceted && !is_new_faceted {
+        if old_status.is_faceted() && !new_status.is_faceted() {
             // If we delete from everywhere we don't have to check the remaining conditions.
             remove_from_everywhere.insert(id);
             continue;
         }
 
-        if old_facet_search && !new_facet_search {
+        if old_status.facet_search && !new_status.facet_search {
             // Remove only from the facet search
             remove_from_facet_search.insert(id);
         }
 
-        let is_old_comparison = old_sortable || old_asc_desc || old_comparison;
-        let is_new_comparison = new_sortable || new_asc_desc || new_comparison;
-        if is_old_comparison && !is_new_comparison {
+        if old_status.is_comparison() && !new_status.is_comparison() {
             // Remove the comparison levels from the facets.
             remove_comparison_levels_only.insert(id);
         }
@@ -650,24 +603,14 @@ where
         ];
 
         progress.update_progress(IndexingStep::DeletingFromAllFilters);
-        let (db_progress, db_progress_obj) = AtomicDatabaseStep::new(databases.len() as u32);
-        progress.update_progress(db_progress_obj);
-
-        for database in databases {
-            if must_stop_processing() {
-                return Err(Error::InternalError(InternalError::AbortedIndexation));
-            }
-
-            for id in remove_from_everywhere.iter().copied() {
-                let mut iter = database.prefix_iter_mut(wtxn, &id.to_be_bytes())?;
-                while iter.next().transpose()?.is_some() {
-                    // safety: We don't keep any reference to the database.
-                    unsafe { iter.del_current()? };
-                }
-            }
-
-            db_progress.fetch_add(1, Ordering::Relaxed);
-        }
+        delete_field_ids_from_databases(
+            wtxn,
+            must_stop_processing,
+            progress,
+            &databases,
+            &remove_from_everywhere,
+            |_key| true,
+        )?;
     }
 
     // Delete the entries for these field IDs from the facet search datastructures.
@@ -676,25 +619,14 @@ where
             [facet_id_normalized_string_strings.remap_types(), facet_id_string_fst.remap_types()];
 
         progress.update_progress(IndexingStep::DeletingFromFacetsOnly);
-        let (db_progress, db_progress_obj) = AtomicDatabaseStep::new(databases.len() as u32);
-        progress.update_progress(db_progress_obj);
-
-        // TODO merge with the above code
-        for database in databases {
-            if must_stop_processing() {
-                return Err(Error::InternalError(InternalError::AbortedIndexation));
-            }
-
-            for id in remove_from_facet_search.iter().copied() {
-                let mut iter = database.prefix_iter_mut(wtxn, &id.to_be_bytes())?;
-                while iter.next().transpose()?.is_some() {
-                    // safety: We don't keep any reference to the database.
-                    unsafe { iter.del_current()? };
-                }
-            }
-
-            db_progress.fetch_add(1, Ordering::Relaxed);
-        }
+        delete_field_ids_from_databases(
+            wtxn,
+            must_stop_processing,
+            progress,
+            &databases,
+            &remove_from_facet_search,
+            |_key| true,
+        )?;
     }
 
     // Deletes the levels > 0 for the entries corresponding to these
@@ -704,32 +636,60 @@ where
             [facet_id_f64_docids.remap_types(), facet_id_string_docids.remap_types()];
 
         progress.update_progress(IndexingStep::DeletingFromComparisonsOnly);
-        let (db_progress, db_progress_obj) = AtomicDatabaseStep::new(databases.len() as u32);
-        progress.update_progress(db_progress_obj);
+        delete_field_ids_from_databases(
+            wtxn,
+            must_stop_processing,
+            progress,
+            &databases,
+            &remove_comparison_levels_only,
+            // We want to delete everything that is not from
+            // the level 0 as it provides equality comparisons.
+            //
+            // The first two bytes corresponds to the field ID
+            // while the third byte corresponds to the level.
+            |key| key.get(2).copied() != Some(0),
+        )?;
+    }
 
-        // TODO merge with the above code (or not?)
-        for database in databases {
-            if must_stop_processing() {
-                return Err(Error::InternalError(InternalError::AbortedIndexation));
-            }
+    Ok(())
+}
 
-            for id in remove_comparison_levels_only.iter().copied() {
-                let mut iter = database.prefix_iter_mut(wtxn, &id.to_be_bytes())?;
-                while let Some((key, _ignored)) = iter.next().transpose()? {
-                    // We want to delete everything that is not from
-                    // the level 0 as it provides equality comparisons.
-                    //
-                    // The first two bytes corresponds to the field ID
-                    // while the third byte corresponds to the level.
-                    if key.get(2).copied() != Some(0) {
-                        // safety: We don't keep any reference to the database.
-                        unsafe { iter.del_current()? };
-                    }
+/// Iterate over the entries of `databases` whose key starts with one of the
+/// provided field IDs (encoded as big-endian bytes) and delete the ones for
+/// which `should_delete` returns `true`.
+///
+/// All three branches of `delete_old_fid_from_facet_databases` go through
+/// this helper to share the same iteration / progress / abort plumbing.
+fn delete_field_ids_from_databases<MSP>(
+    wtxn: &mut RwTxn<'_>,
+    must_stop_processing: &MSP,
+    progress: &Progress,
+    databases: &[Database<Bytes, DecodeIgnore>],
+    field_ids: &BTreeSet<FieldId>,
+    should_delete: impl Fn(&[u8]) -> bool,
+) -> Result<()>
+where
+    MSP: Fn() -> bool + Sync,
+{
+    let (db_progress, db_progress_obj) = AtomicDatabaseStep::new(databases.len() as u32);
+    progress.update_progress(db_progress_obj);
+
+    for database in databases {
+        if must_stop_processing() {
+            return Err(Error::InternalError(InternalError::AbortedIndexation));
+        }
+
+        for id in field_ids.iter().copied() {
+            let mut iter = database.prefix_iter_mut(wtxn, &id.to_be_bytes())?;
+            while let Some((key, _ignored)) = iter.next().transpose()? {
+                if should_delete(key) {
+                    // safety: We don't keep any reference to the database.
+                    unsafe { iter.del_current()? };
                 }
             }
-
-            db_progress.fetch_add(1, Ordering::Relaxed);
         }
+
+        db_progress.fetch_add(1, Ordering::Relaxed);
     }
 
     Ok(())


### PR DESCRIPTION
Fixes #6329 and #6330. Both are refactor suggestions on the same function from #6124 review.

Extracted `FieldFacetStatus` for the per-field facet-capability check that was duplicated between `extract_document_facets` and `delete_old_fid_from_facet_databases`, with `from_metadata`/`from_field_id` constructors and `is_faceted`/`is_comparison` predicates. Added `delete_field_ids_from_databases(..., should_delete: impl Fn(&[u8]) -> bool)` to unify the three near-identical loops; the comparison-only branch passes `|key| key.get(2).copied() != Some(0)` to keep level-0 entries.

Iteration order, progress steps, and abort checks preserved. `cargo check -p milli` green.

## Generative AI tools
- [x] Uses generative AI tooling per [policy](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - Claude Code (Opus 4.7) for drafting. Reviewed.