### PR TITLE
Remote facet search

### DIFF
--- a/crates/benchmarks/benches/utils.rs
+++ b/crates/benchmarks/benches/utils.rs
@@ -192,7 +192,7 @@ pub fn run_benches(c: &mut criterion::Criterion, confs: &[Conf]) {
                                 .terms_matching_strategy(TermsMatchingStrategy::default());
                             if let Some(filter) = conf.filter {
                                 let filter = Filter::from_str(filter).unwrap().unwrap();
-                                search.filter(filter_to_index_filter(filter));
+                                search.filter(Some(filter_to_index_filter(filter)));
                             }
                             if let Some(sort) = &conf.sort {
                                 let sort = sort.iter().map(|sort| sort.parse().unwrap()).collect();

--- a/crates/meilisearch-types/src/error.rs
+++ b/crates/meilisearch-types/src/error.rs
@@ -397,6 +397,7 @@ NotLeader                                      , InvalidRequest       , BAD_REQU
 PayloadTooLarge                                , InvalidRequest       , PAYLOAD_TOO_LARGE ;
 RemoteBadResponse                              , System               , BAD_GATEWAY ;
 RemoteBadRequest                               , InvalidRequest       , BAD_REQUEST ;
+UnknownRemote                                  , InvalidRequest       , BAD_REQUEST ;
 RemoteCouldNotSendRequest                      , System               , BAD_GATEWAY ;
 RemoteInvalidApiKey                            , Auth                 , FORBIDDEN ;
 RemoteRemoteError                              , System               , BAD_GATEWAY ;

--- a/crates/meilisearch-types/src/network.rs
+++ b/crates/meilisearch-types/src/network.rs
@@ -145,6 +145,13 @@ pub mod route {
         PathAndQuery::from_static("/multi-search")
     }
 
+    pub fn facet_search_path(
+        index_uid: &crate::index_uid::IndexUid,
+    ) -> Result<PathAndQuery, HttpError> {
+        // WARNING: if you change this path, you must also change the path in the federated search route macro in the meilisearch crate.
+        Ok(PathAndQuery::try_from(format!("/indexes/{index_uid}/facet-search"))?)
+    }
+
     pub fn indexes_root_path() -> PathAndQuery {
         PathAndQuery::from_static("/indexes")
     }

--- a/crates/meilisearch/src/routes/indexes/facet_search.rs
+++ b/crates/meilisearch/src/routes/indexes/facet_search.rs
@@ -105,6 +105,35 @@ pub struct FacetSearchQuery {
     #[schema(required = false)]
     #[deserr(default, error = DeserrJsonError<InvalidFacetSearchExhaustiveFacetCount>, default)]
     pub exhaustive_facet_count: Option<bool>,
+    /// When `true`, runs the query on the whole network (all shards covered exactly once).
+    ///
+    /// When `false`, the query runs locally.
+    ///
+    /// When omitted or `null`, the default value depends on whether the sharding is enabled for the instance:
+    ///
+    /// - If the instance has sharding enabled (has a leader), defaults to `true`.
+    /// - Otherwise defaults to `false`.
+    ///
+    /// **Enterprise Edition only.** This feature is available in the Enterprise Edition.
+    ///
+    /// It also requires the `network` [experimental feature](http://localhost:3000/reference/api/experimental-features/configure-experimental-features).
+    ///
+    /// Values: `true` = use the whole network; `false` = local, default = see above.
+    ///
+    /// When using the network, the index must exist with compatible settings on all remotes.
+    #[schema(required = false)]
+    #[deserr(default, error = DeserrJsonError<InvalidSearchUseNetwork>)]
+    pub use_network: Option<bool>,
+}
+
+impl NetworkableQuery for FacetSearchQuery {
+    fn use_network_field(&mut self) -> &mut Option<bool> {
+        &mut self.use_network
+    }
+
+    fn has_remote(&self) -> bool {
+        false
+    }
 }
 
 #[derive(Default)]
@@ -137,6 +166,7 @@ impl FacetSearchAggregator {
             ranking_score_threshold,
             locales,
             exhaustive_facet_count,
+            use_network,
         } = query;
 
         Self {
@@ -151,13 +181,19 @@ impl FacetSearchAggregator {
                 || hybrid.is_some()
                 || ranking_score_threshold.is_some()
                 || locales.is_some()
-                || exhaustive_facet_count.is_some(),
+                || exhaustive_facet_count.is_some()
+                || use_network.is_some(),
             ..Default::default()
         }
     }
 
     pub fn succeed(&mut self, result: &FacetSearchResult) {
-        let FacetSearchResult { facet_hits: _, facet_query: _, processing_time_ms } = result;
+        let FacetSearchResult {
+            facet_hits: _,
+            facet_query: _,
+            processing_time_ms,
+            remote_errors: _,
+        } = result;
         self.total_succeeded = 1;
         self.time_spent.push(*processing_time_ms as usize);
     }
@@ -275,24 +311,275 @@ pub async fn search(
     analytics: web::Data<Analytics>,
 ) -> Result<HttpResponse, ResponseError> {
     let progress = Progress::default();
-    let permit = search_queue.try_get_search_permit().await?;
     let index_uid = IndexUid::try_from(index_uid.into_inner())?;
 
-    let query = params.into_inner();
+    let permit = search_queue.try_get_search_permit().await?;
+
+    let mut query = params.into_inner();
     debug!(parameters = ?query, "Facet search");
 
-    let mut aggregate = FacetSearchAggregator::from_query(&query);
+    // Tenant token search_rules.
+    // NOTE: must be applied **BEFORE** proxying the query so that the tenant token sent to the original machine is taken into account
+    if let Some(search_rules) = index_scheduler.filters().get_index_search_rules(&index_uid) {
+        add_search_rules(&mut query.filter, search_rules);
+    }
 
+    let mut aggregate = FacetSearchAggregator::from_query(&query);
+    let features = index_scheduler.features();
+    let network = index_scheduler.network();
+
+    let search_result = if query.must_use_network(&network, &features)? {
+        search_federated(index_scheduler.clone(), query, index_uid, progress, features, network)
+            .await
+    } else {
+        search_local(index_scheduler.clone(), query, index_uid, progress, features).await
+    };
+
+    permit.drop().await;
+
+    if let Ok(ref search_result) = search_result {
+        aggregate.succeed(search_result);
+    }
+    analytics.publish(aggregate, &req);
+
+    let search_result = search_result?;
+
+    debug!(returns = ?search_result, "Facet search");
+    Ok(HttpResponse::Ok().json(search_result))
+}
+
+async fn search_federated(
+    index_scheduler: Data<IndexScheduler>,
+    mut query: FacetSearchQuery,
+    index_uid: IndexUid,
+    progress: Progress,
+    features: RoFeatures,
+    network: Network,
+) -> Result<FacetSearchResult, ResponseError> {
+    let before_search = std::time::Instant::now();
+    let remote_availability = index_scheduler.remote_availability();
+    let partition = Partition::new(network.clone(), remote_availability);
+
+    let (local_queries, remote_queries): (Vec<_>, Vec<_>) =
+        partition.into_partition(&query)?.partition(
+            // true is left, false is right
+            |(remote, _)| Some(remote) == network.local.as_ref(),
+        );
+
+    let timeout = std::env::var("MEILI_EXPERIMENTAL_REMOTE_SEARCH_TIMEOUT_SECONDS")
+        .ok()
+        .map(|p| p.parse().unwrap())
+        .unwrap_or(25);
+
+    let deadline = before_search + std::time::Duration::from_secs(timeout);
+
+    let params = ProxySearchParams {
+        deadline: Some(deadline),
+        try_count: 3,
+        client: index_scheduler.web_client().clone(),
+    };
+
+    let mut results: Vec<FacetSearchResult> = Vec::with_capacity(remote_queries.len() + 1);
+
+    let mut errors: BTreeMap<String, ResponseError> = BTreeMap::new();
+
+    const MAX_IN_FLIGHT_REQUESTS: usize = 40;
+    let mut in_flight_requests = VecDeque::with_capacity(MAX_IN_FLIGHT_REQUESTS);
+
+    for (remote_name, filter) in remote_queries {
+        let Some(remote) = network.remotes.get(&remote_name) else {
+            errors.insert(
+                remote_name.clone(),
+                ProxySearchError::UnknownRemote { remote: remote_name }.as_response_error(),
+            );
+            continue;
+        };
+
+        let path_and_query = match meilisearch_types::network::route::facet_search_path(&index_uid)
+        {
+            Ok(path_and_query) => path_and_query,
+            Err(err) => {
+                errors.insert(
+                    remote_name,
+                    ProxySearchError::InvalidRemoteUrl { cause: err.to_string() }
+                        .as_response_error(),
+                );
+                continue;
+            }
+        };
+        query.filter = filter;
+        let request = match json_proxy(
+            path_and_query,
+            http_client::reqwest::Method::POST,
+            remote,
+            &query,
+            &params,
+            false, // no metadata on facet-search
+        ) {
+            Ok(request) => request,
+            Err(err) => {
+                errors.insert(remote_name, err.as_response_error());
+                continue;
+            }
+        };
+
+        if in_flight_requests.len() == MAX_IN_FLIGHT_REQUESTS {
+            // unwrap: MAX_IN_FLIGHT_REQUESTS > 0
+            let task: tokio::task::JoinHandle<(
+                Result<FacetSearchResult, ProxySearchError>,
+                String,
+            )> = in_flight_requests.pop_front().unwrap();
+            match task.await.unwrap() {
+                (Ok(result), _) => results.push(result),
+                (Err(err), remote_name) => {
+                    errors.insert(remote_name, err.as_response_error());
+                    continue;
+                }
+            }
+        }
+        in_flight_requests.push_back(tokio::spawn(async move { (request.await, remote_name) }));
+    }
+
+    let (mut local_results, order) =
+        search_multi_local(local_queries, index_scheduler, query, index_uid, progress, features)
+            .await?;
+
+    for task in in_flight_requests {
+        match task.await.unwrap() {
+            (Ok(result), _) => results.push(result),
+            (Err(err), remote_name) => {
+                errors.insert(remote_name, err.as_response_error());
+            }
+        }
+    }
+
+    let facet_query = local_results.facet_query.take();
+    let processing_time_ms = local_results.processing_time_ms;
+    results.push(local_results);
+
+    let facet_hits = match order {
+        OrderBy::Lexicographic => lexicographic_merge(results),
+        OrderBy::Count => count_merge(results),
+    };
+
+    Ok(FacetSearchResult {
+        facet_hits,
+        facet_query,
+        processing_time_ms,
+        remote_errors: Some(errors),
+    })
+}
+
+fn count_merge(mut results: Vec<FacetSearchResult>) -> Vec<FacetValueHit> {
+    // sort lexicographically so we can merge results, then sort again by the new hit count
+    results
+        .iter_mut()
+        .for_each(|v| v.facet_hits.sort_unstable_by(|left, right| left.value.cmp(&right.value)));
+    let mut hits = lexicographic_merge(results);
+    hits.sort_unstable_by_key(|hit| std::cmp::Reverse(hit.count));
+    hits
+}
+
+// Precondition: all `FacetSearchResult::facet_hits` in `results` are sorted lexicographically
+fn lexicographic_merge(results: Vec<FacetSearchResult>) -> Vec<FacetValueHit> {
+    itertools::kmerge_by(
+        results.into_iter().map(|results| results.facet_hits.into_iter()),
+        |left: &FacetValueHit, right: &FacetValueHit| left.value <= right.value,
+    )
+    .coalesce(|left, right| {
+        if left.value == right.value {
+            Ok(FacetValueHit { value: right.value, count: left.count + right.count })
+        } else {
+            Err((left, right))
+        }
+    })
+    .collect()
+}
+
+async fn search_multi_local(
+    local_queries: Vec<(String, Option<serde_json::Value>)>,
+    index_scheduler: Data<IndexScheduler>,
+    query: FacetSearchQuery,
+    index_uid: IndexUid,
+    progress: Progress,
+    features: RoFeatures,
+) -> Result<(FacetSearchResult, OrderBy), ResponseError> {
     let facet_query = query.facet_query.clone();
     let facet_name = query.facet_name.clone();
     let locales = query.locales.clone().map(|l| l.into_iter().map(Into::into).collect());
-    let mut search_query = SearchQuery::from(query);
+    let search_query = SearchQuery::from(query);
 
-    // Tenant token search_rules.
-    if let Some(search_rules) = index_scheduler.filters().get_index_search_rules(&index_uid) {
-        add_search_rules(&mut search_query.filter, search_rules);
-    }
-    let features = index_scheduler.features();
+    let progress_clone = progress.clone();
+    let search_result = tokio::task::spawn_blocking(move || {
+        let index = index_scheduler.index(&index_uid)?;
+        let rtxn = index.read_txn()?;
+        let deadline = index.search_deadline(&rtxn)?;
+        let search_kind =
+            search_kind(&search_query, &index_scheduler, index_uid.to_string(), &index)?;
+
+        let filters: Result<Vec<_>, ResponseError> = local_queries
+            .iter() // no into_iter: we need to keep the original filters live as the IndexFilters reference them
+            .map(|(_, filter)| {
+                Ok(match filter {
+                    Some(filter) => {
+                        let filter = parse_filter(filter, Code::InvalidSearchFilter, features)?;
+                        filter
+                            .map(|f| {
+                                filter_into_index_filter(
+                                    f,
+                                    &index,
+                                    &rtxn,
+                                    &index_scheduler,
+                                    &progress_clone,
+                                    &index_uid,
+                                )
+                            })
+                            .transpose()?
+                    }
+                    None => None,
+                })
+            })
+            .collect();
+        let filters = filters?;
+
+        let (search, _, _, _) = prepare_search(
+            &index,
+            &rtxn,
+            &search_query,
+            None,
+            &search_kind,
+            deadline,
+            features,
+            &progress_clone,
+        )?;
+
+        perform_facet_search(
+            &index,
+            &rtxn,
+            search,
+            filters.into_iter(),
+            facet_query,
+            facet_name,
+            search_kind,
+            locales,
+        )
+    })
+    .await;
+    search_result?
+}
+
+async fn search_local(
+    index_scheduler: Data<IndexScheduler>,
+    query: FacetSearchQuery,
+    index_uid: IndexUid,
+    progress: Progress,
+    features: RoFeatures,
+) -> Result<FacetSearchResult, ResponseError> {
+    let facet_query = query.facet_query.clone();
+    let facet_name = query.facet_name.clone();
+    let locales = query.locales.clone().map(|l| l.into_iter().map(Into::into).collect());
+    let search_query = SearchQuery::from(query);
+
     let progress_clone = progress.clone();
     let search_result = tokio::task::spawn_blocking(move || {
         let index = index_scheduler.index(&index_uid)?;
@@ -323,28 +610,28 @@ pub async fn search(
             &index,
             &rtxn,
             &search_query,
-            filter,
+            // Filter is passed as an iterator to facet search
+            None,
             &search_kind,
             deadline,
             features,
             &progress_clone,
         )?;
 
-        perform_facet_search(&index, &rtxn, search, facet_query, facet_name, search_kind, locales)
+        perform_facet_search(
+            &index,
+            &rtxn,
+            search,
+            std::iter::once(filter),
+            facet_query,
+            facet_name,
+            search_kind,
+            locales,
+        )
+        .map(|(results, _)| results)
     })
     .await;
-    permit.drop().await;
-    let search_result = search_result?;
-
-    if let Ok(ref search_result) = search_result {
-        aggregate.succeed(search_result);
-    }
-    analytics.publish(aggregate, &req);
-
-    let search_result = search_result?;
-
-    debug!(returns = ?search_result, "Facet search");
-    Ok(HttpResponse::Ok().json(search_result))
+    search_result?
 }
 
 impl From<FacetSearchQuery> for SearchQuery {
@@ -362,6 +649,7 @@ impl From<FacetSearchQuery> for SearchQuery {
             ranking_score_threshold,
             locales,
             exhaustive_facet_count,
+            use_network,
         } = value;
 
         // If exhaustive_facet_count is true, we need to set the page to 0
@@ -404,8 +692,7 @@ impl From<FacetSearchQuery> for SearchQuery {
             ranking_score_threshold,
             locales,
             personalize: None,
-            // TODO: remote federated facet search not supported
-            use_network: None,
+            use_network,
         }
     }
 }

--- a/crates/meilisearch/src/routes/indexes/facet_search.rs
+++ b/crates/meilisearch/src/routes/indexes/facet_search.rs
@@ -25,10 +25,11 @@ use crate::extractors::authentication::GuardedData;
 use crate::routes::indexes::search::search_kind;
 use crate::search::proxy::{json_proxy, ProxySearchError, ProxySearchParams};
 use crate::search::{
-    add_search_rules, parse_filter, perform_facet_search, prepare_search, FacetSearchResult,
-    HybridQuery, MatchingStrategy, NetworkableQuery, Partition, RankingScoreThreshold, SearchQuery,
-    SearchResult, DEFAULT_CROP_LENGTH, DEFAULT_CROP_MARKER, DEFAULT_HIGHLIGHT_POST_TAG,
-    DEFAULT_HIGHLIGHT_PRE_TAG, DEFAULT_SEARCH_LIMIT, DEFAULT_SEARCH_OFFSET,
+    add_search_rules, fuse_filters, parse_filter, perform_facet_search, prepare_search,
+    FacetSearchResult, HybridQuery, MatchingStrategy, NetworkableQuery, Partition,
+    RankingScoreThreshold, SearchQuery, SearchResult, DEFAULT_CROP_LENGTH, DEFAULT_CROP_MARKER,
+    DEFAULT_HIGHLIGHT_POST_TAG, DEFAULT_HIGHLIGHT_PRE_TAG, DEFAULT_SEARCH_LIMIT,
+    DEFAULT_SEARCH_OFFSET,
 };
 use crate::search_queue::SearchQueue;
 
@@ -374,7 +375,9 @@ async fn search_federated(
     const MAX_IN_FLIGHT_REQUESTS: usize = 40;
     let mut in_flight_requests = VecDeque::with_capacity(MAX_IN_FLIGHT_REQUESTS);
 
-    for (remote_name, filter) in remote_queries {
+    let original_filter = query.filter.clone();
+
+    for (remote_name, shard_filter) in remote_queries {
         let Some(remote) = network.remotes.get(&remote_name) else {
             errors.insert(
                 remote_name.clone(),
@@ -395,7 +398,7 @@ async fn search_federated(
                 continue;
             }
         };
-        query.filter = filter;
+        query.filter = fuse_filters(original_filter.clone(), shard_filter);
         let request = match json_proxy(
             path_and_query,
             http_client::reqwest::Method::POST,
@@ -427,6 +430,8 @@ async fn search_federated(
         }
         in_flight_requests.push_back(tokio::spawn(async move { (request.await, remote_name) }));
     }
+
+    query.filter = original_filter;
 
     let (mut local_results, order) =
         search_multi_local(local_queries, index_scheduler, query, index_uid, progress, features)
@@ -495,7 +500,7 @@ async fn search_multi_local(
     let facet_query = query.facet_query.clone();
     let facet_name = query.facet_name.clone();
     let locales = query.locales.clone().map(|l| l.into_iter().map(Into::into).collect());
-    let search_query = SearchQuery::from(query);
+    let mut search_query = SearchQuery::from(query);
 
     let progress_clone = progress.clone();
     let search_result = tokio::task::spawn_blocking(move || {
@@ -505,52 +510,43 @@ async fn search_multi_local(
         let search_kind =
             search_kind(&search_query, &index_scheduler, index_uid.to_string(), &index)?;
 
-        let filters: Result<Vec<_>, ResponseError> = local_queries
-            .iter() // no into_iter: we need to keep the original filters live as the IndexFilters reference them
-            .map(|(_, filter)| {
-                Ok(match filter {
-                    Some(filter) => {
-                        let filter = parse_filter(filter, Code::InvalidSearchFilter, features)?;
-                        filter
-                            .map(|f| {
-                                filter_into_index_filter(
-                                    f,
-                                    &index,
-                                    &rtxn,
-                                    &index_scheduler,
-                                    &progress_clone,
-                                    &index_uid,
-                                )
-                            })
-                            .transpose()?
-                    }
-                    None => None,
+        let shard_filters: Vec<serde_json::Value> =
+            local_queries.iter().filter_map(|(_, filter)| filter.clone()).collect();
+
+        // inner array is OR, which is what we want
+        let shard_filters = serde_json::Value::Array(vec![serde_json::Value::Array(shard_filters)]);
+
+        let filter = fuse_filters(search_query.filter.take(), Some(shard_filters));
+
+        let filter = filter
+            .as_ref()
+            .and_then(|f| parse_filter(f, Code::InvalidSearchFilter, features).transpose())
+            .map(|f| {
+                f.and_then(|f| {
+                    Ok(filter_into_index_filter(
+                        f,
+                        &index,
+                        &rtxn,
+                        &index_scheduler,
+                        &progress_clone,
+                        &index_uid,
+                    )?)
                 })
             })
-            .collect();
-        let filters = filters?;
+            .transpose()?;
 
         let (search, _, _, _) = prepare_search(
             &index,
             &rtxn,
             &search_query,
-            None,
+            filter,
             &search_kind,
             deadline,
             features,
             &progress_clone,
         )?;
 
-        perform_facet_search(
-            &index,
-            &rtxn,
-            search,
-            filters.into_iter(),
-            facet_query,
-            facet_name,
-            search_kind,
-            locales,
-        )
+        perform_facet_search(&index, &rtxn, search, facet_query, facet_name, search_kind, locales)
     })
     .await;
     search_result?
@@ -598,25 +594,15 @@ async fn search_local(
             &index,
             &rtxn,
             &search_query,
-            // Filter is passed as an iterator to facet search
-            None,
+            filter,
             &search_kind,
             deadline,
             features,
             &progress_clone,
         )?;
 
-        perform_facet_search(
-            &index,
-            &rtxn,
-            search,
-            std::iter::once(filter),
-            facet_query,
-            facet_name,
-            search_kind,
-            locales,
-        )
-        .map(|(results, _)| results)
+        perform_facet_search(&index, &rtxn, search, facet_query, facet_name, search_kind, locales)
+            .map(|(results, _)| results)
     })
     .await;
     search_result?

--- a/crates/meilisearch/src/routes/indexes/facet_search.rs
+++ b/crates/meilisearch/src/routes/indexes/facet_search.rs
@@ -48,8 +48,9 @@ pub struct FacetSearchApi;
 //
 // Intentionally don't use `deny_unknown_fields` to ignore search parameters sent by user
 /// Request body for searching facet values
-#[derive(Debug, Clone, Default, PartialEq, deserr::Deserr, ToSchema)]
+#[derive(Debug, Clone, Default, PartialEq, deserr::Deserr, Serialize, ToSchema)]
 #[deserr(error = DeserrJsonError, rename_all = camelCase)]
+#[serde(rename_all = "camelCase")]
 pub struct FacetSearchQuery {
     /// Query string to search for facet values
     #[schema(required = false)]

--- a/crates/meilisearch/src/routes/indexes/facet_search.rs
+++ b/crates/meilisearch/src/routes/indexes/facet_search.rs
@@ -1,16 +1,20 @@
-use std::collections::{BinaryHeap, HashSet};
+use std::collections::{BTreeMap, BinaryHeap, HashSet, VecDeque};
 
 use actix_web::web::Data;
 use actix_web::{web, HttpRequest, HttpResponse};
 use deserr::actix_web::AwebJson;
 use index_scheduler::filter::filter_into_index_filter;
-use index_scheduler::IndexScheduler;
+use index_scheduler::{IndexScheduler, RoFeatures};
+use itertools::Itertools as _;
 use meilisearch_types::deserr::DeserrJsonError;
-use meilisearch_types::error::ResponseError;
-use meilisearch_types::error::{deserr_codes::*, Code};
+use meilisearch_types::error::deserr_codes::*;
+use meilisearch_types::error::{Code, ResponseError};
 use meilisearch_types::index_uid::IndexUid;
 use meilisearch_types::locales::Locale;
 use meilisearch_types::milli::progress::Progress;
+use meilisearch_types::milli::{FacetValueHit, OrderBy};
+use meilisearch_types::network::Network;
+use serde::Serialize;
 use serde_json::Value;
 use tracing::debug;
 use utoipa::ToSchema;
@@ -19,10 +23,11 @@ use crate::analytics::{Aggregate, Analytics};
 use crate::extractors::authentication::policies::*;
 use crate::extractors::authentication::GuardedData;
 use crate::routes::indexes::search::search_kind;
+use crate::search::proxy::{json_proxy, ProxySearchError, ProxySearchParams};
 use crate::search::{
     add_search_rules, parse_filter, perform_facet_search, prepare_search, FacetSearchResult,
-    HybridQuery, MatchingStrategy, RankingScoreThreshold, SearchQuery, SearchResult,
-    DEFAULT_CROP_LENGTH, DEFAULT_CROP_MARKER, DEFAULT_HIGHLIGHT_POST_TAG,
+    HybridQuery, MatchingStrategy, NetworkableQuery, Partition, RankingScoreThreshold, SearchQuery,
+    SearchResult, DEFAULT_CROP_LENGTH, DEFAULT_CROP_MARKER, DEFAULT_HIGHLIGHT_POST_TAG,
     DEFAULT_HIGHLIGHT_PRE_TAG, DEFAULT_SEARCH_LIMIT, DEFAULT_SEARCH_OFFSET,
 };
 use crate::search_queue::SearchQueue;

--- a/crates/meilisearch/src/routes/indexes/facet_search.rs
+++ b/crates/meilisearch/src/routes/indexes/facet_search.rs
@@ -356,7 +356,8 @@ async fn search_federated(
     features: RoFeatures,
     network: Network,
 ) -> Result<FacetSearchResult, ResponseError> {
-    let before_search = std::time::Instant::now();
+    let params =
+        ProxySearchParams::new_with_deadline_from_env(index_scheduler.web_client().clone());
     let remote_availability = index_scheduler.remote_availability();
     let partition = Partition::new(network.clone(), remote_availability);
 
@@ -365,19 +366,6 @@ async fn search_federated(
             // true is left, false is right
             |(remote, _)| Some(remote) == network.local.as_ref(),
         );
-
-    let timeout = std::env::var("MEILI_EXPERIMENTAL_REMOTE_SEARCH_TIMEOUT_SECONDS")
-        .ok()
-        .map(|p| p.parse().unwrap())
-        .unwrap_or(25);
-
-    let deadline = before_search + std::time::Duration::from_secs(timeout);
-
-    let params = ProxySearchParams {
-        deadline: Some(deadline),
-        try_count: 3,
-        client: index_scheduler.web_client().clone(),
-    };
 
     let mut results: Vec<FacetSearchResult> = Vec::with_capacity(remote_queries.len() + 1);
 

--- a/crates/meilisearch/src/routes/multi_search.rs
+++ b/crates/meilisearch/src/routes/multi_search.rs
@@ -19,9 +19,10 @@ use crate::error::MeilisearchHttpError;
 use crate::extractors::authentication::policies::ActionPolicy;
 use crate::extractors::authentication::{AuthenticationError, GuardedData};
 use crate::routes::parse_include_metadata_header;
+use crate::search::proxy::{PROXY_SEARCH_HEADER, PROXY_SEARCH_HEADER_VALUE};
 use crate::search::{
     add_search_rules, perform_federated_search, FederatedSearch, FederatedSearchResult,
-    SearchQueryWithIndex, SearchResultWithIndex, PROXY_SEARCH_HEADER, PROXY_SEARCH_HEADER_VALUE,
+    SearchQueryWithIndex, SearchResultWithIndex,
 };
 use crate::search_queue::SearchQueue;
 

--- a/crates/meilisearch/src/search/federated/mod.rs
+++ b/crates/meilisearch/src/search/federated/mod.rs
@@ -1,12 +1,11 @@
 mod network;
 mod perform;
-mod proxy;
+pub mod proxy;
 mod types;
 mod weighted_scores;
 
 pub use network::Partition;
 pub use perform::perform_federated_search;
-pub use proxy::{PROXY_SEARCH_HEADER, PROXY_SEARCH_HEADER_VALUE};
 pub use types::{
     FederatedSearch, FederatedSearchResult, Federation, FederationOptions, MergeFacets,
 };

--- a/crates/meilisearch/src/search/federated/network.rs
+++ b/crates/meilisearch/src/search/federated/network.rs
@@ -23,6 +23,51 @@ pub enum Partition {
     ByShard { remote_for_shard: BTreeMap<String, String> },
 }
 
+/// A trait defining how to proxy a query.
+///
+/// Proxying a query entails two main things:
+///
+/// 1. Setting the remote for the query
+/// 2. Adjusting the `filter` field to filter on the correct shard
+pub trait ProxyQuery {
+    type ProxiedQuery;
+
+    /// Set the remote for this proxy query, returning the proxied query
+    fn proxy_with_remote(&self, remote: String) -> Self::ProxiedQuery;
+
+    /// Provide an exclusive reference to the `filter` field of a proxied query
+    fn filter_field(query: &mut Self::ProxiedQuery) -> &mut Option<Value>;
+}
+
+impl ProxyQuery for SearchQueryWithIndex {
+    /// Output type is the same, as SearchQueryWithIndex already allows for specifying a remote
+    type ProxiedQuery = SearchQueryWithIndex;
+
+    fn proxy_with_remote(&self, remote: String) -> Self::ProxiedQuery {
+        let mut query = (*self).clone();
+        query.federation_options.get_or_insert_default().remote = Some(remote);
+        query
+    }
+
+    fn filter_field(query: &mut Self::ProxiedQuery) -> &mut Option<Value> {
+        &mut query.filter
+    }
+}
+
+impl ProxyQuery for &FacetSearchQuery {
+    /// The only things that can change are the filter on shard and the remote, so recover this
+    type ProxiedQuery = (String, Option<serde_json::Value>);
+
+    fn proxy_with_remote(&self, remote: String) -> Self::ProxiedQuery {
+        let filter = self.filter.clone();
+        (remote, filter)
+    }
+
+    fn filter_field(query: &mut Self::ProxiedQuery) -> &mut Option<Value> {
+        &mut query.1
+    }
+}
+
 impl Partition {
     pub fn new(network: Network, remote_availability: &RemoteAvailability) -> Self {
         if network.leader.is_some() {
@@ -34,6 +79,37 @@ impl Partition {
         }
     }
 
+    pub fn to_partition<'a, Q: ProxyQuery + 'a>(
+        &'a self,
+        query: Q,
+    ) -> Result<impl Iterator<Item = Q::ProxiedQuery> + 'a, ResponseError> {
+        Ok(match self {
+            Partition::ByRemote { remotes } => either::Left(
+                remotes.keys().map(move |remote| query.proxy_with_remote(remote.clone())),
+            ),
+            Partition::ByShard { remote_for_shard } => {
+                either::Right(current_edition::partition_shards(
+                    query,
+                    remote_for_shard.iter().map(|(shard, remote)| (shard, remote.clone())),
+                )?)
+            }
+        })
+    }
+
+    pub fn into_partition<Q: ProxyQuery>(
+        self,
+        query: Q,
+    ) -> Result<impl Iterator<Item = Q::ProxiedQuery>, ResponseError> {
+        Ok(match self {
+            Partition::ByRemote { remotes } => {
+                either::Left(remotes.into_keys().map(move |remote| query.proxy_with_remote(remote)))
+            }
+            Partition::ByShard { remote_for_shard } => either::Right(
+                current_edition::partition_shards(query, remote_for_shard.into_iter())?,
+            ),
+        })
+    }
+
     pub fn to_query_partition(
         &self,
         federation: &mut Federation,
@@ -42,20 +118,7 @@ impl Partition {
         index_uid: &IndexUid,
     ) -> Result<impl Iterator<Item = SearchQueryWithIndex> + '_, ResponseError> {
         let query = fixup_query_federation(federation, query, federation_options, index_uid);
-
-        Ok(match self {
-            Partition::ByRemote { remotes } => either::Left(remotes.keys().map(move |remote| {
-                let mut query = query.clone();
-                query.federation_options.get_or_insert_default().remote = Some(remote.clone());
-                query
-            })),
-            Partition::ByShard { remote_for_shard } => {
-                either::Right(current_edition::partition_shards(
-                    query,
-                    remote_for_shard.iter().map(|(shard, remote)| (shard, remote.clone())),
-                )?)
-            }
-        })
+        self.to_partition(query)
     }
 
     pub fn into_query_partition(
@@ -67,18 +130,7 @@ impl Partition {
     ) -> Result<impl Iterator<Item = SearchQueryWithIndex>, ResponseError> {
         let query = fixup_query_federation(federation, query, federation_options, index_uid);
 
-        Ok(match self {
-            Partition::ByRemote { remotes } => {
-                either::Left(remotes.into_keys().map(move |remote| {
-                    let mut query = query.clone();
-                    query.federation_options.get_or_insert_default().remote = Some(remote);
-                    query
-                }))
-            }
-            Partition::ByShard { remote_for_shard } => either::Right(
-                current_edition::partition_shards(query, remote_for_shard.into_iter())?,
-            ),
-        })
+        self.into_partition(query)
     }
 }
 

--- a/crates/meilisearch/src/search/federated/network.rs
+++ b/crates/meilisearch/src/search/federated/network.rs
@@ -59,8 +59,7 @@ impl ProxyQuery for &FacetSearchQuery {
     type ProxiedQuery = (String, Option<serde_json::Value>);
 
     fn proxy_with_remote(&self, remote: String) -> Self::ProxiedQuery {
-        let filter = self.filter.clone();
-        (remote, filter)
+        (remote, None)
     }
 
     fn filter_field(query: &mut Self::ProxiedQuery) -> &mut Option<Value> {

--- a/crates/meilisearch/src/search/federated/network.rs
+++ b/crates/meilisearch/src/search/federated/network.rs
@@ -3,7 +3,9 @@ use std::collections::BTreeMap;
 use meilisearch_types::error::ResponseError;
 use meilisearch_types::index_uid::IndexUid;
 use meilisearch_types::network::{Network, Remote, RemoteAvailability};
+use serde_json::Value;
 
+use crate::routes::indexes::facet_search::FacetSearchQuery;
 use crate::search::{Federation, FederationOptions, SearchQuery, SearchQueryWithIndex};
 
 #[cfg(not(feature = "enterprise"))]

--- a/crates/meilisearch/src/search/federated/network/community_edition.rs
+++ b/crates/meilisearch/src/search/federated/network/community_edition.rs
@@ -3,13 +3,13 @@ use std::collections::BTreeMap;
 use meilisearch_types::error::{Code, ResponseError};
 use meilisearch_types::network::{Network, RemoteAvailability};
 
-use crate::search::SearchQueryWithIndex;
+use super::ProxyQuery;
 
-pub fn partition_shards(
-    _query: SearchQueryWithIndex,
+pub fn partition_shards<Q: ProxyQuery>(
+    _query: Q,
     _remote_for_shard: impl Iterator<Item = (impl AsRef<str>, String)>,
-) -> Result<impl Iterator<Item = SearchQueryWithIndex>, ResponseError> {
-    Err::<std::iter::Empty<SearchQueryWithIndex>, _>(ResponseError::from_msg(
+) -> Result<impl Iterator<Item = Q::ProxiedQuery>, ResponseError> {
+    Err::<std::iter::Empty<Q::ProxiedQuery>, _>(ResponseError::from_msg(
         "Meilisearch Enterprise Edition is required to use `useNetwork` when `network.leader` is set".into(),
         Code::RequiresEnterpriseEdition,
     ))

--- a/crates/meilisearch/src/search/federated/network/enterprise_edition.rs
+++ b/crates/meilisearch/src/search/federated/network/enterprise_edition.rs
@@ -5,28 +5,30 @@
 
 use std::collections::BTreeMap;
 
+use meilisearch_types::error::ResponseError;
 use meilisearch_types::milli::SHARD_FIELD;
-use meilisearch_types::network::RemoteAvailability;
-use meilisearch_types::{error::ResponseError, network::Network};
+use meilisearch_types::network::{Network, RemoteAvailability};
 use rand::seq::IteratorRandom as _;
 
-use crate::search::{fuse_filters, SearchQueryWithIndex};
+use crate::search::federated::network::ProxyQuery;
+use crate::search::fuse_filters;
 
 /// Partition over all shards such that each shard appears exactly once.
 ///
 /// The remote responsible for each shard is picked at random among the remotes that own the shard.
-pub fn partition_shards(
-    query: SearchQueryWithIndex,
+pub fn partition_shards<Q: ProxyQuery>(
+    query: Q,
     remote_for_shard: impl Iterator<Item = (impl AsRef<str>, String)>,
-) -> Result<impl Iterator<Item = SearchQueryWithIndex>, ResponseError> {
+) -> Result<impl Iterator<Item = Q::ProxiedQuery>, ResponseError> {
     Ok(remote_for_shard.map(move |(shard, remote)| {
-        let mut query = query.clone();
-        query.federation_options.get_or_insert_default().remote = Some(remote);
+        let mut query = query.proxy_with_remote(remote);
 
         let shard_filter =
             Some(serde_json::Value::String(format!("{SHARD_FIELD} = \"{}\"", shard.as_ref())));
 
-        query.filter = fuse_filters(query.filter.take(), shard_filter);
+        let filter = Q::filter_field(&mut query);
+
+        *filter = fuse_filters(filter.take(), shard_filter);
         query
     }))
 }

--- a/crates/meilisearch/src/search/federated/perform.rs
+++ b/crates/meilisearch/src/search/federated/perform.rs
@@ -4,7 +4,7 @@ use std::iter::Zip;
 use std::rc::Rc;
 use std::str::FromStr as _;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use std::vec::{IntoIter, Vec};
 
 use actix_http::StatusCode;
@@ -68,12 +68,8 @@ pub async fn perform_federated_search(
     }
     let before_search = std::time::Instant::now();
 
-    let timeout = std::env::var("MEILI_EXPERIMENTAL_REMOTE_SEARCH_TIMEOUT_SECONDS")
-        .ok()
-        .map(|p| p.parse().unwrap())
-        .unwrap_or(25);
-
-    let deadline = before_search + std::time::Duration::from_secs(timeout);
+    let params =
+        ProxySearchParams::new_with_deadline_from_env(index_scheduler.web_client().clone());
 
     let required_hit_count = match (federation.page, federation.hits_per_page) {
         // no pagination, use limit and offset
@@ -185,9 +181,8 @@ pub async fn perform_federated_search(
     let remote_search = RemoteSearch::start(
         partitioned_queries.remote_queries_by_host,
         &federation,
-        deadline,
+        &params,
         include_metadata,
-        index_scheduler.web_client(),
     );
 
     // 2.2. concurrently execute local queries
@@ -1147,9 +1142,8 @@ impl RemoteSearch {
     fn start(
         queries: RemoteQueriesByHost,
         federation: &Federation,
-        deadline: Instant,
+        params: &ProxySearchParams,
         include_metadata: bool,
-        client: &http_client::reqwest::Client,
     ) -> Self {
         let mut in_flight_remote_queries = BTreeMap::new();
 
@@ -1157,8 +1151,6 @@ impl RemoteSearch {
             return Self { in_flight_remote_queries };
         }
 
-        let params =
-            ProxySearchParams { deadline: Some(deadline), try_count: 3, client: client.clone() };
         for (node_name, (node, queries)) in queries {
             // spawn one task per host
             in_flight_remote_queries.insert(

--- a/crates/meilisearch/src/search/federated/proxy.rs
+++ b/crates/meilisearch/src/search/federated/proxy.rs
@@ -110,14 +110,33 @@ pub async fn proxy_search(
     params: &ProxySearchParams,
     include_metadata: bool,
 ) -> Result<FederatedSearchResult, ProxySearchError> {
-    let url = route::url_from_base_and_route(&node.url, route::multi_search_path())
+    let federated = FederatedSearch { queries, federation: Some(federation) };
+
+    json_proxy(
+        route::multi_search_path(),
+        Method::POST,
+        node,
+        &federated,
+        params,
+        include_metadata,
+    )?
+    .await
+}
+
+pub fn json_proxy<Body: Serialize, Response: DeserializeOwned>(
+    path_and_query: PathAndQuery,
+    method: Method,
+    remote: &Remote,
+    body: Body,
+    params: &ProxySearchParams,
+    include_metadata: bool,
+) -> Result<impl Future<Output = Result<Response, ProxySearchError>> + 'static, ProxySearchError> {
+    let url = route::url_from_base_and_route(&remote.url, path_and_query)
         .map_err(|err| ProxySearchError::InvalidRemoteUrl { cause: err.to_string() })?;
 
     let url = url.to_string();
 
-    let federated = FederatedSearch { queries, federation: Some(federation) };
-
-    let search_api_key = node.search_api_key.as_deref();
+    let search_api_key = remote.search_api_key.as_deref();
 
     let timeout = std::env::var("MEILI_EXPERIMENTAL_REMOTE_SEARCH_TIMEOUT_SECONDS")
         .ok()
@@ -132,41 +151,8 @@ pub async fn proxy_search(
         max_deadline
     };
 
-    for i in 0..params.try_count {
-        match try_proxy_search(
-            &url,
-            search_api_key,
-            &federated,
-            &params.client,
-            deadline,
-            include_metadata,
-        )
-        .await
-        {
-            Ok(response) => return Ok(response),
-            Err(retry) => {
-                let duration = retry.into_duration(i)?;
-                tokio::time::sleep(duration).await;
-            }
-        }
-    }
-    try_proxy_search(&url, search_api_key, &federated, &params.client, deadline, include_metadata)
-        .await
-        .map_err(Retry::into_error)
-}
-
-async fn try_proxy_search(
-    url: &str,
-    search_api_key: Option<&str>,
-    federated: &FederatedSearch,
-    client: &Client,
-    deadline: std::time::Instant,
-    include_metadata: bool,
-) -> Result<FederatedSearchResult, Retry> {
-    let timeout = deadline.saturating_duration_since(std::time::Instant::now());
-
-    let request = client.post(url).prepare(|request| {
-        let request = request.json(&federated).timeout(timeout);
+    let request = params.client.request(method, url).prepare(|request| {
+        let request = request.json(&body);
         let request = if let Some(search_api_key) = search_api_key {
             request.bearer_auth(search_api_key)
         } else {
@@ -179,6 +165,33 @@ async fn try_proxy_search(
             request
         }
     });
+
+    let try_count = params.try_count;
+
+    Ok(async move {
+        for i in 0..try_count {
+            // unwrap: we are passing `json` body, no streaming.
+            let request = request.try_clone().unwrap();
+
+            match try_json_proxy(request, deadline).await {
+                Ok(response) => return Ok(response),
+                Err(retry) => {
+                    let duration = retry.into_duration(i)?;
+                    tokio::time::sleep(duration).await;
+                }
+            }
+        }
+        try_json_proxy(request, deadline).await.map_err(Retry::into_error)
+    })
+}
+
+async fn try_json_proxy<Response: DeserializeOwned>(
+    request: RequestBuilder,
+    deadline: std::time::Instant,
+) -> Result<Response, Retry> {
+    let timeout = deadline.saturating_duration_since(std::time::Instant::now());
+
+    let request = request.prepare(|request| request.timeout(timeout));
 
     let response = request.send().await;
     let response = match response {

--- a/crates/meilisearch/src/search/federated/proxy.rs
+++ b/crates/meilisearch/src/search/federated/proxy.rs
@@ -1,9 +1,13 @@
+use std::future::Future;
+
+use actix_http::uri::PathAndQuery;
 pub use error::ProxySearchError;
 use error::ReqwestErrorWithoutUrl;
-use http_client::reqwest::{Client, Response, StatusCode};
+use http_client::reqwest::{Method, RequestBuilder, Response, StatusCode};
 use meilisearch_types::network::{route, Remote};
 use rand::Rng as _;
 use serde::de::DeserializeOwned;
+use serde::Serialize;
 use serde_json::Value;
 
 use super::types::{FederatedSearch, FederatedSearchResult, Federation};

--- a/crates/meilisearch/src/search/federated/proxy.rs
+++ b/crates/meilisearch/src/search/federated/proxy.rs
@@ -24,6 +24,8 @@ mod error {
     pub enum ProxySearchError {
         #[error("Invalid remote url: {cause}")]
         InvalidRemoteUrl { cause: String },
+        #[error("Unknown remote `{remote}")]
+        UnknownRemote { remote: String },
         #[error("{0}")]
         CouldNotSendRequest(ReqwestErrorWithoutUrl),
         #[error("could not authenticate against the remote host\n  - hint: check that the remote instance was registered with a valid API key having the `search` action")]
@@ -56,6 +58,7 @@ mod error {
             use meilisearch_types::error::Code;
             let message = self.to_string();
             let code = match self {
+                ProxySearchError::UnknownRemote { .. } => Code::UnknownRemote,
                 ProxySearchError::InvalidRemoteUrl { .. } => Code::InvalidNetworkUrl,
                 ProxySearchError::CouldNotSendRequest(_) => Code::RemoteCouldNotSendRequest,
                 ProxySearchError::AuthenticationError => Code::RemoteInvalidApiKey,

--- a/crates/meilisearch/src/search/federated/proxy.rs
+++ b/crates/meilisearch/src/search/federated/proxy.rs
@@ -97,9 +97,22 @@ mod error {
 
 #[derive(Clone)]
 pub struct ProxySearchParams {
-    pub deadline: Option<std::time::Instant>,
+    pub deadline: std::time::Instant,
     pub try_count: u32,
     pub client: http_client::reqwest::Client,
+}
+
+impl ProxySearchParams {
+    pub fn new_with_deadline_from_env(client: http_client::reqwest::Client) -> Self {
+        let timeout = std::env::var("MEILI_EXPERIMENTAL_REMOTE_SEARCH_TIMEOUT_SECONDS")
+            .ok()
+            .map(|p| p.parse().unwrap())
+            .unwrap_or(25);
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(timeout);
+
+        Self { deadline, try_count: 3, client }
+    }
 }
 
 /// Performs a federated search on a remote host and returns the results
@@ -138,18 +151,7 @@ pub fn json_proxy<Body: Serialize, Response: DeserializeOwned>(
 
     let search_api_key = remote.search_api_key.as_deref();
 
-    let timeout = std::env::var("MEILI_EXPERIMENTAL_REMOTE_SEARCH_TIMEOUT_SECONDS")
-        .ok()
-        .map(|p| p.parse().unwrap())
-        .unwrap_or(25);
-
-    let max_deadline = std::time::Instant::now() + std::time::Duration::from_secs(timeout);
-
-    let deadline = if let Some(deadline) = params.deadline {
-        std::time::Instant::min(deadline, max_deadline)
-    } else {
-        max_deadline
-    };
+    let deadline = params.deadline;
 
     let request = params.client.request(method, url).prepare(|request| {
         let request = request.json(&body);

--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -37,6 +37,7 @@ use milli::{
 };
 use permissive_json_pointer::contained_in;
 use regex::Regex;
+use roaring::RoaringBitmap;
 use serde::de::DeserializeSeed as _;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};

--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -1756,9 +1756,7 @@ pub fn prepare_search<'t>(
     search.offset(offset);
     search.limit(limit);
 
-    if let Some(filter) = filter {
-        search.filter(filter);
-    }
+    search.filter(filter);
 
     if let Some(ref sort) = query.sort {
         let sort = match sort.iter().map(|s| AscDesc::from_str(s)).collect() {

--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -1603,7 +1603,7 @@ pub struct FacetStats {
     pub max: f64,
 }
 
-#[derive(Serialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct FacetSearchResult {
     pub facet_hits: Vec<FacetValueHit>,

--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -37,7 +37,6 @@ use milli::{
 };
 use permissive_json_pointer::contained_in;
 use regex::Regex;
-use roaring::RoaringBitmap;
 use serde::de::DeserializeSeed as _;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -2483,12 +2482,10 @@ fn make_hits<'a>(
     Ok(documents)
 }
 
-#[allow(clippy::too_many_arguments)]
 pub fn perform_facet_search<'a>(
     index: &Index,
     rtxn: &RoTxn,
-    mut search: milli::Search<'a>,
-    mut filters: impl Iterator<Item = Option<IndexFilter<'a>>>,
+    search: milli::Search<'a>,
     facet_query: Option<String>,
     facet_name: String,
     search_kind: SearchKind,
@@ -2518,13 +2515,8 @@ pub fn perform_facet_search<'a>(
             .collect()
     });
 
-    let candidates = filters.try_fold(RoaringBitmap::new(), |mut candidates, filter| {
-        search.filter(filter);
-
-        candidates |=
-            search.execute_for_candidates(matches!(search_kind, SearchKind::Hybrid { .. }))?;
-        Ok::<_, ResponseError>(candidates)
-    })?;
+    let candidates =
+        search.execute_for_candidates(matches!(search_kind, SearchKind::Hybrid { .. }))?;
 
     let mut facet_search = SearchForFacetValues::new(facet_name, index, rtxn);
     if let Some(facet_query) = &facet_query {

--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -1609,6 +1609,9 @@ pub struct FacetSearchResult {
     pub facet_hits: Vec<FacetValueHit>,
     pub facet_query: Option<String>,
     pub processing_time_ms: u128,
+    /// Errors from remote shards. Federated search only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remote_errors: Option<BTreeMap<String, ResponseError>>,
 }
 
 /// Incorporate search rules in search query
@@ -2480,15 +2483,17 @@ fn make_hits<'a>(
     Ok(documents)
 }
 
-pub fn perform_facet_search(
+#[allow(clippy::too_many_arguments)]
+pub fn perform_facet_search<'a>(
     index: &Index,
     rtxn: &RoTxn,
-    search: milli::Search,
+    mut search: milli::Search<'a>,
+    mut filters: impl Iterator<Item = Option<IndexFilter<'a>>>,
     facet_query: Option<String>,
     facet_name: String,
     search_kind: SearchKind,
     locales: Option<Vec<Language>>,
-) -> Result<FacetSearchResult, ResponseError> {
+) -> Result<(FacetSearchResult, OrderBy), ResponseError> {
     let before_search = Instant::now();
 
     if !index.facet_search(rtxn)? {
@@ -2512,11 +2517,16 @@ pub fn perform_facet_search(
             .filter(|locale| locales.as_ref().is_none_or(|locales| locales.contains(locale)))
             .collect()
     });
-    let mut facet_search = SearchForFacetValues::new(
-        facet_name,
-        search,
-        matches!(search_kind, SearchKind::Hybrid { .. }),
-    );
+
+    let candidates = filters.try_fold(RoaringBitmap::new(), |mut candidates, filter| {
+        search.filter(filter);
+
+        candidates |=
+            search.execute_for_candidates(matches!(search_kind, SearchKind::Hybrid { .. }))?;
+        Ok::<_, ResponseError>(candidates)
+    })?;
+
+    let mut facet_search = SearchForFacetValues::new(facet_name, index, rtxn);
     if let Some(facet_query) = &facet_query {
         facet_search.query(facet_query);
     }
@@ -2528,11 +2538,17 @@ pub fn perform_facet_search(
         facet_search.locales(locales);
     }
 
-    Ok(FacetSearchResult {
-        facet_hits: facet_search.execute()?,
-        facet_query,
-        processing_time_ms: before_search.elapsed().as_millis(),
-    })
+    let (facet_hits, order) = facet_search.execute(&candidates)?;
+
+    Ok((
+        FacetSearchResult {
+            facet_hits,
+            facet_query,
+            remote_errors: None,
+            processing_time_ms: before_search.elapsed().as_millis(),
+        },
+        order,
+    ))
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -51,8 +51,8 @@ use crate::search::value_paths_visitor::ValuePathsVisitor;
 
 mod federated;
 pub use federated::{
-    perform_federated_search, FederatedSearch, FederatedSearchResult, Federation,
-    FederationOptions, MergeFacets, Partition, PROXY_SEARCH_HEADER, PROXY_SEARCH_HEADER_VALUE,
+    perform_federated_search, proxy, FederatedSearch, FederatedSearchResult, Federation,
+    FederationOptions, MergeFacets, Partition,
 };
 
 mod dynamic_rules;

--- a/crates/meilisearch/tests/search/multi/proxy.rs
+++ b/crates/meilisearch/tests/search/multi/proxy.rs
@@ -6305,3 +6305,432 @@ async fn remote_auto_sharding_with_custom_metadata() {
     }
     "###);
 }
+
+#[cfg(feature = "enterprise")]
+#[actix_rt::test]
+async fn remote_auto_sharding_auto_facet_search() {
+    let ms0 = Server::new().await;
+    let ms1 = Server::new().await;
+    let ms2 = Server::new().await;
+
+    // enable feature
+
+    let (response, code) = ms0.set_features(json!({"network": true})).await;
+    snapshot!(code, @"200 OK");
+    snapshot!(json_string!(response["network"]), @"true");
+    let (response, code) = ms1.set_features(json!({"network": true})).await;
+    snapshot!(code, @"200 OK");
+    snapshot!(json_string!(response["network"]), @"true");
+    let (response, code) = ms2.set_features(json!({"network": true})).await;
+    snapshot!(code, @"200 OK");
+    snapshot!(json_string!(response["network"]), @"true");
+
+    // wrap servers
+    let ms0 = Arc::new(ms0);
+    let ms1 = Arc::new(ms1);
+    let ms2 = Arc::new(ms2);
+
+    let rms0 = LocalMeili::new(ms0.clone()).await;
+    let rms1 = LocalMeili::new(ms1.clone()).await;
+    let rms2 = LocalMeili::new(ms2.clone()).await;
+
+    // set network
+    let network = json!(
+      {
+        "self": "ms0",
+        "leader": "ms0",
+        "remotes": {
+          "ms0": {
+              "url": rms0.url()
+          },
+          "ms1": {
+              "url": rms1.url()
+          },
+          "ms2": {
+              "url": rms2.url()
+          }
+        },
+        "shards": {
+            "a": {
+              "remotes": ["ms0", "ms1"]
+            },
+            "b": {
+              "remotes": ["ms1", "ms2"]
+            },
+            "c": {
+              "remotes": ["ms2", "ms0"]
+            }
+        }
+      }
+    );
+
+    println!("{}", serde_json::to_string_pretty(&network).unwrap());
+
+    let (task, status_code) = ms0.set_network(network.clone()).await;
+    snapshot!(status_code, @"202 Accepted");
+
+    let t0 = task.uid();
+    let (t, _) = ms0.get_task(t0).await;
+
+    let t1 = t["network"]["remote_tasks"]["ms1"]["taskUid"].as_u64().unwrap();
+    let t2 = t["network"]["remote_tasks"]["ms2"]["taskUid"].as_u64().unwrap();
+
+    ms0.wait_task(t0).await.succeeded();
+    ms1.wait_task(t1).await.succeeded();
+    ms2.wait_task(t2).await.succeeded();
+
+    let (response, status_code) = ms0.get_network().await;
+    snapshot!(status_code, @"200 OK");
+    snapshot!(json_string!(response, {".version" => "[version]", ".remotes.*.url" => "[url]"}), @r###"
+    {
+      "self": "ms0",
+      "remotes": {
+        "ms0": {
+          "url": "[url]",
+          "searchApiKey": null,
+          "writeApiKey": null,
+          "status": "available"
+        },
+        "ms1": {
+          "url": "[url]",
+          "searchApiKey": null,
+          "writeApiKey": null,
+          "status": "available"
+        },
+        "ms2": {
+          "url": "[url]",
+          "searchApiKey": null,
+          "writeApiKey": null,
+          "status": "available"
+        }
+      },
+      "shards": {
+        "a": {
+          "remotes": [
+            "ms0",
+            "ms1"
+          ]
+        },
+        "b": {
+          "remotes": [
+            "ms1",
+            "ms2"
+          ]
+        },
+        "c": {
+          "remotes": [
+            "ms0",
+            "ms2"
+          ]
+        }
+      },
+      "leader": "ms0",
+      "version": "[version]"
+    }
+    "###);
+
+    let (response, status_code) = ms1.get_network().await;
+    snapshot!(status_code, @"200 OK");
+    snapshot!(json_string!(response, {".version" => "[version]", ".remotes.*.url" => "[url]"}), @r###"
+    {
+      "self": "ms1",
+      "remotes": {
+        "ms0": {
+          "url": "[url]",
+          "searchApiKey": null,
+          "writeApiKey": null,
+          "status": "available"
+        },
+        "ms1": {
+          "url": "[url]",
+          "searchApiKey": null,
+          "writeApiKey": null,
+          "status": "available"
+        },
+        "ms2": {
+          "url": "[url]",
+          "searchApiKey": null,
+          "writeApiKey": null,
+          "status": "available"
+        }
+      },
+      "shards": {
+        "a": {
+          "remotes": [
+            "ms0",
+            "ms1"
+          ]
+        },
+        "b": {
+          "remotes": [
+            "ms1",
+            "ms2"
+          ]
+        },
+        "c": {
+          "remotes": [
+            "ms0",
+            "ms2"
+          ]
+        }
+      },
+      "leader": "ms0",
+      "version": "[version]"
+    }
+    "###);
+
+    let (response, status_code) = ms2.get_network().await;
+    snapshot!(status_code, @"200 OK");
+    snapshot!(json_string!(response, {".version" => "[version]", ".remotes.*.url" => "[url]"}), @r###"
+    {
+      "self": "ms2",
+      "remotes": {
+        "ms0": {
+          "url": "[url]",
+          "searchApiKey": null,
+          "writeApiKey": null,
+          "status": "available"
+        },
+        "ms1": {
+          "url": "[url]",
+          "searchApiKey": null,
+          "writeApiKey": null,
+          "status": "available"
+        },
+        "ms2": {
+          "url": "[url]",
+          "searchApiKey": null,
+          "writeApiKey": null,
+          "status": "available"
+        }
+      },
+      "shards": {
+        "a": {
+          "remotes": [
+            "ms0",
+            "ms1"
+          ]
+        },
+        "b": {
+          "remotes": [
+            "ms1",
+            "ms2"
+          ]
+        },
+        "c": {
+          "remotes": [
+            "ms0",
+            "ms2"
+          ]
+        }
+      },
+      "leader": "ms0",
+      "version": "[version]"
+    }
+    "###);
+
+    // add documents
+    let documents = json!([
+      {
+        "id": 1,
+        "title": "Carol",
+        "genres": [
+          "Romance",
+          "Drama"
+        ],
+        "color": [
+          "red"
+        ],
+        "platforms": [
+          "MacOS",
+          "Linux",
+          "Windows"
+        ]
+      },
+      {
+        "id": 2,
+        "title": "Wonder Woman",
+        "genres": [
+          "Action",
+          "Adventure"
+        ],
+        "color": [
+          "green"
+        ],
+        "platforms": [
+          "MacOS"
+        ]
+      },
+      {
+        "id": 3,
+        "title": "Life of Pi",
+        "genres": [
+          "Adventure",
+          "Drama"
+        ],
+        "color": [
+          "blue"
+        ],
+        "platforms": [
+          "Windows"
+        ]
+      },
+      {
+        "id": 4,
+        "title": "Mad Max: Fury Road",
+        "genres": [
+          "Adventure",
+          "Science Fiction"
+        ],
+        "color": [
+          "red"
+        ],
+        "platforms": [
+          "MacOS",
+          "Linux"
+        ]
+      },
+      {
+        "id": 5,
+        "title": "Moana",
+        "genres": [
+          "Fantasy",
+          "Action"
+        ],
+        "color": [
+          "red"
+        ],
+        "platforms": [
+          "Windows"
+        ]
+      },
+      {
+        "id": 6,
+        "title": "Philadelphia",
+        "genres": [
+          "Drama"
+        ],
+        "color": [
+          "blue"
+        ],
+        "platforms": [
+          "MacOS",
+          "Linux",
+          "Windows"
+        ]
+      }
+    ]);
+    let index0 = ms0.index("test");
+    let _index1 = ms1.index("test");
+    let _index2 = ms2.index("test");
+
+    let (task, code) = index0.add_documents(documents, None).await;
+    snapshot!(code, @"202 Accepted");
+    let t0 = task.uid();
+    let (t, _) = ms0.get_task(task.uid()).await;
+    let t1 = t["network"]["remote_tasks"]["ms1"]["taskUid"].as_u64().unwrap();
+    let t2 = t["network"]["remote_tasks"]["ms2"]["taskUid"].as_u64().unwrap();
+
+    ms0.wait_task(t0).await.succeeded();
+    ms1.wait_task(t1).await.succeeded();
+    ms2.wait_task(t2).await.succeeded();
+
+    let (task, _status_code) =
+        index0.update_settings_filterable_attributes(json!(["genres", "color", "platforms"])).await;
+
+    let t0 = task.uid();
+    let (t, _) = ms0.get_task(task.uid()).await;
+
+    let t1 = t["network"]["remote_tasks"]["ms1"]["taskUid"].as_u64().unwrap();
+    let t2 = t["network"]["remote_tasks"]["ms2"]["taskUid"].as_u64().unwrap();
+
+    ms0.wait_task(t0).await.succeeded();
+    ms1.wait_task(t1).await.succeeded();
+    ms2.wait_task(t2).await.succeeded();
+
+    let (response, code) = index0.facet_search(json!({"facetName": "platforms"})).await;
+    snapshot!(code, @"200 OK");
+
+    snapshot!(json_string!(response, { ".processingTimeMs" => "[time]", ".requestUid" => "[uuid]" }), @r###"
+    {
+      "facetHits": [
+        {
+          "value": "Linux",
+          "count": 3
+        },
+        {
+          "value": "MacOS",
+          "count": 4
+        },
+        {
+          "value": "Windows",
+          "count": 4
+        }
+      ],
+      "facetQuery": null,
+      "processingTimeMs": "[time]",
+      "remoteErrors": {}
+    }
+    "###);
+    let (response, code) =
+        index0.facet_search(json!({"facetName": "platforms", "useNetwork": false})).await;
+    snapshot!(code, @"200 OK");
+    snapshot!(json_string!(response, { ".processingTimeMs" => "[time]", ".requestUid" => "[uuid]" }), @r###"
+    {
+      "facetHits": [
+        {
+          "value": "Linux",
+          "count": 2
+        },
+        {
+          "value": "MacOS",
+          "count": 3
+        },
+        {
+          "value": "Windows",
+          "count": 4
+        }
+      ],
+      "facetQuery": null,
+      "processingTimeMs": "[time]"
+    }
+    "###);
+
+    let (response, code) =
+        index0.facet_search(json!({"facetName": "genres", "facetQuery": "A"})).await;
+    snapshot!(code, @"200 OK");
+    snapshot!(json_string!(response, { ".processingTimeMs" => "[time]", ".requestUid" => "[uuid]" }), @r###"
+    {
+      "facetHits": [
+        {
+          "value": "Action",
+          "count": 2
+        },
+        {
+          "value": "Adventure",
+          "count": 3
+        }
+      ],
+      "facetQuery": "A",
+      "processingTimeMs": "[time]",
+      "remoteErrors": {}
+    }
+    "###);
+
+    let (response, code) =
+        index0.facet_search(json!({"facetName": "genres", "facetQuery": "A", "filter": "platforms = Linux OR genres = Drama"})).await;
+    snapshot!(code, @"200 OK");
+    snapshot!(json_string!(response, { ".processingTimeMs" => "[time]", ".requestUid" => "[uuid]" }), @r###"
+    {
+      "facetHits": [
+        {
+          "value": "Adventure",
+          "count": 2
+        }
+      ],
+      "facetQuery": "A",
+      "processingTimeMs": "[time]",
+      "remoteErrors": {}
+    }
+    "###);
+}

--- a/crates/milli/src/search/facet/filter/tests.rs
+++ b/crates/milli/src/search/facet/filter/tests.rs
@@ -245,22 +245,22 @@ fn escaped_quote_in_filter_value_2380() {
     let mut search = index.search(&rtxn);
     // this filter is copy pasted from #2380 with the exact same espace sequence
     let filter = Filter::from_str("monitor_diagonal = '27\" to 30\\''").unwrap().unwrap();
-    search.filter(IndexFilter::from(filter));
+    search.filter(Some(IndexFilter::from(filter)));
     let crate::SearchResult { documents_ids, .. } = search.execute().unwrap();
     assert_eq!(documents_ids, vec![2]);
 
     let filter = Filter::from_str(r#"monitor_diagonal = "27' to 30'" "#).unwrap().unwrap();
-    search.filter(IndexFilter::from(filter));
+    search.filter(Some(IndexFilter::from(filter)));
     let crate::SearchResult { documents_ids, .. } = search.execute().unwrap();
     assert_eq!(documents_ids, vec![0]);
 
     let filter = Filter::from_str(r#"monitor_diagonal = "27\" to 30\"" "#).unwrap().unwrap();
-    search.filter(IndexFilter::from(filter));
+    search.filter(Some(IndexFilter::from(filter)));
     let crate::SearchResult { documents_ids, .. } = search.execute().unwrap();
     assert_eq!(documents_ids, vec![1]);
 
     let filter = Filter::from_str(r#"monitor_diagonal = "27\" to 30'" "#).unwrap().unwrap();
-    search.filter(IndexFilter::from(filter));
+    search.filter(Some(IndexFilter::from(filter)));
     let crate::SearchResult { documents_ids, .. } = search.execute().unwrap();
     assert_eq!(documents_ids, vec![2]);
 }
@@ -309,7 +309,7 @@ fn zero_radius() {
     let mut search = index.search(&rtxn);
 
     let filter = Filter::from_str("_geoRadius(45.4777599, 9.1967508, 0)").unwrap().unwrap();
-    search.filter(IndexFilter::from(filter));
+    search.filter(Some(IndexFilter::from(filter)));
     let crate::SearchResult { documents_ids, .. } = search.execute().unwrap();
     assert_eq!(documents_ids, vec![0]);
 }

--- a/crates/milli/src/search/facet/search.rs
+++ b/crates/milli/src/search/facet/search.rs
@@ -261,7 +261,8 @@ impl<'a> SearchForFacetValues<'a> {
     }
 }
 
-#[derive(Debug, Clone, serde::Serialize, PartialEq)]
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub struct FacetValueHit {
     /// The original facet value
     pub value: String,

--- a/crates/milli/src/search/facet/search.rs
+++ b/crates/milli/src/search/facet/search.rs
@@ -6,6 +6,7 @@ use charabia::normalizer::NormalizerOption;
 use charabia::{Language, Normalize, StrDetection, Token};
 use fst::automaton::{Automaton, Str};
 use fst::{IntoStreamer, Streamer};
+use heed::RoTxn;
 use roaring::RoaringBitmap;
 use tracing::error;
 
@@ -13,7 +14,7 @@ use crate::error::UserError;
 use crate::filterable_attributes_rules::{filtered_matching_patterns, matching_features};
 use crate::heed_codec::facet::{FacetGroupKey, FacetGroupValue};
 use crate::search::build_dfa;
-use crate::{DocumentId, FieldId, OrderBy, Result, Search};
+use crate::{DocumentId, FieldId, Index, OrderBy, Result};
 
 /// The maximum number of values per facet returned by the facet search route.
 const DEFAULT_MAX_NUMBER_OF_VALUES_PER_FACET: usize = 100;

--- a/crates/milli/src/search/facet/search.rs
+++ b/crates/milli/src/search/facet/search.rs
@@ -22,24 +22,20 @@ const DEFAULT_MAX_NUMBER_OF_VALUES_PER_FACET: usize = 100;
 pub struct SearchForFacetValues<'a> {
     query: Option<String>,
     facet: String,
-    search_query: Search<'a>,
+    index: &'a Index,
+    rtxn: &'a RoTxn<'a>,
     max_values: usize,
-    is_hybrid: bool,
     locales: Option<Vec<Language>>,
 }
 
 impl<'a> SearchForFacetValues<'a> {
-    pub fn new(
-        facet: String,
-        search_query: Search<'a>,
-        is_hybrid: bool,
-    ) -> SearchForFacetValues<'a> {
+    pub fn new(facet: String, index: &'a Index, rtxn: &'a RoTxn<'a>) -> SearchForFacetValues<'a> {
         SearchForFacetValues {
             query: None,
             facet,
-            search_query,
+            index,
+            rtxn,
             max_values: DEFAULT_MAX_NUMBER_OF_VALUES_PER_FACET,
-            is_hybrid,
             locales: None,
         }
     }
@@ -65,15 +61,14 @@ impl<'a> SearchForFacetValues<'a> {
         facet_str: &str,
         any_docid: DocumentId,
     ) -> Result<Option<String>> {
-        let index = self.search_query.index;
-        let rtxn = self.search_query.rtxn;
         let key: (FieldId, _, &str) = (field_id, any_docid, facet_str);
-        Ok(index.field_id_docid_facet_strings.get(rtxn, &key)?.map(|v| v.to_owned()))
+        Ok(self.index.field_id_docid_facet_strings.get(self.rtxn, &key)?.map(|v| v.to_owned()))
     }
 
-    pub fn execute(&self) -> Result<Vec<FacetValueHit>> {
-        let index = self.search_query.index;
-        let rtxn = self.search_query.rtxn;
+    pub fn execute(&self, candidates: &RoaringBitmap) -> Result<(Vec<FacetValueHit>, OrderBy)> {
+        let index = self.index;
+        let rtxn = self.rtxn;
+        let order = index.sort_facet_values_by(rtxn)?.get(&self.facet);
 
         let filterable_attributes_rules = index.filterable_attributes_rules(rtxn)?;
         let matched_rule = matching_features(&self.facet, &filterable_attributes_rules);
@@ -102,53 +97,55 @@ impl<'a> SearchForFacetValues<'a> {
 
         let fields_ids_map = index.fields_ids_map(rtxn)?;
         let Some(fid) = fields_ids_map.id(&self.facet) else {
-            return Ok(Vec::new());
+            return Ok((Vec::new(), order));
         };
 
-        let fst = match self.search_query.index.facet_id_string_fst.get(rtxn, &fid)? {
+        let fst = match index.facet_id_string_fst.get(rtxn, &fid)? {
             Some(fst) => fst,
-            None => return Ok(Vec::new()),
+            None => return Ok((Vec::new(), order)),
         };
 
-        let search_candidates = self.search_query.execute_for_candidates(
-            self.is_hybrid
-                || self
-                    .search_query
-                    .semantic
-                    .as_ref()
-                    .and_then(|semantic| semantic.vector.as_ref())
-                    .is_some(),
-        )?;
+        let results = self.inner_execute(fid, fst, candidates, order)?;
 
-        let mut results = match index.sort_facet_values_by(rtxn)?.get(&self.facet) {
+        Ok((results.into_sorted_vec(), order))
+    }
+
+    fn inner_execute(
+        &self,
+        fid: u16,
+        fst: fst::Set<&[u8]>,
+        search_candidates: &RoaringBitmap,
+        order: OrderBy,
+    ) -> Result<ValuesCollection, crate::Error> {
+        let index = self.index;
+        let rtxn = self.rtxn;
+        let mut results = match order {
             OrderBy::Lexicographic => ValuesCollection::by_lexicographic(self.max_values),
             OrderBy::Count => ValuesCollection::by_count(self.max_values),
         };
-
         match self.query.as_ref() {
             Some(query) => {
                 let query = normalize_facet_string(query, self.locales.as_deref());
                 let query = query.as_ref();
 
-                let authorize_typos = self.search_query.index.authorize_typos(rtxn)?;
-                let field_authorizes_typos =
-                    !self.search_query.index.exact_attributes_ids(rtxn)?.contains(&fid);
+                let authorize_typos = index.authorize_typos(rtxn)?;
+                let field_authorizes_typos = !index.exact_attributes_ids(rtxn)?.contains(&fid);
 
                 if authorize_typos && field_authorizes_typos {
-                    let exact_words_fst = self.search_query.index.exact_words(rtxn)?;
+                    let exact_words_fst = index.exact_words(rtxn)?;
                     if exact_words_fst.is_some_and(|fst| fst.contains(query)) {
                         if fst.contains(query) {
                             let _ = self.fetch_original_facets_using_normalized(
                                 fid,
                                 query,
                                 query,
-                                &search_candidates,
+                                search_candidates,
                                 &mut results,
                             )?;
                         }
                     } else {
-                        let one_typo = self.search_query.index.min_word_len_one_typo(rtxn)?;
-                        let two_typos = self.search_query.index.min_word_len_two_typos(rtxn)?;
+                        let one_typo = index.min_word_len_one_typo(rtxn)?;
+                        let two_typos = index.min_word_len_two_typos(rtxn)?;
 
                         let is_prefix = true;
                         let automaton = if query.len() < one_typo as usize {
@@ -167,7 +164,7 @@ impl<'a> SearchForFacetValues<'a> {
                                     fid,
                                     value,
                                     query,
-                                    &search_candidates,
+                                    search_candidates,
                                     &mut results,
                                 )?
                                 .is_break()
@@ -186,7 +183,7 @@ impl<'a> SearchForFacetValues<'a> {
                                 fid,
                                 value,
                                 query,
-                                &search_candidates,
+                                search_candidates,
                                 &mut results,
                             )?
                             .is_break()
@@ -213,8 +210,7 @@ impl<'a> SearchForFacetValues<'a> {
                 }
             }
         }
-
-        Ok(results.into_sorted_vec())
+        Ok(results)
     }
 
     fn fetch_original_facets_using_normalized(
@@ -225,8 +221,8 @@ impl<'a> SearchForFacetValues<'a> {
         search_candidates: &RoaringBitmap,
         results: &mut ValuesCollection,
     ) -> Result<ControlFlow<()>> {
-        let index = self.search_query.index;
-        let rtxn = self.search_query.rtxn;
+        let index = self.index;
+        let rtxn = self.rtxn;
 
         let database = index.facet_id_normalized_string_strings;
         let key = (fid, value);

--- a/crates/milli/src/search/mod.rs
+++ b/crates/milli/src/search/mod.rs
@@ -161,8 +161,8 @@ impl<'a> Search<'a> {
         self
     }
 
-    pub fn filter(&mut self, condition: IndexFilter<'a>) -> &mut Search<'a> {
-        self.filter = Some(condition);
+    pub fn filter(&mut self, condition: Option<IndexFilter<'a>>) -> &mut Search<'a> {
+        self.filter = condition;
         self
     }
 

--- a/crates/milli/src/search/mod.rs
+++ b/crates/milli/src/search/mod.rs
@@ -215,8 +215,12 @@ impl<'a> Search<'a> {
         self
     }
 
-    pub fn execute_for_candidates(&self, has_vector_search: bool) -> Result<RoaringBitmap> {
-        if has_vector_search {
+    pub fn execute_for_candidates(&self, is_hybrid_kind: bool) -> Result<RoaringBitmap> {
+        let has_vector = is_hybrid_kind || {
+            self.semantic.as_ref().and_then(|semantic| semantic.vector.as_ref()).is_some()
+        };
+
+        if has_vector {
             let ctx = SearchContext::new(self.index, self.rtxn)?;
             filtered_universe(ctx.index, ctx.txn, &self.filter, self.progress)
         } else {

--- a/crates/milli/src/search/new/tests/cutoff.rs
+++ b/crates/milli/src/search/new/tests/cutoff.rs
@@ -82,7 +82,7 @@ fn degraded_search_cannot_skip_filter() {
     search.limit(100);
     search.deadline(Deadline::from_budget(Duration::from_millis(0)));
     let filter_condition = Filter::from_str("id > 2").unwrap().unwrap();
-    search.filter(IndexFilter::from(filter_condition));
+    search.filter(Some(IndexFilter::from(filter_condition)));
 
     let result = search.execute().unwrap();
     assert!(result.degraded);

--- a/crates/milli/src/test_index.rs
+++ b/crates/milli/src/test_index.rs
@@ -498,72 +498,72 @@ fn test_basic_geo_bounding_box() {
 
     // exact match a document
     let search_result = search
-        .filter(IndexFilter::from(
+        .filter(Some(IndexFilter::from(
             Filter::from_str("_geoBoundingBox([0, 0], [0, 0])").unwrap().unwrap(),
-        ))
+        )))
         .execute()
         .unwrap();
     insta::assert_debug_snapshot!(search_result.candidates, @"RoaringBitmap<[0]>");
 
     // match a document in the middle of the rectangle
     let search_result = search
-        .filter(IndexFilter::from(
+        .filter(Some(IndexFilter::from(
             Filter::from_str("_geoBoundingBox([10, 10], [-10, -10])").unwrap().unwrap(),
-        ))
+        )))
         .execute()
         .unwrap();
     insta::assert_debug_snapshot!(search_result.candidates, @"RoaringBitmap<[0]>");
 
     // select everything
     let search_result = search
-        .filter(IndexFilter::from(
+        .filter(Some(IndexFilter::from(
             Filter::from_str("_geoBoundingBox([90, 180], [-90, -180])").unwrap().unwrap(),
-        ))
+        )))
         .execute()
         .unwrap();
     insta::assert_debug_snapshot!(search_result.candidates, @"RoaringBitmap<[0, 1, 2, 3, 4]>");
 
     // go on the edge of the longitude
     let search_result = search
-        .filter(IndexFilter::from(
+        .filter(Some(IndexFilter::from(
             Filter::from_str("_geoBoundingBox([0, -170], [0, 180])").unwrap().unwrap(),
-        ))
+        )))
         .execute()
         .unwrap();
     insta::assert_debug_snapshot!(search_result.candidates, @"RoaringBitmap<[1]>");
 
     // go on the other edge of the longitude
     let search_result = search
-        .filter(IndexFilter::from(
+        .filter(Some(IndexFilter::from(
             Filter::from_str("_geoBoundingBox([0, -180], [0, 170])").unwrap().unwrap(),
-        ))
+        )))
         .execute()
         .unwrap();
     insta::assert_debug_snapshot!(search_result.candidates, @"RoaringBitmap<[2]>");
 
     // wrap around the longitude
     let search_result = search
-        .filter(IndexFilter::from(
+        .filter(Some(IndexFilter::from(
             Filter::from_str("_geoBoundingBox([0, -170], [0, 170])").unwrap().unwrap(),
-        ))
+        )))
         .execute()
         .unwrap();
     insta::assert_debug_snapshot!(search_result.candidates, @"RoaringBitmap<[1, 2]>");
 
     // go on the edge of the latitude
     let search_result = search
-        .filter(IndexFilter::from(
+        .filter(Some(IndexFilter::from(
             Filter::from_str("_geoBoundingBox([90, 0], [80, 0])").unwrap().unwrap(),
-        ))
+        )))
         .execute()
         .unwrap();
     insta::assert_debug_snapshot!(search_result.candidates, @"RoaringBitmap<[3]>");
 
     // go on the edge of the latitude
     let search_result = search
-        .filter(IndexFilter::from(
+        .filter(Some(IndexFilter::from(
             Filter::from_str("_geoBoundingBox([-80, 0], [-90, 0])").unwrap().unwrap(),
-        ))
+        )))
         .execute()
         .unwrap();
     insta::assert_debug_snapshot!(search_result.candidates, @"RoaringBitmap<[4]>");
@@ -572,9 +572,9 @@ fn test_basic_geo_bounding_box() {
 
     // try to wrap around the latitude
     let error = search
-        .filter(IndexFilter::from(
+        .filter(Some(IndexFilter::from(
             Filter::from_str("_geoBoundingBox([-80, 0], [80, 0])").unwrap().unwrap(),
-        ))
+        )))
         .execute()
         .unwrap_err();
     insta::assert_snapshot!(
@@ -587,9 +587,9 @@ fn test_basic_geo_bounding_box() {
 
     // send a top latitude lower than the bottow latitude
     let error = search
-        .filter(IndexFilter::from(
+        .filter(Some(IndexFilter::from(
             Filter::from_str("_geoBoundingBox([-10, 0], [10, 0])").unwrap().unwrap(),
-        ))
+        )))
         .execute()
         .unwrap_err();
     insta::assert_snapshot!(
@@ -625,19 +625,21 @@ fn test_contains() {
     let rtxn = index.read_txn().unwrap();
     let mut search = index.search(&rtxn);
     let search_result = search
-        .filter(IndexFilter::from(Filter::from_str("doggo CONTAINS kefir").unwrap().unwrap()))
+        .filter(Some(IndexFilter::from(Filter::from_str("doggo CONTAINS kefir").unwrap().unwrap())))
         .execute()
         .unwrap();
     insta::assert_debug_snapshot!(search_result.candidates, @"RoaringBitmap<[0, 1]>");
     let mut search = index.search(&rtxn);
     let search_result = search
-        .filter(IndexFilter::from(Filter::from_str("doggo CONTAINS KEF").unwrap().unwrap()))
+        .filter(Some(IndexFilter::from(Filter::from_str("doggo CONTAINS KEF").unwrap().unwrap())))
         .execute()
         .unwrap();
     insta::assert_debug_snapshot!(search_result.candidates, @"RoaringBitmap<[0, 1, 2]>");
     let mut search = index.search(&rtxn);
     let search_result = search
-        .filter(IndexFilter::from(Filter::from_str("doggo NOT CONTAINS fir").unwrap().unwrap()))
+        .filter(Some(IndexFilter::from(
+            Filter::from_str("doggo NOT CONTAINS fir").unwrap().unwrap(),
+        )))
         .execute()
         .unwrap();
     insta::assert_debug_snapshot!(search_result.candidates, @"RoaringBitmap<[2, 4, 5]>");
@@ -1407,7 +1409,9 @@ fn vectors_are_never_indexed_as_searchable_or_filterable() {
 
     let mut search = index.search(&rtxn);
     let results = dbg!(search
-        .filter(IndexFilter::from(Filter::from_str("_vectors.doggo = 6789").unwrap().unwrap()))
+        .filter(Some(IndexFilter::from(
+            Filter::from_str("_vectors.doggo = 6789").unwrap().unwrap()
+        )))
         .execute())
     .unwrap();
     assert!(results.candidates.is_empty());
@@ -1439,7 +1443,9 @@ fn vectors_are_never_indexed_as_searchable_or_filterable() {
 
     let mut search = index.search(&rtxn);
     let results = search
-        .filter(IndexFilter::from(Filter::from_str("_vectors.doggo = 6789").unwrap().unwrap()))
+        .filter(Some(IndexFilter::from(
+            Filter::from_str("_vectors.doggo = 6789").unwrap().unwrap(),
+        )))
         .execute()
         .unwrap();
     assert!(results.candidates.is_empty());

--- a/crates/milli/src/update/index_documents/mod.rs
+++ b/crates/milli/src/update/index_documents/mod.rs
@@ -1339,27 +1339,27 @@ mod tests {
         let mut search = index.search(&rtxn);
 
         let filter = crate::Filter::from_str(r#"title = "The first document""#).unwrap().unwrap();
-        search.filter(IndexFilter::from(filter));
+        search.filter(Some(IndexFilter::from(filter)));
         let crate::SearchResult { documents_ids, .. } = search.execute().unwrap();
         assert_eq!(documents_ids, vec![1]);
 
         let filter = crate::Filter::from_str(r#"nested.object = field"#).unwrap().unwrap();
-        search.filter(IndexFilter::from(filter));
+        search.filter(Some(IndexFilter::from(filter)));
         let crate::SearchResult { documents_ids, .. } = search.execute().unwrap();
         assert_eq!(documents_ids, vec![1, 2]);
 
         let filter = crate::Filter::from_str(r#"nested.machin = bidule"#).unwrap().unwrap();
-        search.filter(IndexFilter::from(filter));
+        search.filter(Some(IndexFilter::from(filter)));
         let crate::SearchResult { documents_ids, .. } = search.execute().unwrap();
         assert_eq!(documents_ids, vec![1]);
 
         let filter = crate::Filter::from_str(r#"nested = array"#).unwrap().unwrap();
-        search.filter(IndexFilter::from(filter));
+        search.filter(Some(IndexFilter::from(filter)));
         let error = search.execute().map(|_| unreachable!()).unwrap_err(); // nested is not filterable
         assert!(matches!(error, crate::Error::UserError(crate::UserError::InvalidFilter(_))));
 
         let filter = crate::Filter::from_str(r#"nested = "I lied""#).unwrap().unwrap();
-        search.filter(IndexFilter::from(filter));
+        search.filter(Some(IndexFilter::from(filter)));
         let error = search.execute().map(|_| unreachable!()).unwrap_err(); // nested is not filterable
         assert!(matches!(error, crate::Error::UserError(crate::UserError::InvalidFilter(_))));
     }
@@ -1521,7 +1521,7 @@ mod tests {
             let mut search = crate::Search::new(&rtxn, &index, &progress);
             let filter = format!(r#""dog.race.bernese mountain" = {s}"#);
             let filter = crate::Filter::from_str(&filter).unwrap().unwrap();
-            search.filter(IndexFilter::from(filter));
+            search.filter(Some(IndexFilter::from(filter)));
             let crate::SearchResult { documents_ids, .. } = search.execute().unwrap();
             assert_eq!(documents_ids, vec![i]);
         }
@@ -3282,7 +3282,8 @@ mod tests {
         let rtxn = index.read_txn().unwrap();
         // Placeholder search with filter
         let filter = Filter::from_str("label = sign").unwrap().unwrap();
-        let results = index.search(&rtxn).filter(IndexFilter::from(filter)).execute().unwrap();
+        let results =
+            index.search(&rtxn).filter(Some(IndexFilter::from(filter))).execute().unwrap();
         assert!(results.documents_ids.is_empty());
 
         db_snap!(index, word_docids);
@@ -3454,7 +3455,8 @@ mod tests {
 
         // Placeholder search with geo filter
         let filter = Filter::from_str("_geoRadius(50.6924, 3.1763, 20000)").unwrap().unwrap();
-        let results = index.search(&wtxn).filter(IndexFilter::from(filter)).execute().unwrap();
+        let results =
+            index.search(&wtxn).filter(Some(IndexFilter::from(filter))).execute().unwrap();
         assert!(!results.documents_ids.is_empty());
         for id in results.documents_ids.iter() {
             assert!(

--- a/crates/milli/tests/search/filters.rs
+++ b/crates/milli/tests/search/filters.rs
@@ -56,7 +56,7 @@ macro_rules! test_filter {
             search.limit(EXTERNAL_DOCUMENTS_IDS.len());
 
             search.terms_matching_strategy(TermsMatchingStrategy::default());
-            search.filter(from_filter(filter_conditions));
+            search.filter(Some(from_filter(filter_conditions)));
 
             let SearchResult { documents_ids, .. } = search.execute().unwrap();
 


### PR DESCRIPTION
# Changelog

## Remote facet search

Meilisearch now has the ability to search across all shards of a network during facet search via the existing dedicated facet search route.

- If you are using the `network` experimental feature and have a `leader` defined for your network, **remote calls are now the default** for calls to `POST /indexes/{indexUid}/facet-search`
- The behavior can be controlled explicitly via the new `useNetwork` parameter of the [facet search object](https://www.meilisearch.com/docs/reference/api/facet-search/search-in-facets#body-facet-name).

# Implementation

The tests require to pass https://github.com/meilisearch/meilisearch/pull/6380

## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respect the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - *list of used tools and what they were used for*
