### PR TITLE
Better limit read bytes when creating the S3 multipart part

### DIFF
--- a/crates/index-scheduler/src/scheduler/enterprise_edition/s3.rs
+++ b/crates/index-scheduler/src/scheduler/enterprise_edition/s3.rs
@@ -395,7 +395,7 @@ async fn multipart_stream_to_s3(
     use std::os::fd::OwnedFd;
     use std::path::PathBuf;
 
-    use bytes::{Bytes, BytesMut};
+    use bytes::{BufMut as _, Bytes, BytesMut};
     use http_client::reqwest::{Client, Response};
     use rusty_s3::actions::CreateMultipartUpload;
     use rusty_s3::{Bucket, BucketError, Credentials, S3Action as _, UrlStyle};
@@ -477,10 +477,13 @@ async fn multipart_stream_to_s3(
 
         // If we successfully read enough bytes,
         // we can continue and send the buffer/part
-        while buffer.len() < (s3_multipart_part_size as usize / 2) {
+        while buffer.len() < s3_multipart_part_size as usize {
             // Wait for the pipe to be readable
-
             reader.readable().await?;
+
+            // Make sure the multipart buffer is limited to the defined multipart size
+            let remaining = s3_multipart_part_size as usize - buffer.len();
+            let mut buffer = (&mut buffer).limit(remaining);
 
             match reader.try_read_buf(&mut buffer) {
                 Ok(0) => break,


### PR DESCRIPTION
This PR fixes an issue we had with the multipart part size by ensuring we never construct a part larger than the defined multipart part size, rather than doing an ugly division by two. The division by two caused a bug when the multipart part size was set slightly below 10MiB, resulting in a multipart part of 4.99MiB, which is slightly below the AWS S3 multipart part size limit of 5MiB. With this fix, we always create a multipart with the provided multipart part size, except for the last part. Thanks, @vidit-virmani, for the help investigating the issue.

Fixes #6400 and Closes #6404.

## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respects the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)