### PR TITLE
chore(config): add commented-out chat completions experimental feature entry

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -132,3 +132,7 @@ experimental_reduce_indexing_memory_usage = false
 
 # Experimentally reduces the maximum number of tasks that will be processed at once, see: <https://github.com/orgs/meilisearch/discussions/713>
 # experimental_max_number_of_batched_tasks = 100
+
+# Experimental chat completions feature. For more information, see: <https://www.meilisearch.com/docs/learn/experimental/chat_completions>
+# Enable chat completion capabilities on the `/chats` routes.
+# experimental_chat_completions = false


### PR DESCRIPTION
This adds `experimental_chat_completions` as a commented-out entry in config.toml, matching the format of other experimental features.

This makes users aware of the option so they can enable chat completion via config file at startup, rather than having to dispatch an API request.

Closes #5669.