### PR TITLE
Fix broken links in the documentation

### DIFF
--- a/crates/meilisearch/src/routes/indexes/documents.rs
+++ b/crates/meilisearch/src/routes/indexes/documents.rs
@@ -870,7 +870,7 @@ impl<Method: AggregateMethod> Aggregate for DocumentsAggregator<Method> {
 ///
 /// If the provided index does not exist, it will be created.
 ///
-/// For a partial update of the document see [add or update documents route](/reference/api/documents/add-or-update-documents).
+/// For a partial update of the document see [add or update documents route](/docs/reference/api/documents/add-or-update-documents).
 ///
 /// > Use the reserved `_geo` object to add geo coordinates to a document.
 /// > `_geo` is an object made of `lat` and `lng` field.
@@ -982,7 +982,7 @@ pub async fn replace_documents(
 ///
 /// If the provided index does not exist, it will be created.
 ///
-/// To completely overwrite a document, see [add or replace documents route](/reference/api/documents/add-or-replace-documents).
+/// To completely overwrite a document, see [add or replace documents route](/docs/reference/api/documents/add-or-replace-documents).
 ///
 /// > Use the reserved `_geo` object to add geo coordinates to a document.
 /// > `_geo` is an object made of `lat` and `lng` field.

--- a/crates/meilisearch/src/routes/indexes/search.rs
+++ b/crates/meilisearch/src/routes/indexes/search.rs
@@ -483,7 +483,7 @@ pub fn fix_sort_query_parameters(sort_query: &str) -> Vec<String> {
 ///
 /// Search for documents matching a query in the given index.
 ///
-/// > Equivalent to the [search with POST route](/reference/api/search/search-with-post) in the Meilisearch API.
+/// > Equivalent to the [search with POST route](/docs/reference/api/search/search-with-post) in the Meilisearch API.
 #[routes::path(
     security(("Bearer" = ["search", "*"])),
     params(
@@ -686,7 +686,7 @@ pub(crate) async fn search(
 ///
 /// Search for documents matching a query in the given index.
 ///
-/// > Equivalent to the [search with GET route](/reference/api/search/search-with-get) in the Meilisearch API.
+/// > Equivalent to the [search with GET route](/docs/reference/api/search/search-with-get) in the Meilisearch API.
 #[routes::path(
     security(("Bearer" = ["search", "*"])),
     params(


### PR DESCRIPTION
This PR fixes some broken links we have in the documentation.

## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respects the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)