### PR TITLE
Improve the documentation of the health route

### DIFF
--- a/crates/meilisearch/src/routes/mod.rs
+++ b/crates/meilisearch/src/routes/mod.rs
@@ -604,6 +604,10 @@ enum HealthStatus {
 /// Get health
 ///
 /// The health check endpoint enables you to periodically test the health of your Meilisearch instance. Returns a simple status indicating that the server is available.
+///
+/// The engine will return `available` status with a `200` status code when the instance is healthy.
+/// It will return `mustRestart` status with a `500` status code if the instance requires a restart.
+/// This restart is required after a compaction of the task queue for example.
 #[routes::path(
     responses(
         (status = 200, description = "Instance is healthy.", body = HealthResponse, content_type = "application/json", example = json!(


### PR DESCRIPTION
This PR improves the documentation of the /health route to explain the `mustRestart` status and the `500` status code.

## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respects the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - *list of used tools and what they were used for*
