### PR TITLE
Fix S3 Snapshots race condition when trying to recycle buffers

### DIFF
--- a/crates/index-scheduler/src/scheduler/enterprise_edition/s3.rs
+++ b/crates/index-scheduler/src/scheduler/enterprise_edition/s3.rs
@@ -509,15 +509,18 @@ async fn multipart_stream_to_s3(
 
         let body = buffer.freeze();
         tracing::trace!("Sending part {part_number}");
-        let task = tokio::spawn({
-            let client = client.clone();
+        let request = client.put(url).prepare({
             let body = body.clone();
+            |inner| inner.body(body)
+        });
+
+        let task = tokio::spawn({
             backoff::future::retry(retry_backoff.clone(), move || {
-                let client = client.clone();
-                let url = url.clone();
-                let body = body.clone();
-                async move {
-                    match client.put(url).prepare(|inner| inner.body(body)).send().await {
+                // safety: it fails only with stream body
+                let request = request.try_clone().unwrap();
+                let request = request.send();
+                async {
+                    match request.await {
                         Ok(resp) if resp.status().is_client_error() => resp
                             .error_for_status()
                             .map_err(http_client::reqwest::Error::from)
@@ -528,6 +531,7 @@ async fn multipart_stream_to_s3(
                 }
             })
         });
+
         in_flight.push_back((task, body));
     }
 

--- a/crates/index-scheduler/src/scheduler/enterprise_edition/s3.rs
+++ b/crates/index-scheduler/src/scheduler/enterprise_edition/s3.rs
@@ -467,7 +467,13 @@ async fn multipart_stream_to_s3(
 
             let mut buffer = match buffer.try_into_mut() {
                 Ok(buffer) => buffer,
-                Err(_) => unreachable!("All bytes references were consumed in the task"),
+                Err(_) => {
+                    // There could be a race condition where the body is dropped after the task is completed.
+                    // That is a known issue with the tokio runtime: When a task is completed, the tokio runtime
+                    // drops the task body after having informed that the task is done. In this case, we fallback
+                    // on creating a new buffer instead of using the one that was dropped.
+                    BytesMut::with_capacity(s3_multipart_part_size as usize)
+                }
             };
             buffer.clear();
             buffer


### PR DESCRIPTION
This PR fixes [a known tokio issue](https://github.com/tokio-rs/bytes/issues/350) where an async task using [Bytes](https://docs.rs/bytes/latest/bytes/struct.Bytes.html) would finish, and another task is trying to recycle the borrowed Bytes from this task [to convert them into BytesMut ones](https://docs.rs/bytes/latest/bytes/struct.Bytes.html#method.try_into_mut), and the original Bytes are not yet dropped, so there is still a reference to them, and the conversion fails. In this particularly rare case, we decide to allocate a new buffer instead.

## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respects the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)