### PR TITLE
Enable document fetch queue by default

### DIFF
--- a/crates/index-scheduler/src/features.rs
+++ b/crates/index-scheduler/src/features.rs
@@ -52,6 +52,10 @@ impl RoFeatures {
         self.runtime.legacy_search.unwrap_or(false)
     }
 
+    pub fn queue_documents_fetch(&self) -> bool {
+        !self.runtime.disable_documents_fetch_queue
+    }
+
     pub fn check_metrics(&self) -> Result<()> {
         if self.runtime.metrics {
             Ok(())

--- a/crates/meilisearch-types/src/features.rs
+++ b/crates/meilisearch-types/src/features.rs
@@ -23,7 +23,7 @@ pub struct RuntimeTogglableFeatures {
     pub chat_completions: bool,
     pub multimodal: bool,
     pub foreign_keys: bool,
-    pub queue_documents_fetch: bool,
+    pub disable_documents_fetch_queue: bool,
     pub legacy_search: Option<bool>,
 }
 

--- a/crates/meilisearch/src/analytics/segment_analytics.rs
+++ b/crates/meilisearch/src/analytics/segment_analytics.rs
@@ -327,7 +327,7 @@ impl Infos {
             chat_completions,
             multimodal,
             foreign_keys,
-            queue_documents_fetch,
+            disable_documents_fetch_queue,
             legacy_search,
         } = features;
 
@@ -358,7 +358,7 @@ impl Infos {
             experimental_no_edition_2024_for_dumps,
             experimental_allowed_ip_networks: !experimental_allowed_ip_networks.is_empty(),
             experimental_foreign_keys: foreign_keys,
-            experimental_queue_documents_fetch: queue_documents_fetch,
+            experimental_queue_documents_fetch: !disable_documents_fetch_queue,
             experimental_legacy_search: legacy_search.unwrap_or(experimental_legacy_search_default),
             gpu_enabled: meilisearch_types::milli::vector::is_cuda_enabled(),
             db_path: db_path != Path::new("./data.ms"),

--- a/crates/meilisearch/src/routes/features.rs
+++ b/crates/meilisearch/src/routes/features.rs
@@ -45,7 +45,7 @@ pub struct ExperimentalFeaturesApi;
             chat_completions: Some(false),
             multimodal: Some(false),
             foreign_keys: Some(false),
-            queue_documents_fetch: Some(false),
+            disable_documents_fetch_queue: Some(false),
             legacy_search: Some(false),
         })),
         (status = 401, description = "The authorization header is missing.", body = ResponseError, content_type = "application/json", example = json!(
@@ -112,9 +112,9 @@ pub struct RuntimeTogglableFeatures {
     /// Enable foreign key support for document hydration
     #[request(default)]
     pub foreign_keys: Option<bool>,
-    /// Enable queue documents fetch
+    /// Disable documents fetch queue
     #[request(default)]
-    pub queue_documents_fetch: Option<bool>,
+    pub disable_documents_fetch_queue: Option<bool>,
     /// Enable legacy search pipeline
     #[request(default)]
     pub legacy_search: Option<bool>,
@@ -135,7 +135,7 @@ impl From<meilisearch_types::features::RuntimeTogglableFeatures> for RuntimeTogg
             chat_completions,
             multimodal,
             foreign_keys,
-            queue_documents_fetch,
+            disable_documents_fetch_queue,
             legacy_search,
         } = value;
 
@@ -152,7 +152,7 @@ impl From<meilisearch_types::features::RuntimeTogglableFeatures> for RuntimeTogg
             chat_completions: Some(chat_completions),
             multimodal: Some(multimodal),
             foreign_keys: Some(foreign_keys),
-            queue_documents_fetch: Some(queue_documents_fetch),
+            disable_documents_fetch_queue: Some(disable_documents_fetch_queue),
             legacy_search,
         }
     }
@@ -172,7 +172,7 @@ pub struct PatchExperimentalFeatureAnalytics {
     chat_completions: bool,
     multimodal: bool,
     foreign_keys: bool,
-    queue_documents_fetch: bool,
+    disable_documents_fetch_queue: bool,
     legacy_search: bool,
 }
 
@@ -195,7 +195,7 @@ impl Aggregate for PatchExperimentalFeatureAnalytics {
             chat_completions: new.chat_completions,
             multimodal: new.multimodal,
             foreign_keys: new.foreign_keys,
-            queue_documents_fetch: new.queue_documents_fetch,
+            disable_documents_fetch_queue: new.disable_documents_fetch_queue,
             legacy_search: new.legacy_search,
         })
     }
@@ -225,7 +225,7 @@ impl Aggregate for PatchExperimentalFeatureAnalytics {
             chat_completions: Some(false),
             multimodal: Some(false),
             foreign_keys: Some(false),
-            queue_documents_fetch: Some(false),
+            disable_documents_fetch_queue: Some(false),
             legacy_search: Some(false),
          })),
         (status = 401, description = "The authorization header is missing.", body = ResponseError, content_type = "application/json", example = json!(
@@ -279,10 +279,10 @@ async fn patch_features(
         chat_completions: new_features.0.chat_completions.unwrap_or(old_features.chat_completions),
         multimodal: new_features.0.multimodal.unwrap_or(old_features.multimodal),
         foreign_keys: new_features.0.foreign_keys.unwrap_or(old_features.foreign_keys),
-        queue_documents_fetch: new_features
+        disable_documents_fetch_queue: new_features
             .0
-            .queue_documents_fetch
-            .unwrap_or(old_features.queue_documents_fetch),
+            .disable_documents_fetch_queue
+            .unwrap_or(old_features.disable_documents_fetch_queue),
         legacy_search: new_features.0.legacy_search.or(old_features.legacy_search),
     };
 
@@ -302,7 +302,7 @@ async fn patch_features(
         chat_completions,
         multimodal,
         foreign_keys,
-        queue_documents_fetch,
+        disable_documents_fetch_queue,
         legacy_search,
     } = new_features;
 
@@ -320,7 +320,7 @@ async fn patch_features(
             chat_completions,
             multimodal,
             foreign_keys,
-            queue_documents_fetch,
+            disable_documents_fetch_queue,
             legacy_search: legacy_search.unwrap_or(false),
         },
         &req,

--- a/crates/meilisearch/src/routes/indexes/documents.rs
+++ b/crates/meilisearch/src/routes/indexes/documents.rs
@@ -541,7 +541,7 @@ pub async fn documents_by_query_post(
     req: HttpRequest,
     analytics: web::Data<Analytics>,
 ) -> Result<HttpResponse, ResponseError> {
-    let use_queue = index_scheduler.features().runtime_features().queue_documents_fetch;
+    let use_queue = index_scheduler.features().queue_documents_fetch();
     let permit = if use_queue { Some(search_queue.try_get_search_permit().await?) } else { None };
 
     let body = body.into_inner();
@@ -633,7 +633,7 @@ pub async fn get_documents(
 ) -> Result<HttpResponse, ResponseError> {
     debug!(parameters = ?params, "Get documents GET");
 
-    let use_queue = !index_scheduler.features().runtime_features().queue_documents_fetch;
+    let use_queue = index_scheduler.features().queue_documents_fetch();
     let permit = if use_queue { Some(search_queue.try_get_search_permit().await?) } else { None };
 
     let BrowseQueryGet { limit, offset, fields, retrieve_vectors, filter, ids, sort } =

--- a/crates/meilisearch/tests/dumps/mod.rs
+++ b/crates/meilisearch/tests/dumps/mod.rs
@@ -2193,7 +2193,7 @@ async fn import_dump_v6_containing_experimental_features() {
       "chatCompletions": false,
       "multimodal": false,
       "foreignKeys": false,
-      "queueDocumentsFetch": false,
+      "disableDocumentsFetchQueue": false,
       "legacySearch": null
     }
     "###);
@@ -2325,7 +2325,7 @@ async fn import_dump_v6_containing_batches_and_enqueued_tasks() {
       "chatCompletions": false,
       "multimodal": false,
       "foreignKeys": false,
-      "queueDocumentsFetch": false,
+      "disableDocumentsFetchQueue": false,
       "legacySearch": null
     }
     "###);
@@ -2437,7 +2437,7 @@ async fn generate_and_import_dump_containing_vectors() {
       "chatCompletions": false,
       "multimodal": false,
       "foreignKeys": false,
-      "queueDocumentsFetch": false,
+      "disableDocumentsFetchQueue": false,
       "legacySearch": false
     }
     "###);

--- a/crates/meilisearch/tests/features/mod.rs
+++ b/crates/meilisearch/tests/features/mod.rs
@@ -30,7 +30,7 @@ async fn experimental_features() {
       "chatCompletions": false,
       "multimodal": false,
       "foreignKeys": false,
-      "queueDocumentsFetch": false,
+      "disableDocumentsFetchQueue": false,
       "legacySearch": false
     }
     "###);
@@ -52,7 +52,7 @@ async fn experimental_features() {
       "chatCompletions": false,
       "multimodal": false,
       "foreignKeys": false,
-      "queueDocumentsFetch": false,
+      "disableDocumentsFetchQueue": false,
       "legacySearch": false
     }
     "###);
@@ -74,7 +74,7 @@ async fn experimental_features() {
       "chatCompletions": false,
       "multimodal": false,
       "foreignKeys": false,
-      "queueDocumentsFetch": false,
+      "disableDocumentsFetchQueue": false,
       "legacySearch": false
     }
     "###);
@@ -97,7 +97,7 @@ async fn experimental_features() {
       "chatCompletions": false,
       "multimodal": false,
       "foreignKeys": false,
-      "queueDocumentsFetch": false,
+      "disableDocumentsFetchQueue": false,
       "legacySearch": false
     }
     "###);
@@ -120,7 +120,7 @@ async fn experimental_features() {
       "chatCompletions": false,
       "multimodal": false,
       "foreignKeys": false,
-      "queueDocumentsFetch": false,
+      "disableDocumentsFetchQueue": false,
       "legacySearch": false
     }
     "###);
@@ -150,7 +150,7 @@ async fn experimental_feature_metrics() {
       "chatCompletions": false,
       "multimodal": false,
       "foreignKeys": false,
-      "queueDocumentsFetch": false,
+      "disableDocumentsFetchQueue": false,
       "legacySearch": false
     }
     "###);
@@ -198,7 +198,7 @@ async fn errors() {
     meili_snap::snapshot!(code, @"400 Bad Request");
     meili_snap::snapshot!(meili_snap::json_string!(response), @r###"
     {
-      "message": "Unknown field `NotAFeature`: expected one of `metrics`, `logsRoute`, `editDocumentsByFunction`, `containsFilter`, `dynamicSearchRules`, `network`, `getTaskDocumentsRoute`, `taskQueueCompactionRoute`, `compositeEmbedders`, `chatCompletions`, `multimodal`, `foreignKeys`, `queueDocumentsFetch`, `legacySearch`",
+      "message": "Unknown field `NotAFeature`: expected one of `metrics`, `logsRoute`, `editDocumentsByFunction`, `containsFilter`, `dynamicSearchRules`, `network`, `getTaskDocumentsRoute`, `taskQueueCompactionRoute`, `compositeEmbedders`, `chatCompletions`, `multimodal`, `foreignKeys`, `disableDocumentsFetchQueue`, `legacySearch`",
       "code": "bad_request",
       "type": "invalid_request",
       "link": "https://docs.meilisearch.com/errors#bad_request"


### PR DESCRIPTION
## Related issue

Fixes https://linear.app/meilisearch/issue/ENGPROD-2597/enable-document-fetch-queue-by-default

## Generative AI tools

- [x] This PR does not use generative AI tooling

## Changelog

Replace the  `queueDocumentsFetch` experimental feature with `disableDocumentsFetchQueue` converting the feature from an opt-in to an opt-out.
