### PR TITLE
fix: force bash shell for Build step to restore Windows CI

### DIFF
--- a/.github/workflows/publish-release-assets.yml
+++ b/.github/workflows/publish-release-assets.yml
@@ -90,6 +90,7 @@ jobs:
         if: matrix.use_cross
         run: cargo install cross --locked
       - name: Build
+        shell: bash
         env:
           BUILD_TOOL: ${{ matrix.use_cross && 'cross' || 'cargo' }}
         run: $BUILD_TOOL build --release --locked ${{ matrix.feature-flag }} ${{ matrix.extra-args }}


### PR DESCRIPTION
## Summary

My earlier PR #6296 changed the Build step from a hardcoded `cargo build` to a variable-driven `$BUILD_TOOL build` to support both `cargo` and `cross`. This works on Linux/macOS (bash) but broke the Windows publish jobs because PowerShell cannot invoke a command from a bare variable reference (`$BUILD_TOOL build` is a parser error in PowerShell).

The fix is one line: `shell: bash` on the Build step, which forces Git Bash on Windows runners and keeps the variable syntax working across all platforms.

## Changes

- Add `shell: bash` to the Build step in `publish-release-assets.yml`

## Verification

- Windows publish jobs were failing with `ParserError: Unexpected token 'build'`
- Adding `shell: bash` explicitly selects Git Bash on Windows, making `$BUILD_TOOL build` valid
- Linux and macOS jobs are unaffected (they already use bash)

Fixes the regression introduced in #6296. Sorry for the breakage.