### PR TITLE
fix: return task documents as valid ndjson

### DIFF
--- a/crates/meilisearch-types/src/document_formats.rs
+++ b/crates/meilisearch-types/src/document_formats.rs
@@ -10,7 +10,7 @@ use milli::documents::Error;
 use milli::Object;
 use rustc_hash::FxBuildHasher;
 use serde::de::{SeqAccess, Visitor};
-use serde::{Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::error::Category;
 use serde_json::value::RawValue;
 use serde_json::{to_writer, Map, Value};
@@ -149,6 +149,15 @@ fn parse_csv_header(header: &str) -> (&str, AllowedType) {
     }
 }
 
+fn write_ndjson_line<W, T>(output: &mut W, value: &T) -> serde_json::Result<()>
+where
+    W: io::Write,
+    T: Serialize + ?Sized,
+{
+    to_writer(&mut *output, value)?;
+    output.write_all(b"\n").map_err(serde_json::Error::io)
+}
+
 /// Reads CSV from file and write it in NDJSON in a file checking it along the way.
 pub fn read_csv(input: &File, output: impl io::Write, delimiter: u8) -> Result<u64> {
     let ptype = PayloadType::Csv { delimiter };
@@ -204,7 +213,8 @@ pub fn read_csv(input: &File, output: impl io::Write, delimiter: u8) -> Result<u
             *object.get_mut(*name).expect("encountered an unknown field") = value;
         }
 
-        to_writer(&mut output, &object).map_err(|e| DocumentFormatError::from((ptype, e)))?;
+        write_ndjson_line(&mut output, &object)
+            .map_err(|e| DocumentFormatError::from((ptype, e)))?;
     }
 
     Ok(line as u64)
@@ -222,7 +232,7 @@ pub fn read_json(input: &File, output: impl io::Write) -> Result<u64> {
     let res = array_each(&mut deserializer, |obj: &RawValue| {
         doc_alloc.reset();
         let map = RawMap::from_raw_value_and_hasher(obj, FxBuildHasher, &doc_alloc)?;
-        to_writer(&mut out, &map)
+        write_ndjson_line(&mut out, &map)
     });
     let count = match res {
         // The json data has been deserialized and does not need to be processed again.
@@ -239,7 +249,7 @@ pub fn read_json(input: &File, output: impl io::Write) -> Result<u64> {
             let content: Object = serde_json::from_slice(&input)
                 .map_err(Error::Json)
                 .map_err(|e| (PayloadType::Json, e))?;
-            to_writer(&mut out, &content)
+            write_ndjson_line(&mut out, &content)
                 .map(|_| 1)
                 .map_err(|e| DocumentFormatError::from((PayloadType::Json, e)))?
         }
@@ -322,4 +332,69 @@ where
     }
     let visitor = SeqVisitor(f, PhantomData);
     deserializer.deserialize_seq(visitor)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Seek, Write};
+
+    use serde_json::Value;
+
+    use super::{read_csv, read_json};
+
+    fn input_file(content: &str) -> tempfile::NamedTempFile {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        file.write_all(content.as_bytes()).unwrap();
+        file.as_file_mut().rewind().unwrap();
+        file
+    }
+
+    fn parse_lines(output: &[u8]) -> Vec<Value> {
+        std::str::from_utf8(output)
+            .unwrap()
+            .lines()
+            .map(|line| serde_json::from_str(line).unwrap())
+            .collect()
+    }
+
+    #[test]
+    fn read_json_writes_newline_delimited_documents() {
+        let input = input_file(r#"[{"id":1},{"id":2}]"#);
+        let mut output = Vec::new();
+
+        let count = read_json(input.as_file(), &mut output).unwrap();
+        let documents = parse_lines(&output);
+
+        assert_eq!(count, 2);
+        assert_eq!(documents.len(), 2);
+        assert_eq!(documents[0]["id"], 1);
+        assert_eq!(documents[1]["id"], 2);
+    }
+
+    #[test]
+    fn read_json_writes_single_document_with_trailing_newline() {
+        let input = input_file(r#"{"id":1}"#);
+        let mut output = Vec::new();
+
+        let count = read_json(input.as_file(), &mut output).unwrap();
+
+        assert_eq!(count, 1);
+        assert_eq!(std::str::from_utf8(&output).unwrap(), "{\"id\":1}\n");
+    }
+
+    #[test]
+    fn read_csv_writes_newline_delimited_documents() {
+        let input = input_file("id:number,title\n1,Carol\n2,Dune\n");
+        let mut output = Vec::new();
+
+        let count = read_csv(input.as_file(), &mut output, b',').unwrap();
+        let documents = parse_lines(&output);
+
+        assert_eq!(count, 2);
+        assert_eq!(documents.len(), 2);
+        assert_eq!(documents[0]["id"], 1);
+        assert_eq!(documents[0]["title"], "Carol");
+        assert_eq!(documents[1]["id"], 2);
+        assert_eq!(documents[1]["title"], "Dune");
+    }
 }

--- a/crates/meilisearch/tests/tasks/mod.rs
+++ b/crates/meilisearch/tests/tasks/mod.rs
@@ -2,11 +2,13 @@ mod deletion;
 mod errors;
 mod webhook;
 
+use actix_web::http::{header, StatusCode};
+use actix_web::test;
 use meili_snap::{json_string, snapshot};
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
 
-use crate::common::Server;
+use crate::common::{Server, Value};
 use crate::json;
 
 #[actix_rt::test]
@@ -44,6 +46,40 @@ async fn get_task_status() {
     let (_response, code) = index.get_task(add_task.uid()).await;
     assert_eq!(code, 200);
     // TODO check response format, as per #48
+}
+
+#[actix_rt::test]
+async fn get_task_documents_returns_valid_ndjson_for_json_payload() {
+    let server = Server::new().await;
+    let (_response, code) = server.set_features(json!({ "getTaskDocumentsRoute": true })).await;
+    assert_eq!(code, 200);
+
+    let index = server.index("movies");
+    let (task, code) = index
+        .raw_add_documents(
+            r#"[{"id":1,"title":"Carol"},{"id":2,"title":"Dune"}]"#,
+            vec![("Content-Type", "application/json")],
+            "",
+        )
+        .await;
+    assert_eq!(code, 202);
+
+    let app = server.init_web_app().await;
+    let req =
+        test::TestRequest::get().uri(&format!("/tasks/{}/documents", task.uid())).to_request();
+    let response = test::call_service(&app, req).await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.headers().get(header::CONTENT_TYPE).unwrap(), "application/x-ndjson");
+
+    let body = test::read_body(response).await;
+    let body = std::str::from_utf8(&body).unwrap();
+    let documents =
+        body.lines().map(|line| serde_json::from_str::<Value>(line).unwrap()).collect::<Vec<_>>();
+
+    assert_eq!(documents.len(), 2, "{body}");
+    assert_eq!(documents[0]["id"], 1);
+    assert_eq!(documents[1]["id"], 2);
 }
 
 #[actix_rt::test]


### PR DESCRIPTION
## Summary
- write converted JSON and CSV document payloads as newline-delimited JSON records
- keep `/tasks/{taskUid}/documents` aligned with its `application/x-ndjson` response type
- add regression coverage for the document formatter and the task documents endpoint

## Root cause
JSON and CSV uploads were converted into the task update file by writing each JSON object back-to-back without a separator. The task documents endpoint serves that file as `application/x-ndjson`, so JSON-array uploads could return bodies like `{...}{...}`, which are not valid NDJSON.

## Testing
- `cargo test -p meilisearch-types document_formats`
- `cargo test -p meilisearch --test integration get_task_documents_returns_valid_ndjson_for_json_payload`
- `cargo test -p index-scheduler scheduler::test_document_addition::document_addition`
- `rustfmt --edition 2021 --check crates\meilisearch-types\src\document_formats.rs crates\meilisearch\tests\tasks\mod.rs`

Closes #6379