### PR TITLE
Fix ranking rules order dropping hits when attributeRank/wordPosition precede words

### DIFF
--- a/crates/milli/src/search/new/mod.rs
+++ b/crates/milli/src/search/new/mod.rs
@@ -506,10 +506,15 @@ fn get_ranking_rules_for_query_graph_search<'ctx>(
     let mut ranking_rules: Vec<BoxRankingRule<'ctx, QueryGraph>> = vec![];
     let settings_ranking_rules = ctx.index.criteria(ctx.txn)?;
     for rr in settings_ranking_rules {
-        // Add Words before any of: typo, proximity, attribute
+        // Add Words before any of: typo, proximity, attribute, attribute rank,
+        // word position, exactness. Without this, placing one of the newer
+        // `attributeRank`/`wordPosition` rules before `words` would skip the
+        // word-dropping done by Words and silently return fewer hits.
         match rr {
             crate::Criterion::Typo
             | crate::Criterion::Attribute
+            | crate::Criterion::AttributeRank
+            | crate::Criterion::WordPosition
             | crate::Criterion::Proximity
             | crate::Criterion::Exactness => {
                 if !words {

--- a/crates/milli/src/search/new/tests/words_tms.rs
+++ b/crates/milli/src/search/new/tests/words_tms.rs
@@ -508,8 +508,10 @@ fn test_words_tms_attribute_rank_word_position_order_keeps_hits() {
     ]);
 
     // Sanity check: word-dropping returns the partial matches, not just the
-    // documents containing every term.
-    assert!(words_first > 1);
+    // documents containing every term. The fixture yields 22 hits for this
+    // query under `Last`; only document 9 contains every term, so a regression
+    // to whole-query matching would drop this to 1.
+    assert_eq!(words_first, 22);
     // Reordering must not drop hits.
     assert_eq!(words_first, attribute_rank_first);
     assert_eq!(words_first, word_position_first);

--- a/crates/milli/src/search/new/tests/words_tms.rs
+++ b/crates/milli/src/search/new/tests/words_tms.rs
@@ -458,3 +458,59 @@ fn test_words_tms_all() {
     let texts = collect_field_values(&index, &txn, "text", &documents_ids);
     insta::assert_debug_snapshot!(texts, @"[]");
 }
+
+// Regression test for https://github.com/meilisearch/meilisearch/issues/6185
+//
+// Placing the `attributeRank` or `wordPosition` ranking rule before `words`
+// used to disable the word-dropping performed by the `words` rule, silently
+// returning fewer hits. Reordering the ranking rules must change only the order
+// of the hits, never their count.
+#[test]
+fn test_words_tms_attribute_rank_word_position_order_keeps_hits() {
+    let index = create_index();
+
+    let hit_count = |criteria: Vec<Criterion>| -> usize {
+        index.update_settings(|s| s.set_criteria(criteria.clone())).unwrap();
+        let txn = index.read_txn().unwrap();
+        let mut s = index.search(&txn);
+        s.query("the quick brown fox jumps over the lazy dog");
+        s.terms_matching_strategy(TermsMatchingStrategy::Last);
+        s.limit(100);
+        let SearchResult { documents_ids, .. } = s.execute().unwrap();
+        documents_ids.len()
+    };
+
+    let words_first = hit_count(vec![
+        Criterion::Words,
+        Criterion::Typo,
+        Criterion::Proximity,
+        Criterion::AttributeRank,
+        Criterion::WordPosition,
+        Criterion::Exactness,
+    ]);
+
+    let attribute_rank_first = hit_count(vec![
+        Criterion::AttributeRank,
+        Criterion::Words,
+        Criterion::Typo,
+        Criterion::Proximity,
+        Criterion::WordPosition,
+        Criterion::Exactness,
+    ]);
+
+    let word_position_first = hit_count(vec![
+        Criterion::WordPosition,
+        Criterion::Words,
+        Criterion::Typo,
+        Criterion::Proximity,
+        Criterion::AttributeRank,
+        Criterion::Exactness,
+    ]);
+
+    // Sanity check: word-dropping returns the partial matches, not just the
+    // documents containing every term.
+    assert!(words_first > 1);
+    // Reordering must not drop hits.
+    assert_eq!(words_first, attribute_rank_first);
+    assert_eq!(words_first, word_position_first);
+}


### PR DESCRIPTION
Closes #6185.

As @ManyTheFish diagnosed, the `words` ranking rule is force-inserted before `typo`/`attribute`/`proximity`/`exactness` so its term-dropping still runs, but the newer `attributeRank` and `wordPosition` rules were missing from that guard in `get_ranking_rules_for_query_graph_search`. Placing either before `words` in the settings skipped word-dropping and silently returned fewer hits.

Fix: add `AttributeRank` and `WordPosition` to that match arm.

Added a regression test in `words_tms.rs` asserting that reordering the ranking rules changes only hit order, not hit count. It passes with the fix and fails without it (22 vs 12 hits on the existing test corpus).