### PR TITLE
Honor the search cutoff in prepare_search semantic embedding

### DIFF
--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -1623,6 +1623,11 @@ pub fn fuse_filters(left: Option<Value>, right: Option<Value>) -> Option<Value> 
     }
 }
 
+/// Hard upper bound on the time spent computing a semantic-only query
+/// embedding. Acts as a safety net when the search cutoff is unbounded
+/// (`Deadline::never()`); otherwise the parent cutoff is honored.
+const SEMANTIC_EMBED_HARD_DEADLINE: std::time::Duration = std::time::Duration::from_secs(10);
+
 #[allow(clippy::too_many_arguments)]
 pub fn prepare_search<'t>(
     index: &'t Index,
@@ -1638,7 +1643,7 @@ pub fn prepare_search<'t>(
         features.check_multimodal("passing `media` in a search query")?;
     }
     let mut search = index.search(rtxn, progress);
-    search.deadline(deadline);
+    search.deadline(deadline.clone());
     if let Some(ranking_score_threshold) = query.ranking_score_threshold {
         search.ranking_score_threshold(ranking_score_threshold.0);
     }
@@ -1661,7 +1666,9 @@ pub fn prepare_search<'t>(
                     let span = tracing::trace_span!(target: "search::vector", "embed_one");
                     let _entered = span.enter();
 
-                    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+                    // Honor the search cutoff while keeping a hard fallback for unbounded deadlines.
+                    let embed_deadline = deadline
+                        .min_with(std::time::Instant::now() + SEMANTIC_EMBED_HARD_DEADLINE);
 
                     let q = query.q.as_deref();
                     let media = query.media.as_ref();
@@ -1672,7 +1679,7 @@ pub fn prepare_search<'t>(
                     };
 
                     embedder
-                        .embed_search(search_query, Some(deadline))
+                        .embed_search(search_query, Some(embed_deadline))
                         .map_err(milli::vector::Error::from)
                         .map_err(milli::Error::from)?
                 }

--- a/crates/milli/src/lib.rs
+++ b/crates/milli/src/lib.rs
@@ -189,6 +189,16 @@ impl Deadline {
         }
     }
 
+    /// Returns the tighter of this deadline and the provided `other` instant.
+    ///
+    /// If this `Deadline` is bounded, the earlier of the two instants is returned;
+    /// otherwise (`Deadline::never()`) `other` is returned. This lets callers compose
+    /// a parent search budget with a local fallback without reaching into the
+    /// `Deadline`'s internal representation.
+    pub fn min_with(&self, other: std::time::Instant) -> std::time::Instant {
+        self.deadline.map_or(other, |d| d.min(other))
+    }
+
     #[cfg(test)]
     pub fn with_stop_after(mut self, stop_after: usize) -> Self {
         use std::sync::atomic::AtomicUsize;


### PR DESCRIPTION
Fixes #6295

`prepare_search`'s semantic-only embed step hardcoded a 10s deadline that shadowed the function's `Deadline` parameter, bypassing `searchCutoffMs`. Added `Deadline::min_with(other: Instant) -> Instant` (returns the tighter of parent + fallback) and a named `SEMANTIC_EMBED_HARD_DEADLINE` const for the safety bound used when the parent is `Deadline::never()`. Embed call now passes `deadline.min_with(now() + SEMANTIC_EMBED_HARD_DEADLINE)`. `cargo check -p meilisearch` green.

## Generative AI tools
- [x] Uses generative AI tooling per [policy](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - Claude Code (Opus 4.7) for drafting and verification. Reviewed.