### PR TITLE
Clamp single-index map_size to the page size in index_budget

### DIFF
--- a/crates/index-scheduler/src/lib.rs
+++ b/crates/index-scheduler/src/lib.rs
@@ -461,7 +461,9 @@ impl IndexScheduler {
         let mut index_count = budget / base_map_size;
         if index_count < 2 {
             // take a bit less than half than the budget to make sure we can always afford to open an index
-            let map_size = (budget * 2) / 5;
+            // clamp to the page size like the other budget paths: heed rejects an
+            // unaligned map_size on platforms with a larger page size (e.g. Windows, 4096B).
+            let map_size = clamp_to_page_size((budget * 2) / 5);
             // single index of max budget
             tracing::debug!("1 index of {map_size}B can be opened simultaneously.");
             return IndexBudget { map_size, index_count: 1, task_db_size };


### PR DESCRIPTION
## Related issue

Fixes #6233 (and removes one cause of #6051).

## What does this PR do?

In `index_budget()` (`crates/index-scheduler/src/lib.rs`), the `index_count < 2` branch built its `map_size` as:

```rust
let map_size = (budget * 2) / 5;
```

without aligning it to the page size. The two sibling budget paths in the same function both clamp (`task_db_size = clamp_to_page_size(budget * 2 / 5)` and the `>= 2` path returns the already-clamped `base_map_size`). On platforms with a larger page size (Windows, 4096 bytes), `heed` rejects an unaligned `map_size`, so the single-index budget path could produce a value that fails to open — the snapshot failure reported in #6051.

Wrapping the value in `clamp_to_page_size()` makes this path consistent with the other two:

```rust
let map_size = clamp_to_page_size((budget * 2) / 5);
```

`clamp_to_page_size` is already imported in this module. No behavior change on platforms where the value was already aligned.

## Requirements

- [ ] Automated tests have been added.
  - `index_budget` is a private associated function with no existing unit test; its `index_count < 2` branch only triggers when `base_map_size` is large relative to the discovered budget, and reaching it in a test requires opening a real (multi-TiB) `heed` env. This change mirrors the two already-clamped sibling paths in the same function, so it carries no new behavior to assert beyond page alignment. Happy to add a targeted test if you'd prefer one.
- [x] `cargo clippy -p index-scheduler` and `cargo fmt -- --check` pass locally.