### PR TITLE
fix(chats): keep streaming when a provider sends a choice-less chunk

### DIFF
--- a/crates/meilisearch/src/routes/chats/chat_completions.rs
+++ b/crates/meilisearch/src/routes/chats/chat_completions.rs
@@ -736,7 +736,13 @@ async fn run_conversation<C: async_openai::config::Config>(
                 }
                 let choice = match resp.choices.first() {
                     Some(choice) => choice,
-                    None => break,
+                    // Some providers (notably Azure OpenAI) bracket the stream with
+                    // metadata-only chunks that carry an empty `choices` array: a
+                    // leading chunk with the prompt content-filter results, and,
+                    // when `include_usage` is set, a trailing usage-only chunk.
+                    // Neither marks the end of the response, so skip them instead of
+                    // aborting the whole stream on the first one (issue #6341).
+                    None => continue,
                 };
                 finish_reason = choice.finish_reason;
 


### PR DESCRIPTION
# Pull Request

## Related issue

Fixes #6341

## What does this PR do?

Chat completions stop producing any output against Azure OpenAI (and any
provider whose stream opens with a metadata-only chunk).

The streaming loop in `stream_chat_completion` reads each SSE chunk and does:

```rust
let choice = match resp.choices.first() {
    Some(choice) => choice,
    None => break,
};
```

Azure OpenAI opens the stream with a chunk that carries an **empty `choices`
array** (the prompt content-filter results), e.g.:

```jsonl
{"choices":[],"created":0,"id":"","model":"","object":"","prompt_filter_results":[{"prompt_index":0,"content_filter_results":{ ... }}]}
```

That leading chunk hits `None => break`, so the loop exits on the very first
chunk and the whole completion is aborted before any content is streamed back —
the reported "no responses are generated".

This PR skips choice-less chunks (`continue`) instead of treating them as the
end of the stream:

- The leading Azure prompt-filter chunk is skipped, and the subsequent content
  chunks are streamed normally.
- The trailing usage-only chunk (emitted when `include_usage` is set, also
  choice-less) is still accounted for by the `resp.usage` block just above the
  match; it is then skipped, and the stream ends naturally on the next `None`
  from `response.next()` — same outcome as before for the non-Azure path.

So there is no behavior change for OpenAI/Mistral/vLLM streams; the only
difference is that a choice-less chunk no longer kills an in-progress response.

## PR checklist

- The chat streaming path does not yet have an integration-test harness
  (tracked separately in #6179), so this was verified by tracing the code
  against the exact chunk sequence captured in the issue. Glad to add a
  mock-SSE regression test if you'd like one as part of this PR.
