### PR TITLE
fix(s3): clamp multipart flush threshold to S3's 5 MiB minimum

### DIFF
--- a/crates/index-scheduler/src/scheduler/enterprise_edition/s3.rs
+++ b/crates/index-scheduler/src/scheduler/enterprise_edition/s3.rs
@@ -371,6 +371,16 @@ where
     Ok(())
 }
 
+/// S3's hard minimum size for any non-last part in a multipart upload.
+///
+/// See <https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html>.
+const S3_MIN_PART_SIZE: usize = 5 * 1024 * 1024;
+
+/// Extra slack above [`S3_MIN_PART_SIZE`] to absorb the overshoot of a single
+/// `try_read_buf` call (typically a 16–64 KiB kernel pipe chunk). Without this,
+/// a flush at exactly the 5 MiB boundary could land just below.
+const S3_PART_SIZE_HEADROOM: usize = 64 * 1024;
+
 /// Streams the content read from the given reader to S3.
 #[allow(clippy::too_many_arguments)]
 async fn multipart_stream_to_s3(
@@ -439,7 +449,12 @@ async fn multipart_stream_to_s3(
 
     let multipart =
         CreateMultipartUpload::parse_response(&body).map_err(|e| Error::S3XmlError(Box::new(e)))?;
-    tracing::debug!("Starting the upload of the snapshot to {object}");
+    tracing::debug!(
+        object = %object,
+        part_size = s3_multipart_part_size,
+        max_in_flight = s3_max_in_flight_parts.get(),
+        "Starting multipart upload of snapshot"
+    );
 
     // We use this bumpalo for etags strings.
     let bump = bumpalo::Bump::new();
@@ -475,9 +490,25 @@ async fn multipart_stream_to_s3(
             BytesMut::with_capacity(s3_multipart_part_size as usize)
         };
 
+        // S3 requires every non-last multipart part to be at least 5 MiB.
+        // The configured `s3_multipart_part_size / 2` heuristic can fall below
+        // that floor when users set a small part size, so we clamp it.
+        let flush_threshold = std::cmp::max(
+            S3_MIN_PART_SIZE + S3_PART_SIZE_HEADROOM,
+            s3_multipart_part_size as usize / 2,
+        );
+        if part_number == 1 {
+            tracing::debug!(
+                flush_threshold,
+                half_part_size = s3_multipart_part_size as usize / 2,
+                s3_min_part_size = S3_MIN_PART_SIZE,
+                "Resolved multipart flush threshold"
+            );
+        }
+
         // If we successfully read enough bytes,
         // we can continue and send the buffer/part
-        while buffer.len() < (s3_multipart_part_size as usize / 2) {
+        while buffer.len() < flush_threshold {
             // Wait for the pipe to be readable
 
             reader.readable().await?;
@@ -499,7 +530,7 @@ async fn multipart_stream_to_s3(
         }
 
         let body = buffer.freeze();
-        tracing::trace!("Sending part {part_number}");
+        tracing::trace!(part_number, size = body.len(), "Uploading part");
         let task = tokio::spawn({
             let client = client.clone();
             let body = body.clone();
@@ -527,7 +558,7 @@ async fn multipart_stream_to_s3(
         extract_and_append_etag(&bump, &mut etags, resp.headers())?;
     }
 
-    tracing::debug!("Finalizing the multipart upload");
+    tracing::debug!(total_parts = etags.len(), "Finalizing the multipart upload");
 
     let action = bucket.complete_multipart_upload(
         Some(&credential),


### PR DESCRIPTION
The streaming uploader flushed a part as soon as the buffer reached `s3_multipart_part_size / 2`. When users configured a part size below ~10 MiB (e.g. `MEILI_EXPERIMENTAL_S3_MULTIPART_PART_SIZE=10MB`), that threshold dropped under S3's 5 MiB hard minimum for non-last parts and `CompleteMultipartUpload` returned `EntityTooSmall`.

Clamp the threshold so it can never fall below `5 MiB + 64 KiB` (headroom for one pipe-read overshoot). The configured part size still governs the upper bound and buffer capacity; only the flush trigger is floored. The last part is unaffected and may be any size, per the S3 spec.

Also surface part_size, max_in_flight, the resolved flush threshold, part size on upload, and total parts on completion in the existing debug/trace logs to make future capacity-tuning easier to diagnose.

tested with snapshots of size 
852KB (single multipart)
5.6MB  (single possible multipart)
10.2MB (small sized to create ~2 multiparts)
27 MB (small sized to create a few multiparts)
1.2GB (large sized for multiple multiparts)
<img width="1310" height="546" alt="Screenshot 2026-05-22 at 10 39 20 PM" src="https://github.com/user-attachments/assets/10bf6890-a14c-4dba-a202-6cf5bbd6594b" />

Fixes #6400.

## Related issue

Fixes #...

## Generative AI tools

- [ ] This PR does not use generative AI tooling
- [x] This PR uses generative AI tooling and respect the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - *list of used tools and what they were used for*

## Requirements

⚠️ Ensure the following requirements before merging ⚠️
- [ ] Automated tests have been added.
- [ ] If some tests cannot be automated, manual rigorous tests should be applied.
- [ ] ⚠️ If there is any change in the DB:
    - [ ] Test that any impacted DB still works as expected after using `--experimental-dumpless-upgrade` on a DB created with the last released Meilisearch
    - [ ] Test that during the upgrade, **search is still available** (artificially make the upgrade longer if needed)
    - [ ] Set the `db change` label.
- [ ] If necessary, the feature have been tested in the Cloud production environment (with [prototypes](./documentation/prototypes.md)) and the Cloud UI is ready.
- [ ] If necessary, the [documentation](https://github.com/meilisearch/documentation) related to the implemented feature in the PR is ready.
- [ ] If necessary, the [integrations](https://github.com/meilisearch/integration-guides) related to the implemented feature in the PR are ready.
