### PR TITLE
perf(tracing): add missing trace spans to facet bulk post-processing

### DIFF
--- a/crates/milli/src/update/new/indexer/post_processing/facet_bulk.rs
+++ b/crates/milli/src/update/new/indexer/post_processing/facet_bulk.rs
@@ -21,6 +21,12 @@ use crate::{CboRoaringBitmapCodec, FieldId, Index};
 /// The function will generate all the group levels from
 /// the group 1 to the level n until the number of group
 /// is smaller than the minimum required size.
+#[tracing::instrument(
+    level = "trace",
+    skip_all,
+    target = "indexing::post_processing::facet_bulk",
+    fields(%field_id, ?facet_type)
+)]
 pub fn generate_facet_levels(
     index: &Index,
     wtxn: &mut RwTxn,
@@ -69,6 +75,12 @@ pub fn generate_facet_levels(
 
 /// Compute the groups of facets from the provided base level
 /// and write the content into different grenad files.
+#[tracing::instrument(
+    level = "trace",
+    skip_all,
+    target = "indexing::post_processing::facet_bulk",
+    fields(%field_id, %base_level)
+)]
 fn compute_level(
     wtxn: &heed::RwTxn,
     db: Database<FacetGroupKeyCodec<BytesRefCodec>, LazyDecode<FacetGroupValueCodec>>,
@@ -151,6 +163,12 @@ fn compute_level(
 }
 
 /// Clears all the levels and only keeps the level 0 of the specified field id.
+#[tracing::instrument(
+    level = "trace",
+    skip_all,
+    target = "indexing::post_processing::facet_bulk",
+    fields(%field_id)
+)]
 fn clear_levels(
     db: Database<FacetGroupKeyCodec<BytesRefCodec>, LazyDecode<FacetGroupValueCodec>>,
     wtxn: &mut RwTxn<'_>,


### PR DESCRIPTION
Closes #5654

## Problem

The three functions in `crates/milli/src/update/new/indexer/post_processing/facet_bulk.rs` had no tracing instrumentation:

- `generate_facet_levels` — called once per filterable field in bulk mode
- `compute_level` — called once per level while building the facet hierarchy  
- `clear_levels` — clears existing levels before rebuilding

This meant ~6 seconds of bulk facet post-processing time was invisible in profiling traces (puffin / tracing spans), making it impossible to attribute time to individual field IDs or hierarchy levels.

## Fix

Add `#[tracing::instrument]` to all three functions with relevant fields:

| Function | Fields |
|---|---|
| `generate_facet_levels` | `field_id`, `facet_type` |
| `compute_level` | `field_id`, `base_level` |
| `clear_levels` | `field_id` |

The spans use `level = "trace"` and `target = "indexing::post_processing::facet_bulk"` consistent with the existing instrumentation in `mod.rs`.

## Testing

`cargo check -p milli` passes. No logic was changed — tracing attributes only.