### PR TITLE
Add dumpless-upgrade orchestration test on a user-populated database

### DIFF
--- a/crates/meilisearch/tests/upgrade/mod.rs
+++ b/crates/meilisearch/tests/upgrade/mod.rs
@@ -6,7 +6,8 @@ use std::{fs, io};
 use meili_snap::snapshot;
 use meilisearch::Opt;
 
-use crate::common::{default_settings, Server};
+use crate::common::{Server, Value, default_settings};
+use crate::json;
 
 fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
     fs::create_dir_all(&dst)?;
@@ -99,4 +100,108 @@ async fn upgrade_to_the_current_version() {
       "next": null
     }
     "#);
+}
+
+/// Exercises the dumpless-upgrade orchestration end-to-end on a database that was
+/// populated by the *current* binary. We boot a server, write an index + settings +
+/// documents, then copy the resulting database to a fresh location and overwrite the
+/// VERSION file with `1.12.0`. Re-booting with `--experimental-dumpless-upgrade`
+/// should:
+///   1. rewrite the VERSION file to the current binary version,
+///   2. auto-enqueue an `upgradeDatabase` task (`from = 1.12.0`) that succeeds,
+///   3. preserve the user's pre-existing index, settings, documents and task uids.
+///
+/// `1.12.0` is the only `from` value where `update_version_file_for_dumpless_upgrade`
+/// also syncs the index-scheduler's internal version DB; any later `from` would leave
+/// the internal version equal to the current binary, and `upgrade_index_scheduler`
+/// would short-circuit before enqueuing the upgrade task. So picking 1.12.0 here is
+/// what actually triggers the migration pipeline.
+#[actix_rt::test]
+async fn dumpless_upgrade_from_v1_12_with_local_db() {
+    let temp_source = tempfile::tempdir().unwrap();
+    let source_settings = default_settings(temp_source.path());
+    let source_db_path = source_settings.db_path.clone();
+
+    // Phase 1: populate a fresh DB with the current binary.
+    {
+        let server = Server::new_with_options(source_settings).await.unwrap();
+        let index = server.index("kefir");
+
+        let (task, _) = index
+            .update_settings(json!({
+                "searchableAttributes": ["name", "description"],
+                "filterableAttributes": ["age"],
+                "sortableAttributes": ["age"],
+            }))
+            .await;
+        server.wait_task(task.uid()).await.succeeded();
+
+        let (task, _) = index
+            .add_documents(
+                json!([
+                    { "id": 1, "name": "kefir", "age": 6, "description": "the patou" },
+                    { "id": 2, "name": "echo", "age": 4, "description": "the labrador" },
+                ]),
+                Some("id"),
+            )
+            .await;
+        server.wait_task(task.uid()).await.succeeded();
+    }
+
+    // Phase 2: clone the populated DB into a fresh location and pretend it was
+    // written by v1.12.0. Copying into a new tempdir avoids re-opening LMDB on the
+    // same path within the same process.
+    let temp_target = tempfile::tempdir().unwrap();
+    let target_settings =
+        Opt { experimental_dumpless_upgrade: true, ..default_settings(temp_target.path()) };
+    let target_db_path = target_settings.db_path.clone();
+    copy_dir_all(&source_db_path, &target_db_path).unwrap();
+    fs::write(target_db_path.join("VERSION"), "1.12.0").unwrap();
+
+    // Phase 3: boot the second server with dumpless upgrade enabled.
+    let server = Server::new_with_options(target_settings).await.unwrap();
+
+    // The VERSION file on disk must have been rewritten to the current binary version.
+    let bumped_version = fs::read_to_string(target_db_path.join("VERSION")).unwrap();
+    let expected_version = format!(
+        "{}.{}.{}",
+        meilisearch_types::versioning::VERSION_MAJOR,
+        meilisearch_types::versioning::VERSION_MINOR,
+        meilisearch_types::versioning::VERSION_PATCH,
+    );
+    assert_eq!(bumped_version, expected_version);
+
+    // The `upgradeDatabase` task must have been auto-enqueued; wait for it to finish.
+    let (tasks, _) = server.tasks_filter("types=upgradeDatabase&limit=1").await;
+    let upgrade_uid = Value(tasks["results"][0].clone()).uid();
+    let upgrade_task = server.wait_task(upgrade_uid).await.succeeded();
+    assert_eq!(upgrade_task["type"], "upgradeDatabase");
+    assert_eq!(upgrade_task["status"], "succeeded");
+    assert_eq!(upgrade_task["details"]["upgradeFrom"], "v1.12.0");
+    assert_eq!(upgrade_task["details"]["upgradeTo"], format!("v{expected_version}"));
+    assert!(upgrade_task["error"].is_null());
+
+    // The user's index, settings and documents must survive the upgrade.
+    let index = server.index("kefir");
+    let (settings, _) = index.settings().await;
+    assert_eq!(settings["searchableAttributes"], json!(["name", "description"]));
+    assert_eq!(settings["filterableAttributes"], json!(["age"]));
+    assert_eq!(settings["sortableAttributes"], json!(["age"]));
+
+    let (results, _) =
+        index.search_post(json!({ "sort": ["age:asc"], "filter": "age >= 5" })).await;
+    snapshot!(results["estimatedTotalHits"], @"1");
+    let hits = results["hits"].as_array().unwrap();
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0]["id"], 1);
+    assert_eq!(hits[0]["name"], "kefir");
+
+    // The pre-existing task uids (settings update and document addition) must still
+    // be retrievable from the queue.
+    let (settings_task, _) = server.get_task(0).await;
+    assert_eq!(settings_task["type"], "settingsUpdate");
+    assert_eq!(settings_task["status"], "succeeded");
+    let (docs_task, _) = server.get_task(1).await;
+    assert_eq!(docs_task["type"], "documentAdditionOrUpdate");
+    assert_eq!(docs_task["status"], "succeeded");
 }


### PR DESCRIPTION
## Related issue

Addresses #5392.

This is a partial step toward the issue — see [Scope](#scope) below for what is and isn't covered.

## What this PR adds

One new integration test in `crates/meilisearch/tests/upgrade/mod.rs`:

```
dumpless_upgrade_from_v1_12_with_local_db
```

It exercises the dumpless-upgrade orchestration end-to-end without depending on a checked-in `.ms` fixture:

1. Boots a server with the current binary, creates an index, updates settings (`searchableAttributes`, `filterableAttributes`, `sortableAttributes`) and adds two documents — waits for every task to succeed.
2. Copies the populated database into a fresh tempdir and overwrites the `VERSION` file with `1.12.0`. The copy step sidesteps re-opening the same LMDB env twice in the same process.
3. Boots a second server on the new tempdir with `experimental_dumpless_upgrade: true` and asserts that:
   - the `VERSION` file is rewritten to the current binary version,
   - an `upgradeDatabase` task is auto-enqueued with `details.upgradeFrom = "v1.12.0"` and succeeds,
   - the user's index, settings (all three attribute lists) and documents survive,
   - a sort+filter search returns the expected hit (`age >= 5` → `kefir`),
   - the original two task uids (`0 = settingsUpdate`, `1 = documentAdditionOrUpdate`) remain queryable.

## Why `from = 1.12.0`

While picking a `from` version I noticed anything other than 1.12.0 silently no-ops. `update_version_file_for_dumpless_upgrade` (in `crates/meilisearch/src/lib.rs`) only syncs the index-scheduler's internal version DB on the `from_minor == 12` branch — that's the entry `upgrade_index_scheduler` reads to decide whether to run migrations. For any later `from`, the internal version is left at the current binary, so `upgrade_index_scheduler` early-returns at `initial_version == target_version` and no upgrade task is ever enqueued. Picking 1.12.0 is what actually fires the migration pipeline. There's also a doc comment on the test calling this out for future readers.

## Scope

This is an **orchestration** test on a current-format database — it verifies the `check_version → update_version_file_for_dumpless_upgrade → Versioning::new → upgrade_index_scheduler → UpgradeDatabase task` chain works end-to-end and preserves user data. It is **not** a real format-migration test: the underlying LMDB bytes were written by the current binary, so the per-version migration functions run but have no meaningful format work to do.

Real format migration is already covered by the existing `crates/meilisearch/tests/upgrade/v1_12/v1_12_0.rs` test, which loads a checked-in v1.12.0 database fixture. The new test complements that one — it adds coverage for the orchestration on a user-populated DB, which the static-fixture test can't (its DB is a fixed reference).

A follow-up PR could add a real fixture for a more recent starting version (e.g. v1.45.0) once someone with the previous-version binary available can generate and commit the `.ms` directory.

## Test plan

Local (Rust 1.91.1, macOS):

- `cargo test -p meilisearch --test integration upgrade` — all 6 upgrade tests pass (4 pre-existing in `mod.rs` + `import_v1_12_0` + the new test).
- `cargo clippy -p meilisearch --tests -- -D warnings` — clean.
- `cargo fmt -- --check crates/meilisearch/tests/upgrade/mod.rs` — clean. (Pre-existing fmt diff in `crates/meilisearch/tests/upgrade/v1_12/v1_12_0.rs:7` exists on `main` too — not touched.)

## Generative AI tools

- [ ] This PR does not use generative AI tooling
- [x] This PR uses generative AI tooling and respects the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - Claude Code (Anthropic, Opus 4.7): used to research the dumpless-upgrade code path and write the test.

## Requirements

- [x] Automated tests have been added.
- [ ] If some tests cannot be automated, manual rigorous tests should be applied. — N/A
- [ ] ⚠️ If there is any change in the DB: — N/A (no DB-format change; this PR only adds a test)
    - [ ] Test that any impacted DB still works as expected after using `--experimental-dumpless-upgrade` on a DB created with the last released Meilisearch
    - [ ] Test that during the upgrade, **search is still available** (artificially make the upgrade longer if needed)
    - [ ] Set the `db change` label.
- [ ] If necessary, the feature have been tested in the Cloud production environment — N/A
- [ ] If necessary, the [documentation](https://github.com/meilisearch/documentation) related to the implemented feature in the PR is ready. — N/A
- [ ] If necessary, the [integrations](https://github.com/meilisearch/integration-guides) related to the implemented feature in the PR are ready. — N/A