### PR TITLE
Avoid opening a read transaction inside search_kind

### DIFF
--- a/crates/meilisearch/src/routes/chats/chat_completions.rs
+++ b/crates/meilisearch/src/routes/chats/chat_completions.rs
@@ -351,7 +351,7 @@ async fn process_search_request(
         add_search_rules(&mut query.filter, search_rules);
     }
     let search_kind =
-        search_kind(&query, index_scheduler.get_ref(), index_uid.to_string(), &index)?;
+        search_kind(&query, index_scheduler.get_ref(), index_uid.to_string(), &index, &rtxn)?;
 
     progress.update_progress(TotalProcessingTimeStep::WaitInQueue);
     let permit = search_queue.try_get_search_permit().await?;

--- a/crates/meilisearch/src/routes/chats/chat_completions.rs
+++ b/crates/meilisearch/src/routes/chats/chat_completions.rs
@@ -350,8 +350,13 @@ async fn process_search_request(
     if let Some(search_rules) = auth_filter.get_index_search_rules(&index_uid) {
         add_search_rules(&mut query.filter, search_rules);
     }
-    let search_kind =
-        search_kind(&query, index_scheduler.get_ref(), index_uid.to_string(), &index, &rtxn)?;
+    let search_kind = search_kind(
+        &query,
+        index_scheduler.get_ref(),
+        index_uid.to_string(),
+        &index,
+        Some(&rtxn),
+    )?;
 
     progress.update_progress(TotalProcessingTimeStep::WaitInQueue);
     let permit = search_queue.try_get_search_permit().await?;

--- a/crates/meilisearch/src/routes/indexes/facet_search.rs
+++ b/crates/meilisearch/src/routes/indexes/facet_search.rs
@@ -293,7 +293,7 @@ pub async fn search(
         let rtxn = index.read_txn()?;
         let deadline = index.search_deadline(&rtxn)?;
         let search_kind =
-            search_kind(&search_query, &index_scheduler, index_uid.to_string(), &index)?;
+            search_kind(&search_query, &index_scheduler, index_uid.to_string(), &index, &rtxn)?;
         let filter = match &search_query.filter {
             Some(filter) => {
                 let filter = parse_filter(filter, Code::InvalidSearchFilter, features)?;

--- a/crates/meilisearch/src/routes/indexes/facet_search.rs
+++ b/crates/meilisearch/src/routes/indexes/facet_search.rs
@@ -292,8 +292,13 @@ pub async fn search(
         let index = index_scheduler.index(&index_uid)?;
         let rtxn = index.read_txn()?;
         let deadline = index.search_deadline(&rtxn)?;
-        let search_kind =
-            search_kind(&search_query, &index_scheduler, index_uid.to_string(), &index, &rtxn)?;
+        let search_kind = search_kind(
+            &search_query,
+            &index_scheduler,
+            index_uid.to_string(),
+            &index,
+            Some(&rtxn),
+        )?;
         let filter = match &search_query.filter {
             Some(filter) => {
                 let filter = parse_filter(filter, Code::InvalidSearchFilter, features)?;

--- a/crates/meilisearch/src/routes/indexes/search.rs
+++ b/crates/meilisearch/src/routes/indexes/search.rs
@@ -641,10 +641,8 @@ pub(crate) async fn search(
             _ => ResponseError::from(err),
         })?;
 
-        let rtxn = index.read_txn()?;
         let search_kind =
-            search_kind(&query, &index_scheduler, index_uid.to_string(), &index, &rtxn)?;
-        drop(rtxn);
+            search_kind(&query, &index_scheduler, index_uid.to_string(), &index, None)?;
         let retrieve_vector = RetrieveVectors::new(query.retrieve_vectors);
 
         let progress_clone = progress.clone();
@@ -800,7 +798,7 @@ pub fn search_kind(
     index_scheduler: &IndexScheduler,
     index_uid: String,
     index: &milli::Index,
-    rtxn: &milli::heed::RoTxn,
+    rtxn: Option<&milli::heed::RoTxn>,
 ) -> Result<SearchKind, ResponseError> {
     let is_placeholder_query =
         if let Some(q) = query.q.as_deref() { q.trim().is_empty() } else { true };

--- a/crates/meilisearch/src/routes/indexes/search.rs
+++ b/crates/meilisearch/src/routes/indexes/search.rs
@@ -641,7 +641,10 @@ pub(crate) async fn search(
             _ => ResponseError::from(err),
         })?;
 
-        let search_kind = search_kind(&query, &index_scheduler, index_uid.to_string(), &index)?;
+        let rtxn = index.read_txn()?;
+        let search_kind =
+            search_kind(&query, &index_scheduler, index_uid.to_string(), &index, &rtxn)?;
+        drop(rtxn);
         let retrieve_vector = RetrieveVectors::new(query.retrieve_vectors);
 
         let progress_clone = progress.clone();
@@ -797,6 +800,7 @@ pub fn search_kind(
     index_scheduler: &IndexScheduler,
     index_uid: String,
     index: &milli::Index,
+    rtxn: &milli::heed::RoTxn,
 ) -> Result<SearchKind, ResponseError> {
     let is_placeholder_query =
         if let Some(q) = query.q.as_deref() { q.trim().is_empty() } else { true };
@@ -818,21 +822,34 @@ pub fn search_kind(
         (false, false, _, None) => Ok(SearchKind::KeywordOnly),
         // hybrid S100 => semantic
         (_, _, Some(HybridQuery { semantic_ratio, embedder }), v) if **semantic_ratio == 1.0 => {
-            SearchKind::semantic(index_scheduler, index_uid, index, embedder, v.map(|v| v.len()))
+            SearchKind::semantic(
+                index_scheduler,
+                index_uid,
+                index,
+                rtxn,
+                embedder,
+                v.map(|v| v.len()),
+            )
         }
         // q + hybrid => hybrid
         (_, true, Some(HybridQuery { semantic_ratio, embedder }), v) => SearchKind::hybrid(
             index_scheduler,
             index_uid,
             index,
+            rtxn,
             embedder,
             **semantic_ratio,
             v.map(|v| v.len()),
         ),
         // !q + hybrid => semantic
-        (_, false, Some(HybridQuery { semantic_ratio: _, embedder }), v) => {
-            SearchKind::semantic(index_scheduler, index_uid, index, embedder, v.map(|v| v.len()))
-        }
+        (_, false, Some(HybridQuery { semantic_ratio: _, embedder }), v) => SearchKind::semantic(
+            index_scheduler,
+            index_uid,
+            index,
+            rtxn,
+            embedder,
+            v.map(|v| v.len()),
+        ),
         // q => keyword
         (false, true, None, None) => Ok(SearchKind::KeywordOnly),
     }

--- a/crates/meilisearch/src/search/federated/perform.rs
+++ b/crates/meilisearch/src/search/federated/perform.rs
@@ -1387,8 +1387,13 @@ impl SearchByIndex {
         for QueryByIndex { query, weight, query_index, filter } in queries {
             // use an immediately invoked lambda to capture the result without returning from the function
             let res: Result<(), ResponseError> = (|| {
-                let search_kind =
-                    search_kind(&query, &params.index_scheduler, index_uid.to_string(), &index)?;
+                let search_kind = search_kind(
+                    &query,
+                    &params.index_scheduler,
+                    index_uid.to_string(),
+                    &index,
+                    &rtxn,
+                )?;
 
                 let canonicalization_kind = match (&search_kind, &query.q) {
                     (SearchKind::SemanticOnly { .. }, _) => {

--- a/crates/meilisearch/src/search/federated/perform.rs
+++ b/crates/meilisearch/src/search/federated/perform.rs
@@ -1392,7 +1392,7 @@ impl SearchByIndex {
                     &params.index_scheduler,
                     index_uid.to_string(),
                     &index,
-                    &rtxn,
+                    Some(&rtxn),
                 )?;
 
                 let canonicalization_kind = match (&search_kind, &query.q) {

--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -713,7 +713,7 @@ impl SearchKind {
         index_scheduler: &index_scheduler::IndexScheduler,
         index_uid: String,
         index: &Index,
-        rtxn: &RoTxn,
+        rtxn: Option<&RoTxn>,
         embedder_name: &str,
         vector_len: Option<usize>,
     ) -> Result<Self, ResponseError> {
@@ -733,7 +733,7 @@ impl SearchKind {
         index_scheduler: &index_scheduler::IndexScheduler,
         index_uid: String,
         index: &Index,
-        rtxn: &RoTxn,
+        rtxn: Option<&RoTxn>,
         embedder_name: &str,
         semantic_ratio: f32,
         vector_len: Option<usize>,
@@ -754,12 +754,18 @@ impl SearchKind {
         index_scheduler: &index_scheduler::IndexScheduler,
         index_uid: String,
         index: &Index,
-        rtxn: &RoTxn,
+        rtxn: Option<&RoTxn>,
         embedder_name: &str,
         vector_len: Option<usize>,
         route: Route,
     ) -> Result<(String, Arc<Embedder>, bool), ResponseError> {
-        let embedder_configs = index.embedding_configs().embedding_configs(rtxn)?;
+        let embedder_configs = match rtxn {
+            Some(rtxn) => index.embedding_configs().embedding_configs(rtxn)?,
+            None => {
+                let rtxn = index.read_txn()?;
+                index.embedding_configs().embedding_configs(&rtxn)?
+            }
+        };
         let embedders = index_scheduler.embedders(index_uid, embedder_configs)?;
 
         let (embedder, quantized) = embedders
@@ -2562,7 +2568,7 @@ pub fn perform_similar(
         index_scheduler,
         index_uid.to_string(),
         &index,
-        &rtxn,
+        Some(&rtxn),
         &embedder,
         None,
         Route::Similar,

--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -713,6 +713,7 @@ impl SearchKind {
         index_scheduler: &index_scheduler::IndexScheduler,
         index_uid: String,
         index: &Index,
+        rtxn: &RoTxn,
         embedder_name: &str,
         vector_len: Option<usize>,
     ) -> Result<Self, ResponseError> {
@@ -720,6 +721,7 @@ impl SearchKind {
             index_scheduler,
             index_uid,
             index,
+            rtxn,
             embedder_name,
             vector_len,
             Route::Search,
@@ -731,6 +733,7 @@ impl SearchKind {
         index_scheduler: &index_scheduler::IndexScheduler,
         index_uid: String,
         index: &Index,
+        rtxn: &RoTxn,
         embedder_name: &str,
         semantic_ratio: f32,
         vector_len: Option<usize>,
@@ -739,6 +742,7 @@ impl SearchKind {
             index_scheduler,
             index_uid,
             index,
+            rtxn,
             embedder_name,
             vector_len,
             Route::Search,
@@ -750,12 +754,12 @@ impl SearchKind {
         index_scheduler: &index_scheduler::IndexScheduler,
         index_uid: String,
         index: &Index,
+        rtxn: &RoTxn,
         embedder_name: &str,
         vector_len: Option<usize>,
         route: Route,
     ) -> Result<(String, Arc<Embedder>, bool), ResponseError> {
-        let rtxn = index.read_txn()?;
-        let embedder_configs = index.embedding_configs().embedding_configs(&rtxn)?;
+        let embedder_configs = index.embedding_configs().embedding_configs(rtxn)?;
         let embedders = index_scheduler.embedders(index_uid, embedder_configs)?;
 
         let (embedder, quantized) = embedders
@@ -2558,6 +2562,7 @@ pub fn perform_similar(
         index_scheduler,
         index_uid.to_string(),
         &index,
+        &rtxn,
         &embedder,
         None,
         Route::Similar,


### PR DESCRIPTION
Fixes #6294

`SearchKind::semantic`/`hybrid`/`embedder` previously opened their own `index.read_txn()` to look up `embedding_configs`, even when the caller already had one. Now they take `Option<&RoTxn>`: four callers (`facet_search`, `chats/chat_completions`, `federated/perform`, `perform_similar`) reuse their existing rtxn; the one caller without one (`routes/indexes/search.rs::search`) passes `None` and `embedder` opens a short-lived rtxn locally — preserving the original behavior for that path.

The issue also hints that the embedder fetch could be deferred from preprocessing entirely; happy to follow up. `cargo check -p meilisearch` green.

## Generative AI tools
- [x] Uses generative AI tooling per [policy](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - Claude Code (Opus 4.7) for drafting and verification. Reviewed.