### PR TITLE
Add missing information from pre-openAPI-migration

### DIFF
--- a/crates/meilisearch-types/src/keys.rs
+++ b/crates/meilisearch-types/src/keys.rs
@@ -54,6 +54,7 @@ pub struct CreateApiKey {
     /// `*` character can be used as a wildcard when located at the last
     /// position. e.g. `documents.*` to authorize access on all documents
     /// endpoints.
+    ///
     /// Valid actions include: `search`, `documents.add`,
     /// `documents.get`, `documents.delete`, `indexes.create`, `indexes.get`,
     /// `indexes.update`, `indexes.delete`, `indexes.swap`, `tasks.get`,

--- a/crates/meilisearch-types/src/keys.rs
+++ b/crates/meilisearch-types/src/keys.rs
@@ -54,6 +54,12 @@ pub struct CreateApiKey {
     /// `*` character can be used as a wildcard when located at the last
     /// position. e.g. `documents.*` to authorize access on all documents
     /// endpoints.
+    /// Valid actions include: `search`, `documents.add`,
+    /// `documents.get`, `documents.delete`, `indexes.create`, `indexes.get`,
+    /// `indexes.update`, `indexes.delete`, `indexes.swap`, `tasks.get`,
+    /// `tasks.cancel`, `tasks.delete`, `settings.get`, `settings.update`,
+    /// `stats.get`, `dumps.create`, `snapshots.create`, `version`, `keys.get`,
+    /// `keys.create`, `keys.update`, `keys.delete`. Use `*` to grant all actions.
     #[request(
         required,
         example = json!(["documents.add"]),
@@ -74,7 +80,8 @@ pub struct CreateApiKey {
     )]
     pub indexes: Vec<IndexUidPattern>,
     /// Represent the expiration date and time as RFC 3339 format. `null`
-    /// equals to no expiration time.
+    /// equals to no expiration time. Set to `null` to create a key that never
+    /// expires. Once a key is past its expiry date, using it returns an error.
     #[request(required,
         error = DeserrJsonError<InvalidApiKeyExpiresAt>,
         try_from(Option<String>) = parse_expiration_date -> ParseOffsetDateTimeError,

--- a/crates/meilisearch/src/routes/api_key.rs
+++ b/crates/meilisearch/src/routes/api_key.rs
@@ -39,6 +39,13 @@ pub struct ApiKeyApi;
 /// Create API key
 ///
 /// Create a new API key with the specified name, description, actions, and index scopes. The key value is returned only once at creation time; store it securely.
+///
+/// **Required fields:** `actions`, `indexes`, `expiresAt`.
+/// **Optional fields:** `name`, `description`, `uid`.
+///
+/// Set `expiresAt` to `null` to create a key that never expires.
+/// Use `"*"` in the `actions` array to grant all permissions (not recommended for production).
+/// Use `["*"]` in the `indexes` array to grant access to all indexes.
 #[routes::path(
     security(("Bearer" = ["keys.create", "keys.*", "*"])),
     request_body = CreateApiKey,
@@ -117,6 +124,9 @@ impl ListApiKeys {
 /// List API keys
 ///
 /// Return all API keys configured on the instance. Results are paginated and can be filtered by offset and limit. The key value itself is never returned after creation.
+///
+/// **Note:** Expired keys are included in the response but deleted keys are not.
+/// Keys are returned in descending order of creation date.
 #[routes::path(
     security(("Bearer" = ["keys.get", "keys.*", "*"])),
     params(ListApiKeys),
@@ -255,6 +265,9 @@ pub async fn get_api_key(
 /// Update the name and description of an API key.
 ///
 /// Updates are partial: only the fields you send are changed, and any fields not present in the payload remain unchanged.
+///
+/// **Note:** Only `name` and `description` can be updated. The fields `actions`, `indexes`,
+/// `expiresAt`, and `uid` cannot be modified after key creation.
 #[routes::path(
     security(("Bearer" = ["keys.update", "keys.*", "*"])),
     params(("key" = String, Path, format = Password, example = "7b198a7f-52a0-4188-8762-9ad93cd608b2", description = "The `uid` or `key` field of an existing API key.", nullable = false)),

--- a/crates/meilisearch/src/routes/indexes/documents.rs
+++ b/crates/meilisearch/src/routes/indexes/documents.rs
@@ -297,6 +297,7 @@ impl Aggregate for DocumentsDeletionAggregator {
     params(
         ("index_uid" = String, Path, example = "movies", description = "Unique identifier of the index.", nullable = false),
         ("document_id" = String, Path, example = "853", description = "Document identifier.", nullable = false),
+        CustomMetadataQuery,
     ),
     responses(
         (status = 202, description = "Task successfully enqueued.", body = SummarizedTaskView, content_type = "application/json", example = json!(
@@ -414,9 +415,9 @@ pub struct BrowseQueryGet {
     #[param(required = false, default, value_type = Option<Vec<String>>)]
     #[deserr(default, error = DeserrQueryParamError<InvalidDocumentIds>)]
     ids: Option<CS<String>>,
-    /// Filter expression to select which documents to return. Uses the same
-    /// syntax as search filters. Only documents matching the filter will be
-    /// included in the response. Example: `genres = action AND rating > 4`.
+    /// Filter expression to select which documents to return. Attributes must be added to the
+    /// `filterableAttributes` index setting before they can be used in filters. Only accepts
+    /// string expressions (not array syntax). Example: `genres = action AND rating > 4`.
     #[param(required = false, default, value_type = Option<String>, example = "popularity > 1000")]
     #[deserr(default, error = DeserrQueryParamError<InvalidDocumentFilter>)]
     filter: Option<String>,
@@ -464,10 +465,11 @@ pub struct BrowseQuery {
     /// fetching specific known documents.
     #[request(default, error = DeserrJsonError<InvalidDocumentIds>, schema_type = Option<Vec<String>>, example = json!(["cody", "finn", "brandy", "gambit"]))]
     ids: Option<Vec<serde_json::Value>>,
-    /// Filter expression to select which documents to return. Uses the same
-    /// syntax as search filters. Only documents matching the filter will be
-    /// included in the response. Example: `"genres = action AND rating > 4"`
-    /// or as an array `[["genres = action"], "rating > 4"]`.
+    /// Filter expression to select which documents to return. Attributes must be added to the
+    /// `filterableAttributes` index setting before they can be used in filters. Accepts a string
+    /// or an array of arrays of strings for AND/OR combinations.
+    /// Example string: `"genres = action AND rating > 4"`.
+    /// Example array: `[["genres = action", "genres = comedy"], "rating > 4"]` (inner array = OR, outer = AND).
     #[request(default, error = DeserrJsonError<InvalidDocumentFilter>, example = "popularity > 1000")]
     filter: Option<Value>,
     /// Array of attributes to sort the documents by. Each entry should be in
@@ -480,7 +482,12 @@ pub struct BrowseQuery {
 
 /// List documents with POST
 ///
-/// Retrieve a set of documents with optional filtering, sorting, and pagination. Use the request body to specify filters, sort order, and which fields to return.
+/// Retrieve a set of documents with optional filtering, sorting, and pagination. Use the request
+/// body to specify filters, sort order, and which fields to return.
+///
+/// **Note:** Sending an empty payload (`{}`) returns all documents in the index.
+///
+/// **Note:** Documents are not returned following the order of their primary keys.
 #[routes::path(
     security(("Bearer" = ["documents.get", "documents.*", "*"])),
     params(("index_uid" = String, example = "movies", description = "Unique identifier of the index.", nullable = false)),
@@ -574,7 +581,11 @@ pub async fn documents_by_query_post(
 
 /// List documents with GET
 ///
-/// Retrieve documents in batches using query parameters for offset, limit, and optional filtering. Suited for browsing or exporting index contents.
+/// Retrieve documents in batches using query parameters for offset, limit, and optional filtering.
+///
+/// **Deprecated:** This endpoint will be deprecated in a future release. Use `POST /indexes/{index_uid}/documents/fetch` instead, which supports more parameters and array-based filter expressions.
+///
+/// **Note:** Documents are not returned following the order of their primary keys.
 #[routes::path(
     security(("Bearer" = ["documents.get", "documents.*", "*"])),
     params(
@@ -777,7 +788,9 @@ pub struct UpdateDocumentsQuery {
     #[param(required = false, example = "id")]
     #[deserr(default, error = DeserrQueryParamError<InvalidIndexPrimaryKey>)]
     pub primary_key: Option<String>,
-    /// Customize the csv delimiter when importing CSV documents.
+    /// Customize the CSV column delimiter when importing CSV documents. Must be a single ASCII
+    /// character. Only valid when the content type is `text/csv`; using this parameter with
+    /// `application/json` or `application/x-ndjson` will return an error. Default: `,`.
     #[param(required = false, value_type = char, default = ",", example = ";")]
     #[deserr(default, try_from(char) = from_char_csv_delimiter -> DeserrQueryParamError<InvalidDocumentCsvDelimiter>, error = DeserrQueryParamError<InvalidDocumentCsvDelimiter>)]
     pub csv_delimiter: Option<u8>,
@@ -879,16 +892,17 @@ impl<Method: AggregateMethod> Aggregate for DocumentsAggregator<Method> {
 ///
 /// Add a list of documents or replace them if they already exist.
 ///
-/// If you send an already existing document (same id) the whole existing
-/// document will be overwritten by the new document. Fields previously in the
-/// document not present in the new document are removed.
+/// If you send an already existing document (same id) the whole existing document will be
+/// overwritten by the new document. Fields previously in the document not present in the new
+/// document are removed.
 ///
 /// If the provided index does not exist, it will be created.
 ///
-/// For a partial update of the document see [add or update documents route](/docs/reference/api/documents/add-or-update-documents).
+/// **Accepted content types:** `application/json`, `application/x-ndjson`, `text/csv`.
 ///
-/// > Use the reserved `_geo` object to add geo coordinates to a document.
-/// > `_geo` is an object made of `lat` and `lng` field.
+/// **Note:** Use the reserved `_geo` object to add geo coordinates: `{"lat": 48.8566, "lng": 2.3522}`.
+///
+/// For a partial update see [add or update documents route](/docs/reference/api/documents/add-or-update-documents).
 
 #[routes::path(
     security(("Bearer" = ["documents.add", "documents.*", "*"])),
@@ -995,12 +1009,17 @@ pub async fn replace_documents(
 /// Thus, any fields not present in the new document are kept and remained
 /// unchanged.
 ///
+/// **Important:** Partial updates apply only to top-level fields. Updating an object attribute
+/// replaces the entire object, removing any subfields not present in the update. Dot notation
+/// in an update request creates a new flat attribute rather than updating an existing nested field.
+///
 /// If the provided index does not exist, it will be created.
 ///
-/// To completely overwrite a document, see [add or replace documents route](/docs/reference/api/documents/add-or-replace-documents).
+/// **Accepted content types:** `application/json`, `application/x-ndjson`, `text/csv`.
 ///
-/// > Use the reserved `_geo` object to add geo coordinates to a document.
-/// > `_geo` is an object made of `lat` and `lng` field.
+/// **Note:** Use the reserved `_geo` object to add geo coordinates: `{"lat": 48.8566, "lng": 2.3522}`.
+///
+/// To completely overwrite a document, see [add or replace documents route](/docs/reference/api/documents/add-or-replace-documents).
 
 #[routes::path(
     security(("Bearer" = ["documents.add", "documents.*", "*"])),
@@ -1316,6 +1335,7 @@ async fn copy_body_to_file(
     security(("Bearer" = ["documents.delete", "documents.*", "*"])),
     params(
         ("index_uid" = String, example = "movies", description = "Unique identifier of the index.", nullable = false),
+        CustomMetadataQuery,
     ),
     request_body(content = Vec<Value>),
     responses(
@@ -1418,7 +1438,9 @@ pub async fn delete_documents_batch(
 #[routes::request(proxied)]
 #[derive(Debug)]
 pub struct DocumentDeletionByFilter {
-    /// Filter expression to match documents for deletion
+    /// Filter expression to match documents for deletion. Attributes must be in
+    /// `filterableAttributes` before they can be used. Accepts a string or an array of arrays.
+    /// Sending an empty filter will return a `bad_request` error.
     #[request(required, error = DeserrJsonError<InvalidDocumentFilter>, missing_field_error = DeserrJsonError::missing_document_filter)]
     filter: Value,
 }
@@ -1428,7 +1450,10 @@ pub struct DocumentDeletionByFilter {
 /// Delete all documents in the index that match the given filter expression.
 #[routes::path(
     security(("Bearer" = ["documents.delete", "documents.*", "*"])),
-    params(("index_uid" = String, example = "movies", description = "Unique identifier of the index.", nullable = false)),
+    params(
+        ("index_uid" = String, example = "movies", description = "Unique identifier of the index.", nullable = false),
+        CustomMetadataQuery,
+    ),
     request_body = DocumentDeletionByFilter,
     responses(
         (status = ACCEPTED, description = "Task successfully enqueued.", body = SummarizedTaskView, content_type = "application/json", example = json!(
@@ -1535,17 +1560,22 @@ pub async fn delete_documents_by_filter(
     Ok(HttpResponse::Accepted().json(task))
 }
 
-/// Request body for editing documents using a JavaScript function
+/// Request body for editing documents using a RHAI function
 #[routes::request(proxied)]
 #[derive(Debug)]
 pub struct DocumentEditionByFunction {
-    /// Filter expression to select which documents to edit
+    /// Filter expression to select which documents to edit. If omitted, all documents in the
+    /// index will be processed. Attributes must be in `filterableAttributes` to be used.
     #[request(default, error = DeserrJsonError<InvalidDocumentFilter>)]
     pub filter: Option<Value>,
-    /// Data to make available for the editing function
+    /// Arbitrary data to pass into the function scope. By default the function only has access
+    /// to the current document being edited via the `doc` variable.
     #[request(default, error = DeserrJsonError<InvalidDocumentEditionContext>)]
     pub context: Option<Value>,
-    /// RHAI function to apply to each document
+    /// A [RHAI](https://rhai.rs) function string to apply to each document. The function has
+    /// access to a `doc` variable representing the current document. Modify `doc` fields to
+    /// update the document. Return `null` or `()` to delete the document.
+    /// To enable this feature: `PATCH /experimental-features/ {"editDocumentsByFunction": true}`.
     #[request(required, error = DeserrJsonError<InvalidDocumentEditionFunctionFilter>, missing_field_error = DeserrJsonError::missing_document_edition_function)]
     pub function: String,
 }
@@ -1587,6 +1617,7 @@ impl Aggregate for EditDocumentsByFunctionAggregator {
     security(("Bearer" = ["documents.*", "*"])),
     params(
         ("index_uid" = String, example = "movies", description = "Unique identifier of the index.", nullable = false),
+        CustomMetadataQuery,
     ),
     request_body = DocumentEditionByFunction,
     responses(
@@ -1720,7 +1751,10 @@ pub async fn edit_documents_by_function(
 /// Permanently delete all documents in the specified index. Settings and index metadata are preserved.
 #[routes::path(
     security(("Bearer" = ["documents.delete", "documents.*", "*"])),
-    params(("index_uid" = String, example = "movies", description = "Unique identifier of the index.", nullable = false)),
+    params(
+        ("index_uid" = String, example = "movies", description = "Unique identifier of the index.", nullable = false),
+        CustomMetadataQuery,
+    ),
     responses(
         (status = 202, description = "Task successfully enqueued.", body = SummarizedTaskView, content_type = "application/json", example = json!(
             {

--- a/crates/meilisearch/src/routes/indexes/facet_search.rs
+++ b/crates/meilisearch/src/routes/indexes/facet_search.rs
@@ -25,7 +25,7 @@ use crate::search::proxy::{json_proxy, ProxySearchError, ProxySearchParams};
 use crate::search::{
     add_search_rules, fuse_filters, perform_facet_search, prepare_search, FacetSearchResult,
     HybridQuery, MatchingStrategy, NetworkableQuery, Partition, RankingScoreThreshold, SearchQuery,
-    SearchResult, DEFAULT_CROP_LENGTH, DEFAULT_CROP_MARKER, DEFAULT_HIGHLIGHT_POST_TAG,
+    DEFAULT_CROP_LENGTH, DEFAULT_CROP_MARKER, DEFAULT_HIGHLIGHT_POST_TAG,
     DEFAULT_HIGHLIGHT_PRE_TAG, DEFAULT_SEARCH_LIMIT, DEFAULT_SEARCH_OFFSET,
 };
 use crate::search_queue::SearchQueue;
@@ -36,7 +36,7 @@ use crate::search_queue::SearchQueue;
     tags(
         (
             name = "Facet Search",
-            description = "The `/facet-search` route allows you to search for facet values. Facet search supports prefix search and typo tolerance. The returned hits are sorted lexicographically in ascending order. You can configure how facets are sorted using the sortFacetValuesBy property of the faceting index settings.",
+            description = "The `/facet-search` route allows you to search for facet values within a given facet attribute.\n\nFacet search supports prefix search and typo tolerance. Results are sorted lexicographically in ascending order by default. You can configure sort order using the `sortFacetValuesBy` property of the faceting index settings.\n\n**Note:** Facet search does not support multi-word queries. Only the first word of `facetQuery` is considered. For example, searching for `Jane` returns `Jane Austen`, but searching for `Austen` does not.\n\n**Note:** Meilisearch does not support facet search on numeric values. Convert numeric facets to strings to make them searchable.\n\n**Prerequisite:** The `facetName` attribute must be in the index's `filterableAttributes` list before facet search can be used.",
         ),
     ),
 )]
@@ -50,13 +50,13 @@ pub struct FacetSearchApi;
 )]
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct FacetSearchQuery {
-    /// Query string to search for facet values
+    /// Query string to search for matching facet values. If not specified, Meilisearch returns all facet values for the `facetName`, limited to 100 results. Note: only the first word is used for matching.
     #[request(default, error = DeserrJsonError<InvalidFacetSearchQuery>)]
     pub facet_query: Option<String>,
-    /// Name of the facet to search
+    /// Name of the facet attribute to search. Must be present in the index's `filterableAttributes` list.
     #[request(required, error = DeserrJsonError<InvalidFacetSearchFacetName>, missing_field_error = DeserrJsonError::missing_facet_search_facet_name)]
     pub facet_name: String,
-    /// Query string to filter documents before facet search
+    /// Query string to filter the underlying documents before computing facet values. This affects which facet values appear and their counts, but does not filter the facet values themselves.
     #[request(default, error = DeserrJsonError<InvalidSearchQ>)]
     pub q: Option<String>,
     /// Custom query vector for semantic search
@@ -71,7 +71,7 @@ pub struct FacetSearchQuery {
     /// be configured in the index settings.
     #[request(default, error = DeserrJsonError<InvalidSearchHybridQuery>)]
     pub hybrid: Option<HybridQuery>,
-    /// Filter expression to apply before facet search
+    /// Filter expression to restrict which documents are considered when computing facet values. Attributes must be in `filterableAttributes` before they can be used in filters.
     #[request(default, error = DeserrJsonError<InvalidSearchFilter>)]
     pub filter: Option<Value>,
     /// Strategy used to match query terms
@@ -234,39 +234,38 @@ impl Aggregate for FacetSearchAggregator {
     }
 }
 
-/// Search in facets
+/// Search for facet values
 ///
-/// Search for facet values within a given facet.
+/// Search for facet values matching a query within a given facet attribute. Use this to build
+/// autocomplete or dropdown UIs for facet filters.
 ///
-/// > Use this to build autocomplete or refinement UIs for facet filters.
+/// **Prerequisite:** The `facetName` attribute must be in the index's `filterableAttributes` list.
+/// Facet search will not work without this configuration.
+///
+/// **Note:** Facet search only considers the first word of `facetQuery`. Searching for `Jane`
+/// returns `Jane Austen`, but searching for `Austen` does not.
+///
+/// **Note:** Numeric facet values are not searchable. Convert numbers to strings if you need
+/// to search them as facets.
 #[routes::path(
     security(("Bearer" = ["search", "*"])),
     params(("index_uid" = String, example = "movies", description = "Unique identifier of the index.", nullable = false)),
     request_body = FacetSearchQuery,
     responses(
-        (status = 200, description = "The documents are returned.", body = SearchResult, content_type = "application/json", example = json!(
+        (status = 200, description = "Facet values matching the query are returned.", body = FacetSearchResult, content_type = "application/json", example = json!(
             {
-              "hits": [
+              "facetHits": [
                 {
-                  "id": 2770,
-                  "title": "American Pie 2",
-                  "poster": "https://image.tmdb.org/t/p/w1280/q4LNgUnRfltxzp3gf1MAGiK5LhV.jpg",
-                  "overview": "The whole gang are back and as close as ever. They decide to get even closer by spending the summer together at a beach house. They decide to hold the biggest…",
-                  "release_date": 997405200
+                  "value": "action",
+                  "count": 273
                 },
                 {
-                  "id": 190859,
-                  "title": "American Sniper",
-                  "poster": "https://image.tmdb.org/t/p/w1280/svPHnYE7N5NAGO49dBmRhq0vDQ3.jpg",
-                  "overview": "U.S. Navy SEAL Chris Kyle takes his sole mission—protect his comrades—to heart and becomes one of the most lethal snipers in American history. His pinpoint accuracy not only saves countless lives but also makes him a prime…",
-                  "release_date": 1418256000
+                  "value": "animated",
+                  "count": 15
                 }
               ],
-              "offset": 0,
-              "limit": 2,
-              "estimatedTotalHits": 976,
-              "processingTimeMs": 35,
-              "query": "american "
+              "facetQuery": "ac",
+              "processingTimeMs": 0
             }
         )),
         (status = 404, description = "Index not found.", body = ResponseError, content_type = "application/json", example = json!(

--- a/crates/meilisearch/src/routes/indexes/search.rs
+++ b/crates/meilisearch/src/routes/indexes/search.rs
@@ -159,6 +159,8 @@ pub struct SearchQueryGet {
     /// Highlighting also applies to [synonyms](https://www.meilisearch.com/docs/learn/relevancy/synonyms) and [stop words](https://www.meilisearch.com/docs/reference/api/settings/update-all-settings#body-stop-words-one-of-0).
     ///
     /// Supported value types are string, number, array, and object.
+    ///
+    /// Note: highlights matches within all listed attributes, even those not in `searchableAttributes`.
     #[deserr(default, error = DeserrQueryParamError<InvalidSearchAttributesToHighlight>)]
     #[param(required = false, value_type = Vec<String>, explode = false)]
     attributes_to_highlight: Option<CS<String>>,
@@ -180,7 +182,7 @@ pub struct SearchQueryGet {
     ///
     /// This is useful when you need custom highlighting.
     ///
-    /// Note that positions are given in bytes, not characters.
+    /// Note: reports match positions in all attributes, even non-searchable ones. Positions are measured in bytes, not characters.
     #[deserr(default, error = DeserrQueryParamError<InvalidSearchShowMatchesPosition>)]
     #[param(required = false, value_type = bool)]
     show_matches_position: Param<bool>,
@@ -486,6 +488,10 @@ pub fn fix_sort_query_parameters(sort_query: &str) -> Vec<String> {
 /// Search for documents matching a query in the given index.
 ///
 /// > Equivalent to the [search with POST route](/docs/reference/api/search/search-with-post) in the Meilisearch API.
+///
+/// **Note:** By default this endpoint returns at most 1000 results. Configure `pagination.maxTotalHits` in index settings to change this limit.
+///
+/// **Note:** The GET route only accepts string filter expressions. Use the POST route if you need array-of-array filter syntax.
 #[routes::path(
     security(("Bearer" = ["search", "*"])),
     params(
@@ -783,6 +789,8 @@ pub(crate) async fn search(
 /// Search for documents matching a query in the given index.
 ///
 /// > Equivalent to the [search with GET route](/docs/reference/api/search/search-with-get) in the Meilisearch API.
+///
+/// **Note:** By default this endpoint returns at most 1000 results. Configure `pagination.maxTotalHits` in index settings to change this limit.
 #[routes::path(
     security(("Bearer" = ["search", "*"])),
     params(

--- a/crates/meilisearch/src/routes/multi_search.rs
+++ b/crates/meilisearch/src/routes/multi_search.rs
@@ -52,6 +52,9 @@ pub struct SearchResults {
 /// Run multiple search queries in a single API request.
 ///
 /// Each query can target a different index, so you can search across several indexes at once and get one combined response.
+///
+/// **Warning:** If Meilisearch encounters an error processing any query in the request, it immediately
+/// stops and returns an error message for the first error encountered. Partial results are not returned.
 #[routes::path(
     request_body = FederatedSearch,
     security(("Bearer" = ["search", "*"])),

--- a/crates/meilisearch/src/routes/tasks.rs
+++ b/crates/meilisearch/src/routes/tasks.rs
@@ -68,7 +68,7 @@ pub struct TasksFilterQuery {
     /// It's possible to specify several batch uids by separating them with
     /// the `,` character.
     #[deserr(default, error = DeserrQueryParamError<InvalidBatchUids>)]
-    #[param(required = false, value_type = Option<u32>, example = 12421)]
+    #[param(required = false, value_type = Option<Vec<u32>>, example = json!([1, 2, 3]))]
     pub batch_uids: OptionStarOrList<BatchId>,
 
     /// Permits to filter tasks by their uid. By default, when the uids query
@@ -335,6 +335,13 @@ impl<Method: AggregateMethod + 'static> Aggregate for TaskFilterAnalytics<Method
 /// Cancel tasks
 ///
 /// Cancel enqueued and/or processing [tasks](https://www.meilisearch.com/docs/learn/async/asynchronous_operations). You must provide at least one filter (e.g. `uids`, `indexUids`, `statuses`) to specify which tasks to cancel.
+///
+/// **Note:** Task cancellation is atomic — either all matched tasks are canceled or none are.
+///
+/// **Note:** Each filter parameter accepts `*` to match all values (e.g., `statuses=*`).
+///
+/// **Tip:** You can cancel `taskCancelation` type tasks as long as they are `enqueued` or `processing`,
+/// because cancellation tasks are processed in reverse order of enqueueing.
 #[routes::path(
     security(("Bearer" = ["tasks.cancel", "tasks.*", "*"])),
     no_request_body,
@@ -420,6 +427,13 @@ async fn cancel_tasks(
 /// Delete tasks
 ///
 /// Permanently delete [tasks](https://docs.meilisearch.com/learn/advanced/asynchronous_operations.html) matching the given filters. You must provide at least one filter (e.g. `uids`, `indexUids`, `statuses`) to specify which tasks to delete.
+///
+/// **Note:** Only finished tasks (`succeeded`, `failed`, or `canceled`) can be deleted.
+/// You cannot delete `enqueued` or `processing` tasks.
+///
+/// **Note:** Task deletion is atomic — either all matched tasks are deleted or none are.
+///
+/// **Note:** Each filter parameter accepts `*` to match all values (e.g., `statuses=*`).
 #[routes::path(
     security(("Bearer" = ["tasks.delete", "tasks.*", "*"])),
     params(TaskDeletionOrCancelationQuery),
@@ -519,7 +533,7 @@ pub struct AllTasks {
     pub limit: u32,
     /// The first task uid returned
     pub from: Option<u32>,
-    /// Value to send in from to fetch the next slice of results. Null when all data has been browsed
+    /// Value to pass as `from` parameter to get the next page. When `null`, there are no more tasks to retrieve.
     pub next: Option<u32>,
 }
 

--- a/crates/meilisearch/src/search/federated/types.rs
+++ b/crates/meilisearch/src/search/federated/types.rs
@@ -40,7 +40,11 @@ pub const FEDERATION_EXTRA_DOCUMENT: &str = "extra_document";
 #[routes::request(proxied)]
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct FederationOptions {
-    /// Weight to apply to results from this query (default: 1.0)
+    /// A multiplicative factor applied to the ranking score for hits from this query.
+    ///
+    /// Values less than 1.0 make hits from this query less likely to appear in final results; values greater than 1.0 make them more likely.
+    ///
+    /// Must be a positive number. Default: `1.0`.
     #[request(default, error = DeserrJsonError<InvalidMultiSearchWeight>, schema_type = f64)]
     pub weight: Weight,
 
@@ -168,6 +172,8 @@ pub struct FederatedSearch {
     /// different index and have its own parameters. When `federation` is
     /// `null`, results are returned separately for each query. When
     /// `federation` is set, results are merged.
+    ///
+    /// Each query object must include `indexUid` to specify which index to search.
     #[request(required)]
     pub queries: Vec<SearchQueryWithIndex>,
     /// Configuration for combining results from multiple queries into a

--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -178,6 +178,8 @@ pub struct SearchQuery {
     /// Highlighting also applies to [synonyms](https://www.meilisearch.com/docs/learn/relevancy/synonyms) and [stop words](https://www.meilisearch.com/docs/reference/api/settings/update-all-settings#body-stop-words-one-of-0).
     ///
     /// Supported value types are string, number, array, and object.
+    ///
+    /// Note: highlights matches within all listed attributes, even those not in `searchableAttributes`.
     #[request(default, error = DeserrJsonError<InvalidSearchAttributesToHighlight>)]
     pub attributes_to_highlight: Option<HashSet<String>>,
     /// String to insert before each highlighted term.
@@ -196,7 +198,7 @@ pub struct SearchQuery {
     ///
     /// This is useful when you need custom highlighting.
     ///
-    /// Note that positions are given in bytes, not characters.
+    /// Note: reports match positions in all attributes, even non-searchable ones. Positions are measured in bytes, not characters.
     #[request(default, error = DeserrJsonError<InvalidSearchShowMatchesPosition>)]
     pub show_matches_position: bool,
     /// A [filter](https://www.meilisearch.com/docs/learn/filtering_and_sorting/filter_search_results) expression to narrow results.
@@ -280,6 +282,8 @@ pub struct SearchQuery {
     /// The `semanticRatio` field controls the balance: 0.0 means keyword-only results, 1.0 means semantic-only.
     ///
     /// When `q` is empty and `semanticRatio` is greater than 0, Meilisearch performs a pure semantic search.
+    ///
+    /// The `semanticRatio` field defaults to `0.5`. A value of `0.0` uses keyword-only results; `1.0` uses semantic-only results.
     #[request(default, error = DeserrJsonError<InvalidSearchHybridQuery>)]
     pub hybrid: Option<HybridQuery>,
     /// Custom query vector for [vector or hybrid search](https://www.meilisearch.com/docs/learn/ai_powered_search/getting_started_with_ai_search).
@@ -1546,13 +1550,31 @@ pub struct FacetStats {
     pub max: f64,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+/// Schema representation of a facet value hit (for OpenAPI documentation only).
+#[derive(ToSchema)]
+#[schema(rename_all = "camelCase")]
+#[allow(dead_code)]
+pub struct FacetValueHitSchema {
+    /// The facet value that matched the query.
+    pub value: String,
+    /// Number of documents with this facet value among the search results.
+    pub count: u64,
+}
+
+/// Result of a facet search operation.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, ToSchema)]
 #[serde(rename_all = "camelCase")]
+#[schema(rename_all = "camelCase")]
 pub struct FacetSearchResult {
+    /// Array of matching facet values with their document counts, sorted lexicographically
+    /// in ascending order (or by count if `sortFacetValuesBy` is set to `"count"`).
+    #[schema(value_type = Vec<FacetValueHitSchema>)]
     pub facet_hits: Vec<FacetValueHit>,
+    /// The original `facetQuery` from the request. `null` if no query was provided.
     pub facet_query: Option<String>,
+    /// Time in milliseconds Meilisearch took to process the request.
     pub processing_time_ms: u128,
-    /// Errors from remote shards. Federated search only.
+    /// Errors from remote shards. Only present in federated search when some remotes failed.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub remote_errors: Option<BTreeMap<String, ResponseError>>,
 }


### PR DESCRIPTION
## Related issue

Fixes the missing information post migration to openAPI

## Generative AI tools

- [ ] This PR does not use generative AI tooling
- [X] This PR uses generative AI tooling and respect the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - To get the missing information from the old docs

## Requirements

⚠️ Ensure the following requirements before merging ⚠️
- [ ] Automated tests have been added.
- [ ] If some tests cannot be automated, manual rigorous tests should be applied.
- [ ] ⚠️ If there is any change in the DB:
    - [ ] Test that any impacted DB still works as expected after using `--experimental-dumpless-upgrade` on a DB created with the last released Meilisearch
    - [ ] Test that during the upgrade, **search is still available** (artificially make the upgrade longer if needed)
    - [ ] Set the `db change` label.
- [ ] If necessary, the feature have been tested in the Cloud production environment (with [prototypes](./documentation/prototypes.md)) and the Cloud UI is ready.
- [ ] If necessary, the [documentation](https://github.com/meilisearch/documentation) related to the implemented feature in the PR is ready.
- [ ] If necessary, the [integrations](https://github.com/meilisearch/integration-guides) related to the implemented feature in the PR are ready.
