### PR TITLE
Experimental feature forcing documents fetch to use the queue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "build-info"
-version = "1.46.0"
+version = "1.46.1"
 dependencies = [
  "anyhow",
  "time",
@@ -1969,7 +1969,7 @@ dependencies = [
 
 [[package]]
 name = "dump"
-version = "1.46.0"
+version = "1.46.1"
 dependencies = [
  "anyhow",
  "big_s",
@@ -2303,7 +2303,7 @@ dependencies = [
 
 [[package]]
 name = "file-store"
-version = "1.46.0"
+version = "1.46.1"
 dependencies = [
  "tempfile",
  "thiserror 2.0.17",
@@ -2325,7 +2325,7 @@ dependencies = [
 
 [[package]]
 name = "filter-parser"
-version = "1.46.0"
+version = "1.46.1"
 dependencies = [
  "insta",
  "levenshtein_automata",
@@ -2353,7 +2353,7 @@ dependencies = [
 
 [[package]]
 name = "flatten-serde-json"
-version = "1.46.0"
+version = "1.46.1"
 dependencies = [
  "criterion",
  "serde_json",
@@ -2527,7 +2527,7 @@ dependencies = [
 
 [[package]]
 name = "fuzzers"
-version = "1.46.0"
+version = "1.46.1"
 dependencies = [
  "arbitrary",
  "bumpalo",
@@ -3251,7 +3251,7 @@ dependencies = [
 
 [[package]]
 name = "http-client"
-version = "1.46.0"
+version = "1.46.1"
 dependencies = [
  "cidr",
  "hyper-util",
@@ -3571,7 +3571,7 @@ dependencies = [
 
 [[package]]
 name = "index-scheduler"
-version = "1.46.0"
+version = "1.46.1"
 dependencies = [
  "anyhow",
  "backoff",
@@ -3841,7 +3841,7 @@ dependencies = [
 
 [[package]]
 name = "json-depth-checker"
-version = "1.46.0"
+version = "1.46.1"
 dependencies = [
  "criterion",
  "serde_json",
@@ -4372,7 +4372,7 @@ checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
 
 [[package]]
 name = "meili-snap"
-version = "1.46.0"
+version = "1.46.1"
 dependencies = [
  "insta",
  "md5 0.8.0",
@@ -4383,7 +4383,7 @@ dependencies = [
 
 [[package]]
 name = "meilisearch"
-version = "1.46.0"
+version = "1.46.1"
 dependencies = [
  "actix-cors",
  "actix-http",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "meilisearch-auth"
-version = "1.46.0"
+version = "1.46.1"
 dependencies = [
  "base64 0.22.1",
  "enum-iterator",
@@ -4504,7 +4504,7 @@ dependencies = [
 
 [[package]]
 name = "meilisearch-types"
-version = "1.46.0"
+version = "1.46.1"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -4543,7 +4543,7 @@ dependencies = [
 
 [[package]]
 name = "meilitool"
-version = "1.46.0"
+version = "1.46.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -4577,7 +4577,7 @@ dependencies = [
 
 [[package]]
 name = "milli"
-version = "1.46.0"
+version = "1.46.1"
 dependencies = [
  "arroy",
  "bbqueue",
@@ -5248,7 +5248,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "permissive-json-pointer"
-version = "1.46.0"
+version = "1.46.1"
 dependencies = [
  "big_s",
  "serde_json",
@@ -6251,7 +6251,7 @@ dependencies = [
 
 [[package]]
 name = "routes"
-version = "1.46.0"
+version = "1.46.1"
 dependencies = [
  "actix-web",
  "routes-macros",
@@ -6260,7 +6260,7 @@ dependencies = [
 
 [[package]]
 name = "routes-macros"
-version = "1.46.0"
+version = "1.46.1"
 dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
@@ -8698,7 +8698,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "1.46.0"
+version = "1.46.1"
 dependencies = [
  "anyhow",
  "build-info",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.46.0"
+version = "1.46.1"
 authors = [
     "Quentin de Quelen <quentin@dequelen.me>",
     "Clément Renault <clement@meilisearch.com>",

--- a/crates/meilisearch-types/src/features.rs
+++ b/crates/meilisearch-types/src/features.rs
@@ -23,6 +23,7 @@ pub struct RuntimeTogglableFeatures {
     pub chat_completions: bool,
     pub multimodal: bool,
     pub foreign_keys: bool,
+    pub queue_documents_fetch: bool,
 }
 
 #[derive(Default, Debug, Clone, Copy)]

--- a/crates/meilisearch/src/analytics/segment_analytics.rs
+++ b/crates/meilisearch/src/analytics/segment_analytics.rs
@@ -213,6 +213,7 @@ struct Infos {
     experimental_no_edition_2024_for_dumps: bool,
     experimental_no_edition_2024_for_settings: bool,
     experimental_foreign_keys: bool,
+    experimental_queue_documents_fetch: bool,
     experimental_personalization: bool,
     experimental_allowed_ip_networks: bool,
     gpu_enabled: bool,
@@ -324,6 +325,7 @@ impl Infos {
             chat_completions,
             multimodal,
             foreign_keys,
+            queue_documents_fetch,
         } = features;
 
         // We're going to override every sensible information.
@@ -353,6 +355,7 @@ impl Infos {
             experimental_no_edition_2024_for_dumps,
             experimental_allowed_ip_networks: !experimental_allowed_ip_networks.is_empty(),
             experimental_foreign_keys: foreign_keys,
+            experimental_queue_documents_fetch: queue_documents_fetch,
             gpu_enabled: meilisearch_types::milli::vector::is_cuda_enabled(),
             db_path: db_path != Path::new("./data.ms"),
             import_dump: import_dump.is_some(),

--- a/crates/meilisearch/src/routes/features.rs
+++ b/crates/meilisearch/src/routes/features.rs
@@ -47,6 +47,7 @@ pub struct ExperimentalFeaturesApi;
             chat_completions: Some(false),
             multimodal: Some(false),
             foreign_keys: Some(false),
+            queue_documents_fetch: Some(false),
         })),
         (status = 401, description = "The authorization header is missing.", body = ResponseError, content_type = "application/json", example = json!(
             {
@@ -114,6 +115,9 @@ pub struct RuntimeTogglableFeatures {
     /// Enable foreign key support for document hydration
     #[deserr(default)]
     pub foreign_keys: Option<bool>,
+    /// Enable queue documents fetch
+    #[deserr(default)]
+    pub queue_documents_fetch: Option<bool>,
 }
 
 impl From<meilisearch_types::features::RuntimeTogglableFeatures> for RuntimeTogglableFeatures {
@@ -131,6 +135,7 @@ impl From<meilisearch_types::features::RuntimeTogglableFeatures> for RuntimeTogg
             chat_completions,
             multimodal,
             foreign_keys,
+            queue_documents_fetch,
         } = value;
 
         Self {
@@ -146,6 +151,7 @@ impl From<meilisearch_types::features::RuntimeTogglableFeatures> for RuntimeTogg
             chat_completions: Some(chat_completions),
             multimodal: Some(multimodal),
             foreign_keys: Some(foreign_keys),
+            queue_documents_fetch: Some(queue_documents_fetch),
         }
     }
 }
@@ -164,6 +170,7 @@ pub struct PatchExperimentalFeatureAnalytics {
     chat_completions: bool,
     multimodal: bool,
     foreign_keys: bool,
+    queue_documents_fetch: bool,
 }
 
 impl Aggregate for PatchExperimentalFeatureAnalytics {
@@ -185,6 +192,7 @@ impl Aggregate for PatchExperimentalFeatureAnalytics {
             chat_completions: new.chat_completions,
             multimodal: new.multimodal,
             foreign_keys: new.foreign_keys,
+            queue_documents_fetch: new.queue_documents_fetch,
         })
     }
 
@@ -212,6 +220,7 @@ impl Aggregate for PatchExperimentalFeatureAnalytics {
             chat_completions: Some(false),
             multimodal: Some(false),
             foreign_keys: Some(false),
+            queue_documents_fetch: Some(false),
          })),
         (status = 401, description = "The authorization header is missing.", body = ResponseError, content_type = "application/json", example = json!(
             {
@@ -264,6 +273,10 @@ async fn patch_features(
         chat_completions: new_features.0.chat_completions.unwrap_or(old_features.chat_completions),
         multimodal: new_features.0.multimodal.unwrap_or(old_features.multimodal),
         foreign_keys: new_features.0.foreign_keys.unwrap_or(old_features.foreign_keys),
+        queue_documents_fetch: new_features
+            .0
+            .queue_documents_fetch
+            .unwrap_or(old_features.queue_documents_fetch),
     };
 
     // explicitly destructure for analytics rather than using the `Serialize` implementation, because
@@ -282,6 +295,7 @@ async fn patch_features(
         chat_completions,
         multimodal,
         foreign_keys,
+        queue_documents_fetch,
     } = new_features;
 
     analytics.publish(
@@ -298,6 +312,7 @@ async fn patch_features(
             chat_completions,
             multimodal,
             foreign_keys,
+            queue_documents_fetch,
         },
         &req,
     );

--- a/crates/meilisearch/src/routes/indexes/documents.rs
+++ b/crates/meilisearch/src/routes/indexes/documents.rs
@@ -544,9 +544,13 @@ pub async fn documents_by_query_post(
     index_scheduler: GuardedData<ActionPolicy<{ actions::DOCUMENTS_GET }>, Data<IndexScheduler>>,
     index_uid: web::Path<String>,
     body: AwebJson<BrowseQuery, DeserrJsonError>,
+    search_queue: web::Data<crate::search_queue::SearchQueue>,
     req: HttpRequest,
     analytics: web::Data<Analytics>,
 ) -> Result<HttpResponse, ResponseError> {
+    let use_queue = index_scheduler.features().runtime_features().queue_documents_fetch;
+    let permit = if use_queue { Some(search_queue.try_get_search_permit().await?) } else { None };
+
     let body = body.into_inner();
     debug!(parameters = ?body, "Get documents POST");
 
@@ -568,7 +572,11 @@ pub async fn documents_by_query_post(
         &req,
     );
 
-    documents_by_query(index_scheduler.clone(), index_uid, body).await
+    let ret = documents_by_query(index_scheduler.clone(), index_uid, body).await;
+    if let Some(permit) = permit {
+        permit.drop().await;
+    }
+    ret
 }
 
 /// List documents with GET
@@ -626,10 +634,14 @@ pub async fn get_documents(
     index_scheduler: GuardedData<ActionPolicy<{ actions::DOCUMENTS_GET }>, Data<IndexScheduler>>,
     index_uid: web::Path<String>,
     params: AwebQueryParameter<BrowseQueryGet, DeserrQueryParamError>,
+    search_queue: web::Data<crate::search_queue::SearchQueue>,
     req: HttpRequest,
     analytics: web::Data<Analytics>,
 ) -> Result<HttpResponse, ResponseError> {
     debug!(parameters = ?params, "Get documents GET");
+
+    let use_queue = !index_scheduler.features().runtime_features().queue_documents_fetch;
+    let permit = if use_queue { Some(search_queue.try_get_search_permit().await?) } else { None };
 
     let BrowseQueryGet { limit, offset, fields, retrieve_vectors, filter, ids, sort } =
         params.into_inner();
@@ -670,7 +682,13 @@ pub async fn get_documents(
         &req,
     );
 
-    documents_by_query(index_scheduler.clone(), index_uid, query).await
+    let ret = documents_by_query(index_scheduler.clone(), index_uid, query).await;
+
+    if let Some(permit) = permit {
+        permit.drop().await;
+    }
+
+    ret
 }
 
 async fn documents_by_query(

--- a/crates/meilisearch/tests/dumps/mod.rs
+++ b/crates/meilisearch/tests/dumps/mod.rs
@@ -2192,7 +2192,8 @@ async fn import_dump_v6_containing_experimental_features() {
       "compositeEmbedders": false,
       "chatCompletions": false,
       "multimodal": false,
-      "foreignKeys": false
+      "foreignKeys": false,
+      "queueDocumentsFetch": false
     }
     "###);
 
@@ -2322,7 +2323,8 @@ async fn import_dump_v6_containing_batches_and_enqueued_tasks() {
       "compositeEmbedders": false,
       "chatCompletions": false,
       "multimodal": false,
-      "foreignKeys": false
+      "foreignKeys": false,
+      "queueDocumentsFetch": false
     }
     "###);
 
@@ -2432,7 +2434,8 @@ async fn generate_and_import_dump_containing_vectors() {
       "compositeEmbedders": false,
       "chatCompletions": false,
       "multimodal": false,
-      "foreignKeys": false
+      "foreignKeys": false,
+      "queueDocumentsFetch": false
     }
     "###);
 

--- a/crates/meilisearch/tests/features/mod.rs
+++ b/crates/meilisearch/tests/features/mod.rs
@@ -29,7 +29,8 @@ async fn experimental_features() {
       "compositeEmbedders": false,
       "chatCompletions": false,
       "multimodal": false,
-      "foreignKeys": false
+      "foreignKeys": false,
+      "queueDocumentsFetch": false
     }
     "###);
 
@@ -49,7 +50,8 @@ async fn experimental_features() {
       "compositeEmbedders": false,
       "chatCompletions": false,
       "multimodal": false,
-      "foreignKeys": false
+      "foreignKeys": false,
+      "queueDocumentsFetch": false
     }
     "###);
 
@@ -69,7 +71,8 @@ async fn experimental_features() {
       "compositeEmbedders": false,
       "chatCompletions": false,
       "multimodal": false,
-      "foreignKeys": false
+      "foreignKeys": false,
+      "queueDocumentsFetch": false
     }
     "###);
 
@@ -90,7 +93,8 @@ async fn experimental_features() {
       "compositeEmbedders": false,
       "chatCompletions": false,
       "multimodal": false,
-      "foreignKeys": false
+      "foreignKeys": false,
+      "queueDocumentsFetch": false
     }
     "###);
 
@@ -111,7 +115,8 @@ async fn experimental_features() {
       "compositeEmbedders": false,
       "chatCompletions": false,
       "multimodal": false,
-      "foreignKeys": false
+      "foreignKeys": false,
+      "queueDocumentsFetch": false
     }
     "###);
 }
@@ -139,7 +144,8 @@ async fn experimental_feature_metrics() {
       "compositeEmbedders": false,
       "chatCompletions": false,
       "multimodal": false,
-      "foreignKeys": false
+      "foreignKeys": false,
+      "queueDocumentsFetch": false
     }
     "###);
 
@@ -184,14 +190,14 @@ async fn errors() {
     let (response, code) = server.set_features(json!({"NotAFeature": true})).await;
 
     meili_snap::snapshot!(code, @"400 Bad Request");
-    meili_snap::snapshot!(meili_snap::json_string!(response), @r#"
+    meili_snap::snapshot!(meili_snap::json_string!(response), @r###"
     {
-      "message": "Unknown field `NotAFeature`: expected one of `metrics`, `logsRoute`, `editDocumentsByFunction`, `containsFilter`, `dynamicSearchRules`, `network`, `getTaskDocumentsRoute`, `taskQueueCompactionRoute`, `compositeEmbedders`, `chatCompletions`, `multimodal`, `foreignKeys`",
+      "message": "Unknown field `NotAFeature`: expected one of `metrics`, `logsRoute`, `editDocumentsByFunction`, `containsFilter`, `dynamicSearchRules`, `network`, `getTaskDocumentsRoute`, `taskQueueCompactionRoute`, `compositeEmbedders`, `chatCompletions`, `multimodal`, `foreignKeys`, `queueDocumentsFetch`",
       "code": "bad_request",
       "type": "invalid_request",
       "link": "https://docs.meilisearch.com/errors#bad_request"
     }
-    "#);
+    "###);
 
     // The type must be a bool, not a number
     let (response, code) = server.set_features(json!({FEATURE_NAME: 42})).await;


### PR DESCRIPTION
## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respect the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - *list of used tools and what they were used for*

## Changes

- upgrade version to v1.46.1
- add an experimental feature, queueDocumentsFetch, forcing documents fetch to use the queue
