### PR TITLE
feat: add query to federated search metadata

### DIFF
--- a/crates/meilisearch/src/search/federated/perform.rs
+++ b/crates/meilisearch/src/search/federated/perform.rs
@@ -99,6 +99,7 @@ pub async fn perform_federated_search(
             .iter()
             .map(|q| {
                 (
+                    q.q.clone(),
                     q.index_uid.to_string(),
                     q.federation_options.as_ref().and_then(|o| o.remote.clone()),
                 )
@@ -867,7 +868,7 @@ struct SearchResultByIndex {
 /// of primary keys to their respective indexes and remotes to prevent collisions when
 /// multiple remotes have the same index_uid but different primary keys.
 fn build_query_metadata(
-    precomputed_query_metadata: Vec<(String, Option<String>)>,
+    precomputed_query_metadata: Vec<(Option<String>, String, Option<String>)>,
     local_remote_name: Option<String>,
     remote_results: &[FederatedSearchResult],
     results_by_index: &[SearchResultByIndex],
@@ -904,13 +905,13 @@ fn build_query_metadata(
 
     // Build metadata in the same order as the original queries
     let mut query_metadata = Vec::new();
-    for (index_uid, remote) in precomputed_query_metadata {
+    for (query, index_uid, remote) in precomputed_query_metadata {
         let primary_key =
             primary_key_per_index.get(&(remote.as_ref(), &index_uid)).map(|pk| pk.to_string());
         let query_uid = Uuid::now_v7();
         // if the remote is not set, use the local remote name
         let remote = remote.or_else(|| local_remote_name.clone());
-        query_metadata.push(SearchMetadata { query_uid, primary_key, index_uid, remote });
+        query_metadata.push(SearchMetadata { query, query_uid, primary_key, index_uid, remote });
     }
     query_metadata
 }

--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -1378,6 +1378,9 @@ impl FacetValue {
 #[serde(rename_all = "camelCase")]
 #[schema(rename_all = "camelCase")]
 pub struct SearchMetadata {
+    /// Query string set for the query. (federated search only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub query: Option<String>,
     /// Unique identifier for the query.
     pub query_uid: Uuid,
     /// UID of the index that was searched.
@@ -1849,6 +1852,7 @@ pub fn perform_search(
         let query_uid = Uuid::now_v7();
         let primary_key = index.primary_key(&rtxn)?.map(|pk| pk.to_string());
         Some(SearchMetadata {
+            query: None,
             query_uid,
             index_uid: index_uid_for_metadata,
             primary_key,

--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -1378,7 +1378,15 @@ impl FacetValue {
 #[serde(rename_all = "camelCase")]
 #[schema(rename_all = "camelCase")]
 pub struct SearchMetadata {
-    /// Query string set for the query. (federated search only).
+    /// Query string set for the query, if not already present in the response.
+    ///
+    /// Only set if:
+    ///
+    /// 1. the metadata corresponds to a query in a federated search request, **and**
+    /// 2. that federated search request query is not a placeholder search (empty or missing `q`)
+    ///
+    /// Never set for regular search and non-federated multi-search because
+    /// the query(ies) are already present in the response.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub query: Option<String>,
     /// Unique identifier for the query.

--- a/crates/meilisearch/tests/search/multi/metadata.rs
+++ b/crates/meilisearch/tests/search/multi/metadata.rs
@@ -1,0 +1,105 @@
+use meili_snap::{json_string, snapshot};
+
+use crate::common::{shared_index_with_score_documents, Server};
+use crate::json;
+
+#[actix_rt::test]
+async fn federated_search_with_metadata_header() {
+    let server = Server::new_shared();
+    let index = shared_index_with_score_documents().await;
+
+    let (response, code) = server
+        .multi_search_with_headers(
+            json!({"federation": {}, "queries": [
+            {"indexUid": index.uid, "q": "the bat"},
+            {"indexUid": index.uid, "q": "badman returns"},
+            {"indexUid" : index.uid, "q": "batman"},
+            {"indexUid": index.uid, "q": "batman returns"},
+            ]}),
+            vec![("Meili-Include-Metadata", "true")],
+        )
+        .await;
+    snapshot!(code, @"200 OK");
+    snapshot!(json_string!(response, { ".processingTimeMs" => "[duration]", ".**._rankingScore" => "[score]", ".**.requestUid" => "[uuid]", ".metadata.**.queryUid" => "[queryUid]" }), @r###"
+    {
+      "hits": [
+        {
+          "title": "Batman",
+          "id": "D",
+          "_federation": {
+            "indexUid": "SHARED_SCORE_DOCUMENTS",
+            "queriesPosition": 2,
+            "weightedRankingScore": 1.0
+          }
+        },
+        {
+          "title": "Batman Returns",
+          "id": "C",
+          "_federation": {
+            "indexUid": "SHARED_SCORE_DOCUMENTS",
+            "queriesPosition": 3,
+            "weightedRankingScore": 1.0
+          }
+        },
+        {
+          "title": "Batman the dark knight returns: Part 1",
+          "id": "A",
+          "_federation": {
+            "indexUid": "SHARED_SCORE_DOCUMENTS",
+            "queriesPosition": 2,
+            "weightedRankingScore": 0.9848484848484848
+          }
+        },
+        {
+          "title": "Batman the dark knight returns: Part 2",
+          "id": "B",
+          "_federation": {
+            "indexUid": "SHARED_SCORE_DOCUMENTS",
+            "queriesPosition": 2,
+            "weightedRankingScore": 0.9848484848484848
+          }
+        },
+        {
+          "title": "Badman",
+          "id": "E",
+          "_federation": {
+            "indexUid": "SHARED_SCORE_DOCUMENTS",
+            "queriesPosition": 1,
+            "weightedRankingScore": 0.5
+          }
+        }
+      ],
+      "processingTimeMs": "[duration]",
+      "limit": 20,
+      "offset": 0,
+      "estimatedTotalHits": 5,
+      "requestUid": "[uuid]",
+      "metadata": [
+        {
+          "query": "the bat",
+          "queryUid": "[queryUid]",
+          "indexUid": "SHARED_SCORE_DOCUMENTS",
+          "primaryKey": "id"
+        },
+        {
+          "query": "badman returns",
+          "queryUid": "[queryUid]",
+          "indexUid": "SHARED_SCORE_DOCUMENTS",
+          "primaryKey": "id"
+        },
+        {
+          "query": "batman",
+          "queryUid": "[queryUid]",
+          "indexUid": "SHARED_SCORE_DOCUMENTS",
+          "primaryKey": "id"
+        },
+        {
+          "query": "batman returns",
+          "queryUid": "[queryUid]",
+          "indexUid": "SHARED_SCORE_DOCUMENTS",
+          "primaryKey": "id"
+        }
+      ]
+    }
+    "###);
+}

--- a/crates/meilisearch/tests/search/multi/mod.rs
+++ b/crates/meilisearch/tests/search/multi/mod.rs
@@ -10,6 +10,7 @@ use crate::common::{
 use crate::json;
 use crate::search::{SCORE_DOCUMENTS, VECTOR_DOCUMENTS};
 
+mod metadata;
 mod proxy;
 
 pub async fn shared_movies_index() -> &'static Index<'static, Shared> {


### PR DESCRIPTION
## Description

This pull request add query to federated search metadata and doesn't impact search and multi search due to query presence in response.

## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respect the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - *list of used tools and what they were used for*

