### PR TITLE
Fix sharding document duplication

### DIFF
--- a/crates/meilisearch/src/search/federated/perform.rs
+++ b/crates/meilisearch/src/search/federated/perform.rs
@@ -53,7 +53,7 @@ use crate::search::federated::types::{
 };
 use crate::search::hydration::{FederatedHydrationFormatter, HydrationContext};
 use crate::search::{
-    parse_filter, NetworkableQuery as _, ShowFederationInfo, DEFAULT_SEARCH_LIMIT,
+    parse_filter, NetworkableQuery as _, Partition, ShowFederationInfo, DEFAULT_SEARCH_LIMIT,
 };
 
 #[allow(clippy::too_many_arguments)]
@@ -170,6 +170,7 @@ pub async fn perform_federated_search(
     let mut partitioned_queries = PartitionedQueries::new();
 
     let mut federation = federation;
+    let mut partition = None;
     for (query_index, (federated_query, filter)) in
         queries.into_iter().zip(precomputed_filters.into_iter()).enumerate()
     {
@@ -177,6 +178,7 @@ pub async fn perform_federated_search(
             .partition(
                 &mut federation,
                 federated_query,
+                &mut partition,
                 filter,
                 query_index,
                 &network,
@@ -1031,6 +1033,7 @@ impl PartitionedQueries {
         &mut self,
         federation: &mut Federation,
         mut federated_query: SearchQueryWithIndex,
+        partition: &mut Option<Partition>,
         precomputed_filter: Option<IndexFilter>,
         query_index: usize,
         network: &Network,
@@ -1066,7 +1069,10 @@ impl PartitionedQueries {
             return Err(MeilisearchHttpError::DistinctInFederatedQueryAndFederation.into());
         }
 
-        let mut partition = None;
+        // Insert back the filter into the query as a string before sending it to the remote
+        federated_query.filter = precomputed_filter.as_ref().map(|f| {
+            serde_json::Value::String(serialize_index_filter_to_filter_string(f).unwrap())
+        });
 
         let (index_uid, query, federation_options);
         let queries = if federated_query.must_use_network(network, &features)? {
@@ -1085,7 +1091,7 @@ impl PartitionedQueries {
         };
 
         for federated_query in queries {
-            let (index_uid, mut query, federation_options) =
+            let (index_uid, query, federation_options) =
                 federated_query.into_index_query_federation();
 
             let federation_options = federation_options.unwrap_or_default();
@@ -1113,13 +1119,6 @@ impl PartitionedQueries {
                                         meilisearch_types::error::Code::InvalidMultiSearchRemote,
                                     ));
                                 };
-
-                                // Insert back the filter into the query as a string before sending it to the remote
-                                query.filter = precomputed_filter.as_ref().map(|f| {
-                                    serde_json::Value::String(
-                                        serialize_index_filter_to_filter_string(f).unwrap(),
-                                    )
-                                });
 
                                 let query = SearchQueryWithIndex::from_index_query_federation(
                                     index_uid,

--- a/crates/meilisearch/src/search/federated/perform.rs
+++ b/crates/meilisearch/src/search/federated/perform.rs
@@ -23,7 +23,7 @@ use meilisearch_types::milli::score_details::{ScoreDetails, WeightedScoreValue};
 use meilisearch_types::milli::vector::Embedding;
 use meilisearch_types::milli::{
     self, merge_positioned_hits_into_page, serialize_index_filter_to_filter_string, Deadline,
-    DocumentId, FederatingResultsStep, IndexFilter, OrderBy, DEFAULT_VALUES_PER_FACET,
+    DocumentId, FederatingResultsStep, OrderBy, DEFAULT_VALUES_PER_FACET,
 };
 use meilisearch_types::network::{Network, Remote, RemoteAvailability};
 use meilisearch_types::settings::DEFAULT_PAGINATION_MAX_TOTAL_HITS;
@@ -171,15 +171,18 @@ pub async fn perform_federated_search(
 
     let mut federation = federation;
     let mut partition = None;
-    for (query_index, (federated_query, filter)) in
+    for (query_index, (mut federated_query, filter)) in
         queries.into_iter().zip(precomputed_filters.into_iter()).enumerate()
     {
+        // Insert back the filter into the query as a string before sending it to the remote
+        federated_query.filter = filter.as_ref().map(|f| {
+            serde_json::Value::String(serialize_index_filter_to_filter_string(f).unwrap())
+        });
         partitioned_queries
             .partition(
                 &mut federation,
                 federated_query,
                 &mut partition,
-                filter,
                 query_index,
                 &network,
                 features,
@@ -501,7 +504,6 @@ pub async fn perform_federated_search(
 
 struct QueryByIndex {
     query: SearchQuery,
-    filter: Option<IndexFilter<'static>>,
     weight: Weight,
     query_index: usize,
 }
@@ -1034,7 +1036,6 @@ impl PartitionedQueries {
         federation: &mut Federation,
         mut federated_query: SearchQueryWithIndex,
         partition: &mut Option<Partition>,
-        precomputed_filter: Option<IndexFilter>,
         query_index: usize,
         network: &Network,
         features: RoFeatures,
@@ -1068,11 +1069,6 @@ impl PartitionedQueries {
         if federated_query.has_distinct() && federation.distinct.is_some() {
             return Err(MeilisearchHttpError::DistinctInFederatedQueryAndFederation.into());
         }
-
-        // Insert back the filter into the query as a string before sending it to the remote
-        federated_query.filter = precomputed_filter.as_ref().map(|f| {
-            serde_json::Value::String(serialize_index_filter_to_filter_string(f).unwrap())
-        });
 
         let (index_uid, query, federation_options);
         let queries = if federated_query.must_use_network(network, &features)? {
@@ -1145,7 +1141,6 @@ impl PartitionedQueries {
 
                 queries_by_index.push(QueryByIndex {
                     query,
-                    filter: precomputed_filter.as_ref().map(|f| f.clone().into_owned()),
                     weight: federation_options.weight,
                     // override query index here with the one in federation.
                     // this will fix-up error messages to refer to the global query index of the original request.
@@ -1406,7 +1401,7 @@ impl SearchByIndex {
                 Default::default()
             };
 
-        for QueryByIndex { query, weight, query_index, filter } in queries {
+        for QueryByIndex { query, weight, query_index } in queries {
             // use an immediately invoked lambda to capture the result without returning from the function
             let res: Result<(), ResponseError> = (|| {
                 let search_kind =
@@ -1478,7 +1473,7 @@ impl SearchByIndex {
                     &index,
                     &rtxn,
                     &query,
-                    filter,
+                    None,
                     &search_kind,
                     // clones of `Deadline` share the deadline rather than restart it
                     deadline.clone(),

--- a/crates/meilisearch/src/search/federated/perform.rs
+++ b/crates/meilisearch/src/search/federated/perform.rs
@@ -1469,11 +1469,22 @@ impl SearchByIndex {
 
                 let retrieve_vectors = RetrieveVectors::new(query.retrieve_vectors);
 
+                let filter = if let Some(filter) = query.filter.as_ref() {
+                    parse_local_index_filter(
+                        filter,
+                        Some(index_uid.as_str()),
+                        params.features,
+                        Code::InvalidSearchFilter,
+                    )?
+                } else {
+                    None
+                };
+
                 let (mut search, _is_finite_pagination, _max_total_hits, _offset) = prepare_search(
                     &index,
                     &rtxn,
                     &query,
-                    None,
+                    filter,
                     &search_kind,
                     // clones of `Deadline` share the deadline rather than restart it
                     deadline.clone(),

--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use deserr::Deserr;
-use index_scheduler::filter::{filter_into_index_filter, parse_filter, parse_local_index_filter};
+use index_scheduler::filter::{filter_into_index_filter, parse_filter};
 use index_scheduler::{IndexScheduler, RoFeatures};
 use indexmap::IndexMap;
 use meilisearch_auth::IndexSearchRules;
@@ -1724,12 +1724,7 @@ pub fn prepare_search<'t>(
     search.offset(offset);
     search.limit(limit);
 
-    // HOTFIX @many: fallback to the filter from the query if the parsed filter is not provided
-    if let Some(filter) = filter {
-        search.filter(Some(filter));
-    } else if let Some(filter) = query.filter.as_ref() {
-        search.filter(parse_local_index_filter(filter, None, features, Code::InvalidSearchFilter)?);
-    }
+    search.filter(filter);
 
     if let Some(ref sort) = query.sort {
         let sort = match sort.iter().map(|s| AscDesc::from_str(s)).collect() {

--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use deserr::Deserr;
-use index_scheduler::filter::{filter_into_index_filter, parse_filter};
+use index_scheduler::filter::{filter_into_index_filter, parse_filter, parse_local_index_filter};
 use index_scheduler::{IndexScheduler, RoFeatures};
 use indexmap::IndexMap;
 use meilisearch_auth::IndexSearchRules;
@@ -1724,7 +1724,12 @@ pub fn prepare_search<'t>(
     search.offset(offset);
     search.limit(limit);
 
-    search.filter(filter);
+    // HOTFIX @many: fallback to the filter from the query if the parsed filter is not provided
+    if let Some(filter) = filter {
+        search.filter(Some(filter));
+    } else if let Some(filter) = query.filter.as_ref() {
+        search.filter(parse_local_index_filter(filter, None, features, Code::InvalidSearchFilter)?);
+    }
 
     if let Some(ref sort) = query.sort {
         let sort = match sort.iter().map(|s| AscDesc::from_str(s)).collect() {

--- a/crates/meilisearch/tests/documents/geojson/mod.rs
+++ b/crates/meilisearch/tests/documents/geojson/mod.rs
@@ -165,7 +165,7 @@ async fn basic_add_geojson_documents_and_settings() {
     snapshot!(response,
     @r###"
     {
-      "message": "Index `[uuid]`: Attribute `_geojson` is not filterable. This index does not have configured filterable attributes.\n_geoPolygon([0,0],[0,2],[2,2],[2,0])",
+      "message": "Index `[uuid]`: Attribute `_geojson` is not filterable. This index does not have configured filterable attributes.\n14:15 _geoPolygon([0, 0], [0, 2], [2, 2], [2, 0])",
       "code": "invalid_search_filter",
       "type": "invalid_request",
       "link": "https://docs.meilisearch.com/errors#invalid_search_filter"

--- a/crates/meilisearch/tests/search/document_join.rs
+++ b/crates/meilisearch/tests/search/document_join.rs
@@ -981,7 +981,7 @@ async fn foreign_filter_on_non_filterable_attribute() {
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response, { ".**.requestUid" => "[uuid]" }), @r###"
     {
-      "message": "Index `[uuid]`: Attribute `author` is not filterable. This index does not have configured filterable attributes.\n_foreign(author, id = a1)",
+      "message": "Index `[uuid]`: Attribute `author` is not filterable. This index does not have configured filterable attributes.\n2:8 \"author\" IN [\"a1\"]",
       "code": "invalid_search_filter",
       "type": "invalid_request",
       "link": "https://docs.meilisearch.com/errors#invalid_search_filter"
@@ -992,7 +992,7 @@ async fn foreign_filter_on_non_filterable_attribute() {
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response, { ".**.requestUid" => "[uuid]" }), @r###"
     {
-      "message": "Inside `.queries[0]`: Index `[uuid]`: Attribute `author` is not filterable. This index does not have configured filterable attributes.\n_foreign(author, id = a1)",
+      "message": "Inside `.queries[0]`: Index `[uuid]`: Attribute `author` is not filterable. This index does not have configured filterable attributes.\n2:8 \"author\" IN [\"a1\"]",
       "code": "invalid_search_filter",
       "type": "invalid_request",
       "link": "https://docs.meilisearch.com/errors#invalid_search_filter"

--- a/crates/meilisearch/tests/search/errors.rs
+++ b/crates/meilisearch/tests/search/errors.rs
@@ -711,7 +711,7 @@ async fn filter_invalid_attribute_array() {
         |response, code| {
             snapshot!(response, @r###"
             {
-              "message": "Index `[uuid]`: Attribute `many` is not filterable. Available filterable attribute patterns are: `title`.\nmany = Glass",
+              "message": "Index `[uuid]`: Attribute `many` is not filterable. Available filterable attribute patterns are: `title`.\n2:6 \"many\" = \"Glass\"",
               "code": "invalid_search_filter",
               "type": "invalid_request",
               "link": "https://docs.meilisearch.com/errors#invalid_search_filter"
@@ -732,7 +732,7 @@ async fn filter_invalid_attribute_string() {
         |response, code| {
             snapshot!(response, @r###"
             {
-              "message": "Index `[uuid]`: Attribute `many` is not filterable. Available filterable attribute patterns are: `title`.\nmany = Glass",
+              "message": "Index `[uuid]`: Attribute `many` is not filterable. Available filterable attribute patterns are: `title`.\n2:6 \"many\" = \"Glass\"",
               "code": "invalid_search_filter",
               "type": "invalid_request",
               "link": "https://docs.meilisearch.com/errors#invalid_search_filter"

--- a/crates/meilisearch/tests/search/filters.rs
+++ b/crates/meilisearch/tests/search/filters.rs
@@ -760,7 +760,7 @@ async fn test_filterable_attributes_priority() {
             snapshot!(code, @"400 Bad Request");
             snapshot!(json_string!(response), @r###"
             {
-              "message": "Index `[uuid]`: Attribute `doggos.age` is not filterable. Available filterable attribute patterns are: `doggos.*`.\ndoggos.age > 2",
+              "message": "Index `[uuid]`: Attribute `doggos.age` is not filterable. Available filterable attribute patterns are: `doggos.*`.\n2:12 \"doggos.age\" > \"2\"",
               "code": "invalid_search_filter",
               "type": "invalid_request",
               "link": "https://docs.meilisearch.com/errors#invalid_search_filter"
@@ -786,7 +786,7 @@ async fn test_filterable_attributes_priority() {
             snapshot!(code, @"400 Bad Request");
             snapshot!(json_string!(response), @r###"
             {
-              "message": "Index `[uuid]`: Attribute `doggos` is not filterable. Available filterable attribute patterns are: `doggos.*`.\ndoggos EXISTS",
+              "message": "Index `[uuid]`: Attribute `doggos` is not filterable. Available filterable attribute patterns are: `doggos.*`.\n2:8 \"doggos\" EXISTS",
               "code": "invalid_search_filter",
               "type": "invalid_request",
               "link": "https://docs.meilisearch.com/errors#invalid_search_filter"
@@ -865,7 +865,7 @@ async fn vector_filter_nonexistent_embedder() {
         .await;
     snapshot!(value, @r###"
     {
-      "message": "Index `[uuid]`: The embedder `other` does not exist. Available embedders are: `rest`.\n_vectors.other EXISTS",
+      "message": "Index `[uuid]`: The embedder `other` does not exist. Available embedders are: `rest`.\n11:16 _vectors.\"other\" EXISTS",
       "code": "invalid_search_filter",
       "type": "invalid_request",
       "link": "https://docs.meilisearch.com/errors#invalid_search_filter"
@@ -887,7 +887,7 @@ async fn vector_filter_all_embedders_user_provided() {
         .await;
     snapshot!(value, @r###"
     {
-      "message": "Index `[uuid]`: The embedder `userProvided` does not exist. Available embedders are: `rest`.\n_vectors.userProvided EXISTS",
+      "message": "Index `[uuid]`: The embedder `userProvided` does not exist. Available embedders are: `rest`.\n11:23 _vectors.\"userProvided\" EXISTS",
       "code": "invalid_search_filter",
       "type": "invalid_request",
       "link": "https://docs.meilisearch.com/errors#invalid_search_filter"
@@ -1028,7 +1028,7 @@ async fn vector_filter_non_existant_fragment() {
         .await;
     snapshot!(value, @r###"
     {
-      "message": "Index `[uuid]`: The fragment `withBred` does not exist on embedder `rest`. Available fragments on this embedder are: `basic`, `withBreed`. Did you mean `withBreed`?\n_vectors.rest.fragments.withBred EXISTS",
+      "message": "Index `[uuid]`: The fragment `withBred` does not exist on embedder `rest`. Available fragments on this embedder are: `basic`, `withBreed`. Did you mean `withBreed`?\n28:36 _vectors.\"rest\".fragments.\"withBred\" EXISTS",
       "code": "invalid_search_filter",
       "type": "invalid_request",
       "link": "https://docs.meilisearch.com/errors#invalid_search_filter"

--- a/crates/meilisearch/tests/search/mod.rs
+++ b/crates/meilisearch/tests/search/mod.rs
@@ -1828,7 +1828,7 @@ async fn test_nested_fields() {
             assert_eq!(code, 400, "{response}");
             snapshot!(json_string!(response), @r###"
             {
-              "message": "Index `[uuid]`: Attribute `nested` is not filterable. Available filterable attribute patterns are: `nested.machin`, `nested.object`, `title`.\nnested = array",
+              "message": "Index `[uuid]`: Attribute `nested` is not filterable. Available filterable attribute patterns are: `nested.machin`, `nested.object`, `title`.\n2:8 \"nested\" = \"array\"",
               "code": "invalid_search_filter",
               "type": "invalid_request",
               "link": "https://docs.meilisearch.com/errors#invalid_search_filter"
@@ -1847,7 +1847,7 @@ async fn test_nested_fields() {
             assert_eq!(code, 400, "{response}");
             snapshot!(json_string!(response), @r###"
             {
-              "message": "Index `[uuid]`: Attribute `nested` is not filterable. Available filterable attribute patterns are: `nested.machin`, `nested.object`, `title`.\nnested = \"I lied\"",
+              "message": "Index `[uuid]`: Attribute `nested` is not filterable. Available filterable attribute patterns are: `nested.machin`, `nested.object`, `title`.\n2:8 \"nested\" = \"I lied\"",
               "code": "invalid_search_filter",
               "type": "invalid_request",
               "link": "https://docs.meilisearch.com/errors#invalid_search_filter"

--- a/crates/meilisearch/tests/search/multi/mod.rs
+++ b/crates/meilisearch/tests/search/multi/mod.rs
@@ -941,7 +941,7 @@ async fn federation_one_query_error() {
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
-      "message": "Inside `.queries[1]`: Index `SHARED_NESTED_DOCUMENTS`: Attribute `title` is not filterable. Available filterable attribute patterns are: `cattos`, `doggos`, `father`.\ntitle = toto",
+      "message": "Inside `.queries[1]`: Index `SHARED_NESTED_DOCUMENTS`: Attribute `title` is not filterable. Available filterable attribute patterns are: `cattos`, `doggos`, `father`.\n2:7 \"title\" = \"toto\"",
       "code": "invalid_search_filter",
       "type": "invalid_request",
       "link": "https://docs.meilisearch.com/errors#invalid_search_filter"
@@ -1010,7 +1010,7 @@ async fn federation_multiple_query_errors() {
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
-      "message": "Inside `.queries[0]`: Index `SHARED_DOCUMENTS`: Attribute `color` is not filterable. Available filterable attribute patterns are: `id`, `title`.\ncolor = toto",
+      "message": "Inside `.queries[0]`: Index `SHARED_DOCUMENTS`: Attribute `color` is not filterable. Available filterable attribute patterns are: `id`, `title`.\n2:7 \"color\" = \"toto\"",
       "code": "invalid_search_filter",
       "type": "invalid_request",
       "link": "https://docs.meilisearch.com/errors#invalid_search_filter"
@@ -1057,7 +1057,7 @@ async fn federation_multiple_query_errors_interleaved() {
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
-      "message": "Inside `.queries[1]`: Index `SHARED_NESTED_DOCUMENTS`: Attribute `mother` is not filterable. Available filterable attribute patterns are: `cattos`, `doggos`, `father`.\nmother IN [intel, kefir]",
+      "message": "Inside `.queries[1]`: Index `SHARED_NESTED_DOCUMENTS`: Attribute `mother` is not filterable. Available filterable attribute patterns are: `cattos`, `doggos`, `father`.\n2:8 \"mother\" IN [\"intel\", \"kefir\"]",
       "code": "invalid_search_filter",
       "type": "invalid_request",
       "link": "https://docs.meilisearch.com/errors#invalid_search_filter"

--- a/crates/meilisearch/tests/search/multi/proxy.rs
+++ b/crates/meilisearch/tests/search/multi/proxy.rs
@@ -5957,6 +5957,664 @@ async fn remote_auto_sharding_auto_search() {
 
 #[cfg(feature = "enterprise")]
 #[actix_rt::test]
+async fn remote_auto_sharding_federated_auto_search() {
+    let ms0 = Server::new().await;
+    let ms1 = Server::new().await;
+    let ms2 = Server::new().await;
+
+    // enable feature
+
+    let (response, code) = ms0.set_features(json!({"network": true})).await;
+    snapshot!(code, @"200 OK");
+    snapshot!(json_string!(response["network"]), @"true");
+    let (response, code) = ms1.set_features(json!({"network": true})).await;
+    snapshot!(code, @"200 OK");
+    snapshot!(json_string!(response["network"]), @"true");
+    let (response, code) = ms2.set_features(json!({"network": true})).await;
+    snapshot!(code, @"200 OK");
+    snapshot!(json_string!(response["network"]), @"true");
+
+    // wrap servers
+    let ms0 = Arc::new(ms0);
+    let ms1 = Arc::new(ms1);
+    let ms2 = Arc::new(ms2);
+
+    let rms0 = LocalMeili::new(ms0.clone()).await;
+    let rms1 = LocalMeili::new(ms1.clone()).await;
+    let rms2 = LocalMeili::new(ms2.clone()).await;
+
+    // set network
+    let network = json!(
+      {
+        "self": "ms0",
+        "leader": "ms0",
+        "remotes": {
+          "ms0": {
+              "url": rms0.url()
+          },
+          "ms1": {
+              "url": rms1.url()
+          },
+          "ms2": {
+              "url": rms2.url()
+          }
+        },
+        "shards": {
+            "s0": {
+              "remotes": ["ms0", "ms1"]
+            },
+            "s1": {
+              "remotes": ["ms1", "ms2"]
+            },
+            "s2": {
+              "remotes": ["ms2", "ms0"]
+            }
+        }
+      }
+    );
+
+    println!("{}", serde_json::to_string_pretty(&network).unwrap());
+
+    let (task, status_code) = ms0.set_network(network.clone()).await;
+    snapshot!(status_code, @"202 Accepted");
+
+    let t0 = task.uid();
+    let (t, _) = ms0.get_task(t0).await;
+
+    let t1 = t["network"]["remote_tasks"]["ms1"]["taskUid"].as_u64().unwrap();
+    let t2 = t["network"]["remote_tasks"]["ms2"]["taskUid"].as_u64().unwrap();
+
+    ms0.wait_task(t0).await.succeeded();
+    ms1.wait_task(t1).await.succeeded();
+    ms2.wait_task(t2).await.succeeded();
+
+    let (response, status_code) = ms0.get_network().await;
+    snapshot!(status_code, @"200 OK");
+    snapshot!(json_string!(response, {".version" => "[version]", ".remotes.*.url" => "[url]"}), @r###"
+    {
+      "self": "ms0",
+      "remotes": {
+        "ms0": {
+          "url": "[url]",
+          "searchApiKey": null,
+          "writeApiKey": null,
+          "status": "available"
+        },
+        "ms1": {
+          "url": "[url]",
+          "searchApiKey": null,
+          "writeApiKey": null,
+          "status": "available"
+        },
+        "ms2": {
+          "url": "[url]",
+          "searchApiKey": null,
+          "writeApiKey": null,
+          "status": "available"
+        }
+      },
+      "shards": {
+        "s0": {
+          "remotes": [
+            "ms0",
+            "ms1"
+          ]
+        },
+        "s1": {
+          "remotes": [
+            "ms1",
+            "ms2"
+          ]
+        },
+        "s2": {
+          "remotes": [
+            "ms0",
+            "ms2"
+          ]
+        }
+      },
+      "leader": "ms0",
+      "version": "[version]"
+    }
+    "###);
+
+    let (response, status_code) = ms1.get_network().await;
+    snapshot!(status_code, @"200 OK");
+    snapshot!(json_string!(response, {".version" => "[version]", ".remotes.*.url" => "[url]"}), @r###"
+    {
+      "self": "ms1",
+      "remotes": {
+        "ms0": {
+          "url": "[url]",
+          "searchApiKey": null,
+          "writeApiKey": null,
+          "status": "available"
+        },
+        "ms1": {
+          "url": "[url]",
+          "searchApiKey": null,
+          "writeApiKey": null,
+          "status": "available"
+        },
+        "ms2": {
+          "url": "[url]",
+          "searchApiKey": null,
+          "writeApiKey": null,
+          "status": "available"
+        }
+      },
+      "shards": {
+        "s0": {
+          "remotes": [
+            "ms0",
+            "ms1"
+          ]
+        },
+        "s1": {
+          "remotes": [
+            "ms1",
+            "ms2"
+          ]
+        },
+        "s2": {
+          "remotes": [
+            "ms0",
+            "ms2"
+          ]
+        }
+      },
+      "leader": "ms0",
+      "version": "[version]"
+    }
+    "###);
+
+    let (response, status_code) = ms2.get_network().await;
+    snapshot!(status_code, @"200 OK");
+    snapshot!(json_string!(response, {".version" => "[version]", ".remotes.*.url" => "[url]"}), @r###"
+    {
+      "self": "ms2",
+      "remotes": {
+        "ms0": {
+          "url": "[url]",
+          "searchApiKey": null,
+          "writeApiKey": null,
+          "status": "available"
+        },
+        "ms1": {
+          "url": "[url]",
+          "searchApiKey": null,
+          "writeApiKey": null,
+          "status": "available"
+        },
+        "ms2": {
+          "url": "[url]",
+          "searchApiKey": null,
+          "writeApiKey": null,
+          "status": "available"
+        }
+      },
+      "shards": {
+        "s0": {
+          "remotes": [
+            "ms0",
+            "ms1"
+          ]
+        },
+        "s1": {
+          "remotes": [
+            "ms1",
+            "ms2"
+          ]
+        },
+        "s2": {
+          "remotes": [
+            "ms0",
+            "ms2"
+          ]
+        }
+      },
+      "leader": "ms0",
+      "version": "[version]"
+    }
+    "###);
+
+    // add documents
+    let documents = SCORE_DOCUMENTS.clone();
+    let documents = documents.as_array().unwrap();
+    let index0 = ms0.index("test");
+    let index1 = ms1.index("test");
+    let index2 = ms2.index("test");
+
+    let (task, _status_code) = index0.add_documents(json!(documents), None).await;
+
+    let t0 = task.uid();
+    let (t, _) = ms0.get_task(task.uid()).await;
+    let t1 = t["network"]["remote_tasks"]["ms1"]["taskUid"].as_u64().unwrap();
+    let t2 = t["network"]["remote_tasks"]["ms2"]["taskUid"].as_u64().unwrap();
+
+    ms0.wait_task(t0).await.succeeded();
+    ms1.wait_task(t1).await.succeeded();
+    ms2.wait_task(t2).await.succeeded();
+
+    // perform search with network
+    let query = "badman returns";
+    let request = json!(
+    {
+        "q": query,
+        "useNetwork": true,
+    });
+
+    let (response, code) = index0.search_post(request.clone()).await;
+    snapshot!(code, @"200 OK");
+    snapshot!(json_string!(response, { ".processingTimeMs" => "[time]", ".requestUid" => "[uuid]", ".hits.*._federation.remote" => "[remote]" }), @r###"
+    {
+      "hits": [
+        {
+          "title": "Batman Returns",
+          "id": "C",
+          "_federation": {
+            "indexUid": "test",
+            "queriesPosition": 0,
+            "weightedRankingScore": 0.8317901234567902,
+            "remote": "[remote]"
+          }
+        },
+        {
+          "title": "Batman the dark knight returns: Part 1",
+          "id": "A",
+          "_federation": {
+            "indexUid": "test",
+            "queriesPosition": 0,
+            "weightedRankingScore": 0.7028218694885362,
+            "remote": "[remote]"
+          }
+        },
+        {
+          "title": "Batman the dark knight returns: Part 2",
+          "id": "B",
+          "_federation": {
+            "indexUid": "test",
+            "queriesPosition": 0,
+            "weightedRankingScore": 0.7028218694885362,
+            "remote": "[remote]"
+          }
+        },
+        {
+          "title": "Badman",
+          "id": "E",
+          "_federation": {
+            "indexUid": "test",
+            "queriesPosition": 0,
+            "weightedRankingScore": 0.5,
+            "remote": "[remote]"
+          }
+        },
+        {
+          "title": "Batman",
+          "id": "D",
+          "_federation": {
+            "indexUid": "test",
+            "queriesPosition": 0,
+            "weightedRankingScore": 0.23106060606060605,
+            "remote": "[remote]"
+          }
+        }
+      ],
+      "query": "badman returns",
+      "processingTimeMs": "[time]",
+      "limit": 20,
+      "offset": 0,
+      "estimatedTotalHits": 5,
+      "requestUid": "[uuid]",
+      "remoteErrors": {}
+    }
+    "###);
+    let (response, code) = index1.search_post(request.clone()).await;
+    snapshot!(code, @"200 OK");
+    snapshot!(json_string!(response, { ".processingTimeMs" => "[time]", ".requestUid" => "[uuid]", ".hits.*._federation.remote" => "[remote]" }), @r###"
+    {
+      "hits": [
+        {
+          "title": "Batman Returns",
+          "id": "C",
+          "_federation": {
+            "indexUid": "test",
+            "queriesPosition": 0,
+            "weightedRankingScore": 0.8317901234567902,
+            "remote": "[remote]"
+          }
+        },
+        {
+          "title": "Batman the dark knight returns: Part 1",
+          "id": "A",
+          "_federation": {
+            "indexUid": "test",
+            "queriesPosition": 0,
+            "weightedRankingScore": 0.7028218694885362,
+            "remote": "[remote]"
+          }
+        },
+        {
+          "title": "Batman the dark knight returns: Part 2",
+          "id": "B",
+          "_federation": {
+            "indexUid": "test",
+            "queriesPosition": 0,
+            "weightedRankingScore": 0.7028218694885362,
+            "remote": "[remote]"
+          }
+        },
+        {
+          "title": "Badman",
+          "id": "E",
+          "_federation": {
+            "indexUid": "test",
+            "queriesPosition": 0,
+            "weightedRankingScore": 0.5,
+            "remote": "[remote]"
+          }
+        },
+        {
+          "title": "Batman",
+          "id": "D",
+          "_federation": {
+            "indexUid": "test",
+            "queriesPosition": 0,
+            "weightedRankingScore": 0.23106060606060605,
+            "remote": "[remote]"
+          }
+        }
+      ],
+      "query": "badman returns",
+      "processingTimeMs": "[time]",
+      "limit": 20,
+      "offset": 0,
+      "estimatedTotalHits": 5,
+      "requestUid": "[uuid]",
+      "remoteErrors": {}
+    }
+    "###);
+    let (response, code) = index2.search_post(request.clone()).await;
+    snapshot!(code, @"200 OK");
+    snapshot!(json_string!(response, { ".processingTimeMs" => "[time]", ".requestUid" => "[uuid]", ".hits.*._federation.remote" => "[remote]" }), @r###"
+    {
+      "hits": [
+        {
+          "title": "Batman Returns",
+          "id": "C",
+          "_federation": {
+            "indexUid": "test",
+            "queriesPosition": 0,
+            "weightedRankingScore": 0.8317901234567902,
+            "remote": "[remote]"
+          }
+        },
+        {
+          "title": "Batman the dark knight returns: Part 1",
+          "id": "A",
+          "_federation": {
+            "indexUid": "test",
+            "queriesPosition": 0,
+            "weightedRankingScore": 0.7028218694885362,
+            "remote": "[remote]"
+          }
+        },
+        {
+          "title": "Batman the dark knight returns: Part 2",
+          "id": "B",
+          "_federation": {
+            "indexUid": "test",
+            "queriesPosition": 0,
+            "weightedRankingScore": 0.7028218694885362,
+            "remote": "[remote]"
+          }
+        },
+        {
+          "title": "Badman",
+          "id": "E",
+          "_federation": {
+            "indexUid": "test",
+            "queriesPosition": 0,
+            "weightedRankingScore": 0.5,
+            "remote": "[remote]"
+          }
+        },
+        {
+          "title": "Batman",
+          "id": "D",
+          "_federation": {
+            "indexUid": "test",
+            "queriesPosition": 0,
+            "weightedRankingScore": 0.23106060606060605,
+            "remote": "[remote]"
+          }
+        }
+      ],
+      "query": "badman returns",
+      "processingTimeMs": "[time]",
+      "limit": 20,
+      "offset": 0,
+      "estimatedTotalHits": 5,
+      "requestUid": "[uuid]",
+      "remoteErrors": {}
+    }
+    "###);
+    // perform search with network
+    let query_1 = "badman";
+    let query_2 = "returns";
+    let request = json!(
+    {
+        "federation": {},
+        "queries": [
+          {
+              "q": query_1,
+              "indexUid": "test",
+              "useNetwork": true,
+          },
+          {
+              "q": query_2,
+              "indexUid": "test",
+              "useNetwork": true,
+          },
+        ]
+    });
+
+    let (response, code) = ms0.multi_search(request.clone()).await;
+    snapshot!(code, @"200 OK");
+    snapshot!(json_string!(response, { ".processingTimeMs" => "[time]", ".requestUid" => "[uuid]", ".hits.*._federation.remote" => "[remote]" }), @r###"
+    {
+      "hits": [
+        {
+          "title": "Badman",
+          "id": "E",
+          "_federation": {
+            "indexUid": "test",
+            "queriesPosition": 0,
+            "weightedRankingScore": 1.0,
+            "remote": "[remote]"
+          }
+        },
+        {
+          "title": "Batman Returns",
+          "id": "C",
+          "_federation": {
+            "indexUid": "test",
+            "queriesPosition": 1,
+            "weightedRankingScore": 0.9242424242424242,
+            "remote": "[remote]"
+          }
+        },
+        {
+          "title": "Batman the dark knight returns: Part 1",
+          "id": "A",
+          "_federation": {
+            "indexUid": "test",
+            "queriesPosition": 1,
+            "weightedRankingScore": 0.8787878787878788,
+            "remote": "[remote]"
+          }
+        },
+        {
+          "title": "Batman the dark knight returns: Part 2",
+          "id": "B",
+          "_federation": {
+            "indexUid": "test",
+            "queriesPosition": 1,
+            "weightedRankingScore": 0.8787878787878788,
+            "remote": "[remote]"
+          }
+        },
+        {
+          "title": "Batman",
+          "id": "D",
+          "_federation": {
+            "indexUid": "test",
+            "queriesPosition": 0,
+            "weightedRankingScore": 0.4621212121212121,
+            "remote": "[remote]"
+          }
+        }
+      ],
+      "processingTimeMs": "[time]",
+      "limit": 20,
+      "offset": 0,
+      "estimatedTotalHits": 5,
+      "requestUid": "[uuid]",
+      "remoteErrors": {}
+    }
+    "###);
+    let (response, code) = ms1.multi_search(request.clone()).await;
+    snapshot!(code, @"200 OK");
+    snapshot!(json_string!(response, { ".processingTimeMs" => "[time]", ".requestUid" => "[uuid]", ".hits.*._federation.remote" => "[remote]" }), @r###"
+    {
+      "hits": [
+        {
+          "title": "Badman",
+          "id": "E",
+          "_federation": {
+            "indexUid": "test",
+            "queriesPosition": 0,
+            "weightedRankingScore": 1.0,
+            "remote": "[remote]"
+          }
+        },
+        {
+          "title": "Batman Returns",
+          "id": "C",
+          "_federation": {
+            "indexUid": "test",
+            "queriesPosition": 1,
+            "weightedRankingScore": 0.9242424242424242,
+            "remote": "[remote]"
+          }
+        },
+        {
+          "title": "Batman the dark knight returns: Part 1",
+          "id": "A",
+          "_federation": {
+            "indexUid": "test",
+            "queriesPosition": 1,
+            "weightedRankingScore": 0.8787878787878788,
+            "remote": "[remote]"
+          }
+        },
+        {
+          "title": "Batman the dark knight returns: Part 2",
+          "id": "B",
+          "_federation": {
+            "indexUid": "test",
+            "queriesPosition": 1,
+            "weightedRankingScore": 0.8787878787878788,
+            "remote": "[remote]"
+          }
+        },
+        {
+          "title": "Batman",
+          "id": "D",
+          "_federation": {
+            "indexUid": "test",
+            "queriesPosition": 0,
+            "weightedRankingScore": 0.4621212121212121,
+            "remote": "[remote]"
+          }
+        }
+      ],
+      "processingTimeMs": "[time]",
+      "limit": 20,
+      "offset": 0,
+      "estimatedTotalHits": 5,
+      "requestUid": "[uuid]",
+      "remoteErrors": {}
+    }
+    "###);
+    let (response, code) = ms2.multi_search(request.clone()).await;
+    snapshot!(code, @"200 OK");
+    snapshot!(json_string!(response, { ".processingTimeMs" => "[time]", ".requestUid" => "[uuid]", ".hits.*._federation.remote" => "[remote]"  }), @r###"
+    {
+      "hits": [
+        {
+          "title": "Badman",
+          "id": "E",
+          "_federation": {
+            "indexUid": "test",
+            "queriesPosition": 0,
+            "weightedRankingScore": 1.0,
+            "remote": "[remote]"
+          }
+        },
+        {
+          "title": "Batman Returns",
+          "id": "C",
+          "_federation": {
+            "indexUid": "test",
+            "queriesPosition": 1,
+            "weightedRankingScore": 0.9242424242424242,
+            "remote": "[remote]"
+          }
+        },
+        {
+          "title": "Batman the dark knight returns: Part 1",
+          "id": "A",
+          "_federation": {
+            "indexUid": "test",
+            "queriesPosition": 1,
+            "weightedRankingScore": 0.8787878787878788,
+            "remote": "[remote]"
+          }
+        },
+        {
+          "title": "Batman the dark knight returns: Part 2",
+          "id": "B",
+          "_federation": {
+            "indexUid": "test",
+            "queriesPosition": 1,
+            "weightedRankingScore": 0.8787878787878788,
+            "remote": "[remote]"
+          }
+        },
+        {
+          "title": "Batman",
+          "id": "D",
+          "_federation": {
+            "indexUid": "test",
+            "queriesPosition": 0,
+            "weightedRankingScore": 0.4621212121212121,
+            "remote": "[remote]"
+          }
+        }
+      ],
+      "processingTimeMs": "[time]",
+      "limit": 20,
+      "offset": 0,
+      "estimatedTotalHits": 5,
+      "requestUid": "[uuid]",
+      "remoteErrors": {}
+    }
+    "###);
+}
+
+#[cfg(feature = "enterprise")]
+#[actix_rt::test]
 async fn remote_auto_sharding_auto_search_apostrophe_catastrophe() {
     use crate::common::C_EST_FRANÇAIS_DOCUMENTS;
 

--- a/crates/meilisearch/tests/search/multi/proxy.rs
+++ b/crates/meilisearch/tests/search/multi/proxy.rs
@@ -6792,7 +6792,7 @@ async fn remote_auto_sharding_auto_search_apostrophe_catastrophe() {
             "indexUid": "test",
             "queriesPosition": 0,
             "weightedRankingScore": 1.0,
-            "remote": "ms0"
+            "remote": "[remote]"
           }
         },
         {
@@ -6802,7 +6802,7 @@ async fn remote_auto_sharding_auto_search_apostrophe_catastrophe() {
             "indexUid": "test",
             "queriesPosition": 0,
             "weightedRankingScore": 1.0,
-            "remote": "ms0"
+            "remote": "[remote]"
           }
         },
         {
@@ -6812,7 +6812,7 @@ async fn remote_auto_sharding_auto_search_apostrophe_catastrophe() {
             "indexUid": "test",
             "queriesPosition": 0,
             "weightedRankingScore": 1.0,
-            "remote": "ms1"
+            "remote": "[remote]"
           }
         }
       ],
@@ -6837,7 +6837,7 @@ async fn remote_auto_sharding_auto_search_apostrophe_catastrophe() {
             "indexUid": "test",
             "queriesPosition": 0,
             "weightedRankingScore": 1.0,
-            "remote": "ms1"
+            "remote": "[remote]"
           }
         },
         {
@@ -6847,7 +6847,7 @@ async fn remote_auto_sharding_auto_search_apostrophe_catastrophe() {
             "indexUid": "test",
             "queriesPosition": 0,
             "weightedRankingScore": 1.0,
-            "remote": "ms0"
+            "remote": "[remote]"
           }
         },
         {
@@ -6857,7 +6857,7 @@ async fn remote_auto_sharding_auto_search_apostrophe_catastrophe() {
             "indexUid": "test",
             "queriesPosition": 0,
             "weightedRankingScore": 1.0,
-            "remote": "ms0"
+            "remote": "[remote]"
           }
         }
       ],
@@ -6890,7 +6890,7 @@ async fn remote_auto_sharding_auto_search_apostrophe_catastrophe() {
             "indexUid": "test",
             "queriesPosition": 0,
             "weightedRankingScore": 1.0,
-            "remote": "ms0"
+            "remote": "[remote]"
           }
         },
         {
@@ -6900,7 +6900,7 @@ async fn remote_auto_sharding_auto_search_apostrophe_catastrophe() {
             "indexUid": "test",
             "queriesPosition": 0,
             "weightedRankingScore": 1.0,
-            "remote": "ms1"
+            "remote": "[remote]"
           }
         }
       ],
@@ -6925,7 +6925,7 @@ async fn remote_auto_sharding_auto_search_apostrophe_catastrophe() {
             "indexUid": "test",
             "queriesPosition": 0,
             "weightedRankingScore": 1.0,
-            "remote": "ms1"
+            "remote": "[remote]"
           }
         },
         {
@@ -6935,7 +6935,7 @@ async fn remote_auto_sharding_auto_search_apostrophe_catastrophe() {
             "indexUid": "test",
             "queriesPosition": 0,
             "weightedRankingScore": 1.0,
-            "remote": "ms0"
+            "remote": "[remote]"
           }
         }
       ],

--- a/crates/meilisearch/tests/search/multi/proxy.rs
+++ b/crates/meilisearch/tests/search/multi/proxy.rs
@@ -1550,36 +1550,36 @@ async fn remote_sharding_federated_auto_search() {
     let (response, code) = ms0.set_network(json!({"self": "ms0"})).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, {".version" => "[version]"}), @r###"
-    {
-      "self": "ms0",
-      "remotes": {},
-      "shards": {},
-      "leader": null,
-      "version": "[version]"
-    }
-    "###);
+  {
+    "self": "ms0",
+    "remotes": {},
+    "shards": {},
+    "leader": null,
+    "version": "[version]"
+  }
+  "###);
     let (response, code) = ms1.set_network(json!({"self": "ms1"})).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, {".version" => "[version]"}), @r###"
-    {
-      "self": "ms1",
-      "remotes": {},
-      "shards": {},
-      "leader": null,
-      "version": "[version]"
-    }
-    "###);
+  {
+    "self": "ms1",
+    "remotes": {},
+    "shards": {},
+    "leader": null,
+    "version": "[version]"
+  }
+  "###);
     let (response, code) = ms2.set_network(json!({"self": "ms2"})).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, {".version" => "[version]"}), @r###"
-    {
-      "self": "ms2",
-      "remotes": {},
-      "shards": {},
-      "leader": null,
-      "version": "[version]"
-    }
-    "###);
+  {
+    "self": "ms2",
+    "remotes": {},
+    "shards": {},
+    "leader": null,
+    "version": "[version]"
+  }
+  "###);
 
     // add documents
     let documents = SCORE_DOCUMENTS.clone();
@@ -1645,195 +1645,195 @@ async fn remote_sharding_federated_auto_search() {
     let (response, _status_code) = ms0.multi_search(request.clone()).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".processingTimeMs" => "[time]", ".requestUid" => "[uuid]" }), @r###"
-    {
-      "hits": [
-        {
-          "title": "Badman",
-          "id": "E",
-          "_federation": {
-            "indexUid": "test",
-            "queriesPosition": 0,
-            "weightedRankingScore": 1.0,
-            "remote": "ms2"
-          }
-        },
-        {
-          "title": "Batman Returns",
-          "id": "C",
-          "_federation": {
-            "indexUid": "test",
-            "queriesPosition": 1,
-            "weightedRankingScore": 0.9242424242424242,
-            "remote": "ms1"
-          }
-        },
-        {
-          "title": "Batman the dark knight returns: Part 1",
-          "id": "A",
-          "_federation": {
-            "indexUid": "test",
-            "queriesPosition": 1,
-            "weightedRankingScore": 0.8787878787878788,
-            "remote": "ms0"
-          }
-        },
-        {
-          "title": "Batman the dark knight returns: Part 2",
-          "id": "B",
-          "_federation": {
-            "indexUid": "test",
-            "queriesPosition": 1,
-            "weightedRankingScore": 0.8787878787878788,
-            "remote": "ms0"
-          }
-        },
-        {
-          "title": "Batman",
-          "id": "D",
-          "_federation": {
-            "indexUid": "test",
-            "queriesPosition": 0,
-            "weightedRankingScore": 0.4621212121212121,
-            "remote": "ms2"
-          }
+  {
+    "hits": [
+      {
+        "title": "Badman",
+        "id": "E",
+        "_federation": {
+          "indexUid": "test",
+          "queriesPosition": 0,
+          "weightedRankingScore": 1.0,
+          "remote": "ms2"
         }
-      ],
-      "processingTimeMs": "[time]",
-      "limit": 20,
-      "offset": 0,
-      "estimatedTotalHits": 5,
-      "requestUid": "[uuid]",
-      "remoteErrors": {}
-    }
-    "###);
+      },
+      {
+        "title": "Batman Returns",
+        "id": "C",
+        "_federation": {
+          "indexUid": "test",
+          "queriesPosition": 1,
+          "weightedRankingScore": 0.9242424242424242,
+          "remote": "ms1"
+        }
+      },
+      {
+        "title": "Batman the dark knight returns: Part 1",
+        "id": "A",
+        "_federation": {
+          "indexUid": "test",
+          "queriesPosition": 1,
+          "weightedRankingScore": 0.8787878787878788,
+          "remote": "ms0"
+        }
+      },
+      {
+        "title": "Batman the dark knight returns: Part 2",
+        "id": "B",
+        "_federation": {
+          "indexUid": "test",
+          "queriesPosition": 1,
+          "weightedRankingScore": 0.8787878787878788,
+          "remote": "ms0"
+        }
+      },
+      {
+        "title": "Batman",
+        "id": "D",
+        "_federation": {
+          "indexUid": "test",
+          "queriesPosition": 0,
+          "weightedRankingScore": 0.4621212121212121,
+          "remote": "ms2"
+        }
+      }
+    ],
+    "processingTimeMs": "[time]",
+    "limit": 20,
+    "offset": 0,
+    "estimatedTotalHits": 5,
+    "requestUid": "[uuid]",
+    "remoteErrors": {}
+  }
+  "###);
     let (response, _status_code) = ms1.multi_search(request.clone()).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".processingTimeMs" => "[time]", ".requestUid" => "[uuid]" }), @r###"
-    {
-      "hits": [
-        {
-          "title": "Badman",
-          "id": "E",
-          "_federation": {
-            "indexUid": "test",
-            "queriesPosition": 0,
-            "weightedRankingScore": 1.0,
-            "remote": "ms2"
-          }
-        },
-        {
-          "title": "Batman Returns",
-          "id": "C",
-          "_federation": {
-            "indexUid": "test",
-            "queriesPosition": 1,
-            "weightedRankingScore": 0.9242424242424242,
-            "remote": "ms1"
-          }
-        },
-        {
-          "title": "Batman the dark knight returns: Part 1",
-          "id": "A",
-          "_federation": {
-            "indexUid": "test",
-            "queriesPosition": 1,
-            "weightedRankingScore": 0.8787878787878788,
-            "remote": "ms0"
-          }
-        },
-        {
-          "title": "Batman the dark knight returns: Part 2",
-          "id": "B",
-          "_federation": {
-            "indexUid": "test",
-            "queriesPosition": 1,
-            "weightedRankingScore": 0.8787878787878788,
-            "remote": "ms0"
-          }
-        },
-        {
-          "title": "Batman",
-          "id": "D",
-          "_federation": {
-            "indexUid": "test",
-            "queriesPosition": 0,
-            "weightedRankingScore": 0.4621212121212121,
-            "remote": "ms2"
-          }
+  {
+    "hits": [
+      {
+        "title": "Badman",
+        "id": "E",
+        "_federation": {
+          "indexUid": "test",
+          "queriesPosition": 0,
+          "weightedRankingScore": 1.0,
+          "remote": "ms2"
         }
-      ],
-      "processingTimeMs": "[time]",
-      "limit": 20,
-      "offset": 0,
-      "estimatedTotalHits": 5,
-      "requestUid": "[uuid]",
-      "remoteErrors": {}
-    }
-    "###);
+      },
+      {
+        "title": "Batman Returns",
+        "id": "C",
+        "_federation": {
+          "indexUid": "test",
+          "queriesPosition": 1,
+          "weightedRankingScore": 0.9242424242424242,
+          "remote": "ms1"
+        }
+      },
+      {
+        "title": "Batman the dark knight returns: Part 1",
+        "id": "A",
+        "_federation": {
+          "indexUid": "test",
+          "queriesPosition": 1,
+          "weightedRankingScore": 0.8787878787878788,
+          "remote": "ms0"
+        }
+      },
+      {
+        "title": "Batman the dark knight returns: Part 2",
+        "id": "B",
+        "_federation": {
+          "indexUid": "test",
+          "queriesPosition": 1,
+          "weightedRankingScore": 0.8787878787878788,
+          "remote": "ms0"
+        }
+      },
+      {
+        "title": "Batman",
+        "id": "D",
+        "_federation": {
+          "indexUid": "test",
+          "queriesPosition": 0,
+          "weightedRankingScore": 0.4621212121212121,
+          "remote": "ms2"
+        }
+      }
+    ],
+    "processingTimeMs": "[time]",
+    "limit": 20,
+    "offset": 0,
+    "estimatedTotalHits": 5,
+    "requestUid": "[uuid]",
+    "remoteErrors": {}
+  }
+  "###);
     let (response, _status_code) = ms2.multi_search(request.clone()).await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".processingTimeMs" => "[time]", ".requestUid" => "[uuid]" }), @r###"
-    {
-      "hits": [
-        {
-          "title": "Badman",
-          "id": "E",
-          "_federation": {
-            "indexUid": "test",
-            "queriesPosition": 0,
-            "weightedRankingScore": 1.0,
-            "remote": "ms2"
-          }
-        },
-        {
-          "title": "Batman Returns",
-          "id": "C",
-          "_federation": {
-            "indexUid": "test",
-            "queriesPosition": 1,
-            "weightedRankingScore": 0.9242424242424242,
-            "remote": "ms1"
-          }
-        },
-        {
-          "title": "Batman the dark knight returns: Part 1",
-          "id": "A",
-          "_federation": {
-            "indexUid": "test",
-            "queriesPosition": 1,
-            "weightedRankingScore": 0.8787878787878788,
-            "remote": "ms0"
-          }
-        },
-        {
-          "title": "Batman the dark knight returns: Part 2",
-          "id": "B",
-          "_federation": {
-            "indexUid": "test",
-            "queriesPosition": 1,
-            "weightedRankingScore": 0.8787878787878788,
-            "remote": "ms0"
-          }
-        },
-        {
-          "title": "Batman",
-          "id": "D",
-          "_federation": {
-            "indexUid": "test",
-            "queriesPosition": 0,
-            "weightedRankingScore": 0.4621212121212121,
-            "remote": "ms2"
-          }
+  {
+    "hits": [
+      {
+        "title": "Badman",
+        "id": "E",
+        "_federation": {
+          "indexUid": "test",
+          "queriesPosition": 0,
+          "weightedRankingScore": 1.0,
+          "remote": "ms2"
         }
-      ],
-      "processingTimeMs": "[time]",
-      "limit": 20,
-      "offset": 0,
-      "estimatedTotalHits": 5,
-      "requestUid": "[uuid]",
-      "remoteErrors": {}
-    }
-    "###);
+      },
+      {
+        "title": "Batman Returns",
+        "id": "C",
+        "_federation": {
+          "indexUid": "test",
+          "queriesPosition": 1,
+          "weightedRankingScore": 0.9242424242424242,
+          "remote": "ms1"
+        }
+      },
+      {
+        "title": "Batman the dark knight returns: Part 1",
+        "id": "A",
+        "_federation": {
+          "indexUid": "test",
+          "queriesPosition": 1,
+          "weightedRankingScore": 0.8787878787878788,
+          "remote": "ms0"
+        }
+      },
+      {
+        "title": "Batman the dark knight returns: Part 2",
+        "id": "B",
+        "_federation": {
+          "indexUid": "test",
+          "queriesPosition": 1,
+          "weightedRankingScore": 0.8787878787878788,
+          "remote": "ms0"
+        }
+      },
+      {
+        "title": "Batman",
+        "id": "D",
+        "_federation": {
+          "indexUid": "test",
+          "queriesPosition": 0,
+          "weightedRankingScore": 0.4621212121212121,
+          "remote": "ms2"
+        }
+      }
+    ],
+    "processingTimeMs": "[time]",
+    "limit": 20,
+    "offset": 0,
+    "estimatedTotalHits": 5,
+    "requestUid": "[uuid]",
+    "remoteErrors": {}
+  }
+  "###);
 }
 
 #[actix_rt::test]
@@ -6782,7 +6782,7 @@ async fn remote_auto_sharding_auto_search_apostrophe_catastrophe() {
 
     let (response, code) = index0.search_post(request.clone()).await;
     snapshot!(code, @"200 OK");
-    snapshot!(json_string!(response, { ".processingTimeMs" => "[time]", ".requestUid" => "[uuid]" }), @r###"
+    snapshot!(json_string!(response, { ".processingTimeMs" => "[time]", ".requestUid" => "[uuid]", ".hits.*._federation.remote" => "[remote]"  }), @r###"
     {
       "hits": [
         {
@@ -6827,7 +6827,7 @@ async fn remote_auto_sharding_auto_search_apostrophe_catastrophe() {
     "###);
     let (response, code) = index1.search_post(request.clone()).await;
     snapshot!(code, @"200 OK");
-    snapshot!(json_string!(response, { ".processingTimeMs" => "[time]", ".requestUid" => "[uuid]" }), @r###"
+    snapshot!(json_string!(response, { ".processingTimeMs" => "[time]", ".requestUid" => "[uuid]", ".hits.*._federation.remote" => "[remote]" }), @r###"
     {
       "hits": [
         {
@@ -6880,7 +6880,7 @@ async fn remote_auto_sharding_auto_search_apostrophe_catastrophe() {
 
     let (response, code) = index0.search_post(request.clone()).await;
     snapshot!(code, @"200 OK");
-    snapshot!(json_string!(response, { ".processingTimeMs" => "[time]", ".requestUid" => "[uuid]" }), @r###"
+    snapshot!(json_string!(response, { ".processingTimeMs" => "[time]", ".requestUid" => "[uuid]", ".hits.*._federation.remote" => "[remote]" }), @r###"
     {
       "hits": [
         {
@@ -6915,7 +6915,7 @@ async fn remote_auto_sharding_auto_search_apostrophe_catastrophe() {
     "###);
     let (response, code) = index1.search_post(request.clone()).await;
     snapshot!(code, @"200 OK");
-    snapshot!(json_string!(response, { ".processingTimeMs" => "[time]", ".requestUid" => "[uuid]" }), @r###"
+    snapshot!(json_string!(response, { ".processingTimeMs" => "[time]", ".requestUid" => "[uuid]", ".hits.*._federation.remote" => "[remote]" }), @r###"
     {
       "hits": [
         {


### PR DESCRIPTION
## Related issue

Fixes https://linear.app/meilisearch/issue/SP-2044

## Generative AI tools

- [x] This PR does not use generative AI tooling


## Changelog

Fix sharding document duplication by:
- instantiating a query partitioner only once per search
- avoiding the shard filter from being overwritten