### PR TITLE
Support computing prefixes in the new settings indexer

### DIFF
--- a/crates/milli/src/update/new/indexer/mod.rs
+++ b/crates/milli/src/update/new/indexer/mod.rs
@@ -9,7 +9,7 @@ use big_s::S;
 use document_changes::{DocumentChanges, IndexingContext};
 pub use document_deletion::DocumentDeletion;
 pub use document_operation::{IndexOperations, PayloadStats};
-use fst::Streamer as _;
+use fst::{IntoStreamer, Streamer as _};
 use hashbrown::HashMap;
 use heed::types::{Bytes, DecodeIgnore, Str, Unit};
 use heed::{BytesDecode, Database, RoTxn, RwTxn};
@@ -34,9 +34,9 @@ use crate::heed_codec::StrBEU16Codec;
 use crate::index::PrefixSearch;
 use crate::progress::{AtomicDatabaseStep, EmbedderStats, Progress};
 use crate::proximity::ProximityPrecision;
-use crate::update::new::steps::SettingsIndexerStep;
+use crate::update::new::steps::{PostProcessingWords, SettingsIndexerStep};
 use crate::update::settings::SettingsDelta;
-use crate::update::GrenadParameters;
+use crate::update::{GrenadParameters, WordsPrefixesFst};
 use crate::vector::settings::{EmbedderAction, RemoveFragments, WriteBackToDocuments};
 use crate::vector::{Embedder, RuntimeEmbedders, VectorStore};
 use crate::{
@@ -393,13 +393,42 @@ where
         .unwrap()?;
 
         pool.install(|| {
+            // This method writes an empty prefix FST when the prefix search is
+            // disabled because it is based on the modified words during the process
+            // and we have not necessarily modified any word during a settings change.
             post_processing::post_process(
                 indexing_context,
                 wtxn,
                 global_fields_ids_map,
                 &word_delta,
                 facet_field_ids_delta,
-            )
+            )?;
+
+            // When the prefix search was disabled and is enabled we need to call the
+            // WordsPrefixesFst::execute to generate and write the words FST from scratch
+            // and call the compute_prefix_database_from_sources a second time to correctly
+            // generate the prefixes databases.
+            if *settings_delta.old_prefix_search() == PrefixSearch::Disabled
+                && *settings_delta.new_prefix_search() == PrefixSearch::IndexingTime
+            {
+                indexing_context.progress.update_progress(PostProcessingWords::ComputePrefixFst);
+                WordsPrefixesFst::new(wtxn, index).execute()?;
+                let prefixes_fst = index.words_prefixes_fst(wtxn)?;
+
+                let mut modified = BTreeSet::new();
+                let deleted = BTreeSet::new();
+                let mut prefix_stream = prefixes_fst.into_stream();
+                while let Some(prefix) = prefix_stream.next() {
+                    let Ok(prefix) = std::str::from_utf8(prefix) else { continue };
+                    let Some(prefix) = MiniString::new(prefix) else { continue };
+                    modified.insert(prefix);
+                }
+                post_processing::compute_prefix_database_from_sources(
+                    index, wtxn, &modified, &deleted, progress,
+                )?;
+            }
+
+            Ok(()) as Result<_>
         })
         .unwrap()?;
 

--- a/crates/milli/src/update/new/indexer/mod.rs
+++ b/crates/milli/src/update/new/indexer/mod.rs
@@ -285,10 +285,8 @@ where
         index.word_pair_proximity_docids.clear(wtxn)?;
     }
 
-    // TODO delete useless searchable databases
-    //      - Clear fid_prefix_* in the post processing
-    //      - clear the prefix + fid_prefix if setting `PrefixSearch` is enabled
     if *settings_delta.new_prefix_search() == PrefixSearch::Disabled {
+        index.delete_words_prefixes_fst(wtxn)?;
         index.word_prefix_docids.clear(wtxn)?;
         index.word_prefix_fid_docids.clear(wtxn)?;
         index.word_prefix_position_docids.clear(wtxn)?;

--- a/crates/milli/src/update/new/indexer/mod.rs
+++ b/crates/milli/src/update/new/indexer/mod.rs
@@ -31,6 +31,7 @@ use crate::disabled_typos_terms::DisabledTyposTerms;
 use crate::documents::PrimaryKey;
 use crate::fields_ids_map::metadata::{FieldIdMapWithMetadata, MetadataBuilder};
 use crate::heed_codec::StrBEU16Codec;
+use crate::index::PrefixSearch;
 use crate::progress::{AtomicDatabaseStep, EmbedderStats, Progress};
 use crate::proximity::ProximityPrecision;
 use crate::update::new::steps::SettingsIndexerStep;
@@ -287,6 +288,12 @@ where
     // TODO delete useless searchable databases
     //      - Clear fid_prefix_* in the post processing
     //      - clear the prefix + fid_prefix if setting `PrefixSearch` is enabled
+    if *settings_delta.new_prefix_search() == PrefixSearch::Disabled {
+        index.word_prefix_docids.clear(wtxn)?;
+        index.word_prefix_fid_docids.clear(wtxn)?;
+        index.word_prefix_position_docids.clear(wtxn)?;
+        index.exact_word_prefix_docids.clear(wtxn)?;
+    }
 
     let mut bbbuffers = Vec::new();
     let finished_extraction = AtomicBool::new(false);

--- a/crates/milli/src/update/new/indexer/post_processing/mod.rs
+++ b/crates/milli/src/update/new/indexer/post_processing/mod.rs
@@ -81,17 +81,35 @@ fn compute_prefix_database(
     let modified = compute_prefixes(&prefix_fst, word_delta.added_or_modified_words())?;
     let deleted = compute_prefixes(&prefix_fst, word_delta.deleted_words())?;
 
+    compute_prefix_database_from_sources(index, wtxn, &modified, &deleted, progress)
+}
+
+#[tracing::instrument(
+    level = "trace",
+    skip_all,
+    target = "indexing::post_processing",
+    name = "prefix_from_sources"
+)]
+pub(crate) fn compute_prefix_database_from_sources(
+    index: &Index,
+    wtxn: &mut RwTxn,
+    modified: &BTreeSet<MiniString>,
+    deleted: &BTreeSet<MiniString>,
+    progress: &Progress,
+) -> Result<()> {
     progress.update_progress(PostProcessingWords::WordPrefixDocids);
-    compute_word_prefix_docids(wtxn, index, &modified, &deleted)?;
+    compute_word_prefix_docids(wtxn, index, modified, deleted)?;
 
     progress.update_progress(PostProcessingWords::ExactWordPrefixDocids);
-    compute_exact_word_prefix_docids(wtxn, index, &modified, &deleted)?;
+    compute_exact_word_prefix_docids(wtxn, index, modified, deleted)?;
 
     progress.update_progress(PostProcessingWords::WordPrefixFieldIdDocids);
-    compute_word_prefix_fid_docids(wtxn, index, &modified, &deleted)?;
+    compute_word_prefix_fid_docids(wtxn, index, modified, deleted)?;
 
     progress.update_progress(PostProcessingWords::WordPrefixPositionDocids);
-    compute_word_prefix_position_docids(wtxn, index, &modified, &deleted)
+    compute_word_prefix_position_docids(wtxn, index, modified, deleted)?;
+
+    Ok(())
 }
 
 /// The words must be sorted.

--- a/crates/milli/src/update/new/steps.rs
+++ b/crates/milli/src/update/new/steps.rs
@@ -53,6 +53,7 @@ make_enum_progress! {
 make_enum_progress! {
     pub enum PostProcessingWords {
         WordFst,
+        ComputePrefixFst,
         ComputePrefixes,
         WordPrefixDocids,
         ExactWordPrefixDocids,

--- a/crates/milli/src/update/settings.rs
+++ b/crates/milli/src/update/settings.rs
@@ -1661,7 +1661,7 @@ impl<'a, 't, 'i> Settings<'a, 't, 'i> {
             embedder_settings: _,
             search_cutoff: _,
             localized_attributes_rules: Setting::NotSet, // TODO (require force reindexing of searchables)
-            prefix_search: Setting::NotSet,              // TODO continue with this
+            prefix_search: _,
             facet_search: _,
             disable_on_numbers: _,
             chat: _,
@@ -1700,6 +1700,7 @@ impl<'a, 't, 'i> Settings<'a, 't, 'i> {
             self.update_search_cutoff()?;
             self.update_chat_config()?;
             self.update_facet_search()?;
+            self.update_prefix_search()?;
             self.update_exact_words()?;
             self.update_disabled_typos_terms()?;
 

--- a/crates/milli/src/update/words_prefixes_fst.rs
+++ b/crates/milli/src/update/words_prefixes_fst.rs
@@ -22,8 +22,7 @@ impl<'t, 'i> WordsPrefixesFst<'t, 'i> {
     /// database. If a word prefix is supposed to match more than this number of words in the
     /// dictionary, therefore this prefix is added to the words prefixes datastructures.
     ///
-    /// Default value is 100. This value must be higher than 50 and will be clamped
-    /// to this bound otherwise.
+    /// Default value is 100.
     pub fn threshold(&mut self, value: usize) -> &mut Self {
         self.threshold = value;
         self


### PR DESCRIPTION
This PR brings support for the prefix search settings in the new settings indexer. Note that I mostly implemented clearing the different databases as the indexing of prefixes [was already correctly implemented](https://github.com/meilisearch/meilisearch/blob/6294894c488663b76f78464937f258424ac1a83d/crates/milli/src/update/new/word_fst_builder.rs#L84). This is tracked in [this internal issue](https://linear.app/meilisearch/issue/SCA-278/support-the-prefix-search-parameter).

## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respects the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - *list of used tools and what they were used for*