### PR TITLE
Support exact and disable on numbers in the new settings indexer

### DIFF
--- a/crates/milli/src/update/new/indexer/mod.rs
+++ b/crates/milli/src/update/new/indexer/mod.rs
@@ -272,63 +272,8 @@ where
     delete_old_geo_databases(wtxn, index, settings_delta, must_stop_processing, progress)?;
 
     // Fetch the numbers from the words FST
-    let mut numbers_to_delete_from_words_fst = BTreeSet::new();
-    let mut numbers_to_add_to_words_fst = BTreeSet::new();
-    let old_disabled_typos_terms = settings_delta.old_disabled_typos_terms();
-    let new_disabled_typos_terms = settings_delta.new_disabled_typos_terms();
-    match (old_disabled_typos_terms, new_disabled_typos_terms) {
-        (
-            DisabledTyposTerms { disable_on_numbers: false },
-            DisabledTyposTerms { disable_on_numbers: true },
-        ) => {
-            // We enable disableOnNumbers so we need to remove those from the words FST
-            numbers_to_delete_from_words_fst =
-                extract_numbers_from_words_fst(wtxn, index, new_disabled_typos_terms)?;
-            let rtxn = index.read_txn()?;
-            migrate_word_docids(
-                &rtxn,
-                index.word_docids,
-                wtxn,
-                index.exact_word_docids,
-                &numbers_to_delete_from_words_fst,
-            )?;
-            migrate_word_docids(
-                &rtxn,
-                index.word_prefix_docids,
-                wtxn,
-                index.exact_word_prefix_docids,
-                &numbers_to_delete_from_words_fst,
-            )?;
-        }
-        (
-            DisabledTyposTerms { disable_on_numbers: true },
-            DisabledTyposTerms { disable_on_numbers: false },
-        ) => {
-            // We disable disableOnNumbers so we need to add those words to the words FST
-            numbers_to_add_to_words_fst = extract_numbers_from_word_fid_docids(
-                wtxn,
-                index,
-                settings_delta.old_fields_ids_map(),
-                old_disabled_typos_terms,
-            )?;
-            let rtxn = index.read_txn()?;
-            migrate_word_docids(
-                &rtxn,
-                index.exact_word_docids,
-                wtxn,
-                index.word_docids,
-                &numbers_to_add_to_words_fst,
-            )?;
-            migrate_word_docids(
-                &rtxn,
-                index.exact_word_prefix_docids,
-                wtxn,
-                index.word_prefix_docids,
-                &numbers_to_add_to_words_fst,
-            )?;
-        }
-        _ => (),
-    };
+    let (numbers_to_delete_from_words_fst, numbers_to_add_to_words_fst) =
+        migrate_numbers(wtxn, index, settings_delta)?;
 
     // Clear word_pair_proximity if byWord to byAttribute
     let old_proximity_precision = settings_delta.old_proximity_precision();
@@ -623,6 +568,76 @@ where
     Ok(())
 }
 
+pub fn migrate_numbers<SD>(
+    wtxn: &mut RwTxn<'_>,
+    index: &Index,
+    settings_delta: &SD,
+) -> Result<(BTreeSet<String>, BTreeSet<String>)>
+where
+    SD: SettingsDelta + Sync,
+{
+    let mut numbers_to_delete_from_words_fst = BTreeSet::new();
+    let mut numbers_to_add_to_words_fst = BTreeSet::new();
+
+    let old_disabled_typos_terms = settings_delta.old_disabled_typos_terms();
+    let new_disabled_typos_terms = settings_delta.new_disabled_typos_terms();
+    match (old_disabled_typos_terms, new_disabled_typos_terms) {
+        (
+            DisabledTyposTerms { disable_on_numbers: false },
+            DisabledTyposTerms { disable_on_numbers: true },
+        ) => {
+            // We enable disableOnNumbers so we need to remove those from the words FST
+            numbers_to_delete_from_words_fst =
+                extract_numbers_from_words_fst(wtxn, index, new_disabled_typos_terms)?;
+            let rtxn = index.read_txn()?;
+            migrate_word_docids(
+                &rtxn,
+                index.word_docids,
+                wtxn,
+                index.exact_word_docids,
+                &numbers_to_delete_from_words_fst,
+            )?;
+            migrate_word_docids(
+                &rtxn,
+                index.word_prefix_docids,
+                wtxn,
+                index.exact_word_prefix_docids,
+                &numbers_to_delete_from_words_fst,
+            )?;
+        }
+        (
+            DisabledTyposTerms { disable_on_numbers: true },
+            DisabledTyposTerms { disable_on_numbers: false },
+        ) => {
+            // We disable disableOnNumbers so we need to add those words to the words FST
+            numbers_to_add_to_words_fst = extract_numbers_from_non_exact_searchable_attributes(
+                wtxn,
+                index,
+                settings_delta.old_fields_ids_map(),
+                old_disabled_typos_terms,
+            )?;
+            let rtxn = index.read_txn()?;
+            migrate_word_docids(
+                &rtxn,
+                index.exact_word_docids,
+                wtxn,
+                index.word_docids,
+                &numbers_to_add_to_words_fst,
+            )?;
+            migrate_word_docids(
+                &rtxn,
+                index.exact_word_prefix_docids,
+                wtxn,
+                index.word_prefix_docids,
+                &numbers_to_add_to_words_fst,
+            )?;
+        }
+        _ => (),
+    }
+
+    Ok((numbers_to_delete_from_words_fst, numbers_to_add_to_words_fst))
+}
+
 pub fn extract_numbers_from_words_fst(
     rtxn: &RoTxn<'_>,
     index: &Index,
@@ -643,7 +658,7 @@ pub fn extract_numbers_from_words_fst(
     Ok(removed_numbers)
 }
 
-pub fn extract_numbers_from_word_fid_docids(
+pub fn extract_numbers_from_non_exact_searchable_attributes(
     rtxn: &RoTxn<'_>,
     index: &Index,
     exact_attributes: &FieldIdMapWithMetadata,
@@ -653,7 +668,7 @@ pub fn extract_numbers_from_word_fid_docids(
     for result in index.word_fid_docids.remap_data_type::<DecodeIgnore>().iter(rtxn)? {
         let ((word, fid), _) = result?;
         let Some(metadata) = exact_attributes.metadata(fid) else { continue };
-        if metadata.exact == PatternMatch::Match && disabled_typos_terms.is_exact(word) {
+        if metadata.exact != PatternMatch::Match && disabled_typos_terms.is_exact(word) {
             numbers.insert(word.to_string());
         }
     }

--- a/crates/milli/src/update/new/indexer/mod.rs
+++ b/crates/milli/src/update/new/indexer/mod.rs
@@ -305,8 +305,12 @@ where
             DisabledTyposTerms { disable_on_numbers: false },
         ) => {
             // We disable disableOnNumbers so we need to add those words to the words FST
-            numbers_to_add_to_words_fst =
-                extract_numbers_from_words_fst(wtxn, index, new_disabled_typos_terms)?;
+            numbers_to_add_to_words_fst = extract_numbers_from_word_fid_docids(
+                wtxn,
+                index,
+                settings_delta.old_fields_ids_map(),
+                old_disabled_typos_terms,
+            )?;
             let rtxn = index.read_txn()?;
             migrate_word_docids(
                 &rtxn,
@@ -637,6 +641,23 @@ pub fn extract_numbers_from_words_fst(
     }
 
     Ok(removed_numbers)
+}
+
+pub fn extract_numbers_from_word_fid_docids(
+    rtxn: &RoTxn<'_>,
+    index: &Index,
+    exact_attributes: &FieldIdMapWithMetadata,
+    disabled_typos_terms: &DisabledTyposTerms,
+) -> Result<BTreeSet<String>> {
+    let mut numbers = BTreeSet::new();
+    for result in index.word_fid_docids.remap_data_type::<DecodeIgnore>().iter(rtxn)? {
+        let ((word, fid), _) = result?;
+        let Some(metadata) = exact_attributes.metadata(fid) else { continue };
+        if metadata.exact == PatternMatch::Match && disabled_typos_terms.is_exact(word) {
+            numbers.insert(word.to_string());
+        }
+    }
+    Ok(numbers)
 }
 
 pub fn migrate_word_docids(

--- a/crates/milli/src/update/new/indexer/mod.rs
+++ b/crates/milli/src/update/new/indexer/mod.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet, HashSet, LinkedList};
 use std::iter;
 use std::ops::{Bound, Not as _};
@@ -10,7 +9,7 @@ use big_s::S;
 use document_changes::{DocumentChanges, IndexingContext};
 pub use document_deletion::DocumentDeletion;
 pub use document_operation::{IndexOperations, PayloadStats};
-use fst::{IntoStreamer, Set, Streamer as _};
+use fst::Streamer as _;
 use hashbrown::HashMap;
 use heed::types::{Bytes, DecodeIgnore, Unit};
 use heed::{BytesDecode, Database, RoTxn, RwTxn};
@@ -280,10 +279,6 @@ where
         Default::default()
     };
 
-    // TODO Can't I do that another way? With the SettingsDelta maybe?
-    //      Is it correct to touch the FST like that after the indexing is done?
-    let (to_remove_exact_words, to_add_exact_words) = extract_exact_words_from_fst(wtxn, index)?;
-
     // Clear word_pair_proximity if byWord to byAttribute
     let old_proximity_precision = settings_delta.old_proximity_precision();
     let new_proximity_precision = settings_delta.new_proximity_precision();
@@ -378,12 +373,6 @@ where
         // Insert the recently removed numbers into deleted words
         // so that the FST and prefixes are correctly updated
         word_delta.deleted.extend(removed_numbers);
-
-        // Insert the words to add and remove from the FST based on the exact words settings.
-        // TODO this is probably incorrect to do that this way as there could be common
-        //      words between the added and removed sets. What should I do in this case?
-        word_delta.added.extend(to_remove_exact_words);
-        word_delta.deleted.extend(to_add_exact_words);
 
         indexing_context.progress.update_progress(IndexingStep::WritingEmbeddingsToDatabase);
 
@@ -596,50 +585,6 @@ pub fn extract_numbers_from_words_fst(rtxn: &RoTxn<'_>, index: &Index) -> Result
     }
 
     Ok(removed_numbers)
-}
-
-fn extract_exact_words_from_fst(
-    new_rtxn: &RoTxn<'_>,
-    index: &Index,
-) -> Result<(HashSet<String>, HashSet<String>)> {
-    let mut to_remove_exact_words = HashSet::new();
-    let mut to_add_exact_words = HashSet::new();
-
-    let old_rtxn = index.read_txn()?;
-    let old_exact_words = index.exact_words(&old_rtxn)?;
-    let new_exact_words = index.exact_words(new_rtxn)?;
-
-    if old_exact_words.as_ref().map(|f| f.as_fst().as_bytes())
-        == new_exact_words.as_ref().map(|f| f.as_fst().as_bytes())
-    {
-        return Ok(Default::default());
-    }
-
-    let fst = index.words_fst(&old_rtxn)?;
-
-    let old_exact_words =
-        old_exact_words.unwrap_or_else(|| Set::default().map_data(Cow::Owned).unwrap());
-    let new_exact_words =
-        new_exact_words.unwrap_or_else(|| Set::default().map_data(Cow::Owned).unwrap());
-
-    let added_exact_words = new_exact_words.op().add(old_exact_words.stream()).difference();
-    let removed_exact_words = old_exact_words.op().add(new_exact_words.stream()).difference();
-
-    // Yes, that's in the reverse order because we want exact words not to be included in the words fst
-    let mut words_to_remove_stream = fst.op().add(added_exact_words).intersection().into_stream();
-    let mut words_to_add_stream = fst.op().add(removed_exact_words).intersection().into_stream();
-
-    while let Some(bytes) = words_to_remove_stream.next() {
-        let word = std::str::from_utf8(bytes)?;
-        to_remove_exact_words.insert(word.to_string());
-    }
-
-    while let Some(bytes) = words_to_add_stream.next() {
-        let word = std::str::from_utf8(bytes)?;
-        to_add_exact_words.insert(word.to_string());
-    }
-
-    Ok((to_remove_exact_words, to_add_exact_words))
 }
 
 pub fn delete_old_fid_from_facet_databases<SD, MSP>(

--- a/crates/milli/src/update/new/indexer/mod.rs
+++ b/crates/milli/src/update/new/indexer/mod.rs
@@ -27,6 +27,7 @@ use super::channel::*;
 use super::steps::IndexingStep;
 use super::thread_local::ThreadLocal;
 use crate::constants::{RESERVED_GEOJSON_FIELD_NAME, RESERVED_GEO_FIELD_NAME};
+use crate::disabled_typos_terms::DisabledTyposTerms;
 use crate::documents::PrimaryKey;
 use crate::fields_ids_map::metadata::{FieldIdMapWithMetadata, MetadataBuilder};
 use crate::heed_codec::StrBEU16Codec;
@@ -271,10 +272,11 @@ where
     delete_old_geo_databases(wtxn, index, settings_delta, must_stop_processing, progress)?;
 
     // Fetch the numbers from the words FST
-    let removed_numbers = if settings_delta.old_disabled_typos_terms().disable_on_numbers
-        && settings_delta.new_disabled_typos_terms().disable_on_numbers.not()
+    let new_disabled_typos_terms = settings_delta.new_disabled_typos_terms();
+    let removed_numbers = if settings_delta.old_disabled_typos_terms().disable_on_numbers.not()
+        && new_disabled_typos_terms.disable_on_numbers
     {
-        extract_numbers_from_words_fst(wtxn, index)?
+        extract_numbers_from_words_fst(wtxn, index, new_disabled_typos_terms)?
     } else {
         Default::default()
     };
@@ -571,16 +573,20 @@ where
     Ok(())
 }
 
-pub fn extract_numbers_from_words_fst(rtxn: &RoTxn<'_>, index: &Index) -> Result<HashSet<String>> {
+pub fn extract_numbers_from_words_fst(
+    rtxn: &RoTxn<'_>,
+    index: &Index,
+    disabled_typos_terms: &DisabledTyposTerms,
+) -> Result<HashSet<String>> {
     let mut removed_numbers = HashSet::new();
     let fst = index.words_fst(rtxn)?;
     let mut stream = fst.stream();
     // TODO use an automaton to only iterate over strings that are numbers
     //      (and thus starts with a digit)
     while let Some(bytes) = stream.next() {
-        if bytes.iter().all(|c| c.is_ascii_digit()) {
-            let number = std::str::from_utf8(bytes)?;
-            removed_numbers.insert(number.to_string());
+        let word = std::str::from_utf8(bytes)?;
+        if disabled_typos_terms.is_exact(word) {
+            removed_numbers.insert(word.to_string());
         }
     }
 

--- a/crates/milli/src/update/new/indexer/mod.rs
+++ b/crates/milli/src/update/new/indexer/mod.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet, HashSet, LinkedList};
 use std::iter;
 use std::ops::{Bound, Not as _};
@@ -9,7 +10,7 @@ use big_s::S;
 use document_changes::{DocumentChanges, IndexingContext};
 pub use document_deletion::DocumentDeletion;
 pub use document_operation::{IndexOperations, PayloadStats};
-use fst::Streamer as _;
+use fst::{IntoStreamer, Set, Streamer as _};
 use hashbrown::HashMap;
 use heed::types::{Bytes, DecodeIgnore, Unit};
 use heed::{BytesDecode, Database, RoTxn, RwTxn};
@@ -274,10 +275,14 @@ where
     let removed_numbers = if settings_delta.old_disabled_typos_terms().disable_on_numbers
         && settings_delta.new_disabled_typos_terms().disable_on_numbers.not()
     {
-        fetch_numbers_from_words_fst(wtxn, index)?
+        extract_numbers_from_words_fst(wtxn, index)?
     } else {
         Default::default()
     };
+
+    // TODO Can't I do that another way? With the SettingsDelta maybe?
+    //      Is it correct to touch the FST like that after the indexing is done?
+    let (to_remove_exact_words, to_add_exact_words) = extract_exact_words_from_fst(wtxn, index)?;
 
     // Clear word_pair_proximity if byWord to byAttribute
     let old_proximity_precision = settings_delta.old_proximity_precision();
@@ -373,6 +378,12 @@ where
         // Insert the recently removed numbers into deleted words
         // so that the FST and prefixes are correctly updated
         word_delta.deleted.extend(removed_numbers);
+
+        // Insert the words to add and remove from the FST based on the exact words settings.
+        // TODO this is probably incorrect to do that this way as there could be common
+        //      words between the added and removed sets. What should I do in this case?
+        word_delta.added.extend(to_remove_exact_words);
+        word_delta.deleted.extend(to_add_exact_words);
 
         indexing_context.progress.update_progress(IndexingStep::WritingEmbeddingsToDatabase);
 
@@ -571,7 +582,7 @@ where
     Ok(())
 }
 
-pub fn fetch_numbers_from_words_fst(rtxn: &RoTxn<'_>, index: &Index) -> Result<HashSet<String>> {
+pub fn extract_numbers_from_words_fst(rtxn: &RoTxn<'_>, index: &Index) -> Result<HashSet<String>> {
     let mut removed_numbers = HashSet::new();
     let fst = index.words_fst(rtxn)?;
     let mut stream = fst.stream();
@@ -585,6 +596,50 @@ pub fn fetch_numbers_from_words_fst(rtxn: &RoTxn<'_>, index: &Index) -> Result<H
     }
 
     Ok(removed_numbers)
+}
+
+fn extract_exact_words_from_fst(
+    new_rtxn: &RoTxn<'_>,
+    index: &Index,
+) -> Result<(HashSet<String>, HashSet<String>)> {
+    let mut to_remove_exact_words = HashSet::new();
+    let mut to_add_exact_words = HashSet::new();
+
+    let old_rtxn = index.read_txn()?;
+    let old_exact_words = index.exact_words(&old_rtxn)?;
+    let new_exact_words = index.exact_words(new_rtxn)?;
+
+    if old_exact_words.as_ref().map(|f| f.as_fst().as_bytes())
+        == new_exact_words.as_ref().map(|f| f.as_fst().as_bytes())
+    {
+        return Ok(Default::default());
+    }
+
+    let fst = index.words_fst(&old_rtxn)?;
+
+    let old_exact_words =
+        old_exact_words.unwrap_or_else(|| Set::default().map_data(Cow::Owned).unwrap());
+    let new_exact_words =
+        new_exact_words.unwrap_or_else(|| Set::default().map_data(Cow::Owned).unwrap());
+
+    let added_exact_words = new_exact_words.op().add(old_exact_words.stream()).difference();
+    let removed_exact_words = old_exact_words.op().add(new_exact_words.stream()).difference();
+
+    // Yes, that's in the reverse order because we want exact words not to be included in the words fst
+    let mut words_to_remove_stream = fst.op().add(added_exact_words).intersection().into_stream();
+    let mut words_to_add_stream = fst.op().add(removed_exact_words).intersection().into_stream();
+
+    while let Some(bytes) = words_to_remove_stream.next() {
+        let word = std::str::from_utf8(bytes)?;
+        to_remove_exact_words.insert(word.to_string());
+    }
+
+    while let Some(bytes) = words_to_add_stream.next() {
+        let word = std::str::from_utf8(bytes)?;
+        to_add_exact_words.insert(word.to_string());
+    }
+
+    Ok((to_remove_exact_words, to_add_exact_words))
 }
 
 pub fn delete_old_fid_from_facet_databases<SD, MSP>(

--- a/crates/milli/src/update/new/indexer/mod.rs
+++ b/crates/milli/src/update/new/indexer/mod.rs
@@ -1,6 +1,6 @@
-use std::collections::{BTreeMap, BTreeSet, HashSet, LinkedList};
+use std::collections::{BTreeMap, BTreeSet, LinkedList};
 use std::iter;
-use std::ops::{Bound, Not as _};
+use std::ops::Bound;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Once, RwLock};
 use std::thread::{self, Builder};
@@ -11,7 +11,7 @@ pub use document_deletion::DocumentDeletion;
 pub use document_operation::{IndexOperations, PayloadStats};
 use fst::Streamer as _;
 use hashbrown::HashMap;
-use heed::types::{Bytes, DecodeIgnore, Unit};
+use heed::types::{Bytes, DecodeIgnore, Str, Unit};
 use heed::{BytesDecode, Database, RoTxn, RwTxn};
 pub use mini_string::MiniString;
 pub use partial_dump::PartialDump;
@@ -39,8 +39,8 @@ use crate::update::GrenadParameters;
 use crate::vector::settings::{EmbedderAction, RemoveFragments, WriteBackToDocuments};
 use crate::vector::{Embedder, RuntimeEmbedders, VectorStore};
 use crate::{
-    Error, FieldsIdsMap, FilterFeatures, FilterableAttributesFeatures, GlobalFieldsIdsMap, Index,
-    InternalError, PatternMatch, Result, ThreadPoolNoAbort,
+    CboRoaringBitmapCodec, Error, FieldsIdsMap, FilterFeatures, FilterableAttributesFeatures,
+    GlobalFieldsIdsMap, Index, InternalError, PatternMatch, Result, ThreadPoolNoAbort,
 };
 
 pub(crate) mod de;
@@ -272,13 +272,58 @@ where
     delete_old_geo_databases(wtxn, index, settings_delta, must_stop_processing, progress)?;
 
     // Fetch the numbers from the words FST
+    let mut numbers_to_delete_from_words_fst = BTreeSet::new();
+    let mut numbers_to_add_to_words_fst = BTreeSet::new();
+    let old_disabled_typos_terms = settings_delta.old_disabled_typos_terms();
     let new_disabled_typos_terms = settings_delta.new_disabled_typos_terms();
-    let removed_numbers = if settings_delta.old_disabled_typos_terms().disable_on_numbers.not()
-        && new_disabled_typos_terms.disable_on_numbers
-    {
-        extract_numbers_from_words_fst(wtxn, index, new_disabled_typos_terms)?
-    } else {
-        Default::default()
+    match (old_disabled_typos_terms, new_disabled_typos_terms) {
+        (
+            DisabledTyposTerms { disable_on_numbers: false },
+            DisabledTyposTerms { disable_on_numbers: true },
+        ) => {
+            // We enable disableOnNumbers so we need to remove those from the words FST
+            numbers_to_delete_from_words_fst =
+                extract_numbers_from_words_fst(wtxn, index, new_disabled_typos_terms)?;
+            let rtxn = index.read_txn()?;
+            migrate_word_docids(
+                &rtxn,
+                index.word_docids,
+                wtxn,
+                index.exact_word_docids,
+                &numbers_to_delete_from_words_fst,
+            )?;
+            migrate_word_docids(
+                &rtxn,
+                index.word_prefix_docids,
+                wtxn,
+                index.exact_word_prefix_docids,
+                &numbers_to_delete_from_words_fst,
+            )?;
+        }
+        (
+            DisabledTyposTerms { disable_on_numbers: true },
+            DisabledTyposTerms { disable_on_numbers: false },
+        ) => {
+            // We disable disableOnNumbers so we need to add those words to the words FST
+            numbers_to_add_to_words_fst =
+                extract_numbers_from_words_fst(wtxn, index, new_disabled_typos_terms)?;
+            let rtxn = index.read_txn()?;
+            migrate_word_docids(
+                &rtxn,
+                index.exact_word_docids,
+                wtxn,
+                index.word_docids,
+                &numbers_to_add_to_words_fst,
+            )?;
+            migrate_word_docids(
+                &rtxn,
+                index.exact_word_prefix_docids,
+                wtxn,
+                index.word_prefix_docids,
+                &numbers_to_add_to_words_fst,
+            )?;
+        }
+        _ => (),
     };
 
     // Clear word_pair_proximity if byWord to byAttribute
@@ -372,9 +417,10 @@ where
         let (index_embeddings, mut word_delta, facet_field_ids_delta) =
             extractor_handle.join().unwrap()?;
 
+        // Insert the recently added numbers into the added words
+        word_delta.added.extend(numbers_to_add_to_words_fst);
         // Insert the recently removed numbers into deleted words
-        // so that the FST and prefixes are correctly updated
-        word_delta.deleted.extend(removed_numbers);
+        word_delta.deleted.extend(numbers_to_delete_from_words_fst);
 
         indexing_context.progress.update_progress(IndexingStep::WritingEmbeddingsToDatabase);
 
@@ -577,8 +623,8 @@ pub fn extract_numbers_from_words_fst(
     rtxn: &RoTxn<'_>,
     index: &Index,
     disabled_typos_terms: &DisabledTyposTerms,
-) -> Result<HashSet<String>> {
-    let mut removed_numbers = HashSet::new();
+) -> Result<BTreeSet<String>> {
+    let mut removed_numbers = BTreeSet::new();
     let fst = index.words_fst(rtxn)?;
     let mut stream = fst.stream();
     // TODO use an automaton to only iterate over strings that are numbers
@@ -591,6 +637,25 @@ pub fn extract_numbers_from_words_fst(
     }
 
     Ok(removed_numbers)
+}
+
+pub fn migrate_word_docids(
+    rtxn: &RoTxn<'_>,
+    src: Database<Str, CboRoaringBitmapCodec>,
+    wtxn: &mut RwTxn<'_>,
+    dst: Database<Str, CboRoaringBitmapCodec>,
+    words: &BTreeSet<String>,
+) -> Result<()> {
+    let src = src.remap_data_type::<Bytes>();
+    let dst = dst.remap_data_type::<Bytes>();
+
+    for word in words {
+        let Some(docids_bytes) = src.get(rtxn, word)? else { continue };
+        dst.put(wtxn, word, docids_bytes)?;
+        src.delete(wtxn, word)?;
+    }
+
+    Ok(())
 }
 
 pub fn delete_old_fid_from_facet_databases<SD, MSP>(

--- a/crates/milli/src/update/new/indexer/mod.rs
+++ b/crates/milli/src/update/new/indexer/mod.rs
@@ -1,6 +1,6 @@
-use std::collections::{BTreeMap, BTreeSet, LinkedList};
+use std::collections::{BTreeMap, BTreeSet, HashSet, LinkedList};
 use std::iter;
-use std::ops::Bound;
+use std::ops::{Bound, Not as _};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Once, RwLock};
 use std::thread::{self, Builder};
@@ -270,6 +270,15 @@ where
     )?;
     delete_old_geo_databases(wtxn, index, settings_delta, must_stop_processing, progress)?;
 
+    // Fetch the numbers from the words FST
+    let removed_numbers = if settings_delta.old_disabled_typos_terms().disable_on_numbers
+        && settings_delta.new_disabled_typos_terms().disable_on_numbers.not()
+    {
+        fetch_numbers_from_words_fst(wtxn, index)?
+    } else {
+        Default::default()
+    };
+
     // Clear word_pair_proximity if byWord to byAttribute
     let old_proximity_precision = settings_delta.old_proximity_precision();
     let new_proximity_precision = settings_delta.new_proximity_precision();
@@ -358,8 +367,12 @@ where
 
         indexing_context.progress.update_progress(IndexingStep::WaitingForExtractors);
 
-        let (index_embeddings, word_delta, facet_field_ids_delta) =
+        let (index_embeddings, mut word_delta, facet_field_ids_delta) =
             extractor_handle.join().unwrap()?;
+
+        // Insert the recently removed numbers into deleted words
+        // so that the FST and prefixes are correctly updated
+        word_delta.deleted.extend(removed_numbers);
 
         indexing_context.progress.update_progress(IndexingStep::WritingEmbeddingsToDatabase);
 
@@ -556,6 +569,22 @@ where
     }
 
     Ok(())
+}
+
+pub fn fetch_numbers_from_words_fst(rtxn: &RoTxn<'_>, index: &Index) -> Result<HashSet<String>> {
+    let mut removed_numbers = HashSet::new();
+    let fst = index.words_fst(rtxn)?;
+    let mut stream = fst.stream();
+    // TODO use an automaton to only iterate over strings that are numbers
+    //      (and thus starts with a digit)
+    while let Some(bytes) = stream.next() {
+        if bytes.iter().all(|c| c.is_ascii_digit()) {
+            let number = std::str::from_utf8(bytes)?;
+            removed_numbers.insert(number.to_string());
+        }
+    }
+
+    Ok(removed_numbers)
 }
 
 pub fn delete_old_fid_from_facet_databases<SD, MSP>(

--- a/crates/milli/src/update/settings.rs
+++ b/crates/milli/src/update/settings.rs
@@ -1663,7 +1663,7 @@ impl<'a, 't, 'i> Settings<'a, 't, 'i> {
             localized_attributes_rules: Setting::NotSet, // TODO (require force reindexing of searchables)
             prefix_search: Setting::NotSet,              // TODO continue with this
             facet_search: _,
-            disable_on_numbers: Setting::NotSet, // TODO (require force reindexing of searchables)
+            disable_on_numbers: _,
             chat: _,
             vector_store: Setting::NotSet,
             wtxn: _,
@@ -1700,6 +1700,8 @@ impl<'a, 't, 'i> Settings<'a, 't, 'i> {
             self.update_search_cutoff()?;
             self.update_chat_config()?;
             self.update_facet_search()?;
+            self.update_exact_words()?;
+            self.update_disabled_typos_terms()?;
 
             // Note that we don't need to update the searchables here,
             // as it will be done after the settings update.


### PR DESCRIPTION
This PR introduces support for the exact words and disable-on-words parameters in the new settings indexer.

## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respects the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)