### PR TITLE
Forbid changing `self` when a `leader` is defined

### DIFF
--- a/crates/meilisearch/src/error.rs
+++ b/crates/meilisearch/src/error.rs
@@ -142,6 +142,8 @@ pub enum MeilisearchHttpError {
     InvalidHeaderValue { header_name: &'static str, msg: String },
     #[error("This remote is not the leader of the network.\n  - Note: only the leader `{leader}` can receive new tasks.")]
     NotLeader { leader: String },
+    #[error("Renaming a remote is not supported when a leader is defined.\n  - Note: applying this change would rename `{old_self}` to `{new_self}`.\n  - Hint: Send this change to `{new_self}` if it already exists.")]
+    RenamedSelf { old_self: String, new_self: String },
     #[error("Unexpected `previousRemotes` in network call.\n  - Note: `previousRemote` is reserved for internal use.")]
     UnexpectedNetworkPreviousRemotes,
     #[error("The network version in request is too old.\n  - Received: {received}\n  - Expected at least: {expected_at_least}")]
@@ -218,6 +220,7 @@ impl ErrorCode for MeilisearchHttpError {
             }
             MeilisearchHttpError::InvalidHeaderValue { .. } => Code::InvalidHeaderValue,
             MeilisearchHttpError::NotLeader { .. } => Code::NotLeader,
+            MeilisearchHttpError::RenamedSelf { .. } => Code::InvalidNetworkSelf,
             MeilisearchHttpError::UnexpectedNetworkPreviousRemotes => {
                 Code::UnexpectedNetworkPreviousRemotes
             }

--- a/crates/meilisearch/src/routes/network/mod.rs
+++ b/crates/meilisearch/src/routes/network/mod.rs
@@ -380,10 +380,13 @@ fn merge_networks(
         previous_shards: _,
     } = new_network;
 
-    let merged_self = match new_local {
-        Setting::Set(new_self) => Some(new_self),
-        Setting::Reset => None,
-        Setting::NotSet => old_local,
+    let (renamed_from_to, merged_self) = match (new_local, old_local) {
+        (Setting::Set(new_self), Some(old_local)) => {
+            ((new_self != old_local).then_some((old_local, new_self.clone())), Some(new_self))
+        }
+        (Setting::Set(new_self), None) => (None, Some(new_self)),
+        (Setting::Reset, _) => (None, None),
+        (Setting::NotSet, old_local) => (None, old_local),
     };
     let merged_leader = match new_leader {
         Setting::Set(new_leader) => Some(new_leader),
@@ -394,7 +397,12 @@ fn merge_networks(
         // 1. Always allowed if there is no leader
         (None, _) => (),
         // 2. Allowed if the leader is self
-        (Some(leader), Some(this)) if leader == this => (),
+        (Some(leader), Some(this)) if leader == this => {
+            // renaming is forbidden when there is a leader
+            if let Some((old_self, new_self)) = renamed_from_to {
+                return Err(MeilisearchHttpError::RenamedSelf { old_self, new_self }.into());
+            }
+        }
         // 3. Any other change is disallowed
         (Some(leader), _) => {
             return Err(MeilisearchHttpError::NotLeader { leader: leader.to_string() }.into())

--- a/crates/meilisearch/tests/network/mod.rs
+++ b/crates/meilisearch/tests/network/mod.rs
@@ -221,6 +221,163 @@ async fn errors_on_param() {
     "###);
 }
 
+#[cfg(feature = "enterprise")]
+#[actix_rt::test]
+async fn errors_on_param_sharding() {
+    let server = Server::new().await;
+
+    let (response, code) = server.set_features(json!({"network": true})).await;
+    meili_snap::snapshot!(code, @"200 OK");
+    meili_snap::snapshot!(meili_snap::json_string!(response["network"]), @r#"true"#);
+
+    // 1. not leader
+    let (response, code) =
+        server.set_network(json!({"self": "myself", "leader": "someoneelse"})).await;
+    meili_snap::snapshot!(meili_snap::json_string!(response), @r###"
+    {
+      "message": "This remote is not the leader of the network.\n  - Note: only the leader `someoneelse` can receive new tasks.",
+      "code": "not_leader",
+      "type": "invalid_request",
+      "link": "https://docs.meilisearch.com/errors#not_leader"
+    }
+    "###);
+    meili_snap::snapshot!(code, @"400 Bad Request");
+
+    // 2. leader not in remotes
+    let (response, code) = server.set_network(json!({"self": "myself", "leader": "myself"})).await;
+    meili_snap::snapshot!(meili_snap::json_string!(response), @r###"
+    {
+      "message": "leader `myself` is missing from remotes",
+      "code": "invalid_network_remotes",
+      "type": "invalid_request",
+      "link": "https://docs.meilisearch.com/errors#invalid_network_remotes"
+    }
+    "###);
+    meili_snap::snapshot!(code, @"400 Bad Request");
+
+    // 3. no shards
+    let (response, code) = server
+        .set_network(json!({"self": "myself", "leader": "myself",
+        "remotes": {
+          "myself": {"url": "http://localhost:7700"}
+        }}))
+        .await;
+    meili_snap::snapshot!(meili_snap::json_string!(response), @r###"
+    {
+      "message": "there must be at least one shard owned by at least one remote",
+      "code": "invalid_network_shards",
+      "type": "invalid_request",
+      "link": "https://docs.meilisearch.com/errors#invalid_network_shards"
+    }
+    "###);
+    meili_snap::snapshot!(code, @"400 Bad Request");
+
+    // 4. remoteless-shard
+    let (response, code) = server
+        .set_network(json!({"self": "myself", "leader": "myself",
+          "remotes": {
+            "myself": {"url": "http://localhost:7700"}
+          },
+          "shards": {
+            "all": {
+              "remotes": []
+            }
+          }
+        }))
+        .await;
+    meili_snap::snapshot!(meili_snap::json_string!(response), @r###"
+    {
+      "message": "there must be at least one shard owned by at least one remote",
+      "code": "invalid_network_shards",
+      "type": "invalid_request",
+      "link": "https://docs.meilisearch.com/errors#invalid_network_shards"
+    }
+    "###);
+    meili_snap::snapshot!(code, @"400 Bad Request");
+
+    // 5. shard with unknown remote
+    let (response, code) = server
+        .set_network(json!({"self": "myself", "leader": "myself",
+          "remotes": {
+            "myself": {"url": "http://localhost:7700"}
+          },
+          "shards": {
+            "all": {
+              "remotes": [ "unknown" ]
+            }
+          }
+        }))
+        .await;
+    meili_snap::snapshot!(meili_snap::json_string!(response), @r###"
+    {
+      "message": "unknown remote `unknown` in `.all.remotes`",
+      "code": "invalid_network_shards",
+      "type": "invalid_request",
+      "link": "https://docs.meilisearch.com/errors#invalid_network_shards"
+    }
+    "###);
+    meili_snap::snapshot!(code, @"400 Bad Request");
+
+    // 6. renaming
+    let (response, code) = server
+        .set_network(json!({"self": "myself", "leader": null,
+          "remotes": {
+            "myself": {"url": "http://localhost:7700"}
+          },
+          "shards": {
+            "all": {
+              "remotes": [ "myself" ]
+            }
+          }
+        }))
+        .await;
+    meili_snap::snapshot!(meili_snap::json_string!(response, {".version" => "[version]"}), @r###"
+    {
+      "self": "myself",
+      "remotes": {
+        "myself": {
+          "url": "http://localhost:7700",
+          "searchApiKey": null,
+          "writeApiKey": null,
+          "status": "available"
+        }
+      },
+      "shards": {
+        "all": {
+          "remotes": [
+            "myself"
+          ]
+        }
+      },
+      "leader": null,
+      "version": "[version]"
+    }
+    "###);
+    meili_snap::snapshot!(code, @"200 OK");
+
+    let (response, code) = server
+        .set_network(json!({"self": "someoneelse", "leader": "someoneelse",
+          "remotes": {
+            "myself": {"url": "http://localhost:7700"}
+          },
+          "shards": {
+            "all": {
+              "remotes": [ "myself" ]
+            }
+          }
+        }))
+        .await;
+    meili_snap::snapshot!(meili_snap::json_string!(response), @r###"
+    {
+      "message": "Renaming a remote is not supported when a leader is defined.\n  - Note: applying this change would rename `myself` to `someoneelse`.\n  - Hint: Send this change to `someoneelse` if it already exists.",
+      "code": "invalid_network_self",
+      "type": "invalid_request",
+      "link": "https://docs.meilisearch.com/errors#invalid_network_self"
+    }
+    "###);
+    meili_snap::snapshot!(code, @"400 Bad Request");
+}
+
 #[actix_rt::test]
 async fn auth() {
     let mut server = Server::new_auth().await;


### PR DESCRIPTION
## Breaking change

This PR contains the following breaking change:

- When the `network` experimental feature is enabled, sending a `PATCH /network` to an existing remote of a network now responds with a HTTP 400 `network_invalid_self` error if a `leader` has been defined.

## Rationale

- Renaming a remote is not supported
- However, it might happen if a user sends a network payload meant for the leader to a different remote.
- This PR protects against this specific error by making it forbidden to change `self` once a leader has been defined.
- This PR does not fix the general issue of remote aliasing, which is tracked [here](https://linear.app/meilisearch/issue/SCA-297/solve-aliasing-problem) (internal discussion)

# Implementation

- Detect and reject the condition where a remote is renamed when a leader exists (already, or as a result of the new payload)
- Add integration test cases for this case and other error cases related to misconfiguration when a leader is present

## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respect the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - *list of used tools and what they were used for*
