### PR TITLE
Fix a panic with incomplete filters

### DIFF
--- a/crates/filter-parser/src/error.rs
+++ b/crates/filter-parser/src/error.rs
@@ -94,6 +94,7 @@ pub enum ErrorKind<'a> {
     InvalidPrimary,
     InvalidEscapedNumber,
     ExpectedEof,
+    Incomplete(nom::Needed),
     ExpectedValue(ExpectedValueKind),
     MalformedValue,
     InOpeningBracket,
@@ -201,6 +202,9 @@ impl Display for Error<'_> {
             }
             ErrorKind::ExpectedEof => {
                 writeln!(f, "Found unexpected characters at the end of the filter: `{}`. You probably forgot an `OR` or an `AND` rule.", escaped_input)?
+            }
+            ErrorKind::Incomplete(needed) => {
+                writeln!(f, "The filter is incomplete and requires {needed:?} additional bytes to be parsed.")?
             }
             ErrorKind::GeoRadius => {
                 writeln!(f, "The `_geoRadius` filter must be in the form: `_geoRadius(latitude, longitude, radius, optionalResolution)`.")?

--- a/crates/filter-parser/src/lib.rs
+++ b/crates/filter-parser/src/lib.rs
@@ -61,7 +61,6 @@ use nom::combinator::{cut, eof, map, opt};
 use nom::multi::{many0, separated_list1};
 use nom::number::complete::recognize_float;
 use nom::sequence::{delimited, preceded, separated_pair, terminated, tuple};
-use nom::Finish;
 use nom_locate::LocatedSpan;
 pub(crate) use value::parse_value;
 use value::word_exact;
@@ -445,7 +444,13 @@ impl<'a> FilterCondition<'a> {
             return Ok(None);
         }
         let span = Span::new_extra(input, input);
-        parse_filter(span).finish().map(|(_rem, output)| Some(output))
+        match parse_filter(span) {
+            Ok((_rem, output)) => Ok(Some(output)),
+            Err(nom::Err::Error(e) | nom::Err::Failure(e)) => Err(e),
+            Err(nom::Err::Incomplete(needed)) => {
+                Err(Error::new_from_kind(span.into(), ErrorKind::Incomplete(needed)))
+            }
+        }
     }
 }
 
@@ -1444,6 +1449,11 @@ pub mod tests {
         insta::assert_snapshot!(p("channel = ponce ORdog != 'bernese mountain'"), @r###"
         Found unexpected characters at the end of the filter: `ORdog != \'bernese mountain\'`. You probably forgot an `OR` or an `AND` rule.
         17:44 channel = ponce ORdog != 'bernese mountain'
+        "###);
+
+        insta::assert_snapshot!(p(r###"name = "\x""###), @r###"
+        The filter is incomplete and requires Unknown additional bytes to be parsed.
+        1:12 name = "\x"
         "###);
 
         insta::assert_snapshot!(p("colour IN blue, green]"), @r###"


### PR DESCRIPTION
This PR fixes an internal panic when a filter is icomplete by returning an error.

## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respects the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)