### PR TITLE
feat(ci): add musl build targets for linux-amd64 and linux-aarch64

### DIFF
--- a/.github/workflows/publish-release-assets.yml
+++ b/.github/workflows/publish-release-assets.yml
@@ -43,7 +43,16 @@ jobs:
       matrix:
         edition: [community, enterprise]
         release:
-          [macos-amd64, macos-aarch64, windows, linux-amd64, linux-aarch64, linux-riscv64]
+          [
+            macos-amd64,
+            macos-aarch64,
+            windows,
+            linux-amd64,
+            linux-aarch64,
+            linux-riscv64,
+            linux-amd64-musl,
+            linux-aarch64-musl,
+          ]
         include:
           - edition: "community"
             feature-flag: ""
@@ -81,6 +90,18 @@ jobs:
             binary_path: riscv64gc-unknown-linux-gnu/release/meilisearch
             asset_name: linux-riscv64
             extra-args: "--target riscv64gc-unknown-linux-gnu"
+            use_cross: true
+          - release: linux-amd64-musl
+            os: ubuntu-22.04
+            binary_path: x86_64-unknown-linux-musl/release/meilisearch
+            asset_name: linux-amd64-musl
+            extra-args: "--target x86_64-unknown-linux-musl"
+            use_cross: true
+          - release: linux-aarch64-musl
+            os: ubuntu-22.04
+            binary_path: aarch64-unknown-linux-musl/release/meilisearch
+            asset_name: linux-aarch64-musl
+            extra-args: "--target aarch64-unknown-linux-musl"
             use_cross: true
     needs: check-version
     steps:


### PR DESCRIPTION
## Problem

Many Linux distributions still ship with glibc versions earlier than 2.35 (e.g., Amazon Linux 2023, Rocky Linux 9, older Ubuntu/Debian). The current release binaries are dynamically linked against glibc, making them incompatible with these environments.

This was reported in #5673, and the Meilisearch team confirmed in [this comment](https://github.com/meilisearch/meilisearch/issues/5673#issuecomment-3914622697) that adding musl build targets would be a welcome community contribution.

## Proposed Changes

- Add `x86_64-unknown-linux-musl` (linux-amd64-musl) build target to the release workflow
- Add `aarch64-unknown-linux-musl` (linux-aarch64-musl) build target to the release workflow
- Both targets use `cross` for compilation, following the same pattern as the existing `linux-riscv64` target

MUSL binaries are **statically linked** and do not depend on any specific glibc version, ensuring broad compatibility across Linux distributions.

## Verification

All 18 jobs (including the 4 new MUSL targets) passed successfully on a dry run of the workflow:

🔗 **[Passing CI Run](https://github.com/ashish4143/meilisearch/actions/runs/25287097205)**

- ✅ `linux-amd64-musl` community edition
- ✅ `linux-amd64-musl` enterprise edition
- ✅ `linux-aarch64-musl` community edition
- ✅ `linux-aarch64-musl` enterprise edition
- ✅ All 12 existing targets unaffected

## Related Issue

Closes #5673