### PR TITLE
Fix internal vector stores quantization config desync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,7 +630,7 @@ source = "git+https://github.com/meilisearch/bbqueue#e8af4a4bccc8eb36b2b0442c4a9
 
 [[package]]
 name = "benchmarks"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "build-info"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "anyhow",
  "time",
@@ -1992,7 +1992,7 @@ dependencies = [
 
 [[package]]
 name = "dump"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "anyhow",
  "big_s",
@@ -2326,7 +2326,7 @@ dependencies = [
 
 [[package]]
 name = "file-store"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "tempfile",
  "thiserror 2.0.17",
@@ -2348,7 +2348,7 @@ dependencies = [
 
 [[package]]
 name = "filter-parser"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "insta",
  "levenshtein_automata",
@@ -2376,7 +2376,7 @@ dependencies = [
 
 [[package]]
 name = "flatten-serde-json"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "criterion",
  "serde_json",
@@ -2550,7 +2550,7 @@ dependencies = [
 
 [[package]]
 name = "fuzzers"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "arbitrary",
  "bumpalo",
@@ -3274,7 +3274,7 @@ dependencies = [
 
 [[package]]
 name = "http-client"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "cidr",
  "hyper-util",
@@ -3594,7 +3594,7 @@ dependencies = [
 
 [[package]]
 name = "index-scheduler"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "anyhow",
  "backoff",
@@ -3864,7 +3864,7 @@ dependencies = [
 
 [[package]]
 name = "json-depth-checker"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "criterion",
  "serde_json",
@@ -4395,7 +4395,7 @@ checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
 
 [[package]]
 name = "meili-snap"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "insta",
  "md5 0.8.0",
@@ -4406,7 +4406,7 @@ dependencies = [
 
 [[package]]
 name = "meilisearch"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "actix-cors",
  "actix-http",
@@ -4507,7 +4507,7 @@ dependencies = [
 
 [[package]]
 name = "meilisearch-auth"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "base64 0.22.1",
  "enum-iterator",
@@ -4527,7 +4527,7 @@ dependencies = [
 
 [[package]]
 name = "meilisearch-types"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -4566,7 +4566,7 @@ dependencies = [
 
 [[package]]
 name = "meilitool"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -4600,7 +4600,7 @@ dependencies = [
 
 [[package]]
 name = "milli"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "arroy",
  "bbqueue",
@@ -5271,7 +5271,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "permissive-json-pointer"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "big_s",
  "serde_json",
@@ -6274,7 +6274,7 @@ dependencies = [
 
 [[package]]
 name = "routes"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "actix-web",
  "routes-macros",
@@ -6283,7 +6283,7 @@ dependencies = [
 
 [[package]]
 name = "routes-macros"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
@@ -8721,7 +8721,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "anyhow",
  "build-info",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.45.1"
+version = "1.45.2"
 authors = [
     "Quentin de Quelen <quentin@dequelen.me>",
     "Clément Renault <clement@meilisearch.com>",

--- a/crates/milli/src/update/upgrade/mod.rs
+++ b/crates/milli/src/update/upgrade/mod.rs
@@ -5,6 +5,7 @@ mod v1_15;
 mod v1_16;
 mod v1_32;
 mod v1_37;
+mod v1_45;
 
 use heed::RwTxn;
 use v1_12::{FixFieldDistribution, RecomputeStats};
@@ -14,6 +15,7 @@ use v1_15::RecomputeWordFst;
 use v1_16::SwitchToMultimodal;
 use v1_32::{CleanupFidBasedDatabases, RebuildHannoyGraph};
 use v1_37::{AddShards, ConvertArroyToHannoy};
+use v1_45::FixVectorStoreConfig;
 
 use crate::constants::{VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH};
 use crate::progress::{Progress, VariableNameStep};
@@ -49,6 +51,7 @@ const UPGRADE_FUNCTIONS: &[&dyn UpgradeIndex] = &[
     &RebuildHannoyGraph {},
     &ConvertArroyToHannoy {},
     &AddShards {},
+    &FixVectorStoreConfig {},
 ];
 
 /// Return true if the cached stats of the index must be regenerated

--- a/crates/milli/src/update/upgrade/v1_37.rs
+++ b/crates/milli/src/update/upgrade/v1_37.rs
@@ -73,7 +73,7 @@ impl UpgradeIndex for ConvertArroyToHannoy {
                     config.config.quantized = match vector_store.clean_stores(wtxn)? {
                         Some(QuantizationStatus::Quantized) => Some(true),
                         Some(QuantizationStatus::NonQuantized) => Some(false),
-                        None => None,
+                        None => config.config.quantized,
                     };
                 }
             }

--- a/crates/milli/src/update/upgrade/v1_37.rs
+++ b/crates/milli/src/update/upgrade/v1_37.rs
@@ -1,11 +1,11 @@
+use arroy::Error::UnmatchingDistance as ArroyUnmatchingDistance;
+use hannoy::Error::UnmatchingDistance as HannoyUnmatchingDistance;
 use heed::RwTxn;
 
 use super::UpgradeIndex;
 use crate::update::upgrade::UpgradeParams;
-use crate::vector::{VectorStore, VectorStoreBackend};
+use crate::vector::{QuantizationStatus, VectorStore, VectorStoreBackend};
 use crate::{Error, Index, InternalError, Result};
-use arroy::Error::UnmatchingDistance as ArroyUnmatchingDistance;
-use hannoy::Error::UnmatchingDistance as HannoyUnmatchingDistance;
 
 /// Convert old Annoy vector stores to Hannoy ones
 pub(super) struct ConvertArroyToHannoy();
@@ -51,18 +51,31 @@ impl UpgradeIndex for ConvertArroyToHannoy {
                 Ok(_) => vector_store,
             };
 
-            // We make sure to only do the backend conversion when using arroy
-            // TODO what happen for unmatching distances when using hannoy
-            if backend == VectorStoreBackend::Arroy {
-                // Continue the hannoy conversion with the right quantization. Note that when changing
-                // the backend the miss-configured quantization stores are simply deleted.
-                vector_store.change_backend(
-                    &rtxn,
-                    wtxn,
-                    progress.clone(),
-                    &|| must_stop_processing.get(),
-                    None,
-                )?;
+            match backend {
+                VectorStoreBackend::Arroy => {
+                    // We make sure to only do the backend conversion when using arroy.
+                    //
+                    // Continue the hannoy conversion with the right quantization. Note that
+                    // when changing the backend the misconfigured quantization stores are
+                    // simply deleted.
+                    vector_store.change_backend(
+                        &rtxn,
+                        wtxn,
+                        progress.clone(),
+                        &|| must_stop_processing.get(),
+                        None,
+                    )?;
+                }
+                VectorStoreBackend::Hannoy => {
+                    // If the store is hannoy we clean the stores in case some were misconfigured.
+                    // Note that we never experienced an issue with hannoy stores but we are not sure
+                    // they are affected too.
+                    config.config.quantized = match vector_store.clean_stores(wtxn)? {
+                        Some(QuantizationStatus::Quantized) => Some(true),
+                        Some(QuantizationStatus::NonQuantized) => Some(false),
+                        None => None,
+                    };
+                }
             }
         }
 

--- a/crates/milli/src/update/upgrade/v1_37.rs
+++ b/crates/milli/src/update/upgrade/v1_37.rs
@@ -70,16 +70,9 @@ impl UpgradeIndex for ConvertArroyToHannoy {
                     // If the store is hannoy we clean the stores in case some were misconfigured.
                     // Note that we never experienced an issue with hannoy stores but we are not sure
                     // they are affected too.
+                    let detected = vector_store.clean_stores(wtxn)?;
                     config.config.quantized =
-                        match (config.config.quantized, vector_store.clean_stores(wtxn)?) {
-                            (None, None) => None,
-                            (None, Some(QuantizationStatus::NonQuantized)) => None, // None defaults to false
-                            (None, Some(QuantizationStatus::Quantized)) => Some(true),
-                            (Some(value), None) => Some(value),
-                            (Some(true), Some(QuantizationStatus::NonQuantized)) => Some(false),
-                            (Some(false), Some(QuantizationStatus::Quantized)) => Some(true),
-                            (Some(value), Some(_)) => Some(value),
-                        };
+                        change_quantized_config(config.config.quantized, detected);
                 }
             }
         }
@@ -135,5 +128,23 @@ impl super::UpgradeIndex for AddShards {
 
     fn description(&self) -> &'static str {
         "adding shards to network objects"
+    }
+}
+
+pub fn change_quantized_config(
+    config: Option<bool>,
+    detected: Option<QuantizationStatus>,
+) -> Option<bool> {
+    match (config, detected) {
+        // empty store, listen to config
+        (config, None) => config,
+
+        // conflicts, change to detected
+        (Some(false) | None, Some(QuantizationStatus::Quantized)) => Some(true),
+        (Some(true), Some(QuantizationStatus::NonQuantized)) => Some(false),
+
+        // no conflict, retain config
+        (config @ (Some(false) | None), Some(QuantizationStatus::NonQuantized))
+        | (config @ Some(true), Some(QuantizationStatus::Quantized)) => config,
     }
 }

--- a/crates/milli/src/update/upgrade/v1_37.rs
+++ b/crates/milli/src/update/upgrade/v1_37.rs
@@ -70,11 +70,16 @@ impl UpgradeIndex for ConvertArroyToHannoy {
                     // If the store is hannoy we clean the stores in case some were misconfigured.
                     // Note that we never experienced an issue with hannoy stores but we are not sure
                     // they are affected too.
-                    config.config.quantized = match vector_store.clean_stores(wtxn)? {
-                        Some(QuantizationStatus::Quantized) => Some(true),
-                        Some(QuantizationStatus::NonQuantized) => Some(false),
-                        None => config.config.quantized,
-                    };
+                    config.config.quantized =
+                        match (config.config.quantized, vector_store.clean_stores(wtxn)?) {
+                            (None, None) => None,
+                            (None, Some(QuantizationStatus::NonQuantized)) => None, // None defaults to false
+                            (None, Some(QuantizationStatus::Quantized)) => Some(true),
+                            (Some(value), None) => Some(value),
+                            (Some(true), Some(QuantizationStatus::NonQuantized)) => Some(false),
+                            (Some(false), Some(QuantizationStatus::Quantized)) => Some(true),
+                            (Some(value), Some(_)) => Some(value),
+                        };
                 }
             }
         }

--- a/crates/milli/src/update/upgrade/v1_37.rs
+++ b/crates/milli/src/update/upgrade/v1_37.rs
@@ -3,7 +3,9 @@ use heed::RwTxn;
 use super::UpgradeIndex;
 use crate::update::upgrade::UpgradeParams;
 use crate::vector::{VectorStore, VectorStoreBackend};
-use crate::{Index, Result};
+use crate::{Error, Index, InternalError, Result};
+use arroy::Error::UnmatchingDistance as ArroyUnmatchingDistance;
+use hannoy::Error::UnmatchingDistance as HannoyUnmatchingDistance;
 
 /// Convert old Annoy vector stores to Hannoy ones
 pub(super) struct ConvertArroyToHannoy();
@@ -17,30 +19,54 @@ impl UpgradeIndex for ConvertArroyToHannoy {
     ) -> Result<bool> {
         let embedders = index.embedding_configs();
         let backend = index.get_vector_store(wtxn)?.unwrap_or_default();
-        if backend == VectorStoreBackend::Hannoy {
-            return Ok(false);
-        }
 
         let rtxn = index.read_txn()?;
-
-        for config in embedders.embedding_configs(wtxn)? {
+        let mut configs = embedders.embedding_configs(wtxn)?;
+        for config in &mut configs {
             let embedder_info = embedders.embedder_info(wtxn, &config.name)?.unwrap();
-            let vector_store = VectorStore::new(
-                backend,
-                index.vector_store,
-                embedder_info.embedder_id,
-                config.config.quantized(),
-            );
 
-            vector_store.change_backend(
-                &rtxn,
-                wtxn,
-                progress.clone(),
-                &|| must_stop_processing.get(),
-                None,
-            )?;
+            let quantized = config.config.quantized();
+            let vector_store =
+                VectorStore::new(backend, index.vector_store, embedder_info.embedder_id, quantized);
+
+            // Read the dimensions to be able to know the real quantization
+            // parameter, it corresponds to the quantization of the first store.
+            let vector_store = match vector_store.dimensions(&rtxn) {
+                Err(Error::InternalError(internal_error)) => match internal_error {
+                    InternalError::ArroyError(ArroyUnmatchingDistance { .. })
+                    | InternalError::HannoyError(HannoyUnmatchingDistance { .. }) => {
+                        // If there is an error reading the dimensions (first store).
+                        // Change the config to set the correct quantization.
+                        config.config.quantized = Some(!quantized);
+                        VectorStore::new(
+                            backend,
+                            index.vector_store,
+                            embedder_info.embedder_id,
+                            config.config.quantized(),
+                        )
+                    }
+                    otherwise => return Err(otherwise.into()),
+                },
+                Err(e) => return Err(e),
+                Ok(_) => vector_store,
+            };
+
+            // We make sure to only do the backend conversion when using arroy
+            // TODO what happen for unmatching distances when using hannoy
+            if backend == VectorStoreBackend::Arroy {
+                // Continue the hannoy conversion with the right quantization. Note that when changing
+                // the backend the miss-configured quantization stores are simply deleted.
+                vector_store.change_backend(
+                    &rtxn,
+                    wtxn,
+                    progress.clone(),
+                    &|| must_stop_processing.get(),
+                    None,
+                )?;
+            }
         }
 
+        embedders.put_embedding_configs(wtxn, configs)?;
         index.put_vector_store(wtxn, VectorStoreBackend::Hannoy)?;
 
         Ok(false)

--- a/crates/milli/src/update/upgrade/v1_45.rs
+++ b/crates/milli/src/update/upgrade/v1_45.rs
@@ -29,11 +29,16 @@ impl UpgradeIndex for FixVectorStoreConfig {
 
             // Read the dimensions to be able to know the real quantization
             // parameter, it corresponds to the quantization of the first store.
-            config.config.quantized = match vector_store.clean_stores(wtxn)? {
-                Some(QuantizationStatus::Quantized) => Some(true),
-                Some(QuantizationStatus::NonQuantized) => Some(false),
-                None => config.config.quantized,
-            };
+            config.config.quantized =
+                match (config.config.quantized, vector_store.clean_stores(wtxn)?) {
+                    (None, None) => None,
+                    (None, Some(QuantizationStatus::NonQuantized)) => None, // None defaults to false
+                    (None, Some(QuantizationStatus::Quantized)) => Some(true),
+                    (Some(value), None) => Some(value),
+                    (Some(true), Some(QuantizationStatus::NonQuantized)) => Some(false),
+                    (Some(false), Some(QuantizationStatus::Quantized)) => Some(true),
+                    (Some(value), Some(_)) => Some(value),
+                };
         }
 
         embedders.put_embedding_configs(wtxn, configs)?;

--- a/crates/milli/src/update/upgrade/v1_45.rs
+++ b/crates/milli/src/update/upgrade/v1_45.rs
@@ -2,10 +2,10 @@ use std::ops::Not as _;
 
 use heed::RwTxn;
 
-use super::v1_37::ConvertArroyToHannoy;
+use super::v1_37::{change_quantized_config, ConvertArroyToHannoy};
 use super::UpgradeIndex;
 use crate::update::upgrade::UpgradeParams;
-use crate::vector::{QuantizationStatus, VectorStore};
+use crate::vector::VectorStore;
 use crate::{Index, Result};
 
 /// Fix the desync of internal Arroy and Hannoy vector stores
@@ -27,18 +27,8 @@ impl UpgradeIndex for FixVectorStoreConfig {
                 config.config.quantized(),
             );
 
-            // Read the dimensions to be able to know the real quantization
-            // parameter, it corresponds to the quantization of the first store.
-            config.config.quantized =
-                match (config.config.quantized, vector_store.clean_stores(wtxn)?) {
-                    (None, None) => None,
-                    (None, Some(QuantizationStatus::NonQuantized)) => None, // None defaults to false
-                    (None, Some(QuantizationStatus::Quantized)) => Some(true),
-                    (Some(value), None) => Some(value),
-                    (Some(true), Some(QuantizationStatus::NonQuantized)) => Some(false),
-                    (Some(false), Some(QuantizationStatus::Quantized)) => Some(true),
-                    (Some(value), Some(_)) => Some(value),
-                };
+            let detected = vector_store.clean_stores(wtxn)?;
+            config.config.quantized = change_quantized_config(config.config.quantized, detected);
         }
 
         embedders.put_embedding_configs(wtxn, configs)?;

--- a/crates/milli/src/update/upgrade/v1_45.rs
+++ b/crates/milli/src/update/upgrade/v1_45.rs
@@ -1,0 +1,53 @@
+use std::ops::Not as _;
+
+use heed::RwTxn;
+
+use super::UpgradeIndex;
+use crate::update::upgrade::UpgradeParams;
+use crate::vector::{QuantizationStatus, VectorStore};
+use crate::{Index, Result};
+
+use super::v1_37::ConvertArroyToHannoy;
+
+/// Fix the desync of internal Arroy and Hannoy vector stores
+pub(super) struct FixVectorStoreConfig();
+
+impl UpgradeIndex for FixVectorStoreConfig {
+    fn upgrade(&self, wtxn: &mut RwTxn, index: &Index, _: UpgradeParams<'_>) -> Result<bool> {
+        let embedders = index.embedding_configs();
+        let backend = index.get_vector_store(wtxn)?.unwrap_or_default();
+
+        let mut configs = embedders.embedding_configs(wtxn)?;
+        for config in &mut configs {
+            let embedder_info = embedders.embedder_info(wtxn, &config.name)?.unwrap();
+
+            let vector_store = VectorStore::new(
+                backend,
+                index.vector_store,
+                embedder_info.embedder_id,
+                config.config.quantized(),
+            );
+
+            // Read the dimensions to be able to know the real quantization
+            // parameter, it corresponds to the quantization of the first store.
+            config.config.quantized = match vector_store.clean_stores(wtxn)? {
+                Some(QuantizationStatus::Quantized) => Some(true),
+                Some(QuantizationStatus::NonQuantized) => Some(false),
+                None => None,
+            };
+        }
+
+        embedders.put_embedding_configs(wtxn, configs)?;
+
+        Ok(false)
+    }
+
+    fn must_upgrade(&self, initial_version: (u32, u32, u32)) -> bool {
+        (ConvertArroyToHannoy {}).must_upgrade(initial_version).not()
+            && initial_version < (1, 45, 2)
+    }
+
+    fn description(&self) -> &'static str {
+        "Fix vector stores config desync"
+    }
+}

--- a/crates/milli/src/update/upgrade/v1_45.rs
+++ b/crates/milli/src/update/upgrade/v1_45.rs
@@ -2,12 +2,11 @@ use std::ops::Not as _;
 
 use heed::RwTxn;
 
+use super::v1_37::ConvertArroyToHannoy;
 use super::UpgradeIndex;
 use crate::update::upgrade::UpgradeParams;
 use crate::vector::{QuantizationStatus, VectorStore};
 use crate::{Index, Result};
-
-use super::v1_37::ConvertArroyToHannoy;
 
 /// Fix the desync of internal Arroy and Hannoy vector stores
 pub(super) struct FixVectorStoreConfig();
@@ -33,7 +32,7 @@ impl UpgradeIndex for FixVectorStoreConfig {
             config.config.quantized = match vector_store.clean_stores(wtxn)? {
                 Some(QuantizationStatus::Quantized) => Some(true),
                 Some(QuantizationStatus::NonQuantized) => Some(false),
-                None => None,
+                None => config.config.quantized,
             };
         }
 

--- a/crates/milli/src/vector/mod.rs
+++ b/crates/milli/src/vector/mod.rs
@@ -19,7 +19,7 @@ pub use distribution::DistributionShift;
 pub use embedder::{Embedder, EmbedderOptions, EmbeddingConfig, SearchQuery};
 pub use embeddings::Embeddings;
 pub use runtime::{RuntimeEmbedder, RuntimeEmbedders, RuntimeFragment};
-pub use store::{VectorStore, VectorStoreBackend, VectorStoreStats};
+pub use store::{QuantizationStatus, VectorStore, VectorStoreBackend, VectorStoreStats};
 
 pub const REQUEST_PARALLELISM: usize = 40;
 

--- a/crates/milli/src/vector/store.rs
+++ b/crates/milli/src/vector/store.rs
@@ -1216,6 +1216,159 @@ impl VectorStore {
         }
         Ok(())
     }
+
+    /// Returns the `true` if the stores are quantized, `false` otherwise.
+    pub fn clean_stores(self, wtxn: &mut RwTxn) -> crate::Result<Option<QuantizationStatus>> {
+        let mut store_indexes = vector_store_range_for_embedder(self.embedder_index);
+
+        match self.backend {
+            VectorStoreBackend::Arroy => {
+                use arroy::distances::{BinaryQuantizedCosine, Cosine};
+
+                let store_action = loop {
+                    match store_indexes.next() {
+                        Some(index) => {
+                            match arroy::Reader::<BinaryQuantizedCosine>::open(
+                                wtxn,
+                                index,
+                                self.database.remap_types(),
+                            ) {
+                                Ok(_) => break QuantizationStatus::Quantized,
+                                Err(arroy::Error::MissingMetadata(_)) => continue,
+                                Err(arroy::Error::UnmatchingDistance { .. }) => {
+                                    break QuantizationStatus::NonQuantized
+                                }
+                                Err(err) => return Err(err.into()),
+                            }
+                        }
+                        None => return Ok(None),
+                    }
+                };
+
+                for index in store_indexes {
+                    match store_action {
+                        QuantizationStatus::Quantized => {
+                            match arroy::Reader::<BinaryQuantizedCosine>::open(
+                                wtxn,
+                                index,
+                                self.database.remap_types(),
+                            ) {
+                                Ok(_) => (),
+                                Err(arroy::Error::MissingMetadata(_)) => (),
+                                Err(arroy::Error::UnmatchingDistance { .. }) => {
+                                    clear_arroy_store(wtxn, self.database.remap_types(), index)?;
+                                }
+                                Err(err) => return Err(err.into()),
+                            }
+                        }
+                        QuantizationStatus::NonQuantized => {
+                            match arroy::Reader::<Cosine>::open(
+                                wtxn,
+                                index,
+                                self.database.remap_types(),
+                            ) {
+                                Ok(_) => (),
+                                Err(arroy::Error::MissingMetadata(_)) => (),
+                                Err(arroy::Error::UnmatchingDistance { .. }) => {
+                                    clear_arroy_store(wtxn, self.database.remap_types(), index)?;
+                                }
+                                Err(err) => return Err(err.into()),
+                            }
+                        }
+                    }
+                }
+
+                Ok(Some(store_action))
+            }
+            VectorStoreBackend::Hannoy => {
+                use hannoy::distances::{Cosine, Hamming};
+
+                let store_action = loop {
+                    match store_indexes.next() {
+                        Some(index) => {
+                            match hannoy::Reader::<Hamming>::open(
+                                wtxn,
+                                index,
+                                self.database.remap_types(),
+                            ) {
+                                Ok(_) => break QuantizationStatus::Quantized,
+                                Err(hannoy::Error::MissingMetadata(_)) => continue,
+                                Err(hannoy::Error::UnmatchingDistance { .. }) => {
+                                    break QuantizationStatus::NonQuantized
+                                }
+                                Err(err) => return Err(err.into()),
+                            }
+                        }
+                        None => return Ok(None),
+                    }
+                };
+
+                for index in store_indexes {
+                    match store_action {
+                        QuantizationStatus::Quantized => {
+                            match hannoy::Reader::<Hamming>::open(
+                                wtxn,
+                                index,
+                                self.database.remap_types(),
+                            ) {
+                                Ok(_) => (),
+                                Err(hannoy::Error::MissingMetadata(_)) => (),
+                                Err(hannoy::Error::UnmatchingDistance { .. }) => {
+                                    clear_hannoy_store(wtxn, self.database, index)?;
+                                }
+                                Err(err) => return Err(err.into()),
+                            }
+                        }
+                        QuantizationStatus::NonQuantized => {
+                            match hannoy::Reader::<Cosine>::open(
+                                wtxn,
+                                index,
+                                self.database.remap_types(),
+                            ) {
+                                Ok(_) => (),
+                                Err(hannoy::Error::MissingMetadata(_)) => (),
+                                Err(hannoy::Error::UnmatchingDistance { .. }) => {
+                                    clear_hannoy_store(wtxn, self.database, index)?;
+                                }
+                                Err(err) => return Err(err.into()),
+                            }
+                        }
+                    }
+                }
+
+                Ok(Some(store_action))
+            }
+        }
+    }
+}
+
+pub enum QuantizationStatus {
+    Quantized,
+    NonQuantized,
+}
+
+fn clear_arroy_store(
+    wtxn: &mut RwTxn<'_>,
+    database: arroy::Database<Unspecified>,
+    index: u16,
+) -> arroy::Result<()> {
+    use arroy::distances::Cosine;
+
+    // The metadata are not checked when opening a writer so we can use Cosine
+    // or anything as a Distance, same thing for the dimensions.
+    arroy::Writer::<Cosine>::new(database.remap_types(), index, 0).clear(wtxn)
+}
+
+fn clear_hannoy_store(
+    wtxn: &mut RwTxn<'_>,
+    database: hannoy::Database<Unspecified>,
+    index: u16,
+) -> hannoy::Result<()> {
+    use hannoy::distances::Cosine;
+
+    // The metadata are not checked when opening a writer so we can use Cosine
+    // or anything as a Distance, same thing for the dimensions.
+    hannoy::Writer::<Cosine>::new(database.remap_types(), index, 0).clear(wtxn)
 }
 
 fn arroy_build<R, D>(

--- a/crates/milli/src/vector/store.rs
+++ b/crates/milli/src/vector/store.rs
@@ -149,6 +149,9 @@ impl VectorStore {
         }
     }
 
+    /// Converts the vector store from arroy to hannoy and the other way around.
+    ///
+    /// Note that when changing the backend the miss-configured quantization stores are simply deleted.
     pub fn change_backend<MSP>(
         self,
         rtxn: &RoTxn,
@@ -679,6 +682,7 @@ impl VectorStore {
             .map_err(Into::into)
         }
     }
+
     pub fn item_vectors(&self, rtxn: &RoTxn, item_id: u32) -> crate::Result<Vec<Vec<f32>>> {
         let mut vectors = Vec::new();
 
@@ -1133,6 +1137,13 @@ impl VectorStore {
                 match arroy::Reader::open(arroy_rtxn, index, self.database.remap_types()) {
                     Ok(reader) => reader,
                     Err(arroy::Error::MissingMetadata(_)) => continue,
+                    Err(arroy::Error::UnmatchingDistance { .. }) => {
+                        // TODO it's ugly
+                        // TODO explain why AD while it must not
+                        arroy::Writer::<AD>::new(self.database.remap_types(), index, 0)
+                            .clear(hannoy_wtxn)?;
+                        continue;
+                    }
                     Err(err) => return Err(err.into()),
                 };
             let dimensions = arroy_reader.dimensions();

--- a/crates/milli/src/vector/store.rs
+++ b/crates/milli/src/vector/store.rs
@@ -151,7 +151,7 @@ impl VectorStore {
 
     /// Converts the vector store from arroy to hannoy and the other way around.
     ///
-    /// Note that when changing the backend the miss-configured quantization stores are simply deleted.
+    /// Note that when changing the backend the misconfigured quantization stores are simply deleted.
     pub fn change_backend<MSP>(
         self,
         rtxn: &RoTxn,
@@ -1145,10 +1145,7 @@ impl VectorStore {
                     Ok(reader) => reader,
                     Err(arroy::Error::MissingMetadata(_)) => continue,
                     Err(arroy::Error::UnmatchingDistance { .. }) => {
-                        // TODO it's ugly
-                        // TODO explain why AD while it must not
-                        arroy::Writer::<AD>::new(self.database.remap_types(), index, 0)
-                            .clear(hannoy_wtxn)?;
+                        clear_arroy_store(hannoy_wtxn, self.database.remap_types(), index)?;
                         continue;
                     }
                     Err(err) => return Err(err.into()),
@@ -1224,7 +1221,7 @@ impl VectorStore {
         Ok(())
     }
 
-    /// Returns the `true` if the stores are quantized, `false` otherwise.
+    /// Returns the quantization status as known to the store.
     pub fn clean_stores(self, wtxn: &mut RwTxn) -> crate::Result<Option<QuantizationStatus>> {
         let mut store_indexes = vector_store_range_for_embedder(self.embedder_index);
 

--- a/crates/milli/src/vector/store.rs
+++ b/crates/milli/src/vector/store.rs
@@ -180,7 +180,14 @@ impl VectorStore {
                     let writer = hannoy::Writer::new(self._hannoy_angular_db(), index, dimensions);
                     let mut builder = writer.builder(&mut rng).progress(progress.clone());
                     builder.cancel(must_stop_processing);
-                    builder.prepare_arroy_conversion(wtxn)?;
+                    match builder.prepare_arroy_conversion(wtxn) {
+                        Ok(()) => (),
+                        // When converting from arroy to hannoy we decide to delete stores
+                        // that are corrupted due to misconfigured quantization that results
+                        // in valid embeddings.
+                        Err(hannoy::Error::InvalidVecDimension { .. }) => writer.clear(wtxn)?,
+                        Err(err) => return Err(err.into()),
+                    }
                     builder.build::<HANNOY_M, HANNOY_M0>(wtxn)?;
                 }
 


### PR DESCRIPTION
This PR fixes an issue we noticed when using the dumpless upgrade on a database from v1.33.1 to v1.45.0, but it is most likely affecting earlier versions as well. I initially thought that the bug was related to the configurations of the multiple internal vector stores we use to support multiple embedding by document, but it seems it's a bit more complex than that, and sometimes internal stores are not configured the same as another internal store (tried to open it as binary quantized, but it shouldn't, and vice versa).

We fix this bug by ensuring the internal vector stores are uniformly configured, clearing those that are not, and potentially fixing the internal millis' knowledge of the vector store quantization.

## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respects the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
