### PR TITLE
fix: duplicated words in milli/indexer/write.rs and meilisearch option.rs

### DIFF
--- a/crates/meilisearch/src/option.rs
+++ b/crates/meilisearch/src/option.rs
@@ -1009,7 +1009,7 @@ pub struct S3SnapshotOpts {
     #[serde(default = "default_experimental_s3_snapshot_signature_duration_seconds")]
     pub experimental_s3_signature_duration_seconds: u64,
 
-    /// The size of the the multipart parts.
+    /// The size of the multipart parts.
     ///
     /// Must not be less than 10MiB and larger than 8GiB. Yes,
     /// twice the boundaries of the AWS S3 multipart upload

--- a/crates/milli/src/update/new/indexer/write.rs
+++ b/crates/milli/src/update/new/indexer/write.rs
@@ -26,7 +26,7 @@ pub fn write_to_db(
     wtxn: &mut RwTxn<'_>,
     vector_stores: &HashMap<u8, (&str, &Embedder, VectorStore, usize)>,
 ) -> Result<ChannelCongestion> {
-    // Used by by the HannoySetVector to copy the embedding into an
+    // Used by the HannoySetVector to copy the embedding into an
     // aligned memory area, required by arroy to accept a new vector.
     let mut aligned_embedding = Vec::new();
     let span = tracing::trace_span!(target: "indexing::write_db", "all");


### PR DESCRIPTION
Two one-line typo fixes for duplicated words in source comments:
- `crates/milli/src/update/new/indexer/write.rs` — "// Used by by the HannoySetVector to copy the embedding into an" → "// Used by the HannoySetVector to copy the embedding into an"
- `crates/meilisearch/src/option.rs` — "/// The size of the the multipart parts." → "/// The size of the multipart parts."

No code/behavior change.