### PR TITLE
Fix proxying of settings task spawned from a subroute

### DIFF
--- a/crates/meilisearch-types/src/network.rs
+++ b/crates/meilisearch-types/src/network.rs
@@ -149,6 +149,13 @@ pub mod route {
         PathAndQuery::from_static("/indexes")
     }
 
+    pub fn settings_path(
+        index_uid: &crate::index_uid::IndexUid,
+    ) -> Result<PathAndQuery, HttpError> {
+        // WARNING: if you change this path, you must also change the path in the federated search route macro in the meilisearch crate.
+        Ok(PathAndQuery::try_from(format!("/indexes/{index_uid}/settings"))?)
+    }
+
     pub fn url_from_base_and_route(
         remote_base_url: &str,
         route: PathAndQuery,

--- a/crates/meilisearch/src/proxy/community_edition.rs
+++ b/crates/meilisearch/src/proxy/community_edition.rs
@@ -5,7 +5,7 @@ use meilisearch_types::tasks::network::{DbTaskNetwork, TaskNetwork};
 use meilisearch_types::tasks::Task;
 
 use crate::error::MeilisearchHttpError;
-use crate::proxy::Body;
+use crate::proxy::{Body, Endpoint};
 
 pub fn task_network_and_check_leader_and_version(
     _req: &HttpRequest,
@@ -14,10 +14,10 @@ pub fn task_network_and_check_leader_and_version(
     Ok(None)
 }
 
-pub async fn proxy<T, F>(
+pub async fn proxy<T, F, E: Endpoint>(
     _index_scheduler: &IndexScheduler,
     _index_uid: Option<&str>,
-    _req: &HttpRequest,
+    _req: &E,
     _task_network: DbTaskNetwork,
     _network: Network,
     _body: Body<T, F>,

--- a/crates/meilisearch/src/proxy/enterprise_edition.rs
+++ b/crates/meilisearch/src/proxy/enterprise_edition.rs
@@ -23,7 +23,7 @@ use serde_json::Value;
 use uuid::Uuid;
 
 use crate::error::MeilisearchHttpError;
-use crate::proxy::{Body, ProxyError, ReqwestErrorWithoutUrl};
+use crate::proxy::{Body, Endpoint, ProxyError, ReqwestErrorWithoutUrl};
 use crate::routes::SummarizedTaskView;
 
 mod timeouts {
@@ -185,10 +185,10 @@ pub fn task_network_and_check_leader_and_version(
 /// # Returns
 ///
 /// The updated task. The task is read back from the database to avoid erasing concurrent changes.
-pub async fn proxy<T, F>(
+pub async fn proxy<T, F, E: Endpoint>(
     index_scheduler: &IndexScheduler,
     index_uid: Option<&str>,
-    req: &HttpRequest,
+    req: &E,
     mut task_network: DbTaskNetwork,
     network: meilisearch_types::network::Network,
     body: Body<T, F>,
@@ -210,7 +210,7 @@ where
             // for file bodies, force x-ndjson
             Body::NdJsonPayload(_) => Some(b"application/x-ndjson".as_slice()),
             // otherwise get content type from request
-            _ => req.headers().get(CONTENT_TYPE).map(|h| h.as_bytes()),
+            _ => req.content_type(),
         };
 
         let mut in_flight_remote_queries = BTreeMap::new();
@@ -221,7 +221,7 @@ where
             .build_with_policies(index_scheduler.ip_policy().clone(), Default::default())
             .unwrap();
 
-        let method = from_old_http_method(req.method());
+        let method = req.method();
 
         // send payload to all remotes
         for (body, (node_name, node)) in body
@@ -237,11 +237,7 @@ where
             let this = this.clone();
             let task_uid = task.uid;
             let method = method.clone();
-            let path_and_query = req
-                .uri()
-                .path_and_query()
-                .cloned()
-                .unwrap_or_else(|| PathAndQuery::from_static("/"));
+            let path_and_query = req.path_and_query();
 
             in_flight_remote_queries.insert(
                 node_name,
@@ -462,21 +458,6 @@ where
         }
     };
     Ok(response)
-}
-
-fn from_old_http_method(method: &actix_http::Method) -> http_client::reqwest::Method {
-    match method {
-        &actix_http::Method::CONNECT => http_client::reqwest::Method::CONNECT,
-        &actix_http::Method::DELETE => http_client::reqwest::Method::DELETE,
-        &actix_http::Method::GET => http_client::reqwest::Method::GET,
-        &actix_http::Method::HEAD => http_client::reqwest::Method::HEAD,
-        &actix_http::Method::OPTIONS => http_client::reqwest::Method::OPTIONS,
-        &actix_http::Method::PATCH => http_client::reqwest::Method::PATCH,
-        &actix_http::Method::POST => http_client::reqwest::Method::POST,
-        &actix_http::Method::PUT => http_client::reqwest::Method::PUT,
-        &actix_http::Method::TRACE => http_client::reqwest::Method::TRACE,
-        method => http_client::reqwest::Method::from_bytes(method.as_str().as_bytes()).unwrap(),
-    }
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/meilisearch/src/proxy/mod.rs
+++ b/crates/meilisearch/src/proxy/mod.rs
@@ -2,6 +2,9 @@
 pub mod community_edition;
 #[cfg(feature = "enterprise")]
 pub mod enterprise_edition;
+use actix_http::header::CONTENT_TYPE;
+use actix_http::uri::PathAndQuery;
+use actix_web::HttpRequest;
 #[cfg(not(feature = "enterprise"))]
 pub use community_edition::{proxy, task_network_and_check_leader_and_version};
 #[cfg(feature = "enterprise")]
@@ -15,3 +18,70 @@ mod error;
 
 pub use body::Body;
 pub use error::{ProxyError, ReqwestErrorWithoutUrl};
+
+pub trait Endpoint {
+    fn content_type(&self) -> Option<&[u8]>;
+    fn method(&self) -> http_client::reqwest::Method;
+    fn path_and_query(&self) -> PathAndQuery;
+}
+
+impl Endpoint for HttpRequest {
+    fn content_type(&self) -> Option<&[u8]> {
+        self.headers().get(CONTENT_TYPE).map(|h| h.as_bytes())
+    }
+
+    fn method(&self) -> http_client::reqwest::Method {
+        from_old_http_method(self.method())
+    }
+
+    fn path_and_query(&self) -> PathAndQuery {
+        self.uri().path_and_query().cloned().unwrap_or_else(|| PathAndQuery::from_static("/"))
+    }
+}
+
+fn from_old_http_method(method: &actix_http::Method) -> http_client::reqwest::Method {
+    match method {
+        &actix_http::Method::CONNECT => http_client::reqwest::Method::CONNECT,
+        &actix_http::Method::DELETE => http_client::reqwest::Method::DELETE,
+        &actix_http::Method::GET => http_client::reqwest::Method::GET,
+        &actix_http::Method::HEAD => http_client::reqwest::Method::HEAD,
+        &actix_http::Method::OPTIONS => http_client::reqwest::Method::OPTIONS,
+        &actix_http::Method::PATCH => http_client::reqwest::Method::PATCH,
+        &actix_http::Method::POST => http_client::reqwest::Method::POST,
+        &actix_http::Method::PUT => http_client::reqwest::Method::PUT,
+        &actix_http::Method::TRACE => http_client::reqwest::Method::TRACE,
+        method => http_client::reqwest::Method::from_bytes(method.as_str().as_bytes()).unwrap(),
+    }
+}
+
+pub struct OverrideEndpoint<'a, E> {
+    endpoint: &'a E,
+    path_and_query: Option<PathAndQuery>,
+    method: Option<http_client::reqwest::Method>,
+    content_type: Option<Vec<u8>>,
+}
+
+impl<'a, E> OverrideEndpoint<'a, E> {
+    pub fn new(
+        endpoint: &'a E,
+        path_and_query: Option<PathAndQuery>,
+        method: Option<http_client::reqwest::Method>,
+        content_type: Option<Vec<u8>>,
+    ) -> Self {
+        Self { endpoint, path_and_query, method, content_type }
+    }
+}
+
+impl<'a, E: Endpoint> Endpoint for OverrideEndpoint<'a, E> {
+    fn content_type(&self) -> Option<&[u8]> {
+        self.content_type.as_deref().or_else(|| self.endpoint.content_type())
+    }
+
+    fn method(&self) -> http_client::reqwest::Method {
+        self.method.clone().unwrap_or_else(|| self.endpoint.method())
+    }
+
+    fn path_and_query(&self) -> PathAndQuery {
+        self.path_and_query.clone().unwrap_or_else(|| self.endpoint.path_and_query())
+    }
+}

--- a/crates/meilisearch/src/routes/indexes/settings.rs
+++ b/crates/meilisearch/src/routes/indexes/settings.rs
@@ -6,6 +6,7 @@ use meilisearch_types::deserr::DeserrJsonError;
 use meilisearch_types::error::ResponseError;
 use meilisearch_types::index_uid::IndexUid;
 use meilisearch_types::milli::update::Setting;
+use meilisearch_types::network::route;
 use meilisearch_types::settings::{
     settings, ChatSettings, SecretPolicy, SettingEmbeddingSettings, Settings, Unchecked,
 };
@@ -16,7 +17,7 @@ use super::settings_analytics::*;
 use crate::analytics::Analytics;
 use crate::extractors::authentication::policies::*;
 use crate::extractors::authentication::GuardedData;
-use crate::proxy::{proxy, task_network_and_check_leader_and_version, Body};
+use crate::proxy::{proxy, task_network_and_check_leader_and_version, Body, OverrideEndpoint};
 use crate::routes::{get_task_id, is_dry_run, SummarizedTaskView};
 use crate::Opt;
 
@@ -633,6 +634,8 @@ async fn register_new_settings(
     };
 
     let allow_index_creation = index_scheduler.filters().allow_index_creation(&index_uid);
+    let settings_path = route::settings_path(&index_uid).unwrap();
+
     let index_uid = IndexUid::try_from(index_uid.into_inner())?.into_inner();
     let task = KindWithContent::SettingsUpdate {
         index_uid: index_uid.clone(),
@@ -653,7 +656,13 @@ async fn register_new_settings(
         proxy(
             &index_scheduler,
             Some(&index_uid),
-            req,
+            // since we are sending a full settings object, we need to override the path and method to target the main settings route
+            &OverrideEndpoint::new(
+                req,
+                Some(settings_path),
+                Some(http_client::reqwest::Method::PATCH),
+                None,
+            ),
             task_network,
             network,
             Body::inline(new_settings),


### PR DESCRIPTION
# Changelog

When using sharding with a leader, calls to a setting subroute (e.g. `PUT /indexes/{indexUid}/settings/facet-search`) no longer fail to proxy the task to other remotes.

# Implementation

- Generalize the proxy method to accept any type implementing a new `Endpoint` trait, allowing to recover method, path/query and content-type
- Implement `Endpoint` on actix's request type to maintain the existing behavior
- Add a new type that wraps any Endpoint and allows overriding parts of the endpoint. Implement `Endpoint` on that new type
- Use that type to override the method and path so that the main settings route is always targeted when proxying a settings task.
- This PR is tested by the tests in https://github.com/meilisearch/meilisearch/pull/6375

## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respect the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - *list of used tools and what they were used for*
