### PR TITLE
Support settings that require two tokenizers in the new settings indexer

### DIFF
--- a/crates/meilisearch/tests/search/locales.rs
+++ b/crates/meilisearch/tests/search/locales.rs
@@ -788,6 +788,13 @@ async fn force_different_locales_with_pattern_nested() {
 
 #[actix_rt::test]
 async fn settings_change() {
+    match std::env::var("MEILI_EXPERIMENTAL_NO_EDITION_2024_FOR_SETTINGS") {
+        // If we are running this test with the old settings indexer we must skip it as there
+        // is a bug with the locales in the old settings indexer that we do not plan to fix.
+        Ok(value) if value == "true" => return,
+        Ok(_) | Err(_) => (),
+    };
+
     let server = Server::new_shared();
     let index = server.unique_index();
 

--- a/crates/meilisearch/tests/search/locales.rs
+++ b/crates/meilisearch/tests/search/locales.rs
@@ -842,12 +842,16 @@ async fn settings_change() {
             |response, code| {
                 snapshot!(json_string!(response, { ".processingTimeMs" => "[duration]", ".requestUid" => "[uuid]" }), @r###"
                 {
-                  "hits": [],
+                  "hits": [
+                    {
+                      "id": 852
+                    }
+                  ],
                   "query": "\"进击的巨人\"",
                   "processingTimeMs": "[duration]",
                   "limit": 20,
                   "offset": 0,
-                  "estimatedTotalHits": 0,
+                  "estimatedTotalHits": 1,
                   "requestUid": "[uuid]"
                 }
                 "###);
@@ -907,12 +911,16 @@ async fn settings_change() {
             |response, code| {
                 snapshot!(json_string!(response, { ".processingTimeMs" => "[duration]", ".requestUid" => "[uuid]" }), @r###"
                 {
-                  "hits": [],
+                  "hits": [
+                    {
+                      "id": 852
+                    }
+                  ],
                   "query": "\"进击的巨人\"",
                   "processingTimeMs": "[duration]",
                   "limit": 20,
                   "offset": 0,
-                  "estimatedTotalHits": 0,
+                  "estimatedTotalHits": 1,
                   "requestUid": "[uuid]"
                 }
                 "###);

--- a/crates/meilisearch/tests/vector/settings.rs
+++ b/crates/meilisearch/tests/vector/settings.rs
@@ -1,6 +1,6 @@
 use meili_snap::{json_string, snapshot};
 
-use crate::common::{GetAllDocumentsOptions, Server};
+use crate::common::{self, GetAllDocumentsOptions, Server};
 use crate::json;
 use crate::vector::generate_default_user_provided_documents;
 
@@ -136,47 +136,55 @@ async fn reset_embedder_documents() {
     let (documents, _code) = index
         .get_all_documents(GetAllDocumentsOptions { retrieve_vectors: true, ..Default::default() })
         .await;
+
+    // Make sure the previous settings indexer and the new settings indexer
+    // returns documents fields in the same order.
+    let documents = match documents {
+        common::Value(serde_json::Value::Object(mut map)) => {
+            map.values_mut().for_each(serde_json::Value::sort_all_objects);
+            common::Value(serde_json::Value::Object(map))
+        }
+        otherwise => otherwise,
+    };
+
     snapshot!(json_string!(documents), @r###"
     {
       "results": [
         {
-          "id": 0,
-          "name": "kefir",
           "_vectors": {
             "manual": {
-              "regenerate": false,
               "embeddings": [
                 [
                   0.0,
                   0.0,
                   0.0
                 ]
-              ]
+              ],
+              "regenerate": false
             }
-          }
+          },
+          "id": 0,
+          "name": "kefir"
         },
         {
-          "id": 1,
-          "name": "echo",
           "_vectors": {
             "manual": {
-              "regenerate": false,
               "embeddings": [
                 [
                   1.0,
                   1.0,
                   1.0
                 ]
-              ]
+              ],
+              "regenerate": false
             }
-          }
+          },
+          "id": 1,
+          "name": "echo"
         },
         {
-          "id": 2,
-          "name": "billou",
           "_vectors": {
             "manual": {
-              "regenerate": false,
               "embeddings": [
                 [
                   2.0,
@@ -188,32 +196,32 @@ async fn reset_embedder_documents() {
                   2.0,
                   3.0
                 ]
-              ]
+              ],
+              "regenerate": false
             }
-          }
+          },
+          "id": 2,
+          "name": "billou"
         },
         {
-          "id": 3,
-          "name": "intel",
           "_vectors": {
             "manual": {
-              "regenerate": false,
               "embeddings": [
                 [
                   3.0,
                   3.0,
                   3.0
                 ]
-              ]
+              ],
+              "regenerate": false
             }
-          }
+          },
+          "id": 3,
+          "name": "intel"
         },
         {
-          "id": 4,
-          "name": "max",
           "_vectors": {
             "manual": {
-              "regenerate": false,
               "embeddings": [
                 [
                   4.0,
@@ -225,9 +233,12 @@ async fn reset_embedder_documents() {
                   4.0,
                   5.0
                 ]
-              ]
+              ],
+              "regenerate": false
             }
-          }
+          },
+          "id": 4,
+          "name": "max"
         }
       ],
       "offset": 0,

--- a/crates/meilisearch/tests/vector/settings.rs
+++ b/crates/meilisearch/tests/vector/settings.rs
@@ -144,14 +144,14 @@ async fn reset_embedder_documents() {
           "name": "kefir",
           "_vectors": {
             "manual": {
+              "regenerate": false,
               "embeddings": [
                 [
                   0.0,
                   0.0,
                   0.0
                 ]
-              ],
-              "regenerate": false
+              ]
             }
           }
         },
@@ -160,14 +160,14 @@ async fn reset_embedder_documents() {
           "name": "echo",
           "_vectors": {
             "manual": {
+              "regenerate": false,
               "embeddings": [
                 [
                   1.0,
                   1.0,
                   1.0
                 ]
-              ],
-              "regenerate": false
+              ]
             }
           }
         },
@@ -176,6 +176,7 @@ async fn reset_embedder_documents() {
           "name": "billou",
           "_vectors": {
             "manual": {
+              "regenerate": false,
               "embeddings": [
                 [
                   2.0,
@@ -187,8 +188,7 @@ async fn reset_embedder_documents() {
                   2.0,
                   3.0
                 ]
-              ],
-              "regenerate": false
+              ]
             }
           }
         },
@@ -197,14 +197,14 @@ async fn reset_embedder_documents() {
           "name": "intel",
           "_vectors": {
             "manual": {
+              "regenerate": false,
               "embeddings": [
                 [
                   3.0,
                   3.0,
                   3.0
                 ]
-              ],
-              "regenerate": false
+              ]
             }
           }
         },
@@ -213,6 +213,7 @@ async fn reset_embedder_documents() {
           "name": "max",
           "_vectors": {
             "manual": {
+              "regenerate": false,
               "embeddings": [
                 [
                   4.0,
@@ -224,8 +225,7 @@ async fn reset_embedder_documents() {
                   4.0,
                   5.0
                 ]
-              ],
-              "regenerate": false
+              ]
             }
           }
         }

--- a/crates/milli/src/update/new/extract/searchable/extract_word_docids.rs
+++ b/crates/milli/src/update/new/extract/searchable/extract_word_docids.rs
@@ -597,60 +597,68 @@ impl WordDocidsExtractors {
         }
 
         let mut action = ActionToOperate::SkipDocument;
-        // Here we do a preliminary check to determine the action to take.
-        // This check doesn't trigger the tokenizer as we never return
-        // PatternMatch::Match.
-        document_tokenizer.tokenize_document(
-            current_document,
-            &mut |field_name| {
-                let fid = match new_fields_ids_map.id(field_name) {
-                    Some(field_id) => field_id,
-                    None => panic!("Expected field `{field_name}` in the fields IDs map"),
-                };
 
-                // If the document must be reindexed, early return NoMatch to stop the scanning process.
-                if action == ActionToOperate::ReindexAllFields {
-                    return Ok((fid, PatternMatch::NoMatch));
-                }
+        match document_tokenizers {
+            OneOrTwoTokenizers::OneTokenizer(document_tokenizer) => {
+                // Here we do a preliminary check to determine the action to take.
+                // This check doesn't trigger the tokenizer as we never return
+                // PatternMatch::Match.
+                document_tokenizer.tokenize_document(
+                    current_document,
+                    &mut |field_name| {
+                        let fid = match new_fields_ids_map.id(field_name) {
+                            Some(field_id) => field_id,
+                            None => panic!("Expected field `{field_name}` in the fields IDs map"),
+                        };
 
-                let old_field_metadata = old_fields_ids_map.metadata(fid).unwrap();
-                let new_field_metadata = new_fields_ids_map.metadata(fid).unwrap();
+                        // If the document must be reindexed, early return NoMatch to stop the scanning process.
+                        if action == ActionToOperate::ReindexAllFields {
+                            return Ok((fid, PatternMatch::NoMatch));
+                        }
 
-                action = match (old_field_metadata, new_field_metadata) {
-                    // At least one field is added or removed from the exact fields => ReindexAllFields
-                    (Metadata { exact: old_exact, .. }, Metadata { exact: new_exact, .. })
-                        if old_exact != new_exact =>
-                    {
-                        ActionToOperate::ReindexAllFields
-                    }
-                    // At least one field is removed from the searchable fields => ReindexAllFields
-                    (
-                        Metadata { searchable: (PatternMatch::Match, _), .. },
-                        Metadata { searchable: (PatternMatch::NoMatch, _), .. },
-                    )
-                    | (
-                        Metadata { searchable: (PatternMatch::Match, _), .. },
-                        Metadata { searchable: (PatternMatch::Parent, _), .. },
-                    ) => ActionToOperate::ReindexAllFields,
-                    // At least one field is added in the searchable fields => IndexAddedFields
-                    (
-                        Metadata { searchable: (PatternMatch::NoMatch, _), .. },
-                        Metadata { searchable: (PatternMatch::Match, _), .. },
-                    )
-                    | (
-                        Metadata { searchable: (PatternMatch::Parent, _), .. },
-                        Metadata { searchable: (PatternMatch::Match, _), .. },
-                    ) => {
-                        // We can safely overwrite the action, because we early return when action is ReindexAllFields.
-                        ActionToOperate::IndexAddedFields
-                    }
-                    _ => action,
-                };
+                        let old_field_metadata = old_fields_ids_map.metadata(fid).unwrap();
+                        let new_field_metadata = new_fields_ids_map.metadata(fid).unwrap();
 
-                Ok((fid, PatternMatch::Parent))
-            },
-            &mut |_, _, _, _| Ok(()),
-        )?;
+                        action = match (old_field_metadata, new_field_metadata) {
+                            // At least one field is added or removed from the exact fields => ReindexAllFields
+                            (
+                                Metadata { exact: old_exact, .. },
+                                Metadata { exact: new_exact, .. },
+                            ) if old_exact != new_exact => ActionToOperate::ReindexAllFields,
+                            // At least one field is removed from the searchable fields => ReindexAllFields
+                            (
+                                Metadata { searchable: (PatternMatch::Match, _), .. },
+                                Metadata { searchable: (PatternMatch::NoMatch, _), .. },
+                            )
+                            | (
+                                Metadata { searchable: (PatternMatch::Match, _), .. },
+                                Metadata { searchable: (PatternMatch::Parent, _), .. },
+                            ) => ActionToOperate::ReindexAllFields,
+                            // At least one field is added in the searchable fields => IndexAddedFields
+                            (
+                                Metadata { searchable: (PatternMatch::NoMatch, _), .. },
+                                Metadata { searchable: (PatternMatch::Match, _), .. },
+                            )
+                            | (
+                                Metadata { searchable: (PatternMatch::Parent, _), .. },
+                                Metadata { searchable: (PatternMatch::Match, _), .. },
+                            ) => {
+                                // We can safely overwrite the action, because we early return when action is ReindexAllFields.
+                                ActionToOperate::IndexAddedFields
+                            }
+                            _ => action,
+                        };
+
+                        Ok((fid, PatternMatch::Parent))
+                    },
+                    &mut |_, _, _, _| Ok(()),
+                )?;
+            }
+            OneOrTwoTokenizers::TwoTokenizer { old: _, new: _ } => {
+                // If the tokenizer changed, we need to reindex the whole document.
+                action = ActionToOperate::ReindexAllFields;
+            }
+        }
 
         // Early return when we don't need to index the document
         if action == ActionToOperate::SkipDocument {
@@ -698,85 +706,194 @@ impl WordDocidsExtractors {
 
         let old_disabled_typos_terms = settings_delta.old_disabled_typos_terms();
         let new_disabled_typos_terms = settings_delta.new_disabled_typos_terms();
-        let mut token_fn = |_field_name: &str, field_id, pos, word: &str| {
-            let old_field_metadata = old_fields_ids_map.metadata(field_id).unwrap();
-            let new_field_metadata = new_fields_ids_map.metadata(field_id).unwrap();
 
-            match (old_field_metadata, new_field_metadata) {
-                (
-                    Metadata { searchable: (PatternMatch::Match, _), exact: old_exact, .. },
-                    Metadata { searchable: (PatternMatch::NoMatch, _), .. },
-                )
-                | (
-                    Metadata { searchable: (PatternMatch::Match, _), exact: old_exact, .. },
-                    Metadata { searchable: (PatternMatch::Parent, _), .. },
-                ) => cached_sorter.insert_del_u32(
-                    field_id,
-                    pos,
-                    word,
-                    old_exact == PatternMatch::Match || old_disabled_typos_terms.is_exact(word),
-                    // We deleted the field globally
-                    FieldDbExtraction::Skip,
-                    document.docid(),
-                    doc_alloc,
-                ),
-                (
-                    Metadata { searchable: (PatternMatch::NoMatch, _), .. },
-                    Metadata { searchable: (PatternMatch::Match, _), exact: new_exact, .. },
-                )
-                | (
-                    Metadata { searchable: (PatternMatch::Parent, _), .. },
-                    Metadata { searchable: (PatternMatch::Match, _), exact: new_exact, .. },
-                ) => cached_sorter.insert_add_u32(
-                    field_id,
-                    pos,
-                    word,
-                    new_exact == PatternMatch::Match || new_disabled_typos_terms.is_exact(word),
-                    FieldDbExtraction::Extract,
-                    document.docid(),
-                    doc_alloc,
-                ),
-                (
-                    Metadata { searchable: (PatternMatch::NoMatch, _), .. },
-                    Metadata { searchable: (PatternMatch::NoMatch, _), .. },
-                ) => {
-                    unreachable!()
-                }
-                (Metadata { exact: old_exact, .. }, Metadata { exact: new_exact, .. }) => {
-                    cached_sorter.insert_del_u32(
-                        field_id,
-                        pos,
-                        word,
-                        old_exact == PatternMatch::Match || old_disabled_typos_terms.is_exact(word),
-                        // The field has already been extracted
-                        FieldDbExtraction::Skip,
-                        document.docid(),
-                        doc_alloc,
-                    )?;
-                    cached_sorter.insert_add_u32(
-                        field_id,
-                        pos,
-                        word,
-                        new_exact == PatternMatch::Match || new_disabled_typos_terms.is_exact(word),
-                        // The field has already been extracted
-                        FieldDbExtraction::Skip,
-                        document.docid(),
-                        doc_alloc,
-                    )
-                }
+        // we must tokenize twice when we change global parameters like stop words,
+        // the language settings, dictionary, separators, non-separators...
+        match document_tokenizers {
+            OneOrTwoTokenizers::OneTokenizer(document_tokenizer) => {
+                let mut token_fn = |_field_name: &str, field_id, pos, word: &str| {
+                    use PatternMatch::{Match, NoMatch, Parent};
+
+                    let old_field_metadata = old_fields_ids_map.metadata(field_id).unwrap();
+                    let new_field_metadata = new_fields_ids_map.metadata(field_id).unwrap();
+
+                    match (old_field_metadata, new_field_metadata) {
+                        (
+                            Metadata { searchable: (Match, _), exact: old_exact, .. },
+                            Metadata { searchable: (NoMatch, _), .. },
+                        )
+                        | (
+                            Metadata { searchable: (Match, _), exact: old_exact, .. },
+                            Metadata { searchable: (Parent, _), .. },
+                        ) => cached_sorter.insert_del_u32(
+                            field_id,
+                            pos,
+                            word,
+                            old_exact == Match || old_disabled_typos_terms.is_exact(word),
+                            // We deleted the field globally
+                            FieldDbExtraction::Skip,
+                            document.docid(),
+                            doc_alloc,
+                        ),
+                        (
+                            Metadata { searchable: (NoMatch, _), .. },
+                            Metadata { searchable: (Match, _), exact: new_exact, .. },
+                        )
+                        | (
+                            Metadata { searchable: (Parent, _), .. },
+                            Metadata { searchable: (Match, _), exact: new_exact, .. },
+                        ) => cached_sorter.insert_add_u32(
+                            field_id,
+                            pos,
+                            word,
+                            new_exact == Match || new_disabled_typos_terms.is_exact(word),
+                            FieldDbExtraction::Extract,
+                            document.docid(),
+                            doc_alloc,
+                        ),
+                        (
+                            Metadata { searchable: (NoMatch, _), .. },
+                            Metadata { searchable: (NoMatch, _), .. },
+                        ) => {
+                            unreachable!()
+                        }
+                        (Metadata { exact: old_exact, .. }, Metadata { exact: new_exact, .. }) => {
+                            cached_sorter.insert_del_u32(
+                                field_id,
+                                pos,
+                                word,
+                                old_exact == Match || old_disabled_typos_terms.is_exact(word),
+                                // The field has already been extracted
+                                FieldDbExtraction::Skip,
+                                document.docid(),
+                                doc_alloc,
+                            )?;
+                            cached_sorter.insert_add_u32(
+                                field_id,
+                                pos,
+                                word,
+                                new_exact == Match || new_disabled_typos_terms.is_exact(word),
+                                // The field has already been extracted
+                                FieldDbExtraction::Skip,
+                                document.docid(),
+                                doc_alloc,
+                            )
+                        }
+                    }
+                };
+
+                document_tokenizer.tokenize_document(
+                    current_document,
+                    &mut should_tokenize,
+                    &mut token_fn,
+                )?;
             }
-        };
+            OneOrTwoTokenizers::TwoTokenizer {
+                old: old_document_tokenizer,
+                new: new_document_tokenizer,
+            } => {
+                let mut old_token_fn = |_field_name: &str, field_id, pos, word: &str| {
+                    use PatternMatch::{Match, NoMatch, Parent};
 
-        // TODO we must tokenize twice when we change global parameters like stop words,
-        //      the language settings, dictionary, separators, non-separators...
-        //
-        //      We now have access to both tokenizers, the old and the new one. How can I
-        //      make it so we tokenize the document twice with both tokenizers, now?
-        document_tokenizer.tokenize_document(
-            current_document,
-            &mut should_tokenize,
-            &mut token_fn,
-        )?;
+                    let old_field_metadata = old_fields_ids_map.metadata(field_id).unwrap();
+                    let new_field_metadata = new_fields_ids_map.metadata(field_id).unwrap();
+
+                    match (old_field_metadata, new_field_metadata) {
+                        (
+                            Metadata { searchable: (Match, _), exact: old_exact, .. },
+                            Metadata { searchable: (NoMatch, _), .. },
+                        )
+                        | (
+                            Metadata { searchable: (Match, _), exact: old_exact, .. },
+                            Metadata { searchable: (Parent, _), .. },
+                        ) => cached_sorter.insert_del_u32(
+                            field_id,
+                            pos,
+                            word,
+                            old_exact == Match || old_disabled_typos_terms.is_exact(word),
+                            // We deleted the field globally
+                            FieldDbExtraction::Skip,
+                            document.docid(),
+                            doc_alloc,
+                        ),
+                        (
+                            Metadata { searchable: (NoMatch, _), .. },
+                            Metadata { searchable: (NoMatch, _), .. },
+                        ) => {
+                            unreachable!()
+                        }
+                        (Metadata { exact: old_exact, .. }, Metadata { .. }) => {
+                            cached_sorter.insert_del_u32(
+                                field_id,
+                                pos,
+                                word,
+                                old_exact == Match || old_disabled_typos_terms.is_exact(word),
+                                // The field has already been extracted
+                                FieldDbExtraction::Skip,
+                                document.docid(),
+                                doc_alloc,
+                            )
+                        }
+                    }
+                };
+
+                old_document_tokenizer.tokenize_document(
+                    current_document,
+                    &mut should_tokenize,
+                    &mut old_token_fn,
+                )?;
+
+                let mut new_token_fn = |_field_name: &str, field_id, pos, word: &str| {
+                    use PatternMatch::{Match, NoMatch, Parent};
+
+                    let old_field_metadata = old_fields_ids_map.metadata(field_id).unwrap();
+                    let new_field_metadata = new_fields_ids_map.metadata(field_id).unwrap();
+
+                    match (old_field_metadata, new_field_metadata) {
+                        (
+                            Metadata { searchable: (NoMatch, _), .. },
+                            Metadata { searchable: (Match, _), exact: new_exact, .. },
+                        )
+                        | (
+                            Metadata { searchable: (Parent, _), .. },
+                            Metadata { searchable: (Match, _), exact: new_exact, .. },
+                        ) => cached_sorter.insert_add_u32(
+                            field_id,
+                            pos,
+                            word,
+                            new_exact == Match || new_disabled_typos_terms.is_exact(word),
+                            FieldDbExtraction::Extract,
+                            document.docid(),
+                            doc_alloc,
+                        ),
+                        (
+                            Metadata { searchable: (NoMatch, _), .. },
+                            Metadata { searchable: (NoMatch, _), .. },
+                        ) => {
+                            unreachable!()
+                        }
+                        (Metadata { .. }, Metadata { exact: new_exact, .. }) => {
+                            cached_sorter.insert_add_u32(
+                                field_id,
+                                pos,
+                                word,
+                                new_exact == Match || new_disabled_typos_terms.is_exact(word),
+                                // The field has already been extracted
+                                FieldDbExtraction::Skip,
+                                document.docid(),
+                                doc_alloc,
+                            )
+                        }
+                    }
+                };
+
+                new_document_tokenizer.tokenize_document(
+                    current_document,
+                    &mut should_tokenize,
+                    &mut new_token_fn,
+                )?;
+            }
+        }
 
         Ok(())
     }

--- a/crates/milli/src/update/new/extract/searchable/extract_word_docids.rs
+++ b/crates/milli/src/update/new/extract/searchable/extract_word_docids.rs
@@ -730,8 +730,7 @@ impl WordDocidsExtractors {
                             pos,
                             word,
                             old_exact == Match || old_disabled_typos_terms.is_exact(word),
-                            // We deleted the field globally
-                            FieldDbExtraction::Skip,
+                            FieldDbExtraction::Extract,
                             document.docid(),
                             doc_alloc,
                         ),
@@ -763,7 +762,7 @@ impl WordDocidsExtractors {
                                 pos,
                                 word,
                                 old_exact == Match || old_disabled_typos_terms.is_exact(word),
-                                // The field has already been extracted
+                                // Should we really have this specific case?
                                 FieldDbExtraction::Skip,
                                 document.docid(),
                                 doc_alloc,
@@ -773,7 +772,7 @@ impl WordDocidsExtractors {
                                 pos,
                                 word,
                                 new_exact == Match || new_disabled_typos_terms.is_exact(word),
-                                // The field has already been extracted
+                                // Should we really have this specific case?
                                 FieldDbExtraction::Skip,
                                 document.docid(),
                                 doc_alloc,
@@ -811,8 +810,7 @@ impl WordDocidsExtractors {
                             pos,
                             word,
                             old_exact == Match || old_disabled_typos_terms.is_exact(word),
-                            // We deleted the field globally
-                            FieldDbExtraction::Skip,
+                            FieldDbExtraction::Extract,
                             document.docid(),
                             doc_alloc,
                         ),
@@ -822,18 +820,16 @@ impl WordDocidsExtractors {
                         ) => {
                             unreachable!()
                         }
-                        (Metadata { exact: old_exact, .. }, Metadata { .. }) => {
-                            cached_sorter.insert_del_u32(
+                        (Metadata { exact: old_exact, .. }, Metadata { .. }) => cached_sorter
+                            .insert_del_u32(
                                 field_id,
                                 pos,
                                 word,
                                 old_exact == Match || old_disabled_typos_terms.is_exact(word),
-                                // The field has already been extracted
-                                FieldDbExtraction::Skip,
+                                FieldDbExtraction::Extract,
                                 document.docid(),
                                 doc_alloc,
-                            )
-                        }
+                            ),
                     }
                 };
 
@@ -872,18 +868,16 @@ impl WordDocidsExtractors {
                         ) => {
                             unreachable!()
                         }
-                        (Metadata { .. }, Metadata { exact: new_exact, .. }) => {
-                            cached_sorter.insert_add_u32(
+                        (Metadata { .. }, Metadata { exact: new_exact, .. }) => cached_sorter
+                            .insert_add_u32(
                                 field_id,
                                 pos,
                                 word,
                                 new_exact == Match || new_disabled_typos_terms.is_exact(word),
-                                // The field has already been extracted
-                                FieldDbExtraction::Skip,
+                                FieldDbExtraction::Extract,
                                 document.docid(),
                                 doc_alloc,
-                            )
-                        }
+                            ),
                     }
                 };
 

--- a/crates/milli/src/update/new/extract/searchable/extract_word_docids.rs
+++ b/crates/milli/src/update/new/extract/searchable/extract_word_docids.rs
@@ -792,35 +792,10 @@ impl WordDocidsExtractors {
                 new: new_document_tokenizer,
             } => {
                 let mut old_token_fn = |_field_name: &str, field_id, pos, word: &str| {
-                    use PatternMatch::{Match, NoMatch, Parent};
+                    use PatternMatch::Match;
 
-                    let old_field_metadata = old_fields_ids_map.metadata(field_id).unwrap();
-                    let new_field_metadata = new_fields_ids_map.metadata(field_id).unwrap();
-
-                    match (old_field_metadata, new_field_metadata) {
-                        (
-                            Metadata { searchable: (Match, _), exact: old_exact, .. },
-                            Metadata { searchable: (NoMatch, _), .. },
-                        )
-                        | (
-                            Metadata { searchable: (Match, _), exact: old_exact, .. },
-                            Metadata { searchable: (Parent, _), .. },
-                        ) => cached_sorter.insert_del_u32(
-                            field_id,
-                            pos,
-                            word,
-                            old_exact == Match || old_disabled_typos_terms.is_exact(word),
-                            FieldDbExtraction::Extract,
-                            document.docid(),
-                            doc_alloc,
-                        ),
-                        (
-                            Metadata { searchable: (NoMatch, _), .. },
-                            Metadata { searchable: (NoMatch, _), .. },
-                        ) => {
-                            unreachable!()
-                        }
-                        (Metadata { exact: old_exact, .. }, Metadata { .. }) => cached_sorter
+                    match old_fields_ids_map.metadata(field_id).unwrap() {
+                        Metadata { searchable: (Match, _), exact: old_exact, .. } => cached_sorter
                             .insert_del_u32(
                                 field_id,
                                 pos,
@@ -830,6 +805,7 @@ impl WordDocidsExtractors {
                                 document.docid(),
                                 doc_alloc,
                             ),
+                        _ => Ok(()),
                     }
                 };
 
@@ -840,35 +816,10 @@ impl WordDocidsExtractors {
                 )?;
 
                 let mut new_token_fn = |_field_name: &str, field_id, pos, word: &str| {
-                    use PatternMatch::{Match, NoMatch, Parent};
+                    use PatternMatch::Match;
 
-                    let old_field_metadata = old_fields_ids_map.metadata(field_id).unwrap();
-                    let new_field_metadata = new_fields_ids_map.metadata(field_id).unwrap();
-
-                    match (old_field_metadata, new_field_metadata) {
-                        (
-                            Metadata { searchable: (NoMatch, _), .. },
-                            Metadata { searchable: (Match, _), exact: new_exact, .. },
-                        )
-                        | (
-                            Metadata { searchable: (Parent, _), .. },
-                            Metadata { searchable: (Match, _), exact: new_exact, .. },
-                        ) => cached_sorter.insert_add_u32(
-                            field_id,
-                            pos,
-                            word,
-                            new_exact == Match || new_disabled_typos_terms.is_exact(word),
-                            FieldDbExtraction::Extract,
-                            document.docid(),
-                            doc_alloc,
-                        ),
-                        (
-                            Metadata { searchable: (NoMatch, _), .. },
-                            Metadata { searchable: (NoMatch, _), .. },
-                        ) => {
-                            unreachable!()
-                        }
-                        (Metadata { .. }, Metadata { exact: new_exact, .. }) => cached_sorter
+                    match new_fields_ids_map.metadata(field_id).unwrap() {
+                        Metadata { searchable: (Match, _), exact: new_exact, .. } => cached_sorter
                             .insert_add_u32(
                                 field_id,
                                 pos,
@@ -878,6 +829,7 @@ impl WordDocidsExtractors {
                                 document.docid(),
                                 doc_alloc,
                             ),
+                        _ => Ok(()),
                     }
                 };
 

--- a/crates/milli/src/update/new/extract/searchable/extract_word_docids.rs
+++ b/crates/milli/src/update/new/extract/searchable/extract_word_docids.rs
@@ -6,8 +6,8 @@ use std::ops::DerefMut as _;
 use bumpalo::collections::vec::Vec as BumpVec;
 use bumpalo::Bump;
 
-use super::match_searchable_field;
 use super::tokenize_document::{tokenizer_builder, DocumentTokenizer};
+use super::{match_searchable_field, OneOrTwoTokenizers};
 use crate::fields_ids_map::metadata::Metadata;
 use crate::update::new::document::DocumentContext;
 use crate::update::new::extract::cache::BalancedCaches;
@@ -472,52 +472,75 @@ impl WordDocidsExtractors {
     {
         // Warning: this is highly inspired code from extract_word_pair_proximity_docids.rs so if you
         //          change something here consider modifying the original place if necessary.
+        let old_stop_words = settings_delta.old_stop_words();
+        let old_dictionary = settings_delta.old_dictionary();
+        let old_allowed_separators = settings_delta.old_allowed_separators();
+        let old_localized_attributes_rules = settings_delta.old_localized_attributes_rules();
+
+        let new_stop_words = settings_delta.new_stop_words();
+        let new_dictionary = settings_delta.new_dictionary();
+        let new_allowed_separators = settings_delta.new_allowed_separators();
+        let new_localized_attributes_rules = settings_delta.new_localized_attributes_rules();
 
         // old tokenizer
         let mut tokenizer_builder = charabia::TokenizerBuilder::new();
-        if let Some(stop_words) = settings_delta.old_stop_words() {
+        if let Some(stop_words) = old_stop_words {
             tokenizer_builder.stop_words(stop_words);
         }
         let dictionary_vec: Vec<_>;
-        if let Some(dictionary) = settings_delta.old_dictionary() {
+        if let Some(dictionary) = old_dictionary {
             dictionary_vec = dictionary.iter().map(String::as_ref).collect();
             tokenizer_builder.words_dict(&dictionary_vec);
         }
         let separators_vec: Vec<_>;
-        if let Some(separators) = settings_delta.old_allowed_separators() {
+        if let Some(separators) = old_allowed_separators {
             separators_vec = separators.iter().map(String::as_ref).collect();
             tokenizer_builder.separators(&separators_vec);
         }
         let old_document_tokenizer = DocumentTokenizer {
             tokenizer: &tokenizer_builder.build(),
-            localized_attributes_rules: settings_delta.old_localized_attributes_rules(),
+            localized_attributes_rules: old_localized_attributes_rules,
             max_positions_per_attributes: MAX_POSITION_PER_ATTRIBUTE,
         };
 
-        // new tokenizer
-        let mut tokenizer_builder = charabia::TokenizerBuilder::new();
-        if let Some(stop_words) = settings_delta.new_stop_words() {
-            tokenizer_builder.stop_words(stop_words);
-        }
-        let dictionary_vec: Vec<_>;
-        if let Some(dictionary) = settings_delta.new_dictionary() {
-            dictionary_vec = dictionary.iter().map(String::as_ref).collect();
-            tokenizer_builder.words_dict(&dictionary_vec);
-        }
-        let separators_vec: Vec<_>;
-        if let Some(separators) = settings_delta.new_allowed_separators() {
-            separators_vec = separators.iter().map(String::as_ref).collect();
-            tokenizer_builder.separators(&separators_vec);
-        }
-        let new_document_tokenizer = DocumentTokenizer {
-            tokenizer: &tokenizer_builder.build(),
-            localized_attributes_rules: settings_delta.new_localized_attributes_rules(),
-            max_positions_per_attributes: MAX_POSITION_PER_ATTRIBUTE,
+        let mut new_tokenizer_builder = charabia::TokenizerBuilder::new();
+        let new_dictionary_vec: Vec<_>;
+        let new_separators_vec: Vec<_>;
+        let new_tokenizer;
+        let tokenizers = if old_stop_words.as_ref().map(|f| f.as_fst().as_bytes())
+            == new_stop_words.as_ref().map(|f| f.as_fst().as_bytes())
+            && old_dictionary == new_dictionary
+            && old_allowed_separators == new_allowed_separators
+            && old_localized_attributes_rules == new_localized_attributes_rules
+        {
+            OneOrTwoTokenizers::OneTokenizer(old_document_tokenizer)
+        } else {
+            // new tokenizer
+            if let Some(stop_words) = new_stop_words {
+                new_tokenizer_builder.stop_words(stop_words);
+            }
+            if let Some(dictionary) = new_dictionary {
+                new_dictionary_vec = dictionary.iter().map(String::as_ref).collect();
+                new_tokenizer_builder.words_dict(&new_dictionary_vec);
+            }
+            if let Some(separators) = new_allowed_separators {
+                new_separators_vec = separators.iter().map(String::as_ref).collect();
+                new_tokenizer_builder.separators(&new_separators_vec);
+            }
+            new_tokenizer = new_tokenizer_builder.build();
+            let new_document_tokenizer = DocumentTokenizer {
+                tokenizer: &new_tokenizer,
+                localized_attributes_rules: new_localized_attributes_rules,
+                max_positions_per_attributes: MAX_POSITION_PER_ATTRIBUTE,
+            };
+            OneOrTwoTokenizers::TwoTokenizer {
+                old: old_document_tokenizer,
+                new: new_document_tokenizer,
+            }
         };
 
         let extractor_data = WordDocidsSettingsExtractorsData {
-            old_tokenizer: old_document_tokenizer,
-            new_tokenizer: new_document_tokenizer,
+            tokenizers,
             max_memory_by_thread: indexing_context.grenad_parameters.max_memory_by_thread(),
             buckets: rayon::current_num_threads(),
             settings_delta,
@@ -549,8 +572,7 @@ impl WordDocidsExtractors {
     fn extract_document_from_settings_change<SD: SettingsDelta>(
         document: DocumentIdentifiers<'_>,
         context: &DocumentContext<RefCell<Option<WordDocidsBalancedCaches>>>,
-        old_document_tokenizer: &DocumentTokenizer,
-        new_document_tokenizer: &DocumentTokenizer,
+        document_tokenizers: OneOrTwoTokenizers<'_>,
         settings_delta: &SD,
     ) -> Result<()> {
         let mut cached_sorter_ref = context.data.borrow_mut_or_yield();
@@ -761,8 +783,7 @@ impl WordDocidsExtractors {
 }
 
 pub struct WordDocidsSettingsExtractorsData<'a, SD> {
-    old_tokenizer: DocumentTokenizer<'a>,
-    new_tokenizer: DocumentTokenizer<'a>,
+    tokenizers: OneOrTwoTokenizers<'a>,
     max_memory_by_thread: Option<usize>,
     buckets: usize,
     settings_delta: &'a SD,
@@ -791,8 +812,7 @@ impl<'extractor, SD: SettingsDelta + Sync> SettingsChangeExtractor<'extractor>
             WordDocidsExtractors::extract_document_from_settings_change(
                 document,
                 context,
-                &self.old_tokenizer,
-                &self.new_tokenizer,
+                self.tokenizers,
                 self.settings_delta,
             )?;
         }

--- a/crates/milli/src/update/new/extract/searchable/extract_word_docids.rs
+++ b/crates/milli/src/update/new/extract/searchable/extract_word_docids.rs
@@ -470,31 +470,54 @@ impl WordDocidsExtractors {
     where
         SD: SettingsDelta + Sync,
     {
-        // Warning: this is duplicated code from extract_word_pair_proximity_docids.rs
-        // TODO we need to read the new AND old settings to support changing global parameters
-        let rtxn = indexing_context.index.read_txn()?;
-        let stop_words = indexing_context.index.stop_words(&rtxn)?;
-        let allowed_separators = indexing_context.index.allowed_separators(&rtxn)?;
-        let allowed_separators: Option<Vec<_>> =
-            allowed_separators.as_ref().map(|s| s.iter().map(String::as_str).collect());
-        let dictionary = indexing_context.index.dictionary(&rtxn)?;
-        let dictionary: Option<Vec<_>> =
-            dictionary.as_ref().map(|s| s.iter().map(String::as_str).collect());
-        let mut builder = tokenizer_builder(
-            stop_words.as_ref(),
-            allowed_separators.as_deref(),
-            dictionary.as_deref(),
-        );
-        let tokenizer = builder.build();
-        let localized_attributes_rules =
-            indexing_context.index.localized_attributes_rules(&rtxn)?.unwrap_or_default();
-        let document_tokenizer = DocumentTokenizer {
-            tokenizer: &tokenizer,
-            localized_attributes_rules: &localized_attributes_rules,
+        // Warning: this is highly inspired code from extract_word_pair_proximity_docids.rs so if you
+        //          change something here consider modifying the original place if necessary.
+
+        // old tokenizer
+        let mut tokenizer_builder = charabia::TokenizerBuilder::new();
+        if let Some(stop_words) = settings_delta.old_stop_words() {
+            tokenizer_builder.stop_words(stop_words);
+        }
+        let dictionary_vec: Vec<_>;
+        if let Some(dictionary) = settings_delta.old_dictionary() {
+            dictionary_vec = dictionary.iter().map(String::as_ref).collect();
+            tokenizer_builder.words_dict(&dictionary_vec);
+        }
+        let separators_vec: Vec<_>;
+        if let Some(separators) = settings_delta.old_allowed_separators() {
+            separators_vec = separators.iter().map(String::as_ref).collect();
+            tokenizer_builder.separators(&separators_vec);
+        }
+        let old_document_tokenizer = DocumentTokenizer {
+            tokenizer: &tokenizer_builder.build(),
+            localized_attributes_rules: settings_delta.old_localized_attributes_rules(),
             max_positions_per_attributes: MAX_POSITION_PER_ATTRIBUTE,
         };
+
+        // new tokenizer
+        let mut tokenizer_builder = charabia::TokenizerBuilder::new();
+        if let Some(stop_words) = settings_delta.new_stop_words() {
+            tokenizer_builder.stop_words(stop_words);
+        }
+        let dictionary_vec: Vec<_>;
+        if let Some(dictionary) = settings_delta.new_dictionary() {
+            dictionary_vec = dictionary.iter().map(String::as_ref).collect();
+            tokenizer_builder.words_dict(&dictionary_vec);
+        }
+        let separators_vec: Vec<_>;
+        if let Some(separators) = settings_delta.new_allowed_separators() {
+            separators_vec = separators.iter().map(String::as_ref).collect();
+            tokenizer_builder.separators(&separators_vec);
+        }
+        let new_document_tokenizer = DocumentTokenizer {
+            tokenizer: &tokenizer_builder.build(),
+            localized_attributes_rules: settings_delta.new_localized_attributes_rules(),
+            max_positions_per_attributes: MAX_POSITION_PER_ATTRIBUTE,
+        };
+
         let extractor_data = WordDocidsSettingsExtractorsData {
-            tokenizer: document_tokenizer,
+            old_tokenizer: old_document_tokenizer,
+            new_tokenizer: new_document_tokenizer,
             max_memory_by_thread: indexing_context.grenad_parameters.max_memory_by_thread(),
             buckets: rayon::current_num_threads(),
             settings_delta,
@@ -526,7 +549,8 @@ impl WordDocidsExtractors {
     fn extract_document_from_settings_change<SD: SettingsDelta>(
         document: DocumentIdentifiers<'_>,
         context: &DocumentContext<RefCell<Option<WordDocidsBalancedCaches>>>,
-        document_tokenizer: &DocumentTokenizer,
+        old_document_tokenizer: &DocumentTokenizer,
+        new_document_tokenizer: &DocumentTokenizer,
         settings_delta: &SD,
     ) -> Result<()> {
         let mut cached_sorter_ref = context.data.borrow_mut_or_yield();
@@ -723,6 +747,9 @@ impl WordDocidsExtractors {
 
         // TODO we must tokenize twice when we change global parameters like stop words,
         //      the language settings, dictionary, separators, non-separators...
+        //
+        //      We now have access to both tokenizers, the old and the new one. How can I
+        //      make it so we tokenize the document twice with both tokenizers, now?
         document_tokenizer.tokenize_document(
             current_document,
             &mut should_tokenize,
@@ -734,7 +761,8 @@ impl WordDocidsExtractors {
 }
 
 pub struct WordDocidsSettingsExtractorsData<'a, SD> {
-    tokenizer: DocumentTokenizer<'a>,
+    old_tokenizer: DocumentTokenizer<'a>,
+    new_tokenizer: DocumentTokenizer<'a>,
     max_memory_by_thread: Option<usize>,
     buckets: usize,
     settings_delta: &'a SD,
@@ -763,7 +791,8 @@ impl<'extractor, SD: SettingsDelta + Sync> SettingsChangeExtractor<'extractor>
             WordDocidsExtractors::extract_document_from_settings_change(
                 document,
                 context,
-                &self.tokenizer,
+                &self.old_tokenizer,
+                &self.new_tokenizer,
                 self.settings_delta,
             )?;
         }

--- a/crates/milli/src/update/new/extract/searchable/extract_word_pair_proximity_docids.rs
+++ b/crates/milli/src/update/new/extract/searchable/extract_word_pair_proximity_docids.rs
@@ -374,44 +374,54 @@ impl WordPairProximityDocidsExtractor {
             (_, _) => ActionToOperate::SkipDocument,
         };
 
-        // Here we do a preliminary check to determine the action to take.
-        // This check doesn't trigger the tokenizer as we never return
-        // PatternMatch::Match.
         if action != ActionToOperate::ReindexAllFields {
-            document_tokenizer.tokenize_document(
-                current_document,
-                &mut |field_name| {
-                    let fid = match new_fields_ids_map.id(field_name) {
-                        Some(field_id) => field_id,
-                        None => panic!("Expected field `{field_name}` in the fields IDs map"),
-                    };
+            match tokenizers {
+                OneOrTwoTokenizers::OneTokenizer(document_tokenizer) => {
+                    // Here we do a preliminary check to determine the action to take.
+                    // This check doesn't trigger the tokenizer as we never return
+                    // PatternMatch::Match.
+                    document_tokenizer.tokenize_document(
+                        current_document,
+                        &mut |field_name| {
+                            let fid = match new_fields_ids_map.id(field_name) {
+                                Some(field_id) => field_id,
+                                None => {
+                                    panic!("Expected field `{field_name}` in the fields IDs map")
+                                }
+                            };
 
-                    // If the document must be reindexed, early return NoMatch to stop the scanning process.
-                    if action == ActionToOperate::ReindexAllFields {
-                        return Ok((fid, PatternMatch::NoMatch));
-                    }
+                            // If the document must be reindexed, early return NoMatch to stop the scanning process.
+                            if action == ActionToOperate::ReindexAllFields {
+                                return Ok((fid, PatternMatch::NoMatch));
+                            }
 
-                    let old_field_metadata = old_fields_ids_map.metadata(fid).unwrap();
-                    let new_field_metadata = new_fields_ids_map.metadata(fid).unwrap();
+                            let old_field_metadata = old_fields_ids_map.metadata(fid).unwrap();
+                            let new_field_metadata = new_fields_ids_map.metadata(fid).unwrap();
 
-                    action = match (old_field_metadata, new_field_metadata) {
-                        // At least one field is removed or added from the searchable fields
-                        (
-                            Metadata { searchable: (was_matching, _), .. },
-                            Metadata { searchable: (is_matching, _), .. },
-                        ) if was_matching != is_matching
-                            && (was_matching == PatternMatch::Match
-                                || is_matching == PatternMatch::Match) =>
-                        {
-                            ActionToOperate::ReindexAllFields
-                        }
-                        _ => action,
-                    };
+                            action = match (old_field_metadata, new_field_metadata) {
+                                // At least one field is removed or added from the searchable fields
+                                (
+                                    Metadata { searchable: (was_matching, _), .. },
+                                    Metadata { searchable: (is_matching, _), .. },
+                                ) if was_matching != is_matching
+                                    && (was_matching == PatternMatch::Match
+                                        || is_matching == PatternMatch::Match) =>
+                                {
+                                    ActionToOperate::ReindexAllFields
+                                }
+                                _ => action,
+                            };
 
-                    Ok((fid, PatternMatch::Parent))
-                },
-                &mut |_, _, _, _| Ok(()),
-            )?;
+                            Ok((fid, PatternMatch::Parent))
+                        },
+                        &mut |_, _, _, _| Ok(()),
+                    )?;
+                }
+                OneOrTwoTokenizers::TwoTokenizer { old: _, new: _ } => {
+                    // If the tokenizer changed, we need to reindex the whole document.
+                    action = ActionToOperate::ReindexAllFields;
+                }
+            }
         }
 
         // Early return when we don't need to index the document
@@ -426,9 +436,15 @@ impl WordPairProximityDocidsExtractor {
         let mut word_positions: VecDeque<(Rc<str>, u16)> =
             VecDeque::with_capacity(MAX_DISTANCE as usize);
 
+        let (old_document_tokenizer, new_document_tokenizer) = match tokenizers {
+            OneOrTwoTokenizers::OneTokenizer(old) => (old, None),
+            OneOrTwoTokenizers::TwoTokenizer { old, new } => (old, Some(new)),
+        };
+
+        // TODO we use a match to check if we have one or two tokenizers and call once or twice the functions
         process_document_tokens(
             current_document,
-            old_document_tokenizer,
+            &old_document_tokenizer,
             &mut word_positions,
             &mut |field_name| match old_fields_ids_map.id_with_metadata(field_name) {
                 Some(field_id) => Ok(field_id),
@@ -439,18 +455,20 @@ impl WordPairProximityDocidsExtractor {
             },
         )?;
 
-        process_document_tokens(
-            current_document,
-            new_document_tokenizer,
-            &mut word_positions,
-            &mut |field_name| match new_fields_ids_map.id_with_metadata(field_name) {
-                Some(field_id) => Ok(field_id),
-                None => panic!("Expected field `{field_name}` in the fields IDs map"),
-            },
-            &mut |(w1, w2), prox| {
-                add_word_pair_proximity.push(((w1, w2), prox));
-            },
-        )?;
+        if let Some(new_document_tokenizer) = new_document_tokenizer {
+            process_document_tokens(
+                current_document,
+                &new_document_tokenizer,
+                &mut word_positions,
+                &mut |field_name| match new_fields_ids_map.id_with_metadata(field_name) {
+                    Some(field_id) => Ok(field_id),
+                    None => panic!("Expected field `{field_name}` in the fields IDs map"),
+                },
+                &mut |(w1, w2), prox| {
+                    add_word_pair_proximity.push(((w1, w2), prox));
+                },
+            )?;
+        }
 
         let mut key_buffer = bumpalo::collections::Vec::new_in(doc_alloc);
 

--- a/crates/milli/src/update/new/extract/searchable/extract_word_pair_proximity_docids.rs
+++ b/crates/milli/src/update/new/extract/searchable/extract_word_pair_proximity_docids.rs
@@ -11,6 +11,7 @@ use crate::proximity::ProximityPrecision::*;
 use crate::proximity::{index_proximity, MAX_DISTANCE};
 use crate::update::new::document::{Document, DocumentContext};
 use crate::update::new::extract::cache::BalancedCaches;
+use crate::update::new::extract::searchable::OneOrTwoTokenizers;
 use crate::update::new::indexer::document_changes::{
     extract, DocumentChanges, Extractor, IndexingContext,
 };
@@ -249,52 +250,75 @@ impl WordPairProximityDocidsExtractor {
     {
         // Warning: this is highly inspired code from extract_word_docids.rs so if you
         //          change something here consider modifying the original place if necessary.
+        let old_stop_words = settings_delta.old_stop_words();
+        let old_dictionary = settings_delta.old_dictionary();
+        let old_allowed_separators = settings_delta.old_allowed_separators();
+        let old_localized_attributes_rules = settings_delta.old_localized_attributes_rules();
+
+        let new_stop_words = settings_delta.new_stop_words();
+        let new_dictionary = settings_delta.new_dictionary();
+        let new_allowed_separators = settings_delta.new_allowed_separators();
+        let new_localized_attributes_rules = settings_delta.new_localized_attributes_rules();
 
         // old tokenizer
         let mut tokenizer_builder = charabia::TokenizerBuilder::new();
-        if let Some(stop_words) = settings_delta.old_stop_words() {
+        if let Some(stop_words) = old_stop_words {
             tokenizer_builder.stop_words(stop_words);
         }
         let dictionary_vec: Vec<_>;
-        if let Some(dictionary) = settings_delta.old_dictionary() {
+        if let Some(dictionary) = old_dictionary {
             dictionary_vec = dictionary.iter().map(String::as_ref).collect();
             tokenizer_builder.words_dict(&dictionary_vec);
         }
         let separators_vec: Vec<_>;
-        if let Some(separators) = settings_delta.old_allowed_separators() {
+        if let Some(separators) = old_allowed_separators {
             separators_vec = separators.iter().map(String::as_ref).collect();
             tokenizer_builder.separators(&separators_vec);
         }
         let old_document_tokenizer = DocumentTokenizer {
             tokenizer: &tokenizer_builder.build(),
-            localized_attributes_rules: settings_delta.old_localized_attributes_rules(),
+            localized_attributes_rules: old_localized_attributes_rules,
             max_positions_per_attributes: MAX_POSITION_PER_ATTRIBUTE,
         };
 
-        // new tokenizer
-        let mut tokenizer_builder = charabia::TokenizerBuilder::new();
-        if let Some(stop_words) = settings_delta.new_stop_words() {
-            tokenizer_builder.stop_words(stop_words);
-        }
-        let dictionary_vec: Vec<_>;
-        if let Some(dictionary) = settings_delta.new_dictionary() {
-            dictionary_vec = dictionary.iter().map(String::as_ref).collect();
-            tokenizer_builder.words_dict(&dictionary_vec);
-        }
-        let separators_vec: Vec<_>;
-        if let Some(separators) = settings_delta.new_allowed_separators() {
-            separators_vec = separators.iter().map(String::as_ref).collect();
-            tokenizer_builder.separators(&separators_vec);
-        }
-        let new_document_tokenizer = DocumentTokenizer {
-            tokenizer: &tokenizer_builder.build(),
-            localized_attributes_rules: settings_delta.new_localized_attributes_rules(),
-            max_positions_per_attributes: MAX_POSITION_PER_ATTRIBUTE,
+        let mut new_tokenizer_builder = charabia::TokenizerBuilder::new();
+        let new_dictionary_vec: Vec<_>;
+        let new_separators_vec: Vec<_>;
+        let new_tokenizer;
+        let tokenizers = if old_stop_words.as_ref().map(|f| f.as_fst().as_bytes())
+            == new_stop_words.as_ref().map(|f| f.as_fst().as_bytes())
+            && old_dictionary == new_dictionary
+            && old_allowed_separators == new_allowed_separators
+            && old_localized_attributes_rules == new_localized_attributes_rules
+        {
+            OneOrTwoTokenizers::OneTokenizer(old_document_tokenizer)
+        } else {
+            // new tokenizer
+            if let Some(stop_words) = new_stop_words {
+                new_tokenizer_builder.stop_words(stop_words);
+            }
+            if let Some(dictionary) = new_dictionary {
+                new_dictionary_vec = dictionary.iter().map(String::as_ref).collect();
+                new_tokenizer_builder.words_dict(&new_dictionary_vec);
+            }
+            if let Some(separators) = new_allowed_separators {
+                new_separators_vec = separators.iter().map(String::as_ref).collect();
+                new_tokenizer_builder.separators(&new_separators_vec);
+            }
+            new_tokenizer = new_tokenizer_builder.build();
+            let new_document_tokenizer = DocumentTokenizer {
+                tokenizer: &new_tokenizer,
+                localized_attributes_rules: new_localized_attributes_rules,
+                max_positions_per_attributes: MAX_POSITION_PER_ATTRIBUTE,
+            };
+            OneOrTwoTokenizers::TwoTokenizer {
+                old: old_document_tokenizer,
+                new: new_document_tokenizer,
+            }
         };
 
         let extractor_data = WordPairProximityDocidsSettingsExtractorData {
-            old_tokenizer: old_document_tokenizer,
-            new_tokenizer: new_document_tokenizer,
+            tokenizers,
             max_memory_by_thread: indexing_context.grenad_parameters.max_memory_by_thread(),
             buckets: rayon::current_num_threads(),
             settings_delta,
@@ -321,8 +345,7 @@ impl WordPairProximityDocidsExtractor {
     fn extract_document_from_settings_change<SD: SettingsDelta>(
         document: DocumentIdentifiers<'_>,
         context: &DocumentContext<RefCell<BalancedCaches<'_>>>,
-        old_document_tokenizer: &DocumentTokenizer,
-        new_document_tokenizer: &DocumentTokenizer,
+        tokenizers: OneOrTwoTokenizers<'_>,
         settings_delta: &SD,
     ) -> Result<()> {
         let mut cached_sorter = context.data.borrow_mut_or_yield();
@@ -532,8 +555,7 @@ fn process_document_tokens<'doc>(
 }
 
 pub struct WordPairProximityDocidsSettingsExtractorData<'a, SD> {
-    old_tokenizer: DocumentTokenizer<'a>,
-    new_tokenizer: DocumentTokenizer<'a>,
+    tokenizers: OneOrTwoTokenizers<'a>,
     max_memory_by_thread: Option<usize>,
     buckets: usize,
     settings_delta: &'a SD,
@@ -562,8 +584,7 @@ impl<'extractor, SD: SettingsDelta + Sync> SettingsChangeExtractor<'extractor>
             WordPairProximityDocidsExtractor::extract_document_from_settings_change(
                 document,
                 context,
-                &self.old_tokenizer,
-                &self.new_tokenizer,
+                self.tokenizers,
                 self.settings_delta,
             )?;
         }

--- a/crates/milli/src/update/new/extract/searchable/extract_word_pair_proximity_docids.rs
+++ b/crates/milli/src/update/new/extract/searchable/extract_word_pair_proximity_docids.rs
@@ -247,30 +247,54 @@ impl WordPairProximityDocidsExtractor {
     where
         SD: SettingsDelta + Sync,
     {
-        // Warning: this is duplicated code from extract_word_docids.rs
-        let rtxn = indexing_context.index.read_txn()?;
-        let stop_words = indexing_context.index.stop_words(&rtxn)?;
-        let allowed_separators = indexing_context.index.allowed_separators(&rtxn)?;
-        let allowed_separators: Option<Vec<_>> =
-            allowed_separators.as_ref().map(|s| s.iter().map(String::as_str).collect());
-        let dictionary = indexing_context.index.dictionary(&rtxn)?;
-        let dictionary: Option<Vec<_>> =
-            dictionary.as_ref().map(|s| s.iter().map(String::as_str).collect());
-        let mut builder = tokenizer_builder(
-            stop_words.as_ref(),
-            allowed_separators.as_deref(),
-            dictionary.as_deref(),
-        );
-        let tokenizer = builder.build();
-        let localized_attributes_rules =
-            indexing_context.index.localized_attributes_rules(&rtxn)?.unwrap_or_default();
-        let document_tokenizer = DocumentTokenizer {
-            tokenizer: &tokenizer,
-            localized_attributes_rules: &localized_attributes_rules,
+        // Warning: this is highly inspired code from extract_word_docids.rs so if you
+        //          change something here consider modifying the original place if necessary.
+
+        // old tokenizer
+        let mut tokenizer_builder = charabia::TokenizerBuilder::new();
+        if let Some(stop_words) = settings_delta.old_stop_words() {
+            tokenizer_builder.stop_words(stop_words);
+        }
+        let dictionary_vec: Vec<_>;
+        if let Some(dictionary) = settings_delta.old_dictionary() {
+            dictionary_vec = dictionary.iter().map(String::as_ref).collect();
+            tokenizer_builder.words_dict(&dictionary_vec);
+        }
+        let separators_vec: Vec<_>;
+        if let Some(separators) = settings_delta.old_allowed_separators() {
+            separators_vec = separators.iter().map(String::as_ref).collect();
+            tokenizer_builder.separators(&separators_vec);
+        }
+        let old_document_tokenizer = DocumentTokenizer {
+            tokenizer: &tokenizer_builder.build(),
+            localized_attributes_rules: settings_delta.old_localized_attributes_rules(),
             max_positions_per_attributes: MAX_POSITION_PER_ATTRIBUTE,
         };
+
+        // new tokenizer
+        let mut tokenizer_builder = charabia::TokenizerBuilder::new();
+        if let Some(stop_words) = settings_delta.new_stop_words() {
+            tokenizer_builder.stop_words(stop_words);
+        }
+        let dictionary_vec: Vec<_>;
+        if let Some(dictionary) = settings_delta.new_dictionary() {
+            dictionary_vec = dictionary.iter().map(String::as_ref).collect();
+            tokenizer_builder.words_dict(&dictionary_vec);
+        }
+        let separators_vec: Vec<_>;
+        if let Some(separators) = settings_delta.new_allowed_separators() {
+            separators_vec = separators.iter().map(String::as_ref).collect();
+            tokenizer_builder.separators(&separators_vec);
+        }
+        let new_document_tokenizer = DocumentTokenizer {
+            tokenizer: &tokenizer_builder.build(),
+            localized_attributes_rules: settings_delta.new_localized_attributes_rules(),
+            max_positions_per_attributes: MAX_POSITION_PER_ATTRIBUTE,
+        };
+
         let extractor_data = WordPairProximityDocidsSettingsExtractorData {
-            tokenizer: document_tokenizer,
+            old_tokenizer: old_document_tokenizer,
+            new_tokenizer: new_document_tokenizer,
             max_memory_by_thread: indexing_context.grenad_parameters.max_memory_by_thread(),
             buckets: rayon::current_num_threads(),
             settings_delta,
@@ -297,7 +321,8 @@ impl WordPairProximityDocidsExtractor {
     fn extract_document_from_settings_change<SD: SettingsDelta>(
         document: DocumentIdentifiers<'_>,
         context: &DocumentContext<RefCell<BalancedCaches<'_>>>,
-        document_tokenizer: &DocumentTokenizer,
+        old_document_tokenizer: &DocumentTokenizer,
+        new_document_tokenizer: &DocumentTokenizer,
         settings_delta: &SD,
     ) -> Result<()> {
         let mut cached_sorter = context.data.borrow_mut_or_yield();
@@ -380,8 +405,7 @@ impl WordPairProximityDocidsExtractor {
 
         process_document_tokens(
             current_document,
-            // TODO Tokenize must be based on old settings
-            document_tokenizer,
+            old_document_tokenizer,
             &mut word_positions,
             &mut |field_name| match old_fields_ids_map.id_with_metadata(field_name) {
                 Some(field_id) => Ok(field_id),
@@ -394,8 +418,7 @@ impl WordPairProximityDocidsExtractor {
 
         process_document_tokens(
             current_document,
-            // TODO Tokenize must be based on new settings
-            document_tokenizer,
+            new_document_tokenizer,
             &mut word_positions,
             &mut |field_name| match new_fields_ids_map.id_with_metadata(field_name) {
                 Some(field_id) => Ok(field_id),
@@ -509,7 +532,8 @@ fn process_document_tokens<'doc>(
 }
 
 pub struct WordPairProximityDocidsSettingsExtractorData<'a, SD> {
-    tokenizer: DocumentTokenizer<'a>,
+    old_tokenizer: DocumentTokenizer<'a>,
+    new_tokenizer: DocumentTokenizer<'a>,
     max_memory_by_thread: Option<usize>,
     buckets: usize,
     settings_delta: &'a SD,
@@ -538,7 +562,8 @@ impl<'extractor, SD: SettingsDelta + Sync> SettingsChangeExtractor<'extractor>
             WordPairProximityDocidsExtractor::extract_document_from_settings_change(
                 document,
                 context,
-                &self.tokenizer,
+                &self.old_tokenizer,
+                &self.new_tokenizer,
                 self.settings_delta,
             )?;
         }

--- a/crates/milli/src/update/new/extract/searchable/extract_word_pair_proximity_docids.rs
+++ b/crates/milli/src/update/new/extract/searchable/extract_word_pair_proximity_docids.rs
@@ -437,11 +437,10 @@ impl WordPairProximityDocidsExtractor {
             VecDeque::with_capacity(MAX_DISTANCE as usize);
 
         let (old_document_tokenizer, new_document_tokenizer) = match tokenizers {
-            OneOrTwoTokenizers::OneTokenizer(old) => (old, None),
-            OneOrTwoTokenizers::TwoTokenizer { old, new } => (old, Some(new)),
+            OneOrTwoTokenizers::OneTokenizer(this) => (this, this),
+            OneOrTwoTokenizers::TwoTokenizer { old, new } => (old, new),
         };
 
-        // TODO we use a match to check if we have one or two tokenizers and call once or twice the functions
         process_document_tokens(
             current_document,
             &old_document_tokenizer,
@@ -455,20 +454,18 @@ impl WordPairProximityDocidsExtractor {
             },
         )?;
 
-        if let Some(new_document_tokenizer) = new_document_tokenizer {
-            process_document_tokens(
-                current_document,
-                &new_document_tokenizer,
-                &mut word_positions,
-                &mut |field_name| match new_fields_ids_map.id_with_metadata(field_name) {
-                    Some(field_id) => Ok(field_id),
-                    None => panic!("Expected field `{field_name}` in the fields IDs map"),
-                },
-                &mut |(w1, w2), prox| {
-                    add_word_pair_proximity.push(((w1, w2), prox));
-                },
-            )?;
-        }
+        process_document_tokens(
+            current_document,
+            &new_document_tokenizer,
+            &mut word_positions,
+            &mut |field_name| match new_fields_ids_map.id_with_metadata(field_name) {
+                Some(field_id) => Ok(field_id),
+                None => panic!("Expected field `{field_name}` in the fields IDs map"),
+            },
+            &mut |(w1, w2), prox| {
+                add_word_pair_proximity.push(((w1, w2), prox));
+            },
+        )?;
 
         let mut key_buffer = bumpalo::collections::Vec::new_in(doc_alloc);
 

--- a/crates/milli/src/update/new/extract/searchable/mod.rs
+++ b/crates/milli/src/update/new/extract/searchable/mod.rs
@@ -6,6 +6,13 @@ pub use extract_word_docids::{WordDocidsCaches, WordDocidsExtractors};
 pub use extract_word_pair_proximity_docids::WordPairProximityDocidsExtractor;
 
 use crate::attribute_patterns::{match_field_legacy, PatternMatch};
+use crate::update::new::extract::searchable::tokenize_document::DocumentTokenizer;
+
+#[derive(Clone, Copy)]
+enum OneOrTwoTokenizers<'a> {
+    OneTokenizer(DocumentTokenizer<'a>),
+    TwoTokenizer { old: DocumentTokenizer<'a>, new: DocumentTokenizer<'a> },
+}
 
 pub fn match_searchable_field(
     field_name: &str,

--- a/crates/milli/src/update/new/extract/searchable/tokenize_document.rs
+++ b/crates/milli/src/update/new/extract/searchable/tokenize_document.rs
@@ -13,6 +13,7 @@ use crate::{FieldId, InternalError, LocalizedAttributesRule, Result, MAX_WORD_LE
 // todo: should be crate::proximity::MAX_DISTANCE but it has been forgotten
 const MAX_DISTANCE: u32 = 8;
 
+#[derive(Clone, Copy)]
 pub struct DocumentTokenizer<'a> {
     pub tokenizer: &'a Tokenizer<'a>,
     pub localized_attributes_rules: &'a [LocalizedAttributesRule],

--- a/crates/milli/src/update/settings.rs
+++ b/crates/milli/src/update/settings.rs
@@ -1552,126 +1552,79 @@ impl<'a, 't, 'i> Settings<'a, 't, 'i> {
                 .map(|_| None);
         }
 
-        // only use the new indexer when only the embedder possibly changed
-        if let Self {
-            searchable_fields: _,
-            displayed_fields: _,
-            filterable_fields: _,
-            sortable_fields: _,
-            foreign_keys: _,
-            criteria: _,
-            stop_words: _,
-            non_separator_tokens: _,
-            separator_tokens: _,
-            dictionary: _,
-            distinct_field: _,
-            synonyms: _,
-            primary_key: _,
-            authorize_typos: _,
-            min_word_len_two_typos: _,
-            min_word_len_one_typo: _,
-            exact_words: _,
-            exact_attributes: _,
-            max_values_per_facet: _,
-            sort_facet_values_by: _,
-            pagination_max_total_hits: _,
-            proximity_precision: _,
-            embedder_settings: _,
-            search_cutoff: _,
-            localized_attributes_rules: _,
-            prefix_search: _,
-            facet_search: _,
-            disable_on_numbers: _,
-            chat: _,
-            wtxn: _,
-            index: _,
-            indexer_config: _,
-        } = &self
-        {
-            progress.update_progress(SettingsIndexerStep::UsingExperimentalIndexer);
+        progress.update_progress(SettingsIndexerStep::UsingExperimentalIndexer);
 
-            self.index.set_updated_at(self.wtxn, &OffsetDateTime::now_utc())?;
+        self.index.set_updated_at(self.wtxn, &OffsetDateTime::now_utc())?;
 
-            let old_inner_settings =
-                InnerIndexSettings::from_index(self.index, self.wtxn, ip_policy, None)?;
+        let old_inner_settings =
+            InnerIndexSettings::from_index(self.index, self.wtxn, ip_policy, None)?;
 
-            // Update index settings
-            let embedding_config_updates = self.update_embedding_configs()?;
-            self.update_user_defined_searchable_attributes()?;
-            self.update_exact_attributes()?;
-            self.update_proximity_precision()?;
-            self.update_filterable_attributes()?;
-            self.update_sortable_attributes()?;
-            self.update_distinct_attribute()?;
-            self.update_foreign_keys()?;
-            self.update_criteria()?;
-            self.update_displayed()?;
-            self.update_primary_key()?;
-            self.update_authorize_typos()?;
-            self.update_min_typo_word_len()?;
-            self.update_exact_words()?;
-            self.update_max_values_per_facet()?;
-            self.update_sort_facet_values_by()?;
-            self.update_pagination_max_total_hits()?;
-            self.update_search_cutoff()?;
-            self.update_chat_config()?;
-            self.update_facet_search()?;
-            self.update_prefix_search()?;
-            self.update_exact_words()?;
-            self.update_disabled_typos_terms()?;
-            self.update_stop_words()?;
-            self.update_non_separator_tokens()?;
-            self.update_separator_tokens()?;
-            self.update_dictionary()?;
-            self.update_localized_attributes_rules()?;
-            // Make sure to update the synonyms *after* updating the dictionary
-            // as the dictionary is used by the synonyms to correctly parse them.
-            self.update_synonyms()?;
+        // Update index settings
+        let embedding_config_updates = self.update_embedding_configs()?;
+        self.update_user_defined_searchable_attributes()?;
+        self.update_exact_attributes()?;
+        self.update_proximity_precision()?;
+        self.update_filterable_attributes()?;
+        self.update_sortable_attributes()?;
+        self.update_distinct_attribute()?;
+        self.update_foreign_keys()?;
+        self.update_criteria()?;
+        self.update_displayed()?;
+        self.update_primary_key()?;
+        self.update_authorize_typos()?;
+        self.update_min_typo_word_len()?;
+        self.update_exact_words()?;
+        self.update_max_values_per_facet()?;
+        self.update_sort_facet_values_by()?;
+        self.update_pagination_max_total_hits()?;
+        self.update_search_cutoff()?;
+        self.update_chat_config()?;
+        self.update_facet_search()?;
+        self.update_prefix_search()?;
+        self.update_exact_words()?;
+        self.update_disabled_typos_terms()?;
+        self.update_stop_words()?;
+        self.update_non_separator_tokens()?;
+        self.update_separator_tokens()?;
+        self.update_dictionary()?;
+        self.update_localized_attributes_rules()?;
+        // Make sure to update the synonyms *after* updating the dictionary
+        // as the dictionary is used by the synonyms to correctly parse them.
+        self.update_synonyms()?;
 
-            // Note that we don't need to update the searchables here,
-            // as it will be done after the settings update.
-            let new_inner_settings =
-                InnerIndexSettings::from_index(self.index, self.wtxn, ip_policy, None)?;
+        // Note that we don't need to update the searchables here,
+        // as it will be done after the settings update.
+        let new_inner_settings =
+            InnerIndexSettings::from_index(self.index, self.wtxn, ip_policy, None)?;
 
-            let primary_key_id = self
-                .index
-                .primary_key(self.wtxn)?
-                .and_then(|name| new_inner_settings.fields_ids_map.id(name));
-            let settings_update_only = true;
-            let inner_settings_diff = InnerIndexSettingsDiff::new(
-                old_inner_settings,
-                new_inner_settings,
-                primary_key_id,
-                embedding_config_updates,
-                settings_update_only,
-            );
+        let primary_key_id = self
+            .index
+            .primary_key(self.wtxn)?
+            .and_then(|name| new_inner_settings.fields_ids_map.id(name));
+        let settings_update_only = true;
+        let inner_settings_diff = InnerIndexSettingsDiff::new(
+            old_inner_settings,
+            new_inner_settings,
+            primary_key_id,
+            embedding_config_updates,
+            settings_update_only,
+        );
 
-            if self.index.number_of_documents(self.wtxn)? > 0 {
-                reindex(
-                    self.wtxn,
-                    self.index,
-                    &self.indexer_config.thread_pool,
-                    self.indexer_config.grenad_parameters(),
-                    &inner_settings_diff,
-                    must_stop_processing,
-                    progress,
-                    ip_policy,
-                    embedder_stats,
-                )
-                .map(Some)
-            } else {
-                Ok(None)
-            }
-        } else {
-            progress.update_progress(SettingsIndexerStep::UsingStableIndexer);
-
-            self.legacy_execute(
-                |indexing_step| tracing::debug!(update = ?indexing_step),
+        if self.index.number_of_documents(self.wtxn)? > 0 {
+            reindex(
+                self.wtxn,
+                self.index,
+                &self.indexer_config.thread_pool,
+                self.indexer_config.grenad_parameters(),
+                &inner_settings_diff,
                 must_stop_processing,
+                progress,
                 ip_policy,
                 embedder_stats,
             )
-            .map(|_| None)
+            .map(Some)
+        } else {
+            Ok(None)
         }
     }
 }

--- a/crates/milli/src/update/settings.rs
+++ b/crates/milli/src/update/settings.rs
@@ -2593,6 +2593,18 @@ pub trait SettingsDelta {
     fn old_prefix_search(&self) -> &PrefixSearch;
     fn new_prefix_search(&self) -> &PrefixSearch;
 
+    fn old_stop_words(&self) -> &Option<fst::Set<Vec<u8>>>;
+    fn new_stop_words(&self) -> &Option<fst::Set<Vec<u8>>>;
+
+    fn old_dictionary(&self) -> &Option<BTreeSet<String>>;
+    fn new_dictionary(&self) -> &Option<BTreeSet<String>>;
+
+    fn old_allowed_separators(&self) -> &Option<BTreeSet<String>>;
+    fn new_allowed_separators(&self) -> &Option<BTreeSet<String>>;
+
+    fn old_localized_attributes_rules(&self) -> &[LocalizedAttributesRule];
+    fn new_localized_attributes_rules(&self) -> &[LocalizedAttributesRule];
+
     fn old_filterable_rules(&self) -> &[FilterableAttributesRule];
     fn new_filterable_rules(&self) -> &[FilterableAttributesRule];
 
@@ -2647,6 +2659,34 @@ impl SettingsDelta for InnerIndexSettingsDiff {
     }
     fn new_prefix_search(&self) -> &PrefixSearch {
         &self.new.prefix_search
+    }
+
+    fn old_stop_words(&self) -> &Option<fst::Set<Vec<u8>>> {
+        &self.old.stop_words
+    }
+    fn new_stop_words(&self) -> &Option<fst::Set<Vec<u8>>> {
+        &self.new.stop_words
+    }
+
+    fn old_dictionary(&self) -> &Option<BTreeSet<String>> {
+        &self.old.dictionary
+    }
+    fn new_dictionary(&self) -> &Option<BTreeSet<String>> {
+        &self.new.dictionary
+    }
+
+    fn old_allowed_separators(&self) -> &Option<BTreeSet<String>> {
+        &self.old.allowed_separators
+    }
+    fn new_allowed_separators(&self) -> &Option<BTreeSet<String>> {
+        &self.new.allowed_separators
+    }
+
+    fn old_localized_attributes_rules(&self) -> &[LocalizedAttributesRule] {
+        &self.old.localized_attributes_rules
+    }
+    fn new_localized_attributes_rules(&self) -> &[LocalizedAttributesRule] {
+        &self.new.localized_attributes_rules
     }
 
     fn old_filterable_rules(&self) -> &[FilterableAttributesRule] {

--- a/crates/milli/src/update/settings.rs
+++ b/crates/milli/src/update/settings.rs
@@ -1560,10 +1560,10 @@ impl<'a, 't, 'i> Settings<'a, 't, 'i> {
             sortable_fields: _,
             foreign_keys: _,
             criteria: _,
-            stop_words: Setting::NotSet, // TODO (require force reindexing of searchables)
-            non_separator_tokens: Setting::NotSet, // TODO (require force reindexing of searchables)
-            separator_tokens: Setting::NotSet, // TODO (require force reindexing of searchables)
-            dictionary: Setting::NotSet, // TODO (require force reindexing of searchables)
+            stop_words: _,
+            non_separator_tokens: _,
+            separator_tokens: _,
+            dictionary: _,
             distinct_field: _,
             synonyms: _,
             primary_key: _,
@@ -1578,7 +1578,7 @@ impl<'a, 't, 'i> Settings<'a, 't, 'i> {
             proximity_precision: _,
             embedder_settings: _,
             search_cutoff: _,
-            localized_attributes_rules: Setting::NotSet, // TODO (require force reindexing of searchables)
+            localized_attributes_rules: _,
             prefix_search: _,
             facet_search: _,
             disable_on_numbers: _,
@@ -1620,6 +1620,11 @@ impl<'a, 't, 'i> Settings<'a, 't, 'i> {
             self.update_prefix_search()?;
             self.update_exact_words()?;
             self.update_disabled_typos_terms()?;
+            self.update_stop_words()?;
+            self.update_non_separator_tokens()?;
+            self.update_separator_tokens()?;
+            self.update_dictionary()?;
+            self.update_localized_attributes_rules()?;
 
             // Note that we don't need to update the searchables here,
             // as it will be done after the settings update.

--- a/crates/milli/src/update/settings.rs
+++ b/crates/milli/src/update/settings.rs
@@ -1606,7 +1606,6 @@ impl<'a, 't, 'i> Settings<'a, 't, 'i> {
             self.update_foreign_keys()?;
             self.update_criteria()?;
             self.update_displayed()?;
-            self.update_synonyms()?;
             self.update_primary_key()?;
             self.update_authorize_typos()?;
             self.update_min_typo_word_len()?;
@@ -1625,6 +1624,9 @@ impl<'a, 't, 'i> Settings<'a, 't, 'i> {
             self.update_separator_tokens()?;
             self.update_dictionary()?;
             self.update_localized_attributes_rules()?;
+            // Make sure to update the synonyms *after* updating the dictionary
+            // as the dictionary is used by the synonyms to correctly parse them.
+            self.update_synonyms()?;
 
             // Note that we don't need to update the searchables here,
             // as it will be done after the settings update.

--- a/crates/milli/src/update/test_settings.rs
+++ b/crates/milli/src/update/test_settings.rs
@@ -461,6 +461,9 @@ fn set_and_reset_stop_words() {
         )
         .unwrap();
 
+    wtxn.commit().unwrap();
+
+    let mut wtxn = index.write_txn().unwrap();
     // In the same transaction we provide some stop_words
     let set = btreeset! { "i".to_string(), "the".to_string(), "are".to_string() };
     index


### PR DESCRIPTION
This PR makes the new settings indexer support all the settings that require two indexers to reindex correctly. It means that the new indexer correctly supports changing the localized attribute rules, stop words, non-separator tokens, separator tokens, and the dictionary.

## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respects the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)