### PR TITLE
Fix input/output mismatch in list indexes and list API keys examples

### DIFF
--- a/crates/meilisearch/src/routes/api_key.rs
+++ b/crates/meilisearch/src/routes/api_key.rs
@@ -104,7 +104,7 @@ pub struct ListApiKeys {
     pub offset: Param<usize>,
     /// Maximum number of keys to return. Use with `offset` for pagination. Defaults to 20.
     #[deserr(default = Param(PAGINATION_DEFAULT_LIMIT), error = DeserrQueryParamError<InvalidApiKeyLimit>)]
-    #[param(required = false, value_type = usize, default = PAGINATION_DEFAULT_LIMIT_FN)]
+    #[param(required = false, value_type = usize, default = PAGINATION_DEFAULT_LIMIT_FN, example = 3)]
     pub limit: Param<usize>,
 }
 
@@ -127,22 +127,52 @@ impl ListApiKeys {
                     {
                         "uid": "01b4bc42-eb33-4041-b481-254d00cce834",
                         "key": "d0552b41536279a0ad88bd595327b96f01176a60c2243e906c52ac02375f9bc4",
-                        "name": "An API Key",
+                        "name": "Indexing Products API key",
                         "description": null,
                         "actions": [
                             "documents.add"
                         ],
                         "indexes": [
-                            "movies"
+                            "products"
                         ],
-                        "expiresAt": "2022-11-12T10:00:00Z",
+                        "expiresAt": "2021-11-13T00:00:00Z",
+                        "createdAt": "2021-11-12T10:00:00Z",
+                        "updatedAt": "2021-11-12T10:00:00Z"
+                    },
+                    {
+                        "uid": "5e66e370-f57d-4a30-8ab8-59dc8cd39b51",
+                        "key": "a38b92a5a7e7dbcf9e8a3a71d62b0d15e2e1f3c4d6a7b8c9d0e1f2a3b4c5d6e7",
+                        "name": "Search Products API key",
+                        "description": "Read-only key for searching the products index",
+                        "actions": [
+                            "search"
+                        ],
+                        "indexes": [
+                            "products"
+                        ],
+                        "expiresAt": null,
+                        "createdAt": "2021-11-12T10:00:00Z",
+                        "updatedAt": "2021-11-12T10:00:00Z"
+                    },
+                    {
+                        "uid": "b73d3e5a-4d32-4f1e-bba3-0123456789ab",
+                        "key": "f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1",
+                        "name": "Admin API key",
+                        "description": "Full access key for administration",
+                        "actions": [
+                            "*"
+                        ],
+                        "indexes": [
+                            "*"
+                        ],
+                        "expiresAt": null,
                         "createdAt": "2021-11-12T10:00:00Z",
                         "updatedAt": "2021-11-12T10:00:00Z"
                     }
                 ],
-                "limit": 20,
+                "limit": 3,
                 "offset": 0,
-                "total": 1
+                "total": 3
             }
         )),
         (status = 401, description = "The route has been hit on an unprotected instance.", body = ResponseError, content_type = "application/json", example = json!(

--- a/crates/meilisearch/src/routes/indexes/mod.rs
+++ b/crates/meilisearch/src/routes/indexes/mod.rs
@@ -105,7 +105,7 @@ pub struct ListIndexes {
     #[deserr(default, error = DeserrQueryParamError<InvalidIndexOffset>)]
     pub offset: Param<usize>,
     /// The number of indexes to retrieve.
-    #[param(required = false, value_type = Option<usize>, default = 20, example = 1)]
+    #[param(required = false, value_type = Option<usize>, default = 20, example = 3)]
     #[deserr(default = Param(PAGINATION_DEFAULT_LIMIT), error = DeserrQueryParamError<InvalidIndexLimit>)]
     pub limit: Param<usize>,
 }
@@ -133,11 +133,23 @@ impl ListIndexes {
                         "primaryKey": "movie_id",
                         "createdAt": "2019-11-20T09:40:33.711324Z",
                         "updatedAt": "2019-11-20T09:40:33.711324Z"
+                    },
+                    {
+                        "uid": "books",
+                        "primaryKey": "book_id",
+                        "createdAt": "2019-11-20T09:40:33.711324Z",
+                        "updatedAt": "2019-11-20T09:40:33.711324Z"
+                    },
+                    {
+                        "uid": "clothes",
+                        "primaryKey": "clothes_id",
+                        "createdAt": "2019-11-20T09:40:33.711324Z",
+                        "updatedAt": "2019-11-20T09:40:33.711324Z"
                     }
                 ],
-                "limit": 1,
+                "limit": 3,
                 "offset": 0,
-                "total": 1
+                "total": 3
             }
         )),
         (status = 401, description = "The authorization header is missing.", body = ResponseError, content_type = "application/json", example = json!(


### PR DESCRIPTION
## Related issue

Closes #6293

## What this PR does

The OpenAPI response examples for two paginated list endpoints had mismatches between the documented request `limit` parameter example and the response body:

- **`GET /indexes`**: The `limit` query parameter example was `1`, while the response showed `"limit": 1` with only one result. Updated to use `limit: 3` with three illustrative index entries (`movies`, `books`, `clothes`), and consistent `"limit": 3` and `"total": 3` values in the response.

- **`GET /keys`**: The `limit` query parameter had no example (falling back to the default of 20), while the response showed `"limit": 20` with only one result. Added `example = 3` to the limit parameter annotation and updated the response to show three example API keys with matching `"limit": 3` and `"total": 3`.

Both fixes make the code samples in the API reference self-consistent and more illustrative of how pagination works.

## Generative AI tools

This PR was created with the assistance of AI tools (SwarmFix / sulphur-swarm, powered by Claude). The changes were reviewed for correctness — all values are consistent and follow existing patterns in the codebase.