### PR TITLE
Fix an internal error when changing the binary quantization

### DIFF
--- a/crates/meilisearch/tests/vector/binary_quantized.rs
+++ b/crates/meilisearch/tests/vector/binary_quantized.rs
@@ -336,3 +336,46 @@ async fn binary_quantize_clear_documents() {
     }
     "###);
 }
+
+#[actix_rt::test]
+async fn remove_binary_quantized_embedder() {
+    let server = Server::new().await;
+    let index = server.index("doggo");
+
+    // 1. Insert documents without embeddings
+    let documents = json!([
+      {"id": 0, "name": "kefir", "_vectors": { "default": [1.0, 2.0, 3.0] }},
+      {"id": 1, "name": "echo", "_vectors": { "default": [-1.0, 0.5, -2.0] }},
+    ]);
+    let (value, code) = index.add_documents(documents, None).await;
+    snapshot!(code, @"202 Accepted");
+    server.wait_task(value.uid()).await.succeeded();
+
+    // 2. Set userProvided embedder with binaryQuantized
+    let (response, code) = index
+        .update_settings(json!({
+          "embedders": {
+              "default": {
+                  "source": "userProvided",
+                  "dimensions": 3,
+                  "binaryQuantized": true
+              }
+          },
+        }))
+        .await;
+    snapshot!(code, @"202 Accepted");
+    server.wait_task(response.uid()).await.succeeded();
+
+    // 3. Remove the embedder by setting it to null
+    let (response, code) = index
+        .update_settings(json!({
+          "embedders": {
+              "default": null
+          },
+        }))
+        .await;
+    snapshot!(code, @"202 Accepted");
+    // BUG: this triggers an internal error.
+    // Once the bug is fixed this task should succeed.
+    server.wait_task(response.uid()).await.succeeded();
+}

--- a/crates/milli/src/update/settings.rs
+++ b/crates/milli/src/update/settings.rs
@@ -1269,9 +1269,15 @@ impl<'a, 't, 'i> Settings<'a, 't, 'i> {
                         &name,
                         EmbeddingValidationContext::FullSettings,
                     )?;
+                    let is_being_quantized = setting
+                        .as_ref()
+                        .set()
+                        .and_then(|settings| settings.binary_quantized.set())
+                        .unwrap_or_default();
                     embedder_actions.insert(
                         name.clone(),
-                        EmbedderAction::with_reindex(ReindexAction::FullReindex, false),
+                        EmbedderAction::with_reindex(ReindexAction::FullReindex, false)
+                            .with_is_being_quantized(is_being_quantized),
                     );
                     let mut fragments = FragmentConfigs::new();
                     fragments.add_new_fragments(


### PR DESCRIPTION
This PR fixes an internal error preventing users to change the binary quantization parameters of embedders and introduces a test to catch this internal error.

## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respects the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - *list of used tools and what they were used for*