### PR TITLE
fix(milli): support prefix search on disableOnAttributes and disableOnNumbers fields

### DIFF
--- a/crates/milli/src/search/new/tests/typo.rs
+++ b/crates/milli/src/search/new/tests/typo.rs
@@ -635,3 +635,66 @@ fn test_typo_synonyms() {
     ]
     "###);
 }
+
+fn prefix_search_exact_attribute_documents() -> Vec<serde_json::Value> {
+    (0..100)
+        .map(|id| {
+            serde_json::json!({
+                "id": id,
+                "title": "Hello many",
+                "content": "Goodbye many",
+            })
+        })
+        .collect()
+}
+
+fn assert_prefix_search_on_exact_attribute(index: &TempIndex) {
+    let txn = index.read_txn().unwrap();
+
+    let mut s = index.search(&txn);
+    s.query("ma");
+    let SearchResult { documents_ids, .. } = s.execute().unwrap();
+    assert!(!documents_ids.is_empty(), "prefix search should match tolerant content");
+
+    let mut s = index.search(&txn);
+    s.query("hel");
+    let SearchResult { documents_ids, .. } = s.execute().unwrap();
+    assert!(!documents_ids.is_empty(), "prefix search should match exact-attribute title");
+}
+
+fn configure_prefix_search_exact_attribute_settings(index: &TempIndex) {
+    index
+        .update_settings(|s| {
+            s.set_primary_key("id".to_owned());
+            s.set_searchable_fields(vec!["title".to_owned(), "content".to_owned()]);
+            s.set_exact_attributes(["title"].iter().map(ToString::to_string).collect());
+            s.set_disable_on_numbers(true);
+            s.set_criteria(vec![Criterion::Words]);
+        })
+        .unwrap();
+}
+
+#[test]
+fn test_prefix_search_on_exact_attribute_and_disable_on_numbers() {
+    let index = TempIndex::new();
+    configure_prefix_search_exact_attribute_settings(&index);
+    let docs = prefix_search_exact_attribute_documents();
+    index.add_documents(documents!(docs)).unwrap();
+    assert_prefix_search_on_exact_attribute(&index);
+}
+
+#[test]
+fn test_prefix_search_on_exact_attribute_settings_after_documents() {
+    let index = TempIndex::new();
+    index
+        .update_settings(|s| {
+            s.set_primary_key("id".to_owned());
+            s.set_searchable_fields(vec!["title".to_owned(), "content".to_owned()]);
+            s.set_criteria(vec![Criterion::Words]);
+        })
+        .unwrap();
+    let docs = prefix_search_exact_attribute_documents();
+    index.add_documents(documents!(docs)).unwrap();
+    configure_prefix_search_exact_attribute_settings(&index);
+    assert_prefix_search_on_exact_attribute(&index);
+}

--- a/crates/milli/src/update/new/indexer/extract.rs
+++ b/crates/milli/src/update/new/indexer/extract.rs
@@ -44,7 +44,7 @@ pub(super) fn extract_all<'pl, 'extractor, DC>(
     document_ids: &mut RoaringBitmap,
     modified_docids: &mut RoaringBitmap,
     embedder_stats: &EmbedderStats,
-) -> Result<(FacetFieldIdsDelta, WordDelta, Vec<IndexEmbeddingConfig>)>
+) -> Result<(FacetFieldIdsDelta, WordDelta, WordDelta, Vec<IndexEmbeddingConfig>)>
 where
     DC: DocumentChanges<'pl>,
 {
@@ -89,6 +89,7 @@ where
 
     let facet_field_ids_delta;
     let word_delta;
+    let exact_word_delta;
 
     {
         let caches = {
@@ -186,11 +187,23 @@ where
             let _entered = span.enter();
             indexing_context.progress.update_progress(MergingWordCache::ExactWordDocids);
 
-            merge_and_send_docids(
+            exact_word_delta = merge_scan_and_send_docids(
                 exact_word_docids,
                 index.exact_word_docids.remap_types(),
                 index,
                 extractor_sender.docids::<ExactWordDocids>(),
+                |output: &mut WordDelta, key, operation| {
+                    let word = std::str::from_utf8(key)?.to_string();
+                    match operation {
+                        Operation::Write { bitmap: _, status } => match status {
+                            EntryStatus::Created => output.insert_added(word),
+                            EntryStatus::Updated => output.insert_modified(word),
+                        },
+                        Operation::Delete => output.insert_deleted(word),
+                        Operation::Ignore => (),
+                    }
+                    Ok(())
+                },
                 indexing_context.must_stop_processing,
             )?;
         }
@@ -358,7 +371,7 @@ where
     indexing_context.progress.update_progress(IndexingStep::WaitingForDatabaseWrites);
     finished_extraction.store(true, Ordering::Relaxed);
 
-    Result::Ok((facet_field_ids_delta, word_delta, index_embeddings))
+    Result::Ok((facet_field_ids_delta, word_delta, exact_word_delta, index_embeddings))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -372,7 +385,7 @@ pub(super) fn extract_all_settings_changes<SD>(
     field_distribution: &mut BTreeMap<String, u64>,
     mut index_embeddings: Vec<IndexEmbeddingConfig>,
     embedder_stats: &EmbedderStats,
-) -> Result<(Vec<IndexEmbeddingConfig>, WordDelta, FacetFieldIdsDelta)>
+) -> Result<(Vec<IndexEmbeddingConfig>, WordDelta, WordDelta, FacetFieldIdsDelta)>
 where
     SD: SettingsDelta + Sync,
 {
@@ -388,6 +401,7 @@ where
     let _entered = span.enter();
 
     let word_delta;
+    let exact_word_delta;
     let facet_field_ids_delta;
 
     update_database_documents(
@@ -496,11 +510,23 @@ where
             let _entered = span.enter();
             indexing_context.progress.update_progress(MergingWordCache::ExactWordDocids);
 
-            merge_and_send_docids(
+            exact_word_delta = merge_scan_and_send_docids(
                 exact_word_docids,
                 index.exact_word_docids.remap_types(),
                 index,
                 extractor_sender.docids::<ExactWordDocids>(),
+                |output: &mut WordDelta, key, operation| {
+                    let word = std::str::from_utf8(key)?.to_string();
+                    match operation {
+                        Operation::Write { bitmap: _, status } => match status {
+                            EntryStatus::Created => output.insert_added(word),
+                            EntryStatus::Updated => output.insert_modified(word),
+                        },
+                        Operation::Delete => output.insert_deleted(word),
+                        Operation::Ignore => (),
+                    }
+                    Ok(())
+                },
                 indexing_context.must_stop_processing,
             )?;
         }
@@ -688,7 +714,7 @@ where
     indexing_context.progress.update_progress(IndexingStep::WaitingForDatabaseWrites);
     finished_extraction.store(true, Ordering::Relaxed);
 
-    Result::Ok((index_embeddings, word_delta, facet_field_ids_delta))
+    Result::Ok((index_embeddings, word_delta, exact_word_delta, facet_field_ids_delta))
 }
 
 fn primary_key_from_db<'indexer>(

--- a/crates/milli/src/update/new/indexer/mod.rs
+++ b/crates/milli/src/update/new/indexer/mod.rs
@@ -15,7 +15,9 @@ use heed::types::{Bytes, DecodeIgnore, Str, Unit};
 use heed::{BytesDecode, Database, RoTxn, RwTxn};
 pub use mini_string::MiniString;
 pub use partial_dump::PartialDump;
-pub use post_processing::recompute_word_fst_from_word_docids_database;
+pub use post_processing::{
+    recompute_exact_word_prefix_docids_from_database, recompute_word_fst_from_word_docids_database,
+};
 use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
 pub use settings_changes::settings_change_extract;
 pub use update_by_function::UpdateByFunction;
@@ -181,7 +183,7 @@ where
 
         indexing_context.progress.update_progress(IndexingStep::WaitingForExtractors);
 
-        let (facet_field_ids_delta, word_delta, index_embeddings) =
+        let (facet_field_ids_delta, word_delta, exact_word_delta, index_embeddings) =
             extractor_handle.join().unwrap()?;
 
         indexing_context.progress.update_progress(IndexingStep::WritingEmbeddingsToDatabase);
@@ -206,6 +208,7 @@ where
                 wtxn,
                 global_fields_ids_map,
                 &word_delta,
+                &exact_word_delta,
                 facet_field_ids_delta,
             )
         })
@@ -367,13 +370,15 @@ where
 
         indexing_context.progress.update_progress(IndexingStep::WaitingForExtractors);
 
-        let (index_embeddings, mut word_delta, facet_field_ids_delta) =
+        let (index_embeddings, mut word_delta, mut exact_word_delta, facet_field_ids_delta) =
             extractor_handle.join().unwrap()?;
 
         // Insert the recently added numbers into the added words
-        word_delta.added.extend(numbers_to_add_to_words_fst);
+        word_delta.added.extend(numbers_to_add_to_words_fst.iter().cloned());
         // Insert the recently removed numbers into deleted words
-        word_delta.deleted.extend(numbers_to_delete_from_words_fst);
+        word_delta.deleted.extend(numbers_to_delete_from_words_fst.iter().cloned());
+        exact_word_delta.added.extend(numbers_to_delete_from_words_fst);
+        exact_word_delta.deleted.extend(numbers_to_add_to_words_fst);
 
         indexing_context.progress.update_progress(IndexingStep::WritingEmbeddingsToDatabase);
 
@@ -400,6 +405,7 @@ where
                 wtxn,
                 global_fields_ids_map,
                 &word_delta,
+                &exact_word_delta,
                 facet_field_ids_delta,
             )?;
 
@@ -414,16 +420,23 @@ where
                 WordsPrefixesFst::new(wtxn, index).execute()?;
                 let prefixes_fst = index.words_prefixes_fst(wtxn)?;
 
-                let mut modified = BTreeSet::new();
+                let mut tolerant_modified = BTreeSet::new();
                 let deleted = BTreeSet::new();
                 let mut prefix_stream = prefixes_fst.into_stream();
                 while let Some(prefix) = prefix_stream.next() {
                     let Ok(prefix) = std::str::from_utf8(prefix) else { continue };
                     let Some(prefix) = MiniString::new(prefix) else { continue };
-                    modified.insert(prefix);
+                    tolerant_modified.insert(prefix);
                 }
+                let exact_modified = post_processing::exact_prefixes_from_database(index, wtxn)?;
                 post_processing::compute_prefix_database_from_sources(
-                    index, wtxn, &modified, &deleted, progress,
+                    index,
+                    wtxn,
+                    &tolerant_modified,
+                    &deleted,
+                    &exact_modified,
+                    &deleted,
+                    progress,
                 )?;
             }
 

--- a/crates/milli/src/update/new/indexer/mod.rs
+++ b/crates/milli/src/update/new/indexer/mod.rs
@@ -9,7 +9,7 @@ use big_s::S;
 use document_changes::{DocumentChanges, IndexingContext};
 pub use document_deletion::DocumentDeletion;
 pub use document_operation::{IndexOperations, PayloadStats};
-use fst::{IntoStreamer, Streamer as _};
+use fst::Streamer as _;
 use hashbrown::HashMap;
 use heed::types::{Bytes, DecodeIgnore, Str, Unit};
 use heed::{BytesDecode, Database, RoTxn, RwTxn};
@@ -36,9 +36,9 @@ use crate::heed_codec::StrBEU16Codec;
 use crate::index::PrefixSearch;
 use crate::progress::{AtomicDatabaseStep, EmbedderStats, Progress};
 use crate::proximity::ProximityPrecision;
-use crate::update::new::steps::{PostProcessingWords, SettingsIndexerStep};
+use crate::update::new::steps::SettingsIndexerStep;
 use crate::update::settings::SettingsDelta;
-use crate::update::{GrenadParameters, WordsPrefixesFst};
+use crate::update::GrenadParameters;
 use crate::vector::settings::{EmbedderAction, RemoveFragments, WriteBackToDocuments};
 use crate::vector::{Embedder, RuntimeEmbedders, VectorStore};
 use crate::{
@@ -409,34 +409,13 @@ where
                 facet_field_ids_delta,
             )?;
 
-            // When the prefix search was disabled and is enabled we need to call the
-            // WordsPrefixesFst::execute to generate and write the words FST from scratch
-            // and call the compute_prefix_database_from_sources a second time to correctly
-            // generate the prefixes databases.
+            // When prefix search transitions Disabled → IndexingTime, rebuild the prefix FST
+            // from scratch (tolerant + exact words) and repopulate all prefix databases.
             if *settings_delta.old_prefix_search() == PrefixSearch::Disabled
                 && *settings_delta.new_prefix_search() == PrefixSearch::IndexingTime
             {
-                indexing_context.progress.update_progress(PostProcessingWords::ComputePrefixFst);
-                WordsPrefixesFst::new(wtxn, index).execute()?;
-                let prefixes_fst = index.words_prefixes_fst(wtxn)?;
-
-                let mut tolerant_modified = BTreeSet::new();
-                let deleted = BTreeSet::new();
-                let mut prefix_stream = prefixes_fst.into_stream();
-                while let Some(prefix) = prefix_stream.next() {
-                    let Ok(prefix) = std::str::from_utf8(prefix) else { continue };
-                    let Some(prefix) = MiniString::new(prefix) else { continue };
-                    tolerant_modified.insert(prefix);
-                }
-                let exact_modified = post_processing::exact_prefixes_from_database(index, wtxn)?;
-                post_processing::compute_prefix_database_from_sources(
-                    index,
-                    wtxn,
-                    &tolerant_modified,
-                    &deleted,
-                    &exact_modified,
-                    &deleted,
-                    progress,
+                post_processing::recompute_all_prefix_databases_from_database(
+                    index, wtxn, progress,
                 )?;
             }
 

--- a/crates/milli/src/update/new/indexer/post_processing/mod.rs
+++ b/crates/milli/src/update/new/indexer/post_processing/mod.rs
@@ -92,34 +92,15 @@ fn compute_prefix_database(
     let exact_modified = compute_prefixes(&prefix_fst, exact_word_delta.added_or_modified_words())?;
     let exact_deleted = compute_prefixes(&prefix_fst, exact_word_delta.deleted_words())?;
 
-    let mut modified_for_fid_prefixes = tolerant_modified.clone();
-    modified_for_fid_prefixes.extend(exact_modified.iter().cloned());
-    let mut deleted_for_fid_prefixes = tolerant_deleted.clone();
-    deleted_for_fid_prefixes.extend(exact_deleted.iter().cloned());
-
-    progress.update_progress(PostProcessingWords::WordPrefixDocids);
-    compute_word_prefix_docids(wtxn, index, &tolerant_modified, &tolerant_deleted)?;
-
-    progress.update_progress(PostProcessingWords::ExactWordPrefixDocids);
-    compute_exact_word_prefix_docids(wtxn, index, &exact_modified, &exact_deleted)?;
-
-    progress.update_progress(PostProcessingWords::WordPrefixFieldIdDocids);
-    compute_word_prefix_fid_docids(
-        wtxn,
+    compute_prefix_database_from_sources(
         index,
-        &modified_for_fid_prefixes,
-        &deleted_for_fid_prefixes,
-    )?;
-
-    progress.update_progress(PostProcessingWords::WordPrefixPositionDocids);
-    compute_word_prefix_position_docids(
         wtxn,
-        index,
-        &modified_for_fid_prefixes,
-        &deleted_for_fid_prefixes,
-    )?;
-
-    Ok(())
+        &tolerant_modified,
+        &tolerant_deleted,
+        &exact_modified,
+        &exact_deleted,
+        progress,
+    )
 }
 
 #[tracing::instrument(

--- a/crates/milli/src/update/new/indexer/post_processing/mod.rs
+++ b/crates/milli/src/update/new/indexer/post_processing/mod.rs
@@ -39,6 +39,7 @@ pub(super) fn post_process(
     wtxn: &mut RwTxn<'_>,
     mut global_fields_ids_map: GlobalFieldsIdsMap<'_>,
     word_delta: &WordDelta,
+    exact_word_delta: &WordDelta,
     facet_field_ids_delta: FacetFieldIdsDelta,
 ) -> Result<()> {
     let index = indexing_context.index;
@@ -52,9 +53,17 @@ pub(super) fn post_process(
     )?;
     compute_facet_search_database(index, wtxn, global_fields_ids_map, indexing_context.progress)?;
     indexing_context.progress.update_progress(IndexingStep::PostProcessingWords);
-    if let Some(prefix_data) = compute_word_fst(index, wtxn, word_delta, indexing_context.progress)?
+    if let Some(prefix_data) =
+        compute_word_fst(index, wtxn, word_delta, exact_word_delta, indexing_context.progress)?
     {
-        compute_prefix_database(index, wtxn, word_delta, &prefix_data, indexing_context.progress)?;
+        compute_prefix_database(
+            index,
+            wtxn,
+            word_delta,
+            exact_word_delta,
+            &prefix_data,
+            indexing_context.progress,
+        )?;
     }
 
     Ok(())
@@ -70,15 +79,47 @@ fn compute_prefix_database(
     index: &Index,
     wtxn: &mut RwTxn,
     word_delta: &WordDelta,
+    exact_word_delta: &WordDelta,
     prefix_data: &PrefixData,
     progress: &Progress,
 ) -> Result<()> {
     progress.update_progress(PostProcessingWords::ComputePrefixes);
     let prefix_fst = fst::Set::new(&prefix_data.prefixes_fst_mmap[..])?;
-    let modified = compute_prefixes(&prefix_fst, word_delta.added_or_modified_words())?;
-    let deleted = compute_prefixes(&prefix_fst, word_delta.deleted_words())?;
 
-    compute_prefix_database_from_sources(index, wtxn, &modified, &deleted, progress)
+    let tolerant_modified = compute_prefixes(&prefix_fst, word_delta.added_or_modified_words())?;
+    let tolerant_deleted = compute_prefixes(&prefix_fst, word_delta.deleted_words())?;
+
+    let exact_modified = compute_prefixes(&prefix_fst, exact_word_delta.added_or_modified_words())?;
+    let exact_deleted = compute_prefixes(&prefix_fst, exact_word_delta.deleted_words())?;
+
+    let mut modified_for_fid_prefixes = tolerant_modified.clone();
+    modified_for_fid_prefixes.extend(exact_modified.iter().cloned());
+    let mut deleted_for_fid_prefixes = tolerant_deleted.clone();
+    deleted_for_fid_prefixes.extend(exact_deleted.iter().cloned());
+
+    progress.update_progress(PostProcessingWords::WordPrefixDocids);
+    compute_word_prefix_docids(wtxn, index, &tolerant_modified, &tolerant_deleted)?;
+
+    progress.update_progress(PostProcessingWords::ExactWordPrefixDocids);
+    compute_exact_word_prefix_docids(wtxn, index, &exact_modified, &exact_deleted)?;
+
+    progress.update_progress(PostProcessingWords::WordPrefixFieldIdDocids);
+    compute_word_prefix_fid_docids(
+        wtxn,
+        index,
+        &modified_for_fid_prefixes,
+        &deleted_for_fid_prefixes,
+    )?;
+
+    progress.update_progress(PostProcessingWords::WordPrefixPositionDocids);
+    compute_word_prefix_position_docids(
+        wtxn,
+        index,
+        &modified_for_fid_prefixes,
+        &deleted_for_fid_prefixes,
+    )?;
+
+    Ok(())
 }
 
 #[tracing::instrument(
@@ -90,23 +131,136 @@ fn compute_prefix_database(
 pub(crate) fn compute_prefix_database_from_sources(
     index: &Index,
     wtxn: &mut RwTxn,
-    modified: &BTreeSet<MiniString>,
-    deleted: &BTreeSet<MiniString>,
+    tolerant_modified: &BTreeSet<MiniString>,
+    tolerant_deleted: &BTreeSet<MiniString>,
+    exact_modified: &BTreeSet<MiniString>,
+    exact_deleted: &BTreeSet<MiniString>,
     progress: &Progress,
 ) -> Result<()> {
+    let mut modified_for_fid_prefixes = tolerant_modified.clone();
+    modified_for_fid_prefixes.extend(exact_modified.iter().cloned());
+    let mut deleted_for_fid_prefixes = tolerant_deleted.clone();
+    deleted_for_fid_prefixes.extend(exact_deleted.iter().cloned());
+
     progress.update_progress(PostProcessingWords::WordPrefixDocids);
-    compute_word_prefix_docids(wtxn, index, modified, deleted)?;
+    compute_word_prefix_docids(wtxn, index, tolerant_modified, tolerant_deleted)?;
 
     progress.update_progress(PostProcessingWords::ExactWordPrefixDocids);
-    compute_exact_word_prefix_docids(wtxn, index, modified, deleted)?;
+    compute_exact_word_prefix_docids(wtxn, index, exact_modified, exact_deleted)?;
 
     progress.update_progress(PostProcessingWords::WordPrefixFieldIdDocids);
-    compute_word_prefix_fid_docids(wtxn, index, modified, deleted)?;
+    compute_word_prefix_fid_docids(
+        wtxn,
+        index,
+        &modified_for_fid_prefixes,
+        &deleted_for_fid_prefixes,
+    )?;
 
     progress.update_progress(PostProcessingWords::WordPrefixPositionDocids);
-    compute_word_prefix_position_docids(wtxn, index, modified, deleted)?;
+    compute_word_prefix_position_docids(
+        wtxn,
+        index,
+        &modified_for_fid_prefixes,
+        &deleted_for_fid_prefixes,
+    )?;
 
     Ok(())
+}
+
+/// Recompute the exact-word prefix databases from the exact-word docids database.
+pub fn recompute_exact_word_prefix_docids_from_database(
+    index: &Index,
+    wtxn: &mut RwTxn,
+    progress: &Progress,
+) -> Result<()> {
+    let prefix_settings = index.prefix_settings(wtxn)?;
+    if prefix_settings.compute_prefixes != crate::index::PrefixSearch::IndexingTime {
+        return Ok(());
+    }
+
+    progress.update_progress(PostProcessingWords::ComputePrefixes);
+
+    let exact_modified = exact_prefixes_from_database(index, wtxn)?;
+    let exact_deleted = BTreeSet::new();
+
+    index.exact_word_prefix_docids.clear(wtxn)?;
+
+    compute_prefix_database_from_sources(
+        index,
+        wtxn,
+        &BTreeSet::new(),
+        &BTreeSet::new(),
+        &exact_modified,
+        &exact_deleted,
+        progress,
+    )
+}
+
+/// Collect all prefixes that meet the threshold from the exact-word docids database.
+pub(crate) fn exact_prefixes_from_database(
+    index: &Index,
+    wtxn: &RwTxn,
+) -> Result<BTreeSet<MiniString>> {
+    let prefix_settings = index.prefix_settings(wtxn)?;
+    let mut words = Vec::new();
+    for result in index.exact_word_docids.iter(wtxn)?.remap_data_type::<DecodeIgnore>() {
+        let (word, _) = result?;
+        words.push(word.to_string());
+    }
+
+    prefixes_from_words(
+        words.iter().map(|word| word.as_str()),
+        prefix_settings.prefix_count_threshold,
+        prefix_settings.max_prefix_length,
+    )
+}
+
+/// Collect all prefixes that meet the threshold from a sorted list of words.
+fn prefixes_from_words<'a, I>(
+    words: I,
+    prefix_count_threshold: usize,
+    max_prefix_length: usize,
+) -> Result<BTreeSet<MiniString>>
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    let mut current_prefix = vec![String::new(); max_prefix_length];
+    let mut current_prefix_count = vec![0; max_prefix_length];
+    let mut builders: Vec<BTreeSet<String>> =
+        (0..max_prefix_length).map(|_| BTreeSet::new()).collect();
+
+    for word in words {
+        for n in 0..max_prefix_length {
+            let current_prefix = &mut current_prefix[n];
+            let current_prefix_count = &mut current_prefix_count[n];
+            let builder = &mut builders[n];
+
+            let prefix = match word.get(..=n) {
+                Some(prefix) => prefix,
+                None => continue,
+            };
+
+            if *current_prefix_count == 0 || prefix != current_prefix.as_str() {
+                *current_prefix = prefix.to_owned();
+                *current_prefix_count = 0;
+            }
+
+            *current_prefix_count += 1;
+
+            if *current_prefix_count == prefix_count_threshold {
+                builder.insert(prefix.to_owned());
+            }
+        }
+    }
+
+    let mut output = BTreeSet::new();
+    for prefix in builders.into_iter().flatten() {
+        if let Some(prefix) = MiniString::new(&prefix) {
+            output.insert(prefix);
+        }
+    }
+
+    Ok(output)
 }
 
 /// The words must be sorted.
@@ -156,6 +310,7 @@ fn compute_word_fst(
     index: &Index,
     wtxn: &mut RwTxn,
     word_delta: &WordDelta,
+    exact_word_delta: &WordDelta,
     progress: &Progress,
 ) -> Result<Option<PrefixData>> {
     progress.update_progress(PostProcessingWords::WordFst);
@@ -173,6 +328,19 @@ fn compute_word_fst(
             }
             Either::Right(deleted_word) => {
                 word_fst_builder.register_word(DelAdd::Deletion, deleted_word.as_ref())?;
+            }
+        }
+    }
+
+    for either in exact_word_delta.added_or_deleted_words() {
+        match either {
+            Either::Left(added_word) => {
+                word_fst_builder
+                    .register_exact_word_for_prefixes(DelAdd::Addition, added_word.as_ref())?;
+            }
+            Either::Right(deleted_word) => {
+                word_fst_builder
+                    .register_exact_word_for_prefixes(DelAdd::Deletion, deleted_word.as_ref())?;
             }
         }
     }

--- a/crates/milli/src/update/new/indexer/post_processing/mod.rs
+++ b/crates/milli/src/update/new/indexer/post_processing/mod.rs
@@ -149,6 +149,10 @@ pub(crate) fn compute_prefix_database_from_sources(
 }
 
 /// Recompute the exact-word prefix databases from the exact-word docids database.
+///
+/// Rebuilds the prefix FST to include exact-word prefixes (using the same
+/// [`WordFstBuilder::register_exact_word_for_prefixes`] path as normal indexing), then
+/// repopulates [`Index::exact_word_prefix_docids`] from the updated FST.
 pub fn recompute_exact_word_prefix_docids_from_database(
     index: &Index,
     wtxn: &mut RwTxn,
@@ -161,7 +165,39 @@ pub fn recompute_exact_word_prefix_docids_from_database(
 
     progress.update_progress(PostProcessingWords::ComputePrefixes);
 
-    let exact_modified = exact_prefixes_from_database(index, wtxn)?;
+    // Collect exact words first so that we can release the borrow on `wtxn` before
+    // the FST builder needs exclusive access to write.
+    let mut exact_words: Vec<String> = Vec::new();
+    for result in index.exact_word_docids.iter(wtxn)?.remap_data_type::<DecodeIgnore>() {
+        let (word, _) = result?;
+        exact_words.push(word.to_string());
+    }
+
+    // Build a new prefix FST that contains both tolerant-word prefixes (via drain of the
+    // existing words FST) and exact-word prefixes (registered explicitly).
+    // `FstMergerBuilder::build` drains all remaining entries from the existing FST through
+    // the prefix callback, so we do not need to re-register tolerant words manually.
+    let prefix_data = {
+        let words_fst = index.words_fst(wtxn)?;
+        let mut word_fst_builder = WordFstBuilder::new(&words_fst)?;
+        word_fst_builder.with_prefix_settings(prefix_settings);
+        for word in &exact_words {
+            word_fst_builder.register_exact_word_for_prefixes(DelAdd::Addition, word.as_bytes())?;
+        }
+        word_fst_builder.build()?.1
+        // `words_fst` is dropped here, releasing the shared borrow on `wtxn`.
+    };
+
+    let Some(PrefixData { prefixes_fst_mmap }) = prefix_data else {
+        return Ok(());
+    };
+
+    // Persist the updated prefix FST (words FST is unchanged).
+    index.main.remap_types::<Str, Bytes>().put(wtxn, WORDS_PREFIXES_FST_KEY, &prefixes_fst_mmap)?;
+
+    // Derive which exact prefixes changed and rebuild the docids database.
+    let prefix_fst = fst::Set::new(&prefixes_fst_mmap[..])?;
+    let exact_modified = compute_prefixes(&prefix_fst, exact_words.iter().map(|w| w.as_str()))?;
     let exact_deleted = BTreeSet::new();
 
     index.exact_word_prefix_docids.clear(wtxn)?;
@@ -177,71 +213,72 @@ pub fn recompute_exact_word_prefix_docids_from_database(
     )
 }
 
-/// Collect all prefixes that meet the threshold from the exact-word docids database.
-pub(crate) fn exact_prefixes_from_database(
+/// Rebuild the prefix FST and **all** prefix databases from the current word databases.
+///
+/// Used when prefix search transitions from `Disabled` to `IndexingTime` via a settings change.
+/// Unlike [`recompute_exact_word_prefix_docids_from_database`], this rebuilds the prefix FST
+/// from scratch (both tolerant and exact words) and repopulates every prefix database.
+pub(super) fn recompute_all_prefix_databases_from_database(
     index: &Index,
-    wtxn: &RwTxn,
-) -> Result<BTreeSet<MiniString>> {
+    wtxn: &mut RwTxn,
+    progress: &Progress,
+) -> Result<()> {
     let prefix_settings = index.prefix_settings(wtxn)?;
-    let mut words = Vec::new();
+    if prefix_settings.compute_prefixes != crate::index::PrefixSearch::IndexingTime {
+        return Ok(());
+    }
+
+    progress.update_progress(PostProcessingWords::ComputePrefixes);
+
+    // Collect all words first to avoid holding borrows on `wtxn` while the FST builder runs.
+    let mut tolerant_words: Vec<String> = Vec::new();
+    for result in index.word_docids.iter(wtxn)?.remap_data_type::<DecodeIgnore>() {
+        let (word, _) = result?;
+        tolerant_words.push(word.to_string());
+    }
+    let mut exact_words: Vec<String> = Vec::new();
     for result in index.exact_word_docids.iter(wtxn)?.remap_data_type::<DecodeIgnore>() {
         let (word, _) = result?;
-        words.push(word.to_string());
+        exact_words.push(word.to_string());
     }
 
-    prefixes_from_words(
-        words.iter().map(|word| word.as_str()),
-        prefix_settings.prefix_count_threshold,
-        prefix_settings.max_prefix_length,
+    // Build a fresh prefix FST from both tolerant and exact words.
+    // We start from an empty FST because prefix search was previously disabled and the
+    // existing prefix FST (if any) is stale.
+    let prefix_data = {
+        let empty_fst = fst::Set::default().map_data(std::borrow::Cow::Owned)?;
+        let mut word_fst_builder = WordFstBuilder::new(&empty_fst)?;
+        word_fst_builder.with_prefix_settings(prefix_settings);
+        for word in &tolerant_words {
+            word_fst_builder.register_word(DelAdd::Addition, word.as_bytes())?;
+        }
+        for word in &exact_words {
+            word_fst_builder.register_exact_word_for_prefixes(DelAdd::Addition, word.as_bytes())?;
+        }
+        word_fst_builder.build()?.1
+    };
+
+    let Some(PrefixData { prefixes_fst_mmap }) = prefix_data else {
+        return Ok(());
+    };
+
+    index.main.remap_types::<Str, Bytes>().put(wtxn, WORDS_PREFIXES_FST_KEY, &prefixes_fst_mmap)?;
+
+    let prefix_fst = fst::Set::new(&prefixes_fst_mmap[..])?;
+    let tolerant_modified =
+        compute_prefixes(&prefix_fst, tolerant_words.iter().map(|w| w.as_str()))?;
+    let exact_modified = compute_prefixes(&prefix_fst, exact_words.iter().map(|w| w.as_str()))?;
+    let deleted = BTreeSet::new();
+
+    compute_prefix_database_from_sources(
+        index,
+        wtxn,
+        &tolerant_modified,
+        &deleted,
+        &exact_modified,
+        &deleted,
+        progress,
     )
-}
-
-/// Collect all prefixes that meet the threshold from a sorted list of words.
-fn prefixes_from_words<'a, I>(
-    words: I,
-    prefix_count_threshold: usize,
-    max_prefix_length: usize,
-) -> Result<BTreeSet<MiniString>>
-where
-    I: IntoIterator<Item = &'a str>,
-{
-    let mut current_prefix = vec![String::new(); max_prefix_length];
-    let mut current_prefix_count = vec![0; max_prefix_length];
-    let mut builders: Vec<BTreeSet<String>> =
-        (0..max_prefix_length).map(|_| BTreeSet::new()).collect();
-
-    for word in words {
-        for n in 0..max_prefix_length {
-            let current_prefix = &mut current_prefix[n];
-            let current_prefix_count = &mut current_prefix_count[n];
-            let builder = &mut builders[n];
-
-            let prefix = match word.get(..=n) {
-                Some(prefix) => prefix,
-                None => continue,
-            };
-
-            if *current_prefix_count == 0 || prefix != current_prefix.as_str() {
-                *current_prefix = prefix.to_owned();
-                *current_prefix_count = 0;
-            }
-
-            *current_prefix_count += 1;
-
-            if *current_prefix_count == prefix_count_threshold {
-                builder.insert(prefix.to_owned());
-            }
-        }
-    }
-
-    let mut output = BTreeSet::new();
-    for prefix in builders.into_iter().flatten() {
-        if let Some(prefix) = MiniString::new(&prefix) {
-            output.insert(prefix);
-        }
-    }
-
-    Ok(output)
 }
 
 /// The words must be sorted.

--- a/crates/milli/src/update/new/indexer/word_delta.rs
+++ b/crates/milli/src/update/new/indexer/word_delta.rs
@@ -1,4 +1,5 @@
-use std::{collections::BTreeSet, ops::BitOr};
+use std::collections::BTreeSet;
+use std::ops::BitOr;
 
 use either::Either;
 use itertools::{EitherOrBoth, Itertools};

--- a/crates/milli/src/update/new/word_fst_builder.rs
+++ b/crates/milli/src/update/new/word_fst_builder.rs
@@ -45,6 +45,17 @@ impl<'a> WordFstBuilder<'a> {
         Ok(())
     }
 
+    /// Register a word that only exists in the exact-word database for prefix-FST building.
+    ///
+    /// Exact words must not be added to the words FST, otherwise typo tolerance would apply to
+    /// them, but their prefixes must still be discovered at indexing time.
+    pub fn register_exact_word_for_prefixes(&mut self, deladd: DelAdd, word: &[u8]) -> Result<()> {
+        if let Some(prefix_fst_builder) = &mut self.prefix_fst_builder {
+            prefix_fst_builder.insert_word(word, deladd)?;
+        }
+        Ok(())
+    }
+
     pub fn build(mut self) -> Result<(Mmap, Option<PrefixData>)> {
         let words_fst_mmap = self.word_fst_builder.build(&mut |bytes, deladd| {
             if let Some(prefix_fst_builder) = &mut self.prefix_fst_builder {

--- a/crates/milli/src/update/upgrade/mod.rs
+++ b/crates/milli/src/update/upgrade/mod.rs
@@ -6,6 +6,7 @@ mod v1_16;
 mod v1_32;
 mod v1_37;
 mod v1_45;
+mod v1_46;
 
 use heed::RwTxn;
 use v1_12::{FixFieldDistribution, RecomputeStats};
@@ -16,6 +17,7 @@ use v1_16::SwitchToMultimodal;
 use v1_32::{CleanupFidBasedDatabases, RebuildHannoyGraph};
 use v1_37::{AddShards, ConvertArroyToHannoy};
 use v1_45::FixVectorStoreConfig;
+use v1_46::RecomputeExactWordPrefixDocids;
 
 use crate::constants::{VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH};
 use crate::progress::{Progress, VariableNameStep};
@@ -52,6 +54,7 @@ const UPGRADE_FUNCTIONS: &[&dyn UpgradeIndex] = &[
     &ConvertArroyToHannoy {},
     &AddShards {},
     &FixVectorStoreConfig {},
+    &RecomputeExactWordPrefixDocids {},
 ];
 
 /// Return true if the cached stats of the index must be regenerated

--- a/crates/milli/src/update/upgrade/mod.rs
+++ b/crates/milli/src/update/upgrade/mod.rs
@@ -6,7 +6,7 @@ mod v1_16;
 mod v1_32;
 mod v1_37;
 mod v1_45;
-mod v1_46;
+mod v1_48;
 
 use heed::RwTxn;
 use v1_12::{FixFieldDistribution, RecomputeStats};
@@ -17,7 +17,7 @@ use v1_16::SwitchToMultimodal;
 use v1_32::{CleanupFidBasedDatabases, RebuildHannoyGraph};
 use v1_37::{AddShards, ConvertArroyToHannoy};
 use v1_45::FixVectorStoreConfig;
-use v1_46::RecomputeExactWordPrefixDocids;
+use v1_48::RecomputeExactWordPrefixDocids;
 
 use crate::constants::{VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH};
 use crate::progress::{Progress, VariableNameStep};

--- a/crates/milli/src/update/upgrade/v1_46.rs
+++ b/crates/milli/src/update/upgrade/v1_46.rs
@@ -1,0 +1,28 @@
+use heed::RwTxn;
+
+use super::{UpgradeIndex, UpgradeParams};
+use crate::update::new::indexer::recompute_exact_word_prefix_docids_from_database;
+use crate::{Index, Result};
+
+/// Rebuild exact-word prefix databases that were missing before exact-word deltas were tracked.
+pub(super) struct RecomputeExactWordPrefixDocids();
+
+impl UpgradeIndex for RecomputeExactWordPrefixDocids {
+    fn upgrade(
+        &self,
+        wtxn: &mut RwTxn,
+        index: &Index,
+        UpgradeParams { progress, .. }: UpgradeParams<'_>,
+    ) -> Result<bool> {
+        recompute_exact_word_prefix_docids_from_database(index, wtxn, progress)?;
+        Ok(false)
+    }
+
+    fn must_upgrade(&self, initial_version: (u32, u32, u32)) -> bool {
+        initial_version < (1, 46, 0)
+    }
+
+    fn description(&self) -> &'static str {
+        "Recomputing exact-word prefix databases"
+    }
+}

--- a/crates/milli/src/update/upgrade/v1_48.rs
+++ b/crates/milli/src/update/upgrade/v1_48.rs
@@ -19,7 +19,7 @@ impl UpgradeIndex for RecomputeExactWordPrefixDocids {
     }
 
     fn must_upgrade(&self, initial_version: (u32, u32, u32)) -> bool {
-        initial_version < (1, 46, 0)
+        initial_version < (1, 48, 0)
     }
 
     fn description(&self) -> &'static str {


### PR DESCRIPTION
## Summary

Fixes [#6403](https://github.com/meilisearch/meilisearch/issues/6403).

When `typoTolerance.disableOnAttributes` or `disableOnNumbers` is enabled, matching tokens are stored in `exact_word_docids` instead of `word_docids`. Prefix search still worked on tolerant fields (e.g. query `ma` → `many` in `content`), but failed on exact fields (e.g. query `hel` → `Hello` in `title`) once prefix databases were built at indexing time.

## Root cause

Prefix post-processing only tracked changes from `word_docids` (`WordDelta`). Words that exist solely in `exact_word_docids` were never:

1. Registered in the prefix FST builder during indexing
2. Passed to `compute_exact_word_prefix_docids`

So `exact_word_prefix_docids` stayed empty for prefixes like `hel`, while tolerant prefixes like `ma` were populated correctly.

## What changed

- Track an **exact word delta** alongside the existing word delta during document/settings extraction
- Register exact-word additions/deletions in the prefix FST (without adding them to the tolerant `words_fst`)
- Compute prefix databases separately:
  - `word_prefix_docids` ← tolerant word changes
  - `exact_word_prefix_docids` ← exact word changes
  - `word_prefix_fid_docids` / `word_prefix_position_docids` ← union of both (field data already contains exact words)
- Mirror `disableOnNumbers` FST migration for the new exact-word delta path

## Behavior preserved

- Typo tolerance remains disabled on configured attributes/numbers (no change to ranking or typo rules)
- Prefix search remains disabled when `prefixSearch` is `disabled`
- Existing tolerant-field prefix behavior is unchanged

## Test plan

- [x] Added `test_prefix_search_on_exact_attribute_and_disable_on_numbers` in `crates/milli/src/search/new/tests/typo.rs`
  - 100 documents with `title` (exact) + `content` (tolerant)
  - Asserts `ma` and `hel` prefix queries both return hits
- [x] `cargo test -p milli test_prefix_search_on_exact_attribute_and_disable_on_numbers`

## Requirements

- [x] Automated tests added
- [x] No database schema change (`no db change`)
- [x] This PR does not use generative AI tooling for the implementation *(author used Cursor for development — disclosed per contributing guidelines)*

## Related

- Issue reported from settings indexer work in #6398
- User-facing setting: `typoTolerance.disableOnAttributes` / `disableOnNumbers` ([docs](https://www.meilisearch.com/docs/learn/relevancy/typo_tolerance))