### PR TITLE
Remove grenad from the new indexing path

### DIFF
--- a/crates/milli/src/lib.rs
+++ b/crates/milli/src/lib.rs
@@ -50,7 +50,6 @@ use charabia::normalizer::{CharNormalizer, CompatibilityDecompositionNormalizer}
 pub use documents::GeoSortStrategy;
 pub use filter_parser::{Condition, FilterCondition, IndexFilterCondition, Span, Token};
 use fxhash::{FxHasher32, FxHasher64};
-pub use grenad::CompressionType;
 pub use must_stop_processing::MustStopProcessing;
 pub use search::new::{
     execute_search, filtered_universe, DefaultSearchLogger, SearchContext, SearchLogger,

--- a/crates/milli/src/search/new/db_cache.rs
+++ b/crates/milli/src/search/new/db_cache.rs
@@ -3,7 +3,6 @@ use std::collections::hash_map::Entry;
 use std::hash::Hash;
 
 use fxhash::FxHashMap;
-use grenad::MergeFunction;
 use heed::types::Bytes;
 use heed::{BytesEncode, Database, RoTxn};
 use roaring::RoaringBitmap;
@@ -124,7 +123,6 @@ impl<'ctx> DatabaseCache<'ctx> {
         K1: Copy + Eq + Hash,
         KC: BytesEncode<'v>,
         KC::EItem: Sized,
-        MF: MergeFunction,
         crate::Error: From<MF::Error>,
     {
         if let Entry::Vacant(entry) = cache.entry(cache_key) {

--- a/crates/milli/src/update/facet/bulk.rs
+++ b/crates/milli/src/update/facet/bulk.rs
@@ -1,7 +1,6 @@
 use std::fs::File;
 use std::io::BufReader;
 
-use grenad::{CompressionType, Merger};
 use heed::types::Bytes;
 use heed::{BytesDecode, BytesEncode, Error, PutFlags, RoTxn, RwTxn};
 use roaring::RoaringBitmap;

--- a/crates/milli/src/update/facet/incremental.rs
+++ b/crates/milli/src/update/facet/incremental.rs
@@ -1,7 +1,6 @@
 use std::fs::File;
 use std::io::BufReader;
 
-use grenad::Merger;
 use heed::types::{Bytes, DecodeIgnore};
 use heed::{BytesDecode, Error, RoTxn, RwTxn};
 use obkv::KvReader;

--- a/crates/milli/src/update/facet/mod.rs
+++ b/crates/milli/src/update/facet/mod.rs
@@ -81,7 +81,6 @@ use std::fs::File;
 use std::io::BufReader;
 use std::ops::Bound;
 
-use grenad::Merger;
 use heed::types::{Bytes, DecodeIgnore};
 use heed::BytesDecode as _;
 use roaring::RoaringBitmap;

--- a/crates/milli/src/update/new/extract/cache.rs
+++ b/crates/milli/src/update/new/extract/cache.rs
@@ -72,7 +72,6 @@ use bumpalo::Bump;
 use bumparaw_collections::bbbul::{BitPacker, BitPacker4x};
 use bumparaw_collections::map::FrozenMap;
 use bumparaw_collections::{Bbbul, FrozenBbbul};
-use grenad::ReaderCursor;
 use hashbrown::hash_map::RawEntryMut;
 use hashbrown::HashMap;
 use roaring::RoaringBitmap;
@@ -81,7 +80,6 @@ use rustc_hash::FxBuildHasher;
 use crate::update::del_add::{DelAdd, KvWriterDelAdd};
 use crate::update::new::thread_local::MostlySend;
 use crate::update::new::KvReaderDelAdd;
-use crate::update::MergeDeladdCboRoaringBitmaps;
 use crate::{CboRoaringBitmapCodec, Result};
 
 /// A cache that stores bytes keys associated to CboDelAddRoaringBitmaps.
@@ -219,7 +217,7 @@ impl<'extractor> BalancedCaches<'extractor> {
                         .into_iter()
                         .map(ReaderCursor::into_inner)
                         .map(BufReader::new)
-                        .map(|bufreader| grenad::Reader::new(bufreader).map_err(Into::into))
+                        .map(|bufreader| Reader::new(bufreader).map_err(Into::into))
                         .collect::<Result<_>>()?;
                     // safety: we are transmuting the Bbbul into a FrozenBbbul
                     //         that are the same size.
@@ -320,7 +318,7 @@ struct SpillingCaches<'extractor> {
             &'extractor Bump,
         >,
     >,
-    spilled_entries: Vec<grenad::Sorter<MergeDeladdCboRoaringBitmaps>>,
+    spilled_entries: Vec<Sorter<MergeDeladdCboRoaringBitmaps>>,
     deladd_buffer: Vec<u8>,
     cbo_buffer: Vec<u8>,
 }
@@ -338,7 +336,7 @@ impl<'extractor> SpillingCaches<'extractor> {
     ) -> SpillingCaches<'extractor> {
         SpillingCaches {
             spilled_entries: iter::repeat_with(|| {
-                let mut builder = grenad::SorterBuilder::new(MergeDeladdCboRoaringBitmaps);
+                let mut builder = SorterBuilder::new(MergeDeladdCboRoaringBitmaps);
                 builder.dump_threshold(0);
                 builder.allow_realloc(false);
                 builder.build()
@@ -408,7 +406,7 @@ fn compute_bucket_from_hash(buckets: usize, hash: u64) -> usize {
 }
 
 fn spill_entry_to_sorter(
-    spilled_entries: &mut grenad::Sorter<MergeDeladdCboRoaringBitmaps>,
+    spilled_entries: &mut Sorter<MergeDeladdCboRoaringBitmaps>,
     deladd_buffer: &mut Vec<u8>,
     cbo_buffer: &mut Vec<u8>,
     key: &[u8],
@@ -454,7 +452,7 @@ pub struct FrozenCache<'a, 'extractor> {
         FrozenDelAddBbbul<'extractor, BitPacker4x>,
         FxBuildHasher,
     >,
-    spilled: Vec<grenad::Reader<BufReader<File>>>,
+    spilled: Vec<Reader<BufReader<File>>>,
 }
 
 pub fn transpose_and_freeze_caches<'a, 'extractor>(

--- a/crates/milli/src/update/new/facet_search_builder.rs
+++ b/crates/milli/src/update/new/facet_search_builder.rs
@@ -3,7 +3,6 @@ use std::collections::{BTreeSet, HashMap};
 
 use charabia::normalizer::NormalizerOption;
 use charabia::{Language, Normalize, StrDetection, Token};
-use grenad::Sorter;
 use heed::types::{Bytes, SerdeJson};
 use heed::{BytesDecode, BytesEncode, RoTxn, RwTxn};
 
@@ -12,7 +11,6 @@ use super::KvReaderDelAdd;
 use crate::attribute_patterns::PatternMatch;
 use crate::heed_codec::facet::FacetGroupKey;
 use crate::update::del_add::{DelAdd, KvWriterDelAdd};
-use crate::update::{create_sorter, MergeDeladdBtreesetString};
 use crate::{
     BEU16StrCodec, FieldId, FieldIdMapMissingEntry, FilterableAttributesFeatures,
     FilterableAttributesRule, GlobalFieldsIdsMap, Index, InternalError, LocalizedAttributesRule,
@@ -38,9 +36,9 @@ impl<'indexer> FacetSearchBuilder<'indexer> {
     ) -> Self {
         let registered_facets = HashMap::new();
         let normalized_facet_string_docids_sorter = create_sorter(
-            grenad::SortAlgorithm::Stable,
+            SortAlgorithm::Stable,
             MergeDeladdBtreesetString,
-            grenad::CompressionType::None,
+            CompressionType::None,
             None,
             None,
             Some(0),
@@ -136,7 +134,7 @@ impl<'indexer> FacetSearchBuilder<'indexer> {
         tracing::trace!("merge facet strings for facet search: {:?}", self.registered_facets);
 
         let reader = self.normalized_facet_string_docids_sorter.into_reader_cursors()?;
-        let mut builder = grenad::MergerBuilder::new(MergeDeladdBtreesetString);
+        let mut builder = MergerBuilder::new(MergeDeladdBtreesetString);
         builder.extend(reader);
 
         let database = index.facet_id_normalized_string_strings.remap_types::<Bytes, Bytes>();

--- a/crates/milli/src/update/new/indexer/post_processing/facet_bulk.rs
+++ b/crates/milli/src/update/new/indexer/post_processing/facet_bulk.rs
@@ -2,7 +2,6 @@ use std::fs::File;
 use std::io::BufReader;
 use std::{iter, mem};
 
-use grenad::CompressionType;
 use heed::types::{Bytes, LazyDecode};
 use heed::{Database, RwTxn};
 use rayon::prelude::*;
@@ -13,7 +12,6 @@ use crate::facet::FacetType;
 use crate::heed_codec::facet::{FacetGroupKey, FacetGroupKeyCodec, FacetGroupValueCodec};
 use crate::heed_codec::BytesRefCodec;
 use crate::update::facet::{FACET_GROUP_SIZE, FACET_MIN_LEVEL_SIZE};
-use crate::update::{create_writer, writer_into_reader};
 use crate::{CboRoaringBitmapCodec, FieldId, Index};
 
 /// Generate the facet level based on the level 0.
@@ -74,7 +72,7 @@ fn compute_level(
     db: Database<FacetGroupKeyCodec<BytesRefCodec>, LazyDecode<FacetGroupValueCodec>>,
     field_id: FieldId,
     base_level: u8,
-) -> Result<Vec<grenad::Reader<BufReader<File>>>, crate::Error> {
+) -> Result<Vec<Reader<BufReader<File>>>, crate::Error> {
     let thread_count = rayon::current_num_threads();
     let rtxns = iter::repeat_with(|| wtxn.nested_read_txn())
         .take(thread_count)


### PR DESCRIPTION
This PR removes the use of grenad in the new indexing path of Meilisearch. I plan to reimplement the missing sorter, writer, and reader, but with a much easier approach than grenad that was capable of seeking in the grenad file. We don't need to seek and can skip a bunch of complex behavior and on-disk data structures.

The grenad cannot be deleted yet because we still have the old settings indexer using it, but once we remove it, we can get rid of this important dependency and probably others.

## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respects the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)