### PR TITLE
Improve the synonyms storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,7 +800,7 @@ dependencies = [
 
 [[package]]
 name = "build-info"
-version = "1.48.3"
+version = "1.49.0"
 dependencies = [
  "anyhow",
  "time",
@@ -1925,7 +1925,7 @@ dependencies = [
 
 [[package]]
 name = "dump"
-version = "1.48.3"
+version = "1.49.0"
 dependencies = [
  "big_s",
  "flate2",
@@ -2248,7 +2248,7 @@ dependencies = [
 
 [[package]]
 name = "file-store"
-version = "1.48.3"
+version = "1.49.0"
 dependencies = [
  "tempfile",
  "thiserror 2.0.18",
@@ -2268,7 +2268,7 @@ dependencies = [
 
 [[package]]
 name = "filter-parser"
-version = "1.48.3"
+version = "1.49.0"
 dependencies = [
  "insta",
  "levenshtein_automata",
@@ -2295,7 +2295,7 @@ dependencies = [
 
 [[package]]
 name = "flatten-serde-json"
-version = "1.48.3"
+version = "1.49.0"
 dependencies = [
  "criterion",
  "serde_json",
@@ -2479,7 +2479,7 @@ dependencies = [
 
 [[package]]
 name = "fuzzers"
-version = "1.48.3"
+version = "1.49.0"
 dependencies = [
  "arbitrary",
  "bumpalo",
@@ -3222,7 +3222,7 @@ dependencies = [
 
 [[package]]
 name = "http-client"
-version = "1.48.3"
+version = "1.49.0"
 dependencies = [
  "cidr",
  "hyper-util",
@@ -3542,7 +3542,7 @@ dependencies = [
 
 [[package]]
 name = "index-scheduler"
-version = "1.48.3"
+version = "1.49.0"
 dependencies = [
  "anyhow",
  "backoff",
@@ -3791,7 +3791,7 @@ dependencies = [
 
 [[package]]
 name = "json-depth-checker"
-version = "1.48.3"
+version = "1.49.0"
 dependencies = [
  "criterion",
  "serde_json",
@@ -4310,7 +4310,7 @@ checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
 
 [[package]]
 name = "meili-snap"
-version = "1.48.3"
+version = "1.49.0"
 dependencies = [
  "insta",
  "md5 0.8.0",
@@ -4321,7 +4321,7 @@ dependencies = [
 
 [[package]]
 name = "meilisearch"
-version = "1.48.3"
+version = "1.49.0"
 dependencies = [
  "actix-cors",
  "actix-http",
@@ -4414,7 +4414,7 @@ dependencies = [
 
 [[package]]
 name = "meilisearch-auth"
-version = "1.48.3"
+version = "1.49.0"
 dependencies = [
  "base64 0.22.1",
  "enum-iterator",
@@ -4433,7 +4433,7 @@ dependencies = [
 
 [[package]]
 name = "meilisearch-types"
-version = "1.48.3"
+version = "1.49.0"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -4471,7 +4471,7 @@ dependencies = [
 
 [[package]]
 name = "meilitool"
-version = "1.48.3"
+version = "1.49.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4505,7 +4505,7 @@ dependencies = [
 
 [[package]]
 name = "milli"
-version = "1.48.3"
+version = "1.49.0"
 dependencies = [
  "arroy",
  "bbqueue",
@@ -5129,7 +5129,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "permissive-json-pointer"
-version = "1.48.3"
+version = "1.49.0"
 dependencies = [
  "big_s",
  "serde_json",
@@ -6096,7 +6096,7 @@ dependencies = [
 
 [[package]]
 name = "routes"
-version = "1.48.3"
+version = "1.49.0"
 dependencies = [
  "actix-web",
  "routes-macros",
@@ -6108,7 +6108,7 @@ dependencies = [
 
 [[package]]
 name = "routes-macros"
-version = "1.48.3"
+version = "1.49.0"
 dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
@@ -8671,7 +8671,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "1.48.3"
+version = "1.49.0"
 dependencies = [
  "anyhow",
  "build-info",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.48.3"
+version = "1.49.0"
 authors = [
     "Quentin de Quelen <quentin@dequelen.me>",
     "Clément Renault <clement@meilisearch.com>",

--- a/crates/milli/src/heed_codec/mod.rs
+++ b/crates/milli/src/heed_codec/mod.rs
@@ -10,6 +10,7 @@ mod roaring_bitmap_length;
 mod str_beu32_codec;
 mod str_ref;
 mod str_str_u8_codec;
+mod synonyms_key_codec;
 pub mod version;
 
 pub use byte_slice_ref::BytesRefCodec;
@@ -28,6 +29,7 @@ pub use self::roaring_bitmap_length::{
 };
 pub use self::str_beu32_codec::{StrBEU16Codec, StrBEU32Codec};
 pub use self::str_str_u8_codec::{U8StrStrCodec, UncheckedU8StrStrCodec};
+pub use self::synonyms_key_codec::{SynonymContainsUnitSeparator, SynonymsKeyCodec};
 
 pub trait BytesDecodeOwned {
     type DItem;

--- a/crates/milli/src/heed_codec/synonyms_key_codec.rs
+++ b/crates/milli/src/heed_codec/synonyms_key_codec.rs
@@ -1,36 +1,40 @@
 use std::borrow::Cow;
+use std::marker::PhantomData;
 use std::{fmt, str};
 
 use heed::BoxedError;
 
-/// This ascii character is used as a seperator for fields and
+/// This ascii character is used as a separator for fields and
 /// we use it as a way to separate the different words in synonyms.
 ///
 /// <https://en.wikipedia.org/wiki/C0_and_C1_control_codes#Field_separators>
 const UNIT_SEPARATOR: u8 = b'\x1F';
 
-pub struct SynonymsKeyCodec;
+pub struct SynonymsKeyCodec<S>(PhantomData<S>);
 
-impl<'a> heed::BytesEncode<'a> for SynonymsKeyCodec {
-    type EItem = [&'a str];
+impl<'a, S> heed::BytesEncode<'a> for SynonymsKeyCodec<S>
+where
+    S: AsRef<str> + 'a,
+{
+    type EItem = [S];
 
     fn bytes_encode(item: &Self::EItem) -> Result<Cow<'_, [u8]>, BoxedError> {
-        if item.iter().any(|s| s.contains(char::from(UNIT_SEPARATOR))) {
+        if item.iter().any(|s| s.as_ref().contains(char::from(UNIT_SEPARATOR))) {
             return Err(SynonymContainsUnitSeparator.into());
         }
 
         match item {
             [] => Ok(Cow::Borrowed(&[])),
-            [single] => Ok(Cow::Borrowed(single.as_bytes())),
+            [single] => Ok(Cow::Borrowed(single.as_ref().as_bytes())),
             item => {
                 // The length of all words + the delimiters
                 let length = item.len();
                 let delimiters = length.saturating_sub(1);
-                let capacity = item.iter().map(|s| s.len()).sum::<usize>() + delimiters;
+                let capacity = item.iter().map(|s| s.as_ref().len()).sum::<usize>() + delimiters;
                 let mut encoded = Vec::with_capacity(capacity);
 
                 for (i, word) in item.iter().enumerate() {
-                    encoded.extend(word.as_bytes());
+                    encoded.extend(word.as_ref().as_bytes());
                     // Make sure not to put a separator at the end of list
                     // This way we make sure not to encode empty words
                     if i != length.saturating_sub(1) {
@@ -44,11 +48,11 @@ impl<'a> heed::BytesEncode<'a> for SynonymsKeyCodec {
     }
 }
 
-impl<'a> heed::BytesDecode<'a> for SynonymsKeyCodec {
+impl<'a, S: 'a> heed::BytesDecode<'a> for SynonymsKeyCodec<S> {
     type DItem = Vec<&'a str>;
 
     fn bytes_decode(bytes: &'a [u8]) -> Result<Self::DItem, BoxedError> {
-        // Note that the Unit Separator (UB) ascii character is valid UTF-8
+        // Note that the Unit Separator (US) ascii character is valid UTF-8
         let word_with_separators = str::from_utf8(bytes)?;
         Ok(word_with_separators.split(char::from(UNIT_SEPARATOR)).collect())
     }
@@ -59,7 +63,7 @@ pub struct SynonymContainsUnitSeparator;
 
 impl fmt::Display for SynonymContainsUnitSeparator {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Synonym contains invalid Unit Separator (UB) ascii character")
+        write!(f, "Synonym contains invalid Unit Separator (US) ascii character")
     }
 }
 

--- a/crates/milli/src/heed_codec/synonyms_key_codec.rs
+++ b/crates/milli/src/heed_codec/synonyms_key_codec.rs
@@ -1,0 +1,4 @@
+use std::borrow::Cow;
+use std::{fmt, str};
+
+use heed::BoxedError;

--- a/crates/milli/src/heed_codec/synonyms_key_codec.rs
+++ b/crates/milli/src/heed_codec/synonyms_key_codec.rs
@@ -2,3 +2,65 @@ use std::borrow::Cow;
 use std::{fmt, str};
 
 use heed::BoxedError;
+
+/// This ascii character is used as a seperator for fields and
+/// we use it as a way to separate the different words in synonyms.
+///
+/// <https://en.wikipedia.org/wiki/C0_and_C1_control_codes#Field_separators>
+const UNIT_SEPARATOR: u8 = b'\x1F';
+
+pub struct SynonymsKeyCodec;
+
+impl<'a> heed::BytesEncode<'a> for SynonymsKeyCodec {
+    type EItem = [&'a str];
+
+    fn bytes_encode(item: &Self::EItem) -> Result<Cow<'_, [u8]>, BoxedError> {
+        if item.iter().any(|s| s.contains(char::from(UNIT_SEPARATOR))) {
+            return Err(SynonymContainsUnitSeparator.into());
+        }
+
+        match item {
+            [] => Ok(Cow::Borrowed(&[])),
+            [single] => Ok(Cow::Borrowed(single.as_bytes())),
+            item => {
+                // The length of all words + the delimiters
+                let length = item.len();
+                let delimiters = length.saturating_sub(1);
+                let capacity = item.iter().map(|s| s.len()).sum::<usize>() + delimiters;
+                let mut encoded = Vec::with_capacity(capacity);
+
+                for (i, word) in item.iter().enumerate() {
+                    encoded.extend(word.as_bytes());
+                    // Make sure not to put a separator at the end of list
+                    // This way we make sure not to encode empty words
+                    if i != length.saturating_sub(1) {
+                        encoded.push(UNIT_SEPARATOR);
+                    }
+                }
+
+                Ok(Cow::Owned(encoded))
+            }
+        }
+    }
+}
+
+impl<'a> heed::BytesDecode<'a> for SynonymsKeyCodec {
+    type DItem = Vec<&'a str>;
+
+    fn bytes_decode(bytes: &'a [u8]) -> Result<Self::DItem, BoxedError> {
+        // Note that the Unit Separator (UB) ascii character is valid UTF-8
+        let word_with_separators = str::from_utf8(bytes)?;
+        Ok(word_with_separators.split(char::from(UNIT_SEPARATOR)).collect())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SynonymContainsUnitSeparator;
+
+impl fmt::Display for SynonymContainsUnitSeparator {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Synonym contains invalid Unit Separator (UB) ascii character")
+    }
+}
+
+impl std::error::Error for SynonymContainsUnitSeparator {}

--- a/crates/milli/src/index.rs
+++ b/crates/milli/src/index.rs
@@ -143,7 +143,7 @@ pub struct Index {
     pub exact_word_docids: Database<Str, CboRoaringBitmapCodec>,
 
     /// A list of words and the list of synonyms associated to it.
-    pub synonyms: heed::Database<SynonymsKeyCodec, SerdeJson<Synonyms>>,
+    pub synonyms: heed::Database<SynonymsKeyCodec<String>, SerdeJson<AssociatedSynonyms>>,
 
     /// A prefix of word and all the documents ids containing this prefix.
     pub word_prefix_docids: Database<Str, CboRoaringBitmapCodec>,

--- a/crates/milli/src/index.rs
+++ b/crates/milli/src/index.rs
@@ -68,7 +68,6 @@ pub mod main_key {
     pub const NON_SEPARATOR_TOKENS_KEY: &str = "non-separator-tokens";
     pub const SEPARATOR_TOKENS_KEY: &str = "separator-tokens";
     pub const DICTIONARY_KEY: &str = "dictionary";
-    pub const SYNONYMS_KEY: &str = "synonyms";
     pub const USER_DEFINED_SYNONYMS_KEY: &str = "user-defined-synonyms";
     pub const WORDS_FST_KEY: &str = "words-fst";
     pub const WORDS_PREFIXES_FST_KEY: &str = "words-prefixes-fst";
@@ -98,6 +97,7 @@ pub mod db_name {
     pub const MAIN: &str = "main";
     pub const WORD_DOCIDS: &str = "word-docids";
     pub const EXACT_WORD_DOCIDS: &str = "exact-word-docids";
+    pub const SYNONYMS: &str = "synonyms";
     pub const WORD_PREFIX_DOCIDS: &str = "word-prefix-docids";
     pub const EXACT_WORD_PREFIX_DOCIDS: &str = "exact-word-prefix-docids";
     pub const EXTERNAL_DOCUMENTS_IDS: &str = "external-documents-ids";
@@ -123,7 +123,7 @@ pub mod db_name {
     pub const CELLULITE: &str = "cellulite"; // used as a prefix, counted as `Cellulite::nb_dbs`
     pub const DOCUMENTS: &str = "documents";
 }
-const NUMBER_OF_DBS: u32 = 26 + Cellulite::nb_dbs();
+const NUMBER_OF_DBS: u32 = 27 + Cellulite::nb_dbs();
 
 #[derive(Clone)]
 pub struct Index {
@@ -141,6 +141,9 @@ pub struct Index {
 
     /// A word and all the documents ids containing the word, from attributes for which typos are not allowed.
     pub exact_word_docids: Database<Str, CboRoaringBitmapCodec>,
+
+    /// A list of words and the list of synonyms associated to it.
+    pub synonyms: heed::Database<SynonymsKeyCodec, SerdeJson<Synonyms>>,
 
     /// A prefix of word and all the documents ids containing this prefix.
     pub word_prefix_docids: Database<Str, CboRoaringBitmapCodec>,
@@ -230,6 +233,7 @@ impl Index {
             env.create_database(&mut wtxn, Some(EXTERNAL_DOCUMENTS_IDS))?;
         let exact_word_docids = env.create_database(&mut wtxn, Some(EXACT_WORD_DOCIDS))?;
         let word_prefix_docids = env.create_database(&mut wtxn, Some(WORD_PREFIX_DOCIDS))?;
+        let synonyms = env.create_database(&mut wtxn, Some(SYNONYMS))?;
         let exact_word_prefix_docids =
             env.create_database(&mut wtxn, Some(EXACT_WORD_PREFIX_DOCIDS))?;
         let word_pair_proximity_docids =
@@ -277,6 +281,7 @@ impl Index {
             external_documents_ids,
             word_docids,
             exact_word_docids,
+            synonyms,
             word_prefix_docids,
             exact_word_prefix_docids,
             word_pair_proximity_docids,
@@ -1340,29 +1345,6 @@ impl Index {
 
     /* synonyms */
 
-    pub(crate) fn put_synonyms(
-        &self,
-        wtxn: &mut RwTxn<'_>,
-        synonyms: &HashMap<Vec<String>, Vec<Vec<String>>>,
-        user_defined_synonyms: &BTreeMap<String, Vec<String>>,
-    ) -> heed::Result<()> {
-        self.main.remap_types::<Str, SerdeBincode<_>>().put(
-            wtxn,
-            main_key::SYNONYMS_KEY,
-            synonyms,
-        )?;
-        self.main.remap_types::<Str, SerdeBincode<_>>().put(
-            wtxn,
-            main_key::USER_DEFINED_SYNONYMS_KEY,
-            user_defined_synonyms,
-        )
-    }
-
-    pub(crate) fn delete_synonyms(&self, wtxn: &mut RwTxn<'_>) -> heed::Result<bool> {
-        self.main.remap_key_type::<Str>().delete(wtxn, main_key::SYNONYMS_KEY)?;
-        self.main.remap_key_type::<Str>().delete(wtxn, main_key::USER_DEFINED_SYNONYMS_KEY)
-    }
-
     pub fn user_defined_synonyms(
         &self,
         rtxn: &RoTxn<'_>,
@@ -1374,24 +1356,20 @@ impl Index {
             .unwrap_or_default())
     }
 
-    pub fn synonyms(
+    pub fn put_user_defined_synonyms(
         &self,
-        rtxn: &RoTxn<'_>,
-    ) -> heed::Result<HashMap<Vec<String>, Vec<Vec<String>>>> {
-        Ok(self
-            .main
-            .remap_types::<Str, SerdeBincode<_>>()
-            .get(rtxn, main_key::SYNONYMS_KEY)?
-            .unwrap_or_default())
+        wtxn: &mut RwTxn<'_>,
+        user_defined_synonyms: &BTreeMap<String, Vec<String>>,
+    ) -> heed::Result<()> {
+        self.main.remap_types::<Str, SerdeBincode<_>>().put(
+            wtxn,
+            main_key::USER_DEFINED_SYNONYMS_KEY,
+            user_defined_synonyms,
+        )
     }
 
-    pub fn words_synonyms<S: AsRef<str>>(
-        &self,
-        rtxn: &RoTxn<'_>,
-        words: &[S],
-    ) -> heed::Result<Option<Vec<Vec<String>>>> {
-        let words: Vec<_> = words.iter().map(|s| s.as_ref().to_owned()).collect();
-        Ok(self.synonyms(rtxn)?.remove(&words))
+    pub fn delete_user_defined_synonyms(&self, wtxn: &mut RwTxn<'_>) -> heed::Result<bool> {
+        self.main.remap_key_type::<Str>().delete(wtxn, main_key::USER_DEFINED_SYNONYMS_KEY)
     }
 
     /* words prefixes fst */
@@ -1924,6 +1902,7 @@ impl Index {
             external_documents_ids,
             word_docids,
             exact_word_docids,
+            synonyms,
             word_prefix_docids,
             exact_word_prefix_docids,
             word_pair_proximity_docids,
@@ -1967,6 +1946,7 @@ impl Index {
             .insert("external_documents_ids", external_documents_ids.stat(rtxn).map(compute_size)?);
         sizes.insert("word_docids", word_docids.stat(rtxn).map(compute_size)?);
         sizes.insert("exact_word_docids", exact_word_docids.stat(rtxn).map(compute_size)?);
+        sizes.insert("synonyms", synonyms.stat(rtxn).map(compute_size)?);
         sizes.insert("word_prefix_docids", word_prefix_docids.stat(rtxn).map(compute_size)?);
         sizes.insert(
             "exact_word_prefix_docids",
@@ -2031,6 +2011,32 @@ impl Index {
         sizes.insert("cellulite_metadata", cellulite.metadata_db_stats(rtxn).map(compute_size)?);
 
         Ok(sizes)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Synonyms {
+    synonyms: Vec<String>,
+}
+
+impl Synonyms {
+    pub fn new(synonyms: Vec<String>) -> Synonyms {
+        Synonyms { synonyms }
+    }
+
+    /// The original, unnormalized, unsplit, associated synonyms, e.g. "iphone".
+    pub fn original_synonyms(&self) -> impl Iterator<Item = &str> + '_ {
+        self.synonyms.iter().map(AsRef::as_ref)
+    }
+
+    /// The normalized and split associated synonyms, e.g.
+    pub fn synonyms(&self, tokenizer: &Tokenizer) -> Vec<Vec<String>> {
+        self.original_synonyms()
+            .filter_map(|s| {
+                let normalized = normalize(tokenizer, s);
+                Some(normalized).filter(|n| !n.is_empty())
+            })
+            .collect()
     }
 }
 

--- a/crates/milli/src/index.rs
+++ b/crates/milli/src/index.rs
@@ -2014,14 +2014,15 @@ impl Index {
     }
 }
 
+/// The synonyms that are associated to the synonyms key
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Synonyms {
+pub struct AssociatedSynonyms {
     synonyms: Vec<String>,
 }
 
-impl Synonyms {
-    pub fn new(synonyms: Vec<String>) -> Synonyms {
-        Synonyms { synonyms }
+impl AssociatedSynonyms {
+    pub fn new(synonyms: Vec<String>) -> AssociatedSynonyms {
+        AssociatedSynonyms { synonyms }
     }
 
     /// The original, unnormalized, unsplit, associated synonyms, e.g. "iphone".

--- a/crates/milli/src/index.rs
+++ b/crates/milli/src/index.rs
@@ -1,12 +1,13 @@
 use std::borrow::Cow;
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::error::Error;
 use std::fmt;
 use std::fs::File;
 use std::path::Path;
 
 use cellulite::Cellulite;
-use heed::types::*;
+use charabia::Tokenizer;
+use heed::types::{SerdeJson, *};
 use heed::{CompactionOption, Database, DatabaseStat, RoTxn, RwTxn, Unspecified, WithoutTls};
 use indexmap::IndexMap;
 use roaring::RoaringBitmap;
@@ -24,13 +25,14 @@ use crate::heed_codec::facet::{
     FieldIdCodec, OrderedF64Codec,
 };
 use crate::heed_codec::version::VersionCodec;
-use crate::heed_codec::{BEU16StrCodec, FstSetCodec, StrBEU16Codec, StrRefCodec};
+use crate::heed_codec::{BEU16StrCodec, FstSetCodec, StrBEU16Codec, StrRefCodec, SynonymsKeyCodec};
 use crate::order_by_map::OrderByMap;
 use crate::progress::Progress;
 use crate::prompt::PromptData;
 use crate::proximity::ProximityPrecision;
 use crate::sharding::{DbShardDocids, Shards};
 use crate::update::new::StdResult;
+use crate::update::settings::normalize;
 use crate::vector::db::IndexEmbeddingConfigs;
 use crate::vector::{Embedding, VectorStore, VectorStoreBackend, VectorStoreStats};
 use crate::{

--- a/crates/milli/src/search/new/matches/matching_words.rs
+++ b/crates/milli/src/search/new/matches/matching_words.rs
@@ -264,7 +264,7 @@ pub(crate) mod tests {
         let tokenizer = builder.build();
         let tokens = tokenizer.tokenize("split this world");
         let ExtractedTokens { query_terms, .. } =
-            located_query_terms_from_tokens(&mut ctx, tokens, None).unwrap();
+            located_query_terms_from_tokens(&mut ctx, &tokenizer, tokens, None).unwrap();
         let matching_words = MatchingWords::new(ctx, query_terms);
 
         assert_eq!(

--- a/crates/milli/src/search/new/mod.rs
+++ b/crates/milli/src/search/new/mod.rs
@@ -124,17 +124,6 @@ impl<'ctx> SearchContext<'ctx> {
         self.prefix_search != PrefixSearch::Disabled
     }
 
-    /// Get synonyms with caching to avoid repeated database access
-    pub fn get_synonyms(&mut self) -> Result<&HashMap<Vec<String>, Vec<Vec<String>>>> {
-        match self.synonym_cache.cache {
-            Some(ref synonyms) => Ok(synonyms),
-            None => {
-                let synonyms = self.index.synonyms(self.txn)?;
-                Ok(self.synonym_cache.cache.insert(synonyms))
-            }
-        }
-    }
-
     pub fn attributes_to_search_on(
         &mut self,
         attributes_to_search_on: &'ctx [String],
@@ -775,7 +764,7 @@ pub fn execute_search(
 
     let mut used_negative_operator = false;
     let mut located_query_terms = None;
-    let query_terms = if let Some(query) = query {
+    let bucket_sort_output = if let Some(query) = query {
         let _step = progress.update_progress_scoped(SearchStep::TokenizeQuery);
         let span = tracing::trace_span!(target: "search::tokens", "tokenizer_builder");
         let entered = span.enter();
@@ -850,7 +839,7 @@ pub fn execute_search(
         drop(entered);
 
         let ExtractedTokens { query_terms, negative_words, negative_phrases } =
-            located_query_terms_from_tokens(ctx, tokens, words_limit)?;
+            located_query_terms_from_tokens(ctx, &tokenizer, tokens, words_limit)?;
         used_negative_operator = !negative_words.is_empty() || !negative_phrases.is_empty();
 
         let ignored_documents = resolve_negative_words(ctx, Some(&universe), &negative_words)?;
@@ -861,51 +850,64 @@ pub fn execute_search(
 
         if query_terms.is_empty() {
             // Do a placeholder search instead
-            None
+            let ranking_rules =
+                get_ranking_rules_for_placeholder_search(ctx, sort_criteria, geo_param)?;
+            let _step = progress.update_progress_scoped(SearchStep::PlaceholderRanking);
+            bucket_sort(
+                ctx,
+                ranking_rules,
+                &PlaceholderQuery,
+                distinct.as_deref(),
+                &universe,
+                from,
+                length,
+                scoring_strategy,
+                placeholder_search_logger,
+                deadline,
+                ranking_score_threshold,
+                exhaustive_number_hits,
+                max_total_hits,
+                pins,
+            )?
         } else {
-            Some(query_terms)
+            let (graph, new_located_query_terms) =
+                QueryGraph::from_query(ctx, &tokenizer, &query_terms)?;
+            located_query_terms = Some(new_located_query_terms);
+
+            let ranking_rules = get_ranking_rules_for_query_graph_search(
+                ctx,
+                sort_criteria,
+                geo_param,
+                terms_matching_strategy,
+            )?;
+
+            universe &= resolve_universe(
+                ctx,
+                &universe,
+                &graph,
+                terms_matching_strategy,
+                query_graph_logger,
+                progress,
+            )?;
+
+            let _step = progress.update_progress_scoped(SearchStep::KeywordRanking);
+            bucket_sort(
+                ctx,
+                ranking_rules,
+                &graph,
+                distinct.as_deref(),
+                &universe,
+                from,
+                length,
+                scoring_strategy,
+                query_graph_logger,
+                deadline,
+                ranking_score_threshold,
+                exhaustive_number_hits,
+                max_total_hits,
+                pins,
+            )?
         }
-    } else {
-        None
-    };
-
-    let bucket_sort_output = if let Some(query_terms) = query_terms {
-        let (graph, new_located_query_terms) = QueryGraph::from_query(ctx, &query_terms)?;
-        located_query_terms = Some(new_located_query_terms);
-
-        let ranking_rules = get_ranking_rules_for_query_graph_search(
-            ctx,
-            sort_criteria,
-            geo_param,
-            terms_matching_strategy,
-        )?;
-
-        universe &= resolve_universe(
-            ctx,
-            &universe,
-            &graph,
-            terms_matching_strategy,
-            query_graph_logger,
-            progress,
-        )?;
-
-        let _step = progress.update_progress_scoped(SearchStep::KeywordRanking);
-        bucket_sort(
-            ctx,
-            ranking_rules,
-            &graph,
-            distinct.as_deref(),
-            &universe,
-            from,
-            length,
-            scoring_strategy,
-            query_graph_logger,
-            deadline,
-            ranking_score_threshold,
-            exhaustive_number_hits,
-            max_total_hits,
-            pins,
-        )?
     } else {
         let ranking_rules =
             get_ranking_rules_for_placeholder_search(ctx, sort_criteria, geo_param)?;

--- a/crates/milli/src/search/new/query_graph.rs
+++ b/crates/milli/src/search/new/query_graph.rs
@@ -95,6 +95,7 @@ impl QueryGraph {
     /// which contains ngrams.
     pub fn from_query(
         ctx: &mut SearchContext<'_>,
+        tokenizer: &Tokenizer<'_>,
         // The terms here must be consecutive
         terms: &[LocatedQueryTerm],
     ) -> Result<(QueryGraph, Vec<LocatedQueryTerm>)> {
@@ -125,9 +126,12 @@ impl QueryGraph {
             new_nodes.push(new_node_idx);
 
             if !prev1.is_empty() {
-                if let Some(ngram) =
-                    query_term::make_ngram(ctx, &terms[term_idx - 1..=term_idx], &nbr_typos)?
-                {
+                if let Some(ngram) = query_term::make_ngram(
+                    ctx,
+                    tokenizer,
+                    &terms[term_idx - 1..=term_idx],
+                    &nbr_typos,
+                )? {
                     new_located_query_terms.push(ngram.clone());
                     let ngram_idx = add_node(
                         &mut nodes_data,
@@ -141,9 +145,12 @@ impl QueryGraph {
                 }
             }
             if !prev2.is_empty() {
-                if let Some(ngram) =
-                    query_term::make_ngram(ctx, &terms[term_idx - 2..=term_idx], &nbr_typos)?
-                {
+                if let Some(ngram) = query_term::make_ngram(
+                    ctx,
+                    tokenizer,
+                    &terms[term_idx - 2..=term_idx],
+                    &nbr_typos,
+                )? {
                     new_located_query_terms.push(ngram.clone());
                     let ngram_idx = add_node(
                         &mut nodes_data,

--- a/crates/milli/src/search/new/query_graph.rs
+++ b/crates/milli/src/search/new/query_graph.rs
@@ -2,6 +2,7 @@ use std::cmp::{Ordering, Reverse};
 use std::collections::BTreeMap;
 use std::hash::{Hash, Hasher};
 
+use charabia::Tokenizer;
 use fxhash::{FxHashMap, FxHasher};
 use roaring::RoaringBitmap;
 

--- a/crates/milli/src/search/new/query_term/compute_derivations.rs
+++ b/crates/milli/src/search/new/query_term/compute_derivations.rs
@@ -168,6 +168,7 @@ fn find_one_two_typo_derivations(
 
 pub fn partially_initialized_term_from_word(
     ctx: &mut SearchContext<'_>,
+    tokenizer: &Tokenizer<'_>,
     word: &str,
     max_typo: u8,
     is_prefix: bool,

--- a/crates/milli/src/search/new/query_term/compute_derivations.rs
+++ b/crates/milli/src/search/new/query_term/compute_derivations.rs
@@ -9,6 +9,7 @@ use heed::types::DecodeIgnore;
 use itertools::{merge_join_by, EitherOrBoth};
 
 use super::{OneTypoTerm, Phrase, QueryTerm, ZeroTypoTerm};
+use crate::heed_codec::SynonymsKeyCodec;
 use crate::search::fst_utils::{Complement, Intersection, StartsWith, Union};
 use crate::search::new::interner::{DedupInterner, Interned};
 use crate::search::new::query_term::{Lazy, TwoTypoTerm};
@@ -221,6 +222,7 @@ pub fn partially_initialized_term_from_word(
     let synonyms = ctx
         .index
         .synonyms
+        .remap_key_type::<SynonymsKeyCodec<&str>>()
         .get(ctx.txn, &[word])?
         .map_or(Vec::<Vec<_>>::new(), |synonyms| synonyms.synonyms(tokenizer))
         .into_iter()

--- a/crates/milli/src/search/new/query_term/compute_derivations.rs
+++ b/crates/milli/src/search/new/query_term/compute_derivations.rs
@@ -216,12 +216,13 @@ pub fn partially_initialized_term_from_word(
     if is_prefix && use_prefix_db.is_none() {
         find_zero_typo_prefix_derivations(ctx, word_interned, &mut prefix_of)?;
     }
-    let synonyms = ctx.get_synonyms()?;
+
     let mut synonym_word_count = 0;
-    let synonyms = synonyms
-        .get(&vec![word.to_owned()])
-        .cloned()
-        .unwrap_or_default()
+    let synonyms = ctx
+        .index
+        .synonyms
+        .get(ctx.txn, &[word])?
+        .map_or(Vec::<Vec<_>>::new(), |synonyms| synonyms.synonyms(tokenizer))
         .into_iter()
         .take(limits::MAX_SYNONYM_PHRASE_COUNT)
         .filter_map(|words| {
@@ -229,10 +230,12 @@ pub fn partially_initialized_term_from_word(
                 return None;
             }
             synonym_word_count += words.len();
-            let words = words.into_iter().map(|w| Some(ctx.word_interner.insert(w))).collect();
+            let words =
+                words.into_iter().map(|w| Some(ctx.word_interner.insert(w.to_owned()))).collect();
             Some(ctx.phrase_interner.insert(Phrase { words }))
         })
         .collect();
+
     let zero_typo =
         ZeroTypoTerm { phrase: None, exact: zero_typo, prefix_of, synonyms, use_prefix_db };
 

--- a/crates/milli/src/search/new/query_term/compute_derivations.rs
+++ b/crates/milli/src/search/new/query_term/compute_derivations.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::collections::BTreeSet;
 
+use charabia::Tokenizer;
 use fst::automaton::Str;
 use fst::{IntoStreamer, Streamer};
 use heed::types::DecodeIgnore;

--- a/crates/milli/src/search/new/query_term/parse_query.rs
+++ b/crates/milli/src/search/new/query_term/parse_query.rs
@@ -24,6 +24,7 @@ pub struct ExtractedTokens {
 #[tracing::instrument(level = "trace", skip_all, target = "search::query")]
 pub fn located_query_terms_from_tokens(
     ctx: &mut SearchContext<'_>,
+    tokenizer: &Tokenizer<'_>,
     query: NormalizedTokenIter<'_, '_, '_, '_>,
     words_limit: Option<usize>,
 ) -> Result<ExtractedTokens> {
@@ -76,6 +77,7 @@ pub fn located_query_terms_from_tokens(
                             let word = token.lemma();
                             let term = partially_initialized_term_from_word(
                                 ctx,
+                                tokenizer,
                                 word,
                                 nbr_typos(word),
                                 false,
@@ -93,6 +95,7 @@ pub fn located_query_terms_from_tokens(
                     let word = token.lemma();
                     let term = partially_initialized_term_from_word(
                         ctx,
+                        tokenizer,
                         word,
                         nbr_typos(word),
                         allow_prefix_search,
@@ -216,6 +219,7 @@ pub fn number_of_typos_allowed<'ctx>(
 
 pub fn make_ngram(
     ctx: &mut SearchContext<'_>,
+    tokenizer: &Tokenizer<'_>,
     terms: &[LocatedQueryTerm],
     number_of_typos_allowed: &impl Fn(&str) -> u8,
 ) -> Result<Option<LocatedQueryTerm>> {
@@ -254,18 +258,25 @@ pub fn make_ngram(
     let max_nbr_typos =
         number_of_typos_allowed(ngram_str.as_str()).saturating_sub(terms.len() as u8 - 1);
 
-    let mut term =
-        partially_initialized_term_from_word(ctx, &ngram_str, max_nbr_typos, is_prefix, true)?;
+    let mut term = partially_initialized_term_from_word(
+        ctx,
+        tokenizer,
+        &ngram_str,
+        max_nbr_typos,
+        is_prefix,
+        true,
+    )?;
 
     // Now add the synonyms
-    let index_synonyms = ctx.get_synonyms()?;
-
-    term.zero_typo.synonyms.extend(
-        index_synonyms.get(&words).cloned().unwrap_or_default().into_iter().map(|words| {
-            let words = words.into_iter().map(|w| Some(ctx.word_interner.insert(w))).collect();
-            ctx.phrase_interner.insert(Phrase { words })
-        }),
-    );
+    let words: Vec<_> = words.iter().map(AsRef::as_ref).collect();
+    if let Some(synonyms) = ctx.index.synonyms.get(ctx.txn, &words)? {
+        for synonym in synonyms.synonyms(tokenizer) {
+            let words =
+                synonym.into_iter().map(|w| Some(ctx.word_interner.insert(w.to_owned()))).collect();
+            let interned = ctx.phrase_interner.insert(Phrase { words });
+            term.zero_typo.synonyms.insert(interned);
+        }
+    }
 
     let term = QueryTerm {
         original: ngram_str_interned,
@@ -375,7 +386,7 @@ mod tests {
         let mut ctx = SearchContext::new(&index, &rtxn)?;
         // panics with `attempt to add with overflow` before <https://github.com/meilisearch/meilisearch/issues/3785>
         let ExtractedTokens { query_terms, .. } =
-            located_query_terms_from_tokens(&mut ctx, tokens, None)?;
+            located_query_terms_from_tokens(&mut ctx, &tokenizer, tokens, None)?;
         assert!(query_terms.is_empty());
 
         Ok(())

--- a/crates/milli/src/search/new/query_term/parse_query.rs
+++ b/crates/milli/src/search/new/query_term/parse_query.rs
@@ -268,7 +268,6 @@ pub fn make_ngram(
     )?;
 
     // Now add the synonyms
-    let words: Vec<_> = words.iter().map(AsRef::as_ref).collect();
     if let Some(synonyms) = ctx.index.synonyms.get(ctx.txn, &words)? {
         for synonym in synonyms.synonyms(tokenizer) {
             let words =

--- a/crates/milli/src/search/new/query_term/parse_query.rs
+++ b/crates/milli/src/search/new/query_term/parse_query.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 
 use charabia::normalizer::NormalizedTokenIter;
-use charabia::{SeparatorKind, TokenKind};
+use charabia::{SeparatorKind, TokenKind, Tokenizer};
 
 use super::compute_derivations::partially_initialized_term_from_word;
 use super::{LocatedQueryTerm, ZeroTypoTerm};

--- a/crates/milli/src/snapshot_tests.rs
+++ b/crates/milli/src/snapshot_tests.rs
@@ -376,6 +376,28 @@ pub fn snap_settings(index: &Index) -> String {
     let mut snap = String::new();
     let rtxn = index.read_txn().unwrap();
 
+    let mut builder = TokenizerBuilder::new();
+    let stop_words = index.stop_words(&rtxn).unwrap();
+    if let Some(ref stop_words) = stop_words {
+        builder.stop_words(stop_words);
+    }
+
+    let separators = index.allowed_separators(&rtxn).unwrap();
+    let separators: Option<Vec<_>> =
+        separators.as_ref().map(|x| x.iter().map(String::as_str).collect());
+    if let Some(ref separators) = separators {
+        builder.separators(separators);
+    }
+
+    let dictionary = index.dictionary(&rtxn).unwrap();
+    let dictionary: Option<Vec<_>> =
+        dictionary.as_ref().map(|x| x.iter().map(String::as_str).collect());
+    if let Some(ref dictionary) = dictionary {
+        builder.words_dict(dictionary);
+    }
+
+    let tokenizer = builder.build();
+
     macro_rules! write_setting_to_snap {
         ($name:ident) => {
             let $name = index.$name(&rtxn).unwrap();
@@ -389,7 +411,13 @@ pub fn snap_settings(index: &Index) -> String {
     write_setting_to_snap!(distinct_field);
     write_setting_to_snap!(filterable_attributes_rules);
     write_setting_to_snap!(sortable_fields);
-    write_setting_to_snap!(synonyms);
+
+    // Synonyms are stored in a dedicated database
+    for result in index.synonyms.iter(&rtxn).unwrap() {
+        let (key, synonyms) = result.unwrap();
+        writeln!(&mut snap, "synonyms: {:?}", (key, synonyms.synonyms(&tokenizer))).unwrap();
+    }
+
     write_setting_to_snap!(authorize_typos);
     write_setting_to_snap!(min_word_len_one_typo);
     write_setting_to_snap!(min_word_len_two_typos);

--- a/crates/milli/src/snapshot_tests.rs
+++ b/crates/milli/src/snapshot_tests.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 use std::fmt::Write;
 use std::path::Path;
 
+use charabia::TokenizerBuilder;
 use roaring::RoaringBitmap;
 
 use crate::heed_codec::facet::{FacetGroupKey, FacetGroupValue};

--- a/crates/milli/src/update/clear_documents.rs
+++ b/crates/milli/src/update/clear_documents.rs
@@ -29,6 +29,7 @@ impl<'t, 'i> ClearDocuments<'t, 'i> {
             external_documents_ids,
             word_docids,
             exact_word_docids,
+            synonyms: _,
             word_prefix_docids,
             exact_word_prefix_docids,
             word_pair_proximity_docids,

--- a/crates/milli/src/update/settings.rs
+++ b/crates/milli/src/update/settings.rs
@@ -700,19 +700,6 @@ impl<'a, 't, 'i> Settings<'a, 't, 'i> {
     fn update_synonyms(&mut self) -> Result<bool> {
         match self.synonyms {
             Setting::Set(ref user_synonyms) => {
-                fn normalize(tokenizer: &Tokenizer<'_>, text: &str) -> Vec<String> {
-                    tokenizer
-                        .tokenize(text)
-                        .filter_map(|token| {
-                            if token.is_word() && !token.lemma().is_empty() {
-                                Some(token.lemma().to_string())
-                            } else {
-                                None
-                            }
-                        })
-                        .collect::<Vec<_>>()
-                }
-
                 let mut builder = TokenizerBuilder::new();
                 let stop_words = self.index.stop_words(self.wtxn)?;
                 if let Some(ref stop_words) = stop_words {
@@ -1627,6 +1614,20 @@ impl<'a, 't, 'i> Settings<'a, 't, 'i> {
             Ok(None)
         }
     }
+}
+
+/// Normalize and tokenize a text
+pub fn normalize(tokenizer: &Tokenizer<'_>, text: &str) -> Vec<String> {
+    tokenizer
+        .tokenize(text)
+        .filter_map(|token| {
+            if token.is_word() && !token.lemma().is_empty() {
+                Some(token.lemma().to_string())
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>()
 }
 
 pub struct InnerIndexSettingsDiff {

--- a/crates/milli/src/update/settings.rs
+++ b/crates/milli/src/update/settings.rs
@@ -697,7 +697,7 @@ impl<'a, 't, 'i> Settings<'a, 't, 'i> {
         Ok(changes)
     }
 
-    fn update_synonyms(&mut self) -> Result<bool> {
+    fn update_synonyms(&mut self) -> Result<()> {
         match self.synonyms {
             Setting::Set(ref user_synonyms) => {
                 let mut builder = TokenizerBuilder::new();
@@ -723,40 +723,55 @@ impl<'a, 't, 'i> Settings<'a, 't, 'i> {
                 let tokenizer = builder.build();
 
                 let mut new_synonyms = HashMap::new();
-                for (word, synonyms) in user_synonyms {
-                    // Normalize both the word and associated synonyms.
-                    let normalized_word = normalize(&tokenizer, word);
-                    let normalized_synonyms: Vec<_> = synonyms
-                        .iter()
-                        .map(|synonym| normalize(&tokenizer, synonym))
-                        .filter(|synonym| !synonym.is_empty())
-                        .collect();
+                for (original_word, synonyms) in user_synonyms {
+                    // Normalize only the key
+                    let normalized_word = normalize(&tokenizer, original_word);
 
                     // Store the normalized synonyms under the normalized word,
                     // merging the possible duplicate words.
-                    if !normalized_word.is_empty() && !normalized_synonyms.is_empty() {
-                        let entry = new_synonyms.entry(normalized_word).or_insert_with(Vec::new);
-                        entry.extend(normalized_synonyms.into_iter());
+                    if !normalized_word.is_empty() {
+                        new_synonyms
+                            .entry(normalized_word)
+                            .or_insert_with(Vec::new)
+                            .extend(synonyms.iter().cloned());
                     }
                 }
 
-                // Make sure that we don't have duplicate synonyms.
-                new_synonyms.iter_mut().for_each(|(_, synonyms)| {
-                    synonyms.sort_unstable();
-                    synonyms.dedup();
-                });
+                let new_synonyms: Vec<_> = new_synonyms
+                    .into_iter()
+                    .filter_map(|(key, mut synonyms)| {
+                        synonyms.sort_unstable();
+                        synonyms.dedup();
+                        if synonyms.is_empty() {
+                            return None;
+                        }
 
-                let old_synonyms = self.index.synonyms(self.wtxn)?;
+                        let synonyms = Synonyms::new(synonyms);
+                        let has_synonyms = !synonyms.synonyms(&tokenizer).is_empty();
+                        if has_synonyms {
+                            Some((key, synonyms))
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
 
-                if new_synonyms != old_synonyms {
-                    self.index.put_synonyms(self.wtxn, &new_synonyms, user_synonyms)?;
-                    Ok(true)
-                } else {
-                    Ok(false)
+                self.index.synonyms.clear(self.wtxn)?;
+                for (key, synonyms) in new_synonyms {
+                    let key: Vec<&str> = key.iter().map(|k| k.as_ref()).collect();
+                    self.index.synonyms.put(self.wtxn, &key, &synonyms)?;
                 }
+
+                self.index.put_user_defined_synonyms(self.wtxn, user_synonyms)?;
+
+                Ok(())
             }
-            Setting::Reset => Ok(self.index.delete_synonyms(self.wtxn)?),
-            Setting::NotSet => Ok(false),
+            Setting::Reset => {
+                self.index.synonyms.clear(self.wtxn)?;
+                self.index.delete_user_defined_synonyms(self.wtxn)?;
+                Ok(())
+            }
+            Setting::NotSet => Ok(()),
         }
     }
 

--- a/crates/milli/src/update/settings.rs
+++ b/crates/milli/src/update/settings.rs
@@ -25,7 +25,7 @@ use crate::error::UserError::{self, InvalidChatSettingsDocumentTemplateMaxBytes}
 use crate::fields_ids_map::metadata::{FieldIdMapWithMetadata, MetadataBuilder};
 use crate::filterable_attributes_rules::match_faceted_field;
 use crate::index::{
-    ChatConfig, PrefixSearch, SearchParameters, DEFAULT_MIN_WORD_LEN_ONE_TYPO,
+    ChatConfig, PrefixSearch, SearchParameters, Synonyms, DEFAULT_MIN_WORD_LEN_ONE_TYPO,
     DEFAULT_MIN_WORD_LEN_TWO_TYPOS,
 };
 use crate::order_by_map::OrderByMap;

--- a/crates/milli/src/update/settings.rs
+++ b/crates/milli/src/update/settings.rs
@@ -758,7 +758,6 @@ impl<'a, 't, 'i> Settings<'a, 't, 'i> {
 
                 self.index.synonyms.clear(self.wtxn)?;
                 for (key, synonyms) in new_synonyms {
-                    let key: Vec<&str> = key.iter().map(|k| k.as_ref()).collect();
                     self.index.synonyms.put(self.wtxn, &key, &synonyms)?;
                 }
 

--- a/crates/milli/src/update/settings.rs
+++ b/crates/milli/src/update/settings.rs
@@ -25,7 +25,7 @@ use crate::error::UserError::{self, InvalidChatSettingsDocumentTemplateMaxBytes}
 use crate::fields_ids_map::metadata::{FieldIdMapWithMetadata, MetadataBuilder};
 use crate::filterable_attributes_rules::match_faceted_field;
 use crate::index::{
-    ChatConfig, PrefixSearch, SearchParameters, Synonyms, DEFAULT_MIN_WORD_LEN_ONE_TYPO,
+    AssociatedSynonyms, ChatConfig, PrefixSearch, SearchParameters, DEFAULT_MIN_WORD_LEN_ONE_TYPO,
     DEFAULT_MIN_WORD_LEN_TWO_TYPOS,
 };
 use crate::order_by_map::OrderByMap;
@@ -746,7 +746,7 @@ impl<'a, 't, 'i> Settings<'a, 't, 'i> {
                             return None;
                         }
 
-                        let synonyms = Synonyms::new(synonyms);
+                        let synonyms = AssociatedSynonyms::new(synonyms);
                         let has_synonyms = !synonyms.synonyms(&tokenizer).is_empty();
                         if has_synonyms {
                             Some((key, synonyms))

--- a/crates/milli/src/update/test_settings.rs
+++ b/crates/milli/src/update/test_settings.rs
@@ -556,8 +556,8 @@ fn set_and_reset_synonyms() {
 
     // Ensure synonyms are effectively stored
     let rtxn = index.read_txn().unwrap();
-    let synonyms = index.synonyms(&rtxn).unwrap();
-    assert!(!synonyms.is_empty()); // at this point the index should return something
+    let synonyms = index.synonyms.iter(&rtxn).unwrap();
+    assert_eq!(synonyms.count(), 3); // at this point the index should return something
 
     // Check that we can use synonyms
     let result = index.search(&rtxn).query("blini").execute().unwrap();
@@ -576,8 +576,8 @@ fn set_and_reset_synonyms() {
 
     // Ensure synonyms are reset
     let rtxn = index.read_txn().unwrap();
-    let synonyms = index.synonyms(&rtxn).unwrap();
-    assert!(synonyms.is_empty());
+    let mut synonyms = index.synonyms.iter(&rtxn).unwrap();
+    assert!(synonyms.next().is_none());
 
     // Check that synonyms are no longer work
     let result = index.search(&rtxn).query("blini").execute().unwrap();
@@ -618,8 +618,8 @@ fn thai_synonyms() {
 
     // Ensure synonyms are effectively stored
     let rtxn = index.read_txn().unwrap();
-    let synonyms = index.synonyms(&rtxn).unwrap();
-    assert!(!synonyms.is_empty()); // at this point the index should return something
+    let synonyms = index.synonyms.iter(&rtxn).unwrap();
+    assert_eq!(synonyms.count(), 1); // at this point the index should return something
 
     // Check that we can use synonyms
     let result = index.search(&rtxn).query("japanese").execute().unwrap();

--- a/crates/milli/src/update/upgrade/mod.rs
+++ b/crates/milli/src/update/upgrade/mod.rs
@@ -6,7 +6,7 @@ mod v1_16;
 mod v1_32;
 mod v1_37;
 mod v1_45;
-mod v1_50;
+mod v1_49;
 
 use heed::RwTxn;
 use v1_12::{FixFieldDistribution, RecomputeStats};
@@ -17,7 +17,7 @@ use v1_16::SwitchToMultimodal;
 use v1_32::{CleanupFidBasedDatabases, RebuildHannoyGraph};
 use v1_37::{AddShards, ConvertArroyToHannoy};
 use v1_45::FixVectorStoreConfig;
-use v1_50::MigrateSynonymsToDedicatedDatabase;
+use v1_49::MigrateSynonymsToDedicatedDatabase;
 
 use crate::constants::{VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH};
 use crate::progress::{Progress, VariableNameStep};

--- a/crates/milli/src/update/upgrade/mod.rs
+++ b/crates/milli/src/update/upgrade/mod.rs
@@ -54,6 +54,7 @@ const UPGRADE_FUNCTIONS: &[&dyn UpgradeIndex] = &[
     &ConvertArroyToHannoy {},
     &AddShards {},
     &FixVectorStoreConfig {},
+    &MigrateSynonymsToDedicatedDatabase {},
 ];
 
 /// Return true if the cached stats of the index must be regenerated

--- a/crates/milli/src/update/upgrade/mod.rs
+++ b/crates/milli/src/update/upgrade/mod.rs
@@ -6,6 +6,7 @@ mod v1_16;
 mod v1_32;
 mod v1_37;
 mod v1_45;
+mod v1_50;
 
 use heed::RwTxn;
 use v1_12::{FixFieldDistribution, RecomputeStats};
@@ -16,6 +17,7 @@ use v1_16::SwitchToMultimodal;
 use v1_32::{CleanupFidBasedDatabases, RebuildHannoyGraph};
 use v1_37::{AddShards, ConvertArroyToHannoy};
 use v1_45::FixVectorStoreConfig;
+use v1_50::MigrateSynonymsToDedicatedDatabase;
 
 use crate::constants::{VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH};
 use crate::progress::{Progress, VariableNameStep};

--- a/crates/milli/src/update/upgrade/v1_49.rs
+++ b/crates/milli/src/update/upgrade/v1_49.rs
@@ -1,9 +1,11 @@
+use std::collections::BTreeMap;
+
 use charabia::TokenizerBuilder;
 use heed::types::Str;
 use heed::RwTxn;
 
 use super::{UpgradeIndex, UpgradeParams};
-use crate::{index::Synonyms, update::settings::normalize, Index, Result};
+use crate::{index::AssociatedSynonyms, update::settings::normalize, Index, Result};
 
 pub const SYNONYMS_KEY: &str = "synonyms";
 
@@ -12,8 +14,7 @@ pub(super) struct MigrateSynonymsToDedicatedDatabase();
 
 impl UpgradeIndex for MigrateSynonymsToDedicatedDatabase {
     fn upgrade(&self, wtxn: &mut RwTxn, index: &Index, _params: UpgradeParams<'_>) -> Result<bool> {
-        let rtxn = index.read_txn()?;
-        let user_defined_synonyms = index.user_defined_synonyms(&rtxn)?;
+        let user_defined_synonyms = index.user_defined_synonyms(wtxn)?;
 
         index.main.remap_key_type::<Str>().delete(wtxn, SYNONYMS_KEY)?;
 
@@ -22,19 +23,19 @@ impl UpgradeIndex for MigrateSynonymsToDedicatedDatabase {
         }
 
         let mut builder = TokenizerBuilder::new();
-        let stop_words = index.stop_words(&rtxn)?;
+        let stop_words = index.stop_words(wtxn)?;
         if let Some(ref stop_words) = stop_words {
             builder.stop_words(stop_words);
         }
 
-        let separators = index.allowed_separators(&rtxn)?;
+        let separators = index.allowed_separators(wtxn)?;
         let separators: Option<Vec<_>> =
             separators.as_ref().map(|x| x.iter().map(String::as_str).collect());
         if let Some(ref separators) = separators {
             builder.separators(separators);
         }
 
-        let dictionary = index.dictionary(&rtxn)?;
+        let dictionary = index.dictionary(wtxn)?;
         let dictionary: Option<Vec<_>> =
             dictionary.as_ref().map(|x| x.iter().map(String::as_str).collect());
         if let Some(ref dictionary) = dictionary {
@@ -43,14 +44,18 @@ impl UpgradeIndex for MigrateSynonymsToDedicatedDatabase {
 
         let tokenizer = builder.build();
 
+        let mut entries = BTreeMap::new();
         for (original_key, synonyms) in user_defined_synonyms {
             let normalized = normalize(&tokenizer, &original_key);
-            let key: Vec<_> = normalized.iter().map(AsRef::as_ref).collect();
-            let synonyms = Synonyms::new(synonyms);
+            let synonyms = AssociatedSynonyms::new(synonyms);
             if synonyms.synonyms(&tokenizer).is_empty() {
                 continue;
             }
 
+            entries.insert(normalized, synonyms);
+        }
+
+        for (key, synonyms) in entries {
             index.synonyms.put(wtxn, &key, &synonyms)?;
         }
 
@@ -58,7 +63,7 @@ impl UpgradeIndex for MigrateSynonymsToDedicatedDatabase {
     }
 
     fn must_upgrade(&self, initial_version: (u32, u32, u32)) -> bool {
-        initial_version < (1, 50, 0)
+        initial_version < (1, 49, 0)
     }
 
     fn description(&self) -> &'static str {

--- a/crates/milli/src/update/upgrade/v1_50.rs
+++ b/crates/milli/src/update/upgrade/v1_50.rs
@@ -4,3 +4,64 @@ use heed::RwTxn;
 
 use super::{UpgradeIndex, UpgradeParams};
 use crate::{index::Synonyms, update::settings::normalize, Index, Result};
+
+pub const SYNONYMS_KEY: &str = "synonyms";
+
+/// Migrate the synonyms from the old format to the new database.
+pub(super) struct MigrateSynonymsToDedicatedDatabase();
+
+impl UpgradeIndex for MigrateSynonymsToDedicatedDatabase {
+    fn upgrade(&self, wtxn: &mut RwTxn, index: &Index, _params: UpgradeParams<'_>) -> Result<bool> {
+        let rtxn = index.read_txn()?;
+        let user_defined_synonyms = index.user_defined_synonyms(&rtxn)?;
+
+        index.main.remap_key_type::<Str>().delete(wtxn, SYNONYMS_KEY)?;
+
+        if user_defined_synonyms.is_empty() {
+            return Ok(false);
+        }
+
+        let mut builder = TokenizerBuilder::new();
+        let stop_words = index.stop_words(&rtxn)?;
+        if let Some(ref stop_words) = stop_words {
+            builder.stop_words(stop_words);
+        }
+
+        let separators = index.allowed_separators(&rtxn)?;
+        let separators: Option<Vec<_>> =
+            separators.as_ref().map(|x| x.iter().map(String::as_str).collect());
+        if let Some(ref separators) = separators {
+            builder.separators(separators);
+        }
+
+        let dictionary = index.dictionary(&rtxn)?;
+        let dictionary: Option<Vec<_>> =
+            dictionary.as_ref().map(|x| x.iter().map(String::as_str).collect());
+        if let Some(ref dictionary) = dictionary {
+            builder.words_dict(dictionary);
+        }
+
+        let tokenizer = builder.build();
+
+        for (original_key, synonyms) in user_defined_synonyms {
+            let normalized = normalize(&tokenizer, &original_key);
+            let key: Vec<_> = normalized.iter().map(AsRef::as_ref).collect();
+            let synonyms = Synonyms::new(synonyms);
+            if synonyms.synonyms(&tokenizer).is_empty() {
+                continue;
+            }
+
+            index.synonyms.put(wtxn, &key, &synonyms)?;
+        }
+
+        Ok(false)
+    }
+
+    fn must_upgrade(&self, initial_version: (u32, u32, u32)) -> bool {
+        initial_version < (1, 50, 0)
+    }
+
+    fn description(&self) -> &'static str {
+        "Migrate synonyms to dedicated database"
+    }
+}

--- a/crates/milli/src/update/upgrade/v1_50.rs
+++ b/crates/milli/src/update/upgrade/v1_50.rs
@@ -1,0 +1,6 @@
+use charabia::TokenizerBuilder;
+use heed::types::Str;
+use heed::RwTxn;
+
+use super::{UpgradeIndex, UpgradeParams};
+use crate::{index::Synonyms, update::settings::normalize, Index, Result};

--- a/workloads/tests/movies.json
+++ b/workloads/tests/movies.json
@@ -31,6 +31,11 @@
           "sortableAttributes": [
             "release_date"
           ],
+          "synonyms": {
+            "chaussure": [
+              "sport shoes"
+            ]
+          },
           "typoTolerance": {
             "disableOnAttributes": [
               "genres"
@@ -67,6 +72,7 @@
     {
       "binary": {
         "source": "build",
+        "edition": "community",
         "extraCliArgs": [
           "--experimental-dumpless-upgrade",
           "--experimental-max-number-of-batched-tasks=0"
@@ -150,6 +156,72 @@
         "processingTimeMs": "[duration]",
         "query": "bitcoin",
         "requestUid": "[uuid]"
+      },
+      "synchronous": "DontWait"
+    },
+    {
+      "description": "It is expected not to retrieve any synonyms while the dumpless upgrade is not finished",
+      "route": "indexes/movies/settings",
+      "method": "GET",
+      "body": null,
+      "expectedStatus": 200,
+      "expectedResponse": {
+        "dictionary": [],
+        "displayedAttributes": [
+          "*"
+        ],
+        "distinctAttribute": null,
+        "embedders": {},
+        "facetSearch": true,
+        "faceting": {
+          "maxValuesPerFacet": 100,
+          "sortFacetValuesBy": {
+            "*": "alpha"
+          }
+        },
+        "filterableAttributes": "[filterableAttributes]",
+        "localizedAttributes": null,
+        "nonSeparatorTokens": [],
+        "pagination": {
+          "maxTotalHits": 1000
+        },
+        "prefixSearch": "indexingTime",
+        "proximityPrecision": "byWord",
+        "rankingRules": [
+          "words",
+          "typo",
+          "proximity",
+          "attributeRank",
+          "sort",
+          "wordPosition",
+          "exactness"
+        ],
+        "searchCutoffMs": null,
+        "searchableAttributes": [
+          "title",
+          "overview",
+          "genres"
+        ],
+        "separatorTokens": [],
+        "sortableAttributes": [
+          "release_date"
+        ],
+        "stopWords": [],
+        "synonyms": {
+          "chaussure": ["sport shoes"]
+        },
+        "typoTolerance": {
+          "disableOnAttributes": [
+            "genres"
+          ],
+          "disableOnNumbers": false,
+          "disableOnWords": [],
+          "enabled": true,
+          "minWordSizeForTypos": {
+            "oneTypo": 5,
+            "twoTypos": 9
+          }
+        }
       },
       "synchronous": "DontWait"
     },
@@ -270,6 +342,72 @@
         "processingTimeMs": "[duration]",
         "query": "bitcoin",
         "requestUid": "[uuid]"
+      },
+      "synchronous": "DontWait"
+    },
+    {
+      "description": "Now that the dumpless upgrade is done, synonyms are visible",
+      "route": "indexes/movies/settings",
+      "method": "GET",
+      "body": null,
+      "expectedStatus": 200,
+      "expectedResponse": {
+        "dictionary": [],
+        "displayedAttributes": [
+          "*"
+        ],
+        "distinctAttribute": null,
+        "embedders": {},
+        "facetSearch": true,
+        "faceting": {
+          "maxValuesPerFacet": 100,
+          "sortFacetValuesBy": {
+            "*": "alpha"
+          }
+        },
+        "filterableAttributes": "[filterableAttributes]",
+        "localizedAttributes": null,
+        "nonSeparatorTokens": [],
+        "pagination": {
+          "maxTotalHits": 1000
+        },
+        "prefixSearch": "indexingTime",
+        "proximityPrecision": "byWord",
+        "rankingRules": [
+          "words",
+          "typo",
+          "proximity",
+          "attributeRank",
+          "sort",
+          "wordPosition",
+          "exactness"
+        ],
+        "searchCutoffMs": null,
+        "searchableAttributes": [
+          "title",
+          "overview",
+          "genres"
+        ],
+        "separatorTokens": [],
+        "sortableAttributes": [
+          "release_date"
+        ],
+        "stopWords": [],
+        "synonyms": {
+          "chaussure": ["sport shoes"]
+        },
+        "typoTolerance": {
+          "disableOnAttributes": [
+            "genres"
+          ],
+          "disableOnNumbers": false,
+          "disableOnWords": [],
+          "enabled": true,
+          "minWordSizeForTypos": {
+            "oneTypo": 5,
+            "twoTypos": 9
+          }
+        }
       },
       "synchronous": "DontWait"
     },


### PR DESCRIPTION
This PR improves how we store synonyms, so users can store many more without impacting performance, and will no longer be advised to store keywords in documents instead of using synonyms.

### Changelog

We improve synonyms' performance by changing how we store and retrieve them during query processing. Users may have experienced performance issues when the number of synonyms in an index was high, significantly impacting search performance. The Meilisearch support team advised moving the settings and synonyms-as-keywords to the dedicated documents. This is no longer an issue; synonyms are loaded lazily, only when a word matches a synonym. You can see performance improvements of up to 13x, depending on the number of synonyms.

## To Do
 - [x] Introduce a dumpless upgrade to migrate synonyms to the new dedicated database.
	 - [x] Make sure the version is the right one
 - [x] Use the tokenizer to normalize and split associated synonyms.
 - [x] Reduce the number of allocations.
 - [x] Remove the original key from the new synonyms DB
 - [x] Improve the workload test to show the issue with the dumpless upgrade
 - [x] Benchmark and show actual numbers

## Small benchmarks

Testing with Meilisearch v1.48.3 with 15k synonyms.

```json
"performanceDetails": {
    "wait in queue": "51.00µs",
    "search > partition queries": "61.88µs",
    "search > start remote search": "59.92µs",
    "search > execute local search > tokenize query": "6.18ms",
    "search > execute local search > evaluate query": "166.25µs",
    "search > execute local search > keyword ranking": "192.54µs",
    "search > execute local search > format": "31.04µs",
    "search > execute local search": "13.20ms",
    "search > wait for remote results": "20.17µs",
    "search > merge results": "44.21µs",
    "search > hydrate documents": "46.42µs",
    "search > merge facets": "10.63µs",
    "search": "13.51ms"
}
```

Testing with this PR and still 15k synonyms. Basically 13x faster.

```json
"performanceDetails": {
    "wait in queue": "80.46µs",
    "search > partition queries": "46.00µs",
    "search > start remote search": "67.83µs",
    "search > execute local search > tokenize query": "123.04µs",
    "search > execute local search > evaluate query": "221.50µs",
    "search > execute local search > keyword ranking": "191.00µs",
    "search > execute local search > format": "18.92µs",
    "search > execute local search": "1.01ms",
    "search > wait for remote results": "27.21µs",
    "search > merge results": "40.75µs",
    "search > hydrate documents": "24.38µs",
    "search > merge facets": "12.83µs",
    "search": "1.27ms"
}
```

## This PR makes breaking changes

*Breaking changes are changes to the database such that databases created in an older version of Meilisearch need changes to remain valid in the new version of Meilisearch. This typically happens when the way data is stored changes (change of database, new required key, etc.). This can also happen due to breaking changes in the API of an experimental feature. ⚠️ These kinds of changes are more difficult to achieve safely, so proceed with caution and test the dumpless upgrade right before merging the PR.*

- [x] Detail the changes to the DB format,
    - [x] which are not compatible, why, and how they will be fixed up in the upgrade
			We changed how we store synonyms. Instead of storing them in a large JSON object that must be fully deserialized in RAM when querying the engine, we store the synonyms in a dedicated database, with each entry containing the key and its associated value. This allows us to query only the interesting synonyms on demand and avoid unnecessary deserializations.
 - [ ] ❌ Ensure all the read operations still work!
     We decided it would be easier to avoid reading the previous version of the synonyms (stored in a single large object) and wait for the dumpless upgrade to finish migrating them to the new dedicated database. The impact is that synonyms will not be applied when the migration is not done. Migrations are pretty quick, the impact is therefore minimal, and the amount of code to maintain is way smaller.
  - [x] Write the code to go from the old database to the new one
    - [x] If the change happened in milli, the upgrade function should be written and called [here](https://github.com/meilisearch/meilisearch/blob/3fd86e8d76d7d468b0095d679adb09211ca3b6c0/crates/milli/src/update/upgrade/mod.rs#L24-L47)
  - [x] Declarative test: add a [declarative test containing a dumpless upgrade](https://github.com/meilisearch/meilisearch/blob/main/TESTING.md#typical-usage)
	 I decided to change the movies.json workload to introduce synonyms and demonstrate that synonyms are not visible for a short time while the dumpless upgrade is in progress and available just after it's complete.

## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respects the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
