### PR TITLE
Use the search deadline when embedding at search time

### DIFF
--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -1649,7 +1649,7 @@ pub fn prepare_search<'t>(
         features.check_multimodal("passing `media` in a search query")?;
     }
     let mut search = index.search(rtxn, progress);
-    search.deadline(deadline);
+    search.deadline(deadline.clone());
     if let Some(ranking_score_threshold) = query.ranking_score_threshold {
         search.ranking_score_threshold(ranking_score_threshold.0);
     }
@@ -1672,8 +1672,6 @@ pub fn prepare_search<'t>(
                     let span = tracing::trace_span!(target: "search::vector", "embed_one");
                     let _entered = span.enter();
 
-                    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
-
                     let q = query.q.as_deref();
                     let media = query.media.as_ref();
 
@@ -1683,7 +1681,7 @@ pub fn prepare_search<'t>(
                     };
 
                     embedder
-                        .embed_search(search_query, Some(deadline))
+                        .embed_search(search_query, deadline.to_instant())
                         .map_err(milli::vector::Error::from)
                         .map_err(milli::Error::from)?
                 }

--- a/crates/milli/src/lib.rs
+++ b/crates/milli/src/lib.rs
@@ -214,6 +214,10 @@ impl Deadline {
         };
         std::time::Instant::now() > deadline
     }
+
+    pub fn to_instant(&self) -> Option<std::time::Instant> {
+        self.deadline
+    }
 }
 
 // Convert an absolute word position into a relative position.

--- a/crates/milli/src/search/hybrid.rs
+++ b/crates/milli/src/search/hybrid.rs
@@ -316,9 +316,7 @@ impl Search<'_> {
                     (q, media) => SearchQuery::Media { q, media },
                 };
 
-                let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
-
-                match embedder.embed_search(query, Some(deadline)) {
+                match embedder.embed_search(query, self.deadline.to_instant()) {
                     Ok(embedding) => embedding,
                     Err(error) => {
                         tracing::error!(error=%error, "Embedding failed");


### PR DESCRIPTION
- use search cutoff in pure semantic search
- use search cutoff in hybrid search
- add `Deadline::to_transition`

References: [Slack discussion](https://meilisearch.slack.com/archives/C097JL1UN9F/p1778574963988999?thread_ts=1778570519.014459&cid=C097JL1UN9F) (internal)

This PR fixes #6295 and closes #6358.

## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respect the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - *list of used tools and what they were used for*