### PR TITLE
Add missing searchFilterParam to GET chat workspace settings response

### DIFF
--- a/crates/meilisearch/src/routes/chats/settings.rs
+++ b/crates/meilisearch/src/routes/chats/settings.rs
@@ -50,7 +50,8 @@ use crate::extractors::authentication::GuardedData;
                     "system": "My super system prompt",
                     "searchDescription": "My super search tool description",
                     "searchQParam": "My awesome q search parameter description",
-                    "searchIndexUidParam": "My incredible index uid param description"
+                    "searchIndexUidParam": "My incredible index uid param description",
+                    "searchFilterParam": "My filter parameter description"
                 }
             }
         )),


### PR DESCRIPTION
## Related issue

Fixes documentation issue https://github.com/meilisearch/documentation/issues/3423 

## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respect the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - *list of used tools and what they were used for*

## Requirements

⚠️ Ensure the following requirements before merging ⚠️
- [ ] Automated tests have been added.
- [ ] If some tests cannot be automated, manual rigorous tests should be applied.
- [ ] ⚠️ If there is any change in the DB:
    - [ ] Test that any impacted DB still works as expected after using `--experimental-dumpless-upgrade` on a DB created with the last released Meilisearch
    - [ ] Test that during the upgrade, **search is still available** (artificially make the upgrade longer if needed)
    - [ ] Set the `db change` label.
- [ ] If necessary, the feature have been tested in the Cloud production environment (with [prototypes](./documentation/prototypes.md)) and the Cloud UI is ready.
- [ ] If necessary, the [documentation](https://github.com/meilisearch/documentation) related to the implemented feature in the PR is ready.
- [ ] If necessary, the [integrations](https://github.com/meilisearch/integration-guides) related to the implemented feature in the PR are ready.
