### PR TITLE
Report word count while building the words FST

### DIFF
--- a/crates/milli/src/progress.rs
+++ b/crates/milli/src/progress.rs
@@ -295,6 +295,7 @@ macro_rules! make_atomic_progress {
 make_atomic_progress!(Document alias AtomicDocumentStep => "document");
 make_atomic_progress!(Database alias AtomicDatabaseStep => "database");
 make_atomic_progress!(Payload alias AtomicPayloadStep => "payload");
+make_atomic_progress!(Word alias AtomicWordStep => "word");
 
 make_enum_progress! {
     pub enum MergingWordCache {

--- a/crates/milli/src/update/new/indexer/post_processing/mod.rs
+++ b/crates/milli/src/update/new/indexer/post_processing/mod.rs
@@ -14,7 +14,7 @@ use crate::facet::FacetType;
 use crate::heed_codec::facet::{FacetGroupKey, FacetGroupKeyCodec};
 use crate::heed_codec::StrRefCodec;
 use crate::index::main_key::{WORDS_FST_KEY, WORDS_PREFIXES_FST_KEY};
-use crate::progress::Progress;
+use crate::progress::{AtomicWordStep, Progress};
 use crate::update::del_add::DelAdd;
 use crate::update::facet::new_incremental::FacetsUpdateIncremental;
 use crate::update::facet::{FACET_GROUP_SIZE, FACET_MAX_GROUP_SIZE, FACET_MIN_LEVEL_SIZE};
@@ -165,8 +165,13 @@ fn compute_word_fst(
     let prefix_settings = index.prefix_settings(wtxn)?;
     word_fst_builder.with_prefix_settings(prefix_settings);
 
+    let (word_count, sub_step) =
+        AtomicWordStep::new((word_delta.added.len() + word_delta.deleted.len()) as u32);
+    progress.update_progress(sub_step);
+
     // we ignore modifications when rebuilding the FST
     for either in word_delta.added_or_deleted_words() {
+        word_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         match either {
             Either::Left(added_word) => {
                 word_fst_builder.register_word(DelAdd::Addition, added_word.as_ref())?;
@@ -200,9 +205,14 @@ pub fn recompute_word_fst_from_word_docids_database(
     progress.update_progress(PostProcessingWords::WordFst);
     let fst = fst::Set::default().map_data(std::borrow::Cow::Owned)?;
     let mut word_fst_builder = WordFstBuilder::new(&fst)?;
+
+    let (word_count, sub_step) = AtomicWordStep::new(index.word_docids.len(wtxn)? as u32);
+    progress.update_progress(sub_step);
+
     let words = index.word_docids.iter(wtxn)?.remap_data_type::<DecodeIgnore>();
     for res in words {
         let (word, _) = res?;
+        word_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         word_fst_builder.register_word(DelAdd::Addition, word.as_ref())?;
     }
     let (word_fst_mmap, _) = word_fst_builder.build()?;


### PR DESCRIPTION
## Related issue

Fixes #5591

## What does this PR do?

Until now the post-processing progress only signalled the *start* and the *end* of the words FST build (`PostProcessingWords::WordFst`). On large indexes this step can run for a while with no visible advancement, exactly the blind spot reported in the issue.

This adds a `word` atomic sub-step (following the existing `document` / `payload` / `database` pattern in `progress.rs`) nested under `WordFst`, so the progress now reports how many words have been registered out of the total:

- `compute_word_fst` — total is the number of added + deleted words from the `WordDelta`.
- `recompute_word_fst_from_word_docids_database` (settings reindex path) — total is the size of the `word_docids` database.

No change in behaviour or stored data: the FST output is identical, only progress reporting is enriched.

## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respect the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)

## Requirements

- [ ] Automated tests have been added.
  - This is a progress-reporting-only change with no impact on results or stored data, mirroring the existing atomic progress steps (`document`, `payload`, `database`) which are not unit-tested either. Happy to add coverage if you'd prefer a specific approach.
- [ ] If some tests cannot be automated, manual rigorous tests should be applied.
- [ ] ⚠️ If there is any change in the DB: **N/A — no DB change.**
- [ ] If necessary, the feature have been tested in the Cloud production environment.
- [ ] If necessary, the documentation related to the implemented feature in the PR is ready.
- [ ] If necessary, the integrations related to the implemented feature in the PR are ready.