### PR TITLE
Fixes batching of documentDeletionByFilter with DocumentAddition

### DIFF
--- a/crates/fuzzers/src/bin/fuzz-indexing.rs
+++ b/crates/fuzzers/src/bin/fuzz-indexing.rs
@@ -121,7 +121,9 @@ fn main() {
                                             MissingDocumentPolicy::default(),
                                         )
                                         .unwrap(),
-                                    Either::Right(ids) => indexer.delete_documents(ids),
+                                    Either::Right(ids) => {
+                                        indexer.delete_documents_by_external_ids(ids)
+                                    }
                                 }
                             }
 

--- a/crates/index-scheduler/src/queue/batches_test.rs
+++ b/crates/index-scheduler/src/queue/batches_test.rs
@@ -2,6 +2,7 @@ use meili_snap::snapshot;
 use meilisearch_auth::AuthFilter;
 use meilisearch_types::index_uid_pattern::IndexUidPattern;
 use meilisearch_types::milli::update::MissingDocumentPolicy;
+use meilisearch_types::milli::FilterableAttributesRule;
 use meilisearch_types::tasks::{IndexSwap, KindWithContent, Status};
 use time::{Duration, OffsetDateTime};
 
@@ -622,6 +623,79 @@ fn batch_deletion_nothing_and_add_documents_no_guess_pk() {
     );
     index_scheduler.register(kind, None, false).unwrap();
 
+    handle.advance_one_successful_batch();
+
+    snapshot!(snapshot_index_scheduler(&index_scheduler));
+
+    let index = index_scheduler.index("docs").unwrap();
+    let rtxn = index.read_txn().unwrap();
+    snapshot!(snapshot_bitmap(&index.documents_ids(&rtxn).unwrap()));
+}
+
+#[test]
+fn batch_deletion_by_filter_and_addition() {
+    let (index_scheduler, mut handle) = IndexScheduler::test(true, vec![]);
+    let kind = index_creation_task("docs", "id");
+    let _task = index_scheduler.register(kind, None, false).unwrap();
+
+    handle.advance_one_successful_batch();
+
+    index_scheduler
+        .register(
+            KindWithContent::SettingsUpdate {
+                index_uid: "docs".to_string(),
+                new_settings: Box::new(meilisearch_types::settings::Settings {
+                    filterable_attributes: meilisearch_types::milli::update::Setting::Set(vec![
+                        FilterableAttributesRule::Field("id".to_string()),
+                    ]),
+                    _kind: std::marker::PhantomData,
+                    ..Default::default()
+                }),
+                is_deletion: false,
+                allow_index_creation: true,
+            },
+            None,
+            false,
+        )
+        .unwrap();
+    handle.advance_one_successful_batch();
+
+    let (file0, documents_count0) = sample_documents(&index_scheduler, 1, 1);
+    let (file1, documents_count1) = sample_documents(&index_scheduler, 2, 1);
+    file0.persist().unwrap();
+    file1.persist().unwrap();
+    let kind = replace_document_import_task("docs", Some("id"), 1, documents_count0);
+    index_scheduler.register(kind, None, false).unwrap();
+    index_scheduler
+        .register(
+            KindWithContent::DocumentDeletionByFilter {
+                index_uid: "docs".to_string(),
+                filter_expr: serde_json::json!("id = 1"),
+            },
+            None,
+            false,
+        )
+        .unwrap();
+    index_scheduler
+        .register(
+            KindWithContent::DocumentDeletionByFilter {
+                index_uid: "docs".to_string(),
+                filter_expr: serde_json::json!("NOT id = 3"),
+            },
+            None,
+            false,
+        )
+        .unwrap();
+    let kind = replace_document_import_task_with_opts(
+        "docs",
+        Some("id"),
+        2,
+        documents_count1,
+        MissingDocumentPolicy::Skip,
+    );
+    index_scheduler.register(kind, None, false).unwrap();
+
+    handle.advance_one_successful_batch();
     handle.advance_one_successful_batch();
 
     snapshot!(snapshot_index_scheduler(&index_scheduler));

--- a/crates/index-scheduler/src/queue/snapshots/batches_test.rs/batch_deletion_by_filter_and_addition/1.snap
+++ b/crates/index-scheduler/src/queue/snapshots/batches_test.rs/batch_deletion_by_filter_and_addition/1.snap
@@ -1,0 +1,101 @@
+---
+source: crates/index-scheduler/src/queue/batches_test.rs
+---
+### Autobatching Enabled = true
+### Processing batch None:
+[]
+----------------------------------------------------------------------
+### All Tasks:
+0 {uid: 0, batch_uid: 0, status: succeeded, details: { primary_key: Some("id"), old_new_uid: None, new_index_uid: None }, kind: IndexCreation { index_uid: "docs", primary_key: Some("id") }}
+1 {uid: 1, batch_uid: 1, status: succeeded, details: { settings: Settings { displayed_attributes: WildcardSetting(NotSet), searchable_attributes: WildcardSetting(NotSet), filterable_attributes: Set([Field("id")]), sortable_attributes: NotSet, foreign_keys: NotSet, ranking_rules: NotSet, stop_words: NotSet, non_separator_tokens: NotSet, separator_tokens: NotSet, dictionary: NotSet, synonyms: NotSet, distinct_attribute: NotSet, proximity_precision: NotSet, typo_tolerance: NotSet, faceting: NotSet, pagination: NotSet, embedders: NotSet, search_cutoff_ms: NotSet, localized_attributes: NotSet, facet_search: NotSet, prefix_search: NotSet, chat: NotSet, _kind: PhantomData<meilisearch_types::settings::Unchecked> } }, kind: SettingsUpdate { index_uid: "docs", new_settings: Settings { displayed_attributes: WildcardSetting(NotSet), searchable_attributes: WildcardSetting(NotSet), filterable_attributes: Set([Field("id")]), sortable_attributes: NotSet, foreign_keys: NotSet, ranking_rules: NotSet, stop_words: NotSet, non_separator_tokens: NotSet, separator_tokens: NotSet, dictionary: NotSet, synonyms: NotSet, distinct_attribute: NotSet, proximity_precision: NotSet, typo_tolerance: NotSet, faceting: NotSet, pagination: NotSet, embedders: NotSet, search_cutoff_ms: NotSet, localized_attributes: NotSet, facet_search: NotSet, prefix_search: NotSet, chat: NotSet, _kind: PhantomData<meilisearch_types::settings::Unchecked> }, is_deletion: false, allow_index_creation: true }}
+2 {uid: 2, batch_uid: 2, status: succeeded, details: { received_documents: 1, indexed_documents: Some(1) }, kind: DocumentAdditionOrUpdate { index_uid: "docs", primary_key: Some("id"), method: ReplaceDocuments, content_file: 00000000-0000-0000-0000-000000000001, documents_count: 1, allow_index_creation: true, on_missing_document: Create }}
+3 {uid: 3, batch_uid: 3, status: succeeded, details: { original_filter: "id = 1", deleted_documents: Some(1) }, kind: DocumentDeletionByFilter { index_uid: "docs", filter_expr: String("id = 1") }}
+4 {uid: 4, batch_uid: 3, status: succeeded, details: { original_filter: "NOT id = 3", deleted_documents: Some(1) }, kind: DocumentDeletionByFilter { index_uid: "docs", filter_expr: String("NOT id = 3") }}
+5 {uid: 5, batch_uid: 3, status: succeeded, details: { received_documents: 1, indexed_documents: Some(1) }, kind: DocumentAdditionOrUpdate { index_uid: "docs", primary_key: Some("id"), method: ReplaceDocuments, content_file: 00000000-0000-0000-0000-000000000002, documents_count: 1, allow_index_creation: true, on_missing_document: Skip }}
+----------------------------------------------------------------------
+### Status:
+enqueued []
+succeeded [0,1,2,3,4,5,]
+----------------------------------------------------------------------
+### Kind:
+"documentAdditionOrUpdate" [2,5,]
+"documentDeletion" [3,4,]
+"settingsUpdate" [1,]
+"indexCreation" [0,]
+----------------------------------------------------------------------
+### Index Tasks:
+docs [0,1,2,3,4,5,]
+----------------------------------------------------------------------
+### Index Mapper:
+docs: { number_of_documents: 0, field_distribution: {} }
+
+----------------------------------------------------------------------
+### Canceled By:
+
+----------------------------------------------------------------------
+### Enqueued At:
+[timestamp] [0,]
+[timestamp] [1,]
+[timestamp] [2,]
+[timestamp] [3,]
+[timestamp] [4,]
+[timestamp] [5,]
+----------------------------------------------------------------------
+### Started At:
+[timestamp] [0,]
+[timestamp] [1,]
+[timestamp] [2,]
+[timestamp] [3,4,5,]
+----------------------------------------------------------------------
+### Finished At:
+[timestamp] [0,]
+[timestamp] [1,]
+[timestamp] [2,]
+[timestamp] [3,4,5,]
+----------------------------------------------------------------------
+### All Batches:
+0 {uid: 0, details: {"primaryKey":"id"}, stats: {"totalNbTasks":1,"status":{"succeeded":1},"types":{"indexCreation":1},"indexUids":{"docs":1}}, stop reason: "created batch containing only task with id 0 of type `indexCreation` that cannot be batched with any other task.", }
+1 {uid: 1, details: {"filterableAttributes":["id"]}, stats: {"totalNbTasks":1,"status":{"succeeded":1},"types":{"settingsUpdate":1},"indexUids":{"docs":1}}, stop reason: "batched all enqueued tasks", }
+2 {uid: 2, details: {"receivedDocuments":1,"indexedDocuments":1}, stats: {"totalNbTasks":1,"status":{"succeeded":1},"types":{"documentAdditionOrUpdate":1},"indexUids":{"docs":1}}, stop reason: "stopped before task with id 3 because it is a deletion by filter which cannot be batched with document operations", }
+3 {uid: 3, details: {"receivedDocuments":1,"indexedDocuments":1,"providedIds":0,"deletedDocuments":2,"originalFilter":"\"id = 1\"&\"NOT id = 3\""}, stats: {"totalNbTasks":3,"status":{"succeeded":3},"types":{"documentAdditionOrUpdate":1,"documentDeletion":2},"indexUids":{"docs":3}}, stop reason: "batched all enqueued tasks", }
+----------------------------------------------------------------------
+### Batch to tasks mapping:
+0 [0,]
+1 [1,]
+2 [2,]
+3 [3,4,5,]
+----------------------------------------------------------------------
+### Batches Status:
+succeeded [0,1,2,3,]
+----------------------------------------------------------------------
+### Batches Kind:
+"documentAdditionOrUpdate" [2,3,]
+"documentDeletion" [3,]
+"settingsUpdate" [1,]
+"indexCreation" [0,]
+----------------------------------------------------------------------
+### Batches Index Tasks:
+docs [0,1,2,3,]
+----------------------------------------------------------------------
+### Batches Enqueued At:
+[timestamp] [0,]
+[timestamp] [1,]
+[timestamp] [2,]
+[timestamp] [3,]
+[timestamp] [3,]
+----------------------------------------------------------------------
+### Batches Started At:
+[timestamp] [0,]
+[timestamp] [1,]
+[timestamp] [2,]
+[timestamp] [3,]
+----------------------------------------------------------------------
+### Batches Finished At:
+[timestamp] [0,]
+[timestamp] [1,]
+[timestamp] [2,]
+[timestamp] [3,]
+----------------------------------------------------------------------
+### File Store:
+
+----------------------------------------------------------------------

--- a/crates/index-scheduler/src/queue/snapshots/batches_test.rs/batch_deletion_by_filter_and_addition/2.snap
+++ b/crates/index-scheduler/src/queue/snapshots/batches_test.rs/batch_deletion_by_filter_and_addition/2.snap
@@ -1,0 +1,4 @@
+---
+source: crates/index-scheduler/src/queue/batches_test.rs
+---
+[]

--- a/crates/index-scheduler/src/scheduler/create_batch.rs
+++ b/crates/index-scheduler/src/scheduler/create_batch.rs
@@ -7,6 +7,7 @@ use meilisearch_types::settings::{Settings, Unchecked};
 use meilisearch_types::tasks::network::{DbTaskNetwork, NetworkTopologyState, Origin};
 use meilisearch_types::tasks::{BatchStopReason, Kind, KindWithContent, Status, Task};
 use roaring::RoaringBitmap;
+use serde_json::Value;
 use uuid::Uuid;
 
 use super::autobatcher::{self, BatchKind};
@@ -75,6 +76,7 @@ pub(crate) enum DocumentOperation {
     Replace { content_file: Uuid, on_missing_document: MissingDocumentPolicy },
     Update { content_file: Uuid, on_missing_document: MissingDocumentPolicy },
     Delete(Vec<String>),
+    DeleteByFilter { filter: Value },
 }
 
 /// A [batch](Batch) that combines multiple tasks operating on an index.
@@ -301,7 +303,8 @@ impl IndexScheduler {
                             // we want to stop on the first document addition
                             Some(primary_key.clone())
                         }
-                        KindWithContent::DocumentDeletion { .. } => None,
+                        KindWithContent::DocumentDeletion { .. }
+                        | KindWithContent::DocumentDeletionByFilter { .. } => None,
                         _ => unreachable!(),
                     })
                     .flatten();
@@ -332,6 +335,11 @@ impl IndexScheduler {
                         },
                         KindWithContent::DocumentDeletion { ref documents_ids, .. } => {
                             operations.push(DocumentOperation::Delete(documents_ids.clone()));
+                        }
+                        KindWithContent::DocumentDeletionByFilter { ref filter_expr, .. } => {
+                            operations.push(DocumentOperation::DeleteByFilter {
+                                filter: filter_expr.clone(),
+                            });
                         }
                         _ => unreachable!(),
                     }

--- a/crates/index-scheduler/src/scheduler/process_index_operation.rs
+++ b/crates/index-scheduler/src/scheduler/process_index_operation.rs
@@ -121,6 +121,19 @@ impl IndexScheduler {
                             indexer
                                 .delete_documents_by_external_ids(document_ids.into_bump_slice());
                         }
+                        DocumentOperation::DeleteByFilter { filter } => {
+                            let filter = Filter::from_json(&filter)
+                                .map_err(|e| Error::from_milli(e, Some(index_uid.clone())))?;
+                            if let Some(filter) = filter {
+                                let filter = filter_into_index_filter(
+                                    filter, index, index_wtxn, self, progress, &index_uid,
+                                )?;
+                                let candidates =
+                                    filter.evaluate(index_wtxn, index).map_err(|err| {
+                                        Error::from_milli(err, Some(index_uid.clone()))
+                                    })?;
+                                indexer.delete_documents_by_internal_ids(candidates);
+                            }
                         }
                     }
                 }
@@ -164,6 +177,12 @@ impl IndexScheduler {
                         Some(Details::DocumentDeletion { provided_ids, .. }) => {
                             Some(Details::DocumentDeletion {
                                 provided_ids,
+                                deleted_documents: Some(stats.document_count),
+                            })
+                        }
+                        Some(Details::DocumentDeletionByFilter { ref original_filter, .. }) => {
+                            Some(Details::DocumentDeletionByFilter {
+                                original_filter: original_filter.clone(),
                                 deleted_documents: Some(stats.document_count),
                             })
                         }

--- a/crates/index-scheduler/src/scheduler/process_index_operation.rs
+++ b/crates/index-scheduler/src/scheduler/process_index_operation.rs
@@ -118,7 +118,9 @@ impl IndexScheduler {
                                 .iter()
                                 .map(|s| &*indexer_alloc.alloc_str(s))
                                 .collect_in(&indexer_alloc);
-                            indexer.delete_documents(document_ids.into_bump_slice());
+                            indexer
+                                .delete_documents_by_external_ids(document_ids.into_bump_slice());
+                        }
                         }
                     }
                 }

--- a/crates/milli/src/test_index.rs
+++ b/crates/milli/src/test_index.rs
@@ -191,7 +191,7 @@ impl TempIndex {
         let mut indexer = indexer::IndexOperations::new();
         let external_document_ids: Vec<_> =
             external_document_ids.iter().map(AsRef::as_ref).collect();
-        indexer.delete_documents(external_document_ids.as_slice());
+        indexer.delete_documents_by_external_ids(external_document_ids.as_slice());
 
         let indexer_alloc = Bump::new();
         let (document_changes, operation_stats, primary_key) = indexer.into_changes(

--- a/crates/milli/src/update/index_documents/mod.rs
+++ b/crates/milli/src/update/index_documents/mod.rs
@@ -2340,7 +2340,7 @@ mod tests {
         let embedders = RuntimeEmbedders::default();
         let mut indexer = indexer::IndexOperations::new();
         indexer.replace_documents(&documents, MissingDocumentPolicy::default()).unwrap();
-        indexer.delete_documents(&["2"]);
+        indexer.delete_documents_by_external_ids(&["2"]);
         let (document_changes, _operation_stats, primary_key) = indexer
             .into_changes(
                 &indexer_alloc,
@@ -2403,7 +2403,7 @@ mod tests {
             { "id": 3, "legs": 4 },
         ]);
         indexer.update_documents(&documents, MissingDocumentPolicy::default()).unwrap();
-        indexer.delete_documents(&["1", "2"]);
+        indexer.delete_documents_by_external_ids(&["1", "2"]);
 
         let indexer_alloc = Bump::new();
         let embedders = RuntimeEmbedders::default();
@@ -2518,7 +2518,7 @@ mod tests {
         let embedders = RuntimeEmbedders::default();
         let mut indexer = indexer::IndexOperations::new();
         indexer.update_documents(&documents, MissingDocumentPolicy::default()).unwrap();
-        indexer.delete_documents(&["1", "2"]);
+        indexer.delete_documents_by_external_ids(&["1", "2"]);
 
         let (document_changes, _operation_stats, primary_key) = indexer
             .into_changes(
@@ -2570,7 +2570,7 @@ mod tests {
         let indexer_alloc = Bump::new();
         let embedders = RuntimeEmbedders::default();
         let mut indexer = indexer::IndexOperations::new();
-        indexer.delete_documents(&["1", "2"]);
+        indexer.delete_documents_by_external_ids(&["1", "2"]);
 
         let documents = documents!([
             { "id": 2, "doggo": { "name": "jean", "age": 20 } },
@@ -2630,7 +2630,7 @@ mod tests {
         let embedders = RuntimeEmbedders::default();
         let mut indexer = indexer::IndexOperations::new();
 
-        indexer.delete_documents(&["1", "2", "1", "2"]);
+        indexer.delete_documents_by_external_ids(&["1", "2", "1", "2"]);
 
         let documents = documents!([
             { "id": 1, "doggo": "kevin" },
@@ -2639,7 +2639,7 @@ mod tests {
         ]);
         indexer.update_documents(&documents, MissingDocumentPolicy::default()).unwrap();
 
-        indexer.delete_documents(&["1", "2", "1", "2"]);
+        indexer.delete_documents_by_external_ids(&["1", "2", "1", "2"]);
 
         let (document_changes, _operation_stats, primary_key) = indexer
             .into_changes(
@@ -2745,7 +2745,7 @@ mod tests {
         let embedders = RuntimeEmbedders::default();
         let mut indexer = indexer::IndexOperations::new();
 
-        indexer.delete_documents(&["1"]);
+        indexer.delete_documents_by_external_ids(&["1"]);
 
         let documents = documents!([
             { "id": 1, "catto": "jorts" },
@@ -3029,7 +3029,7 @@ mod tests {
         let embedders = RuntimeEmbedders::default();
         let mut indexer = indexer::IndexOperations::new();
 
-        indexer.delete_documents(&["1"]);
+        indexer.delete_documents_by_external_ids(&["1"]);
 
         let documents = documents!([
             { "id": 0, "catto": "jorts" },

--- a/crates/milli/src/update/new/indexer/document_operation.rs
+++ b/crates/milli/src/update/new/indexer/document_operation.rs
@@ -13,6 +13,7 @@ use indexmap::IndexMap;
 use memmap2::Mmap;
 use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
 use rayon::slice::{ParallelSlice, ParallelSliceMut as _};
+use roaring::RoaringBitmap;
 use rustc_hash::FxBuildHasher;
 use serde_json::value::RawValue;
 use serde_json::Deserializer;
@@ -21,6 +22,7 @@ use thread_local::ThreadLocal;
 use super::super::document_change::DocumentChange;
 use super::document_changes::DocumentChanges;
 use super::guess_primary_key::retrieve_or_guess_primary_key;
+use crate::documents::Error::InvalidDocumentFormat;
 use crate::documents::PrimaryKey;
 use crate::progress::{AtomicPayloadStep, Progress};
 use crate::sharding::{Shard, Shards};
@@ -75,7 +77,10 @@ impl<'pl> IndexOperations<'pl> {
     pub fn delete_documents_by_external_ids(&mut self, to_delete: &'pl [&'pl str]) {
         self.operations.push(Payload::DeletionByExternalIds(to_delete))
     }
-        self.operations.push(Payload::Deletion(to_delete))
+
+    /// Append a deletion of documents by internal IDs.
+    pub fn delete_documents_by_internal_ids(&mut self, to_delete: RoaringBitmap) {
+        self.operations.push(Payload::DeletionByInternalIds(to_delete))
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -96,6 +101,8 @@ impl<'pl> IndexOperations<'pl> {
     {
         progress.update_progress(IndexingStep::PreparingPayloads);
         let Self { operations } = self;
+
+        let db_fields_ids_map = index.fields_ids_map(rtxn)?;
 
         // We first fetch the primary key from the index...
         let primary_key = retrieve_or_guess_primary_key(
@@ -150,7 +157,13 @@ impl<'pl> IndexOperations<'pl> {
                         return Err(InternalError::AbortedIndexation.into());
                     }
                     step.fetch_add(1, Ordering::Relaxed);
-                    IndexedPayloadOperations::from_payload(payload, &primary_key, shards)
+                    IndexedPayloadOperations::from_payload(
+                        payload,
+                        index,
+                        &db_fields_ids_map,
+                        &primary_key,
+                        shards,
+                    )
                 })
                 .try_reduce(IndexedPayloadOperations::default, |lhs, rhs| lhs | rhs)?;
 
@@ -284,7 +297,7 @@ fn fetch_primary_and_ignore_payloads<'pl>(
                     },
                 }
             }
-            Payload::Deletion(_) => {
+            Payload::DeletionByExternalIds(_) | Payload::DeletionByInternalIds(_) => {
                 // We reach this when we don't have a primary key so it's impossible to delete documents.
                 PayloadStats { bytes: 0, document_count: 0, error: None }
             }
@@ -319,6 +332,8 @@ struct IndexedPayloadOperations<'pl> {
 impl<'pl> IndexedPayloadOperations<'pl> {
     fn from_payload(
         payload_operation: Payload<'pl>,
+        index: &Index,
+        fields_ids_map: &FieldsIdsMap,
         primary_key: &PrimaryKey<'_>,
         shards: Option<&'pl Shards>,
     ) -> Result<Self> {
@@ -344,6 +359,14 @@ impl<'pl> IndexedPayloadOperations<'pl> {
                     extract_payload_deletions_by_external_ids(docids, shards);
                 (document_operations, stats, FieldsIdsMap::default())
             }
+            Payload::DeletionByInternalIds(docids) => {
+                let (document_operations, stats) = extract_payload_deletions_by_internal_ids(
+                    &docids,
+                    index,
+                    fields_ids_map,
+                    primary_key,
+                    shards,
+                )?;
                 (document_operations, stats, FieldsIdsMap::default())
             }
         };
@@ -534,6 +557,10 @@ impl<'pl> DocumentOperations<'pl> {
 
         self.operations.push(operation);
     }
+
+    fn push_deletion(&mut self) {
+        self.operations.push(DocumentOperation::Deletion);
+    }
 }
 
 impl<'pl> IntoIterator for DocumentOperations<'pl> {
@@ -641,6 +668,43 @@ fn extract_payload_deletions_by_external_ids<'pl>(
     (docops, payload_stats)
 }
 
+fn extract_payload_deletions_by_internal_ids<'pl>(
+    internal_document_ids: &RoaringBitmap,
+    index: &Index,
+    fields_ids_map: &FieldsIdsMap,
+    primary_key: &PrimaryKey<'_>,
+    shards: Option<&'pl Shards>,
+) -> Result<(IndexMap<String, DocumentOperations<'pl>>, PayloadStats)> {
+    let rtxn = index.read_txn()?;
+    let mut new_docids_version_offsets = IndexMap::<_, DocumentOperations>::new();
+    for internal_id in internal_document_ids {
+        let document = index.document(&rtxn, internal_id)?;
+        let external_document_id = match primary_key.document_id(document, &fields_ids_map)? {
+            Ok(document_id) => document_id,
+            Err(_) => return Err(InternalError::DocumentsError(InvalidDocumentFormat).into()),
+        };
+
+        let shard = shards.and_then(|shards| shards.processing_shard(&external_document_id));
+
+        if let Some(shard) = shard {
+            if !shard.is_own {
+                continue;
+            }
+        }
+
+        match new_docids_version_offsets.entry(external_document_id.to_owned()) {
+            Entry::Occupied(mut occupied_entry) => occupied_entry.get_mut().push_deletion(),
+            Entry::Vacant(vacant_entry) => {
+                vacant_entry.insert(DocumentOperations::one_deletion(shard));
+            }
+        }
+    }
+
+    let payload_stats =
+        PayloadStats { bytes: 0, document_count: internal_document_ids.len(), error: None };
+    Ok((new_docids_version_offsets, payload_stats))
+}
+
 impl<'pl> DocumentChanges<'pl> for DocumentOperationChanges<'pl> {
     type Item = (&'pl str, PayloadOperations<'pl>);
 
@@ -697,6 +761,7 @@ pub enum Payload<'pl> {
     Replace { payload: &'pl [u8], on_missing_document: MissingDocumentPolicy },
     Update { payload: &'pl [u8], on_missing_document: MissingDocumentPolicy },
     DeletionByExternalIds(&'pl [&'pl str]),
+    DeletionByInternalIds(RoaringBitmap),
 }
 
 pub struct PayloadStats {

--- a/crates/milli/src/update/new/indexer/document_operation.rs
+++ b/crates/milli/src/update/new/indexer/document_operation.rs
@@ -71,10 +71,10 @@ impl<'pl> IndexOperations<'pl> {
         Ok(())
     }
 
-    /// Append a deletion of documents IDs.
-    ///
-    /// The list is a set of external documents IDs.
-    pub fn delete_documents(&mut self, to_delete: &'pl [&'pl str]) {
+    /// Append a deletion of documents by external IDs.
+    pub fn delete_documents_by_external_ids(&mut self, to_delete: &'pl [&'pl str]) {
+        self.operations.push(Payload::DeletionByExternalIds(to_delete))
+    }
         self.operations.push(Payload::Deletion(to_delete))
     }
 
@@ -339,8 +339,11 @@ impl<'pl> IndexedPayloadOperations<'pl> {
                 UpdateDocuments,
                 shards,
             )?,
-            Payload::Deletion(docids) => {
-                let (document_operations, stats) = extract_payload_deletions(docids, shards);
+            Payload::DeletionByExternalIds(docids) => {
+                let (document_operations, stats) =
+                    extract_payload_deletions_by_external_ids(docids, shards);
+                (document_operations, stats, FieldsIdsMap::default())
+            }
                 (document_operations, stats, FieldsIdsMap::default())
             }
         };
@@ -617,7 +620,7 @@ fn extract_payload_changes<'pl>(
     Ok((new_docids_version_offsets, payload_stats, fids_map))
 }
 
-fn extract_payload_deletions<'pl>(
+fn extract_payload_deletions_by_external_ids<'pl>(
     external_document_ids: &[&str],
     shards: Option<&'pl Shards>,
 ) -> (IndexMap<String, DocumentOperations<'pl>>, PayloadStats) {
@@ -693,7 +696,7 @@ pub struct DocumentOperationChanges<'pl> {
 pub enum Payload<'pl> {
     Replace { payload: &'pl [u8], on_missing_document: MissingDocumentPolicy },
     Update { payload: &'pl [u8], on_missing_document: MissingDocumentPolicy },
-    Deletion(&'pl [&'pl str]),
+    DeletionByExternalIds(&'pl [&'pl str]),
 }
 
 pub struct PayloadStats {


### PR DESCRIPTION
This PR fixes a regression introduced in #6389, where we added support for auto-batching deletion by filter with document replacement and updates.

## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respects the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)