### PR TITLE
Actually use the deadline as a timeout for the REST request 

### DIFF
--- a/crates/milli/src/vector/embedder/rest.rs
+++ b/crates/milli/src/vector/embedder/rest.rs
@@ -429,10 +429,23 @@ where
         return Ok(Vec::new());
     }
 
+    let timeout = deadline.map(|deadline| {
+        let now = std::time::Instant::now();
+
+        deadline.saturating_duration_since(now)
+    });
+
     // for some reason, ureq 3 `Request` is not `Clone`.
     // So write a closure that will be called each time to setup the request
     let request_builder = || {
         let request = data.client.post(&data.url);
+        let request_config = request.config();
+        let request_config = if let Some(timeout) = timeout {
+            request_config.timeout_global(Some(timeout))
+        } else {
+            request_config
+        };
+        let request = request_config.build();
         let request = if let Some(bearer) = &data.bearer {
             request.header("Authorization", bearer)
         } else {
@@ -489,9 +502,8 @@ where
 
         let retry_duration = retry_duration.min(data.max_retry_duration); // don't wait more than the max duration
 
-        // randomly up to double the retry duration
-        let retry_duration = retry_duration
-            + rand::thread_rng().gen_range(std::time::Duration::ZERO..retry_duration);
+        // randomly divide the retry duration by up to two
+        let retry_duration = retry_duration.mul_f32(rand::thread_rng().gen_range(0.5f32..=1.0f32));
 
         tracing::warn!("Attempt #{}, retrying after {}ms.", attempt, retry_duration.as_millis());
         std::thread::sleep(retry_duration);


### PR DESCRIPTION
## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respect the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - *list of used tools and what they were used for*

## Requirements

⚠️ Ensure the following requirements before merging ⚠️
- [ ] Automated tests have been added.
- [ ] If some tests cannot be automated, manual rigorous tests should be applied.
- [ ] ⚠️ If there is any change in the DB:
    - [ ] Test that any impacted DB still works as expected after using `--experimental-dumpless-upgrade` on a DB created with the last released Meilisearch
    - [ ] Test that during the upgrade, **search is still available** (artificially make the upgrade longer if needed)
    - [ ] Set the `db change` label.
- [ ] If necessary, the feature have been tested in the Cloud production environment (with [prototypes](./documentation/prototypes.md)) and the Cloud UI is ready.
- [ ] If necessary, the [documentation](https://github.com/meilisearch/documentation) related to the implemented feature in the PR is ready.
- [ ] If necessary, the [integrations](https://github.com/meilisearch/integration-guides) related to the implemented feature in the PR are ready.
