### PR TITLE
Support the global facet search in the new settings indexer

### DIFF
--- a/crates/milli/src/update/new/indexer/post_processing/mod.rs
+++ b/crates/milli/src/update/new/indexer/post_processing/mod.rs
@@ -233,6 +233,16 @@ fn compute_facet_search_database(
         }
     });
 
+    // We make sure that the list of filterable attributes is empty
+    // if the facet search was disabled before this change.
+    let empty_facet_searchable_fids;
+    let old_facet_searchable_fids = if index.facet_search(&rtxn)? {
+        &facet_searchable_fids
+    } else {
+        empty_facet_searchable_fids = BTreeSet::new();
+        &empty_facet_searchable_fids
+    };
+
     fn level_0_searchable_facets<'a>(
         txn: &'a RoTxn,
         index: &'a Index,
@@ -250,7 +260,8 @@ fn compute_facet_search_database(
         })
     }
 
-    let previous_facet_id_string = level_0_searchable_facets(&rtxn, index, &facet_searchable_fids);
+    let previous_facet_id_string =
+        level_0_searchable_facets(&rtxn, index, old_facet_searchable_fids);
     let current_facet_id_string = level_0_searchable_facets(wtxn, index, &facet_searchable_fids);
 
     let mut facet_search_builder = FacetSearchBuilder::new(

--- a/crates/milli/src/update/new/indexer/post_processing/mod.rs
+++ b/crates/milli/src/update/new/indexer/post_processing/mod.rs
@@ -215,6 +215,7 @@ fn compute_facet_search_database(
     // facet search data structures and skip the rest of the function
     if !index.facet_search(wtxn)? {
         index.facet_id_string_fst.clear(wtxn)?;
+        index.facet_id_normalized_string_strings.clear(wtxn)?;
         return Ok(());
     }
 

--- a/crates/milli/src/update/new/indexer/post_processing/mod.rs
+++ b/crates/milli/src/update/new/indexer/post_processing/mod.rs
@@ -211,8 +211,10 @@ fn compute_facet_search_database(
     let rtxn = index.read_txn()?;
     progress.update_progress(PostProcessingFacets::FacetSearch);
 
-    // if the facet search is not enabled, we can skip the rest of the function
+    // if the facet search is not enabled, we can clear the
+    // facet search data structures and skip the rest of the function
     if !index.facet_search(wtxn)? {
+        index.facet_id_string_fst.clear(wtxn)?;
         return Ok(());
     }
 

--- a/crates/milli/src/update/settings.rs
+++ b/crates/milli/src/update/settings.rs
@@ -1661,8 +1661,8 @@ impl<'a, 't, 'i> Settings<'a, 't, 'i> {
             embedder_settings: _,
             search_cutoff: _,
             localized_attributes_rules: Setting::NotSet, // TODO (require force reindexing of searchables)
-            prefix_search: Setting::NotSet,
-            facet_search: Setting::NotSet,
+            prefix_search: Setting::NotSet,              // TODO continue with this
+            facet_search: _,
             disable_on_numbers: Setting::NotSet, // TODO (require force reindexing of searchables)
             chat: _,
             vector_store: Setting::NotSet,
@@ -1699,6 +1699,7 @@ impl<'a, 't, 'i> Settings<'a, 't, 'i> {
             self.update_pagination_max_total_hits()?;
             self.update_search_cutoff()?;
             self.update_chat_config()?;
+            self.update_facet_search()?;
 
             // Note that we don't need to update the searchables here,
             // as it will be done after the settings update.


### PR DESCRIPTION
This PR adds support for the `facetSearch` setting in the new settings indexer. This is tracked in [this internal issue](https://linear.app/meilisearch/issue/SCA-363/support-the-facet-search-setting-change).

## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respects the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - *list of used tools and what they were used for*