### PR TITLE
Support target index names in the export route

### DIFF
--- a/crates/index-scheduler/src/error.rs
+++ b/crates/index-scheduler/src/error.rs
@@ -135,6 +135,11 @@ pub enum Error {
     TaskCancelationWithEmptyQuery,
     #[error("Aborted task")]
     AbortedTask,
+    #[error(
+        "Cannot export several indexes to the same target name `{target}`. The following source indexes all resolve to it: {}.",
+        .sources.iter().map(|s| format!("`{s}`")).collect::<Vec<_>>().join(", ")
+    )]
+    ExportSameTargetIndexName { target: String, sources: Vec<String> },
 
     #[error("S3 error: status: {status}, body: {body}")]
     S3Error { status: StatusCode, body: String },
@@ -259,6 +264,7 @@ impl Error {
             | Error::TaskCancelationWithEmptyQuery
             | Error::FromRemoteWhenExporting { .. }
             | Error::AbortedTask
+            | Error::ExportSameTargetIndexName { .. }
             | Error::S3Error { .. }
             | Error::S3HttpError(_)
             | Error::S3XmlError(_)
@@ -332,6 +338,7 @@ impl ErrorCode for Error {
             Error::InvalidTaskTypes { .. } => Code::InvalidTaskTypes,
             Error::InvalidTaskCanceledBy { .. } => Code::InvalidTaskCanceledBy,
             Error::InvalidIndexUid { .. } | Error::ExpectedDsrUid { .. } => Code::InvalidIndexUid,
+            Error::ExportSameTargetIndexName { .. } => Code::ExportSameTargetIndexName,
             Error::TaskNotFound(_) => Code::TaskNotFound,
             Error::TaskFileNotFound(_) => Code::TaskFileNotFound,
             Error::BatchNotFound(_) => Code::BatchNotFound,

--- a/crates/index-scheduler/src/scheduler/process_export.rs
+++ b/crates/index-scheduler/src/scheduler/process_export.rs
@@ -10,6 +10,7 @@ use flate2::write::GzEncoder;
 use flate2::Compression;
 use http_client::ureq::http::header::AUTHORIZATION;
 use meilisearch_types::error::Code;
+use meilisearch_types::index_uid::IndexUid;
 use meilisearch_types::index_uid_pattern::IndexUidPattern;
 use meilisearch_types::milli::constants::RESERVED_VECTORS_FIELD_NAME;
 use meilisearch_types::milli::index::EmbeddingsWithMetadata;
@@ -59,6 +60,12 @@ impl IndexScheduler {
 
         let features = self.features();
 
+        // Resolve the target index name for each matched source index (see
+        // `resolve_target_index_names`).
+        let target_names = resolve_target_index_names(
+            indexes.iter().map(|(_, uid, settings)| (uid.as_str(), settings.name.as_deref())),
+        )?;
+
         let mut output = BTreeMap::new();
 
         let config = http_client::ureq::config::Config::builder()
@@ -83,7 +90,8 @@ impl IndexScheduler {
                 indexes.len() as u32,
             ));
 
-            let ExportIndexSettings { filter, override_settings } = export_settings;
+            let ExportIndexSettings { filter, override_settings, name: _ } = export_settings;
+            let target_uid = &target_names[i];
 
             let index = self.user_index(uid)?;
             let index_rtxn = index.read_txn()?;
@@ -112,7 +120,7 @@ impl IndexScheduler {
                 features,
             };
             let options = ExportOptions {
-                index_uid: uid,
+                index_uid: target_uid,
                 payload_size,
                 override_settings: *override_settings,
                 export_mode: ExportMode::ExportRoute,
@@ -882,3 +890,78 @@ pub(super) enum ExportMode<'a> {
 
 // progress related
 enum ExportIndex {}
+
+/// Resolves the target index name for each matched source index.
+///
+/// Each item is a `(source_uid, name)` pair where `name` is the optional target-name template
+/// provided in the export settings. The `$name` variable in the template is replaced with the
+/// source index name; when no template is provided the source index name is used as-is.
+///
+/// Returns an error if a resolved name is not a valid index uid, or if two source indexes resolve
+/// to the same target name (which would silently merge or overwrite them).
+fn resolve_target_index_names<'a>(
+    sources: impl IntoIterator<Item = (&'a str, Option<&'a str>)>,
+) -> Result<Vec<String>> {
+    let mut target_names = Vec::new();
+    let mut sources_by_target: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for (uid, name) in sources {
+        let target = match name {
+            Some(name) => name.replace("$name", uid),
+            None => uid.to_string(),
+        };
+        let target = IndexUid::try_from(target)
+            .map_err(|e| Error::InvalidIndexUid { index_uid: e.invalid_uid })?
+            .into_inner();
+        sources_by_target.entry(target.clone()).or_default().push(uid.to_string());
+        target_names.push(target);
+    }
+    if let Some((target, sources)) =
+        sources_by_target.into_iter().find(|(_, sources)| sources.len() > 1)
+    {
+        return Err(Error::ExportSameTargetIndexName { target, sources });
+    }
+    Ok(target_names)
+}
+
+#[cfg(test)]
+mod tests {
+    use meilisearch_types::error::{Code, ErrorCode};
+
+    use super::resolve_target_index_names;
+    use crate::Error;
+
+    #[test]
+    fn target_defaults_to_source_name() {
+        let targets = resolve_target_index_names([("movies", None), ("books", None)]).unwrap();
+        assert_eq!(targets, vec!["movies".to_string(), "books".to_string()]);
+    }
+
+    #[test]
+    fn name_variable_is_expanded() {
+        let targets = resolve_target_index_names([("super-toto", Some("mega-$name"))]).unwrap();
+        assert_eq!(targets, vec!["mega-super-toto".to_string()]);
+    }
+
+    #[test]
+    fn static_name_without_variable() {
+        let targets = resolve_target_index_names([("super-toto", Some("everyone"))]).unwrap();
+        assert_eq!(targets, vec!["everyone".to_string()]);
+    }
+
+    #[test]
+    fn colliding_target_names_are_rejected() {
+        let err = resolve_target_index_names([
+            ("super-toto", Some("everyone")),
+            ("super-boby", Some("everyone")),
+        ])
+        .unwrap_err();
+        assert!(matches!(err, Error::ExportSameTargetIndexName { .. }));
+        assert_eq!(err.error_code(), Code::ExportSameTargetIndexName);
+    }
+
+    #[test]
+    fn invalid_resolved_name_is_rejected() {
+        let err = resolve_target_index_names([("toto", Some("not a valid name"))]).unwrap_err();
+        assert!(matches!(err, Error::InvalidIndexUid { .. }));
+    }
+}

--- a/crates/meilisearch-types/src/error.rs
+++ b/crates/meilisearch-types/src/error.rs
@@ -434,6 +434,8 @@ InvalidExportPayloadSize                       , InvalidRequest       , BAD_REQU
 InvalidExportIndexesPatterns                   , InvalidRequest       , BAD_REQUEST ;
 InvalidExportIndexFilter                       , InvalidRequest       , BAD_REQUEST ;
 InvalidExportIndexOverrideSettings             , InvalidRequest       , BAD_REQUEST ;
+InvalidExportIndexName                         , InvalidRequest       , BAD_REQUEST ;
+ExportSameTargetIndexName                      , InvalidRequest       , BAD_REQUEST ;
 // Experimental features - Chat Completions
 UnimplementedExternalFunctionCalling           , InvalidRequest       , NOT_IMPLEMENTED ;
 UnimplementedNonStreamingChatCompletions       , InvalidRequest       , NOT_IMPLEMENTED ;

--- a/crates/meilisearch-types/src/tasks/mod.rs
+++ b/crates/meilisearch-types/src/tasks/mod.rs
@@ -221,6 +221,11 @@ pub struct ExportIndexSettings {
     pub filter: Option<Value>,
     /// Whether to override settings on the destination index
     pub override_settings: bool,
+    /// Target index name on the destination instance. The `$name` variable is
+    /// replaced with the name of the matched source index. When omitted, the
+    /// source index name is used.
+    #[serde(default)]
+    pub name: Option<String>,
 }
 
 impl KindWithContent {

--- a/crates/meilisearch/src/routes/export.rs
+++ b/crates/meilisearch/src/routes/export.rs
@@ -73,8 +73,8 @@ async fn export(
     let indexes = match indexes {
         Some(indexes) => indexes
             .into_iter()
-            .map(|(pattern, ExportIndexSettings { filter, override_settings })| {
-                (pattern, DbExportIndexSettings { filter, override_settings })
+            .map(|(pattern, ExportIndexSettings { filter, override_settings, name })| {
+                (pattern, DbExportIndexSettings { filter, override_settings, name })
             })
             .collect(),
         None => BTreeMap::from([(
@@ -165,4 +165,8 @@ pub struct ExportIndexSettings {
     /// Whether to override settings on the destination index
     #[request(default, error = DeserrJsonError<InvalidExportIndexOverrideSettings>, schema_type = Option<bool>, example = json!(true))]
     pub override_settings: bool,
+    /// Target index name on the destination instance. The `$name` variable is replaced with the
+    /// name of the matched source index. When omitted, the source index name is used.
+    #[request(default, error = DeserrJsonError<InvalidExportIndexName>, example = json!("mega-$name"))]
+    pub name: Option<String>,
 }


### PR DESCRIPTION
## Related issue

Fixes #6049

## What does this PR do?

Adds support for target index names in the export route, as described in the issue and agreed in the discussion.

A new optional `name` field is added to the per-index export settings:

- The `$name` variable in the value is replaced with the matched source index name, e.g. `"name": "mega-$name"` exports `super-toto` and `super-boby` to `mega-super-toto` and `mega-super-boby`.
- A value without the variable is used as-is (static name), e.g. `"name": "everyone"`.
- Omitting the field keeps the current behaviour of reusing the source index name.

```json
// POST /export
{
  "url": "http://ms-xxx-yy.fra.meilisearch.com",
  "indexes": {
    "super-*": { "name": "mega-$name", "filter": "super-power = laser" }
  }
}
```

The resolved name is validated as a valid index uid. As discussed, if several source indexes resolve to the **same** target name the task fails with a clear error listing the colliding indexes (since the processing order of indexes is not deterministic, erroring is preferable to a silent last-one-wins merge).

Implementation notes:
- `name` is threaded from the route payload (`routes/export.rs`) through the task type (`meilisearch-types/tasks`) to `process_export`.
- The resolution + collision logic is extracted into a small `resolve_target_index_names` helper, which is unit-tested directly (the export route itself talks to a remote instance and has no automated test harness in the repo).
- The field is added with `#[serde(default)]` so already-enqueued export tasks keep deserializing.

## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respect the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)

## Requirements

- [x] Automated tests have been added.
  - Unit tests for `resolve_target_index_names` cover: default (source) name, `$name` expansion, static name, collision error, and invalid resolved name.
- [ ] If some tests cannot be automated, manual rigorous tests should be applied.
  - The end-to-end export against a remote instance was not automated (no existing harness for it); happy to add an integration test if you point me at the preferred approach.
- [ ] ⚠️ If there is any change in the DB:
  - The serialized `Export` task gains an optional `name` field, kept backward-compatible via `#[serde(default)]` (existing enqueued tasks deserialize unchanged). No index/data DB migration is involved. Let me know if you'd still like the `db change` label set.
- [ ] If necessary, the feature have been tested in the Cloud production environment (with prototypes) and the Cloud UI is ready.
- [ ] If necessary, the documentation related to the implemented feature in the PR is ready.
- [ ] If necessary, the integrations related to the implemented feature in the PR are ready.