### PR TITLE
Support attribute patterns when asking for facet distribution

### DIFF
--- a/crates/meilisearch/Cargo.toml
+++ b/crates/meilisearch/Cargo.toml
@@ -138,7 +138,7 @@ tempfile = { version = "3.27.0", optional = true }
 zip = { version = "6.0.0", optional = true, default-features = false, features = ["deflate-flate2"] }
 
 [features]
-default = ["meilisearch-types/all-tokenizations", "mini-dashboard"]
+default = ["enterprise", "meilisearch-types/all-tokenizations", "mini-dashboard"]
 swagger = ["utoipa-scalar"]
 test-ollama = []
 mini-dashboard = [

--- a/crates/meilisearch/Cargo.toml
+++ b/crates/meilisearch/Cargo.toml
@@ -138,7 +138,7 @@ tempfile = { version = "3.27.0", optional = true }
 zip = { version = "6.0.0", optional = true, default-features = false, features = ["deflate-flate2"] }
 
 [features]
-default = ["enterprise", "meilisearch-types/all-tokenizations", "mini-dashboard"]
+default = ["meilisearch-types/all-tokenizations", "mini-dashboard"]
 swagger = ["utoipa-scalar"]
 test-ollama = []
 mini-dashboard = [

--- a/crates/meilisearch/src/documents_retrieval/mod.rs
+++ b/crates/meilisearch/src/documents_retrieval/mod.rs
@@ -2,17 +2,17 @@ use std::sync::Arc;
 
 use actix_web::web::Data;
 use index_scheduler::IndexScheduler;
-use meilisearch_types::{error::ResponseError, milli::progress::Progress};
+use meilisearch_types::error::ResponseError;
+use meilisearch_types::milli::progress::Progress;
 use uuid::Uuid;
 
-use crate::{
-    error::MeilisearchHttpError,
-    extractors::authentication::{policies::ActionPolicy, AuthenticationError, GuardedData},
-    personalization::PersonalizationService,
-    search::{
-        add_search_rules, perform_federated_search, FederatedSearchResult, Federation,
-        SearchQueryWithIndex, SearchResultWithIndex, ShowFederationInfo,
-    },
+use crate::error::MeilisearchHttpError;
+use crate::extractors::authentication::policies::ActionPolicy;
+use crate::extractors::authentication::{AuthenticationError, GuardedData};
+use crate::personalization::PersonalizationService;
+use crate::search::{
+    add_search_rules, perform_federated_search, FederatedSearchResult, Federation,
+    SearchQueryWithIndex, SearchResultWithIndex, ShowFederationInfo,
 };
 
 pub struct DocumentSearch {

--- a/crates/meilisearch/src/error.rs
+++ b/crates/meilisearch/src/error.rs
@@ -4,8 +4,7 @@ use byte_unit::{Byte, UnitType};
 use meilisearch_types::document_formats::{DocumentFormatError, PayloadType};
 use meilisearch_types::error::{Code, ErrorCode, ResponseError};
 use meilisearch_types::index_uid::{IndexUid, IndexUidFormatError};
-use meilisearch_types::milli;
-use meilisearch_types::milli::OrderBy;
+use meilisearch_types::milli::{self, AttributePatterns, OrderBy};
 use meilisearch_types::tasks::network::headers::{
     PROXY_IMPORT_DOCS_HEADER, PROXY_IMPORT_INDEX_COUNT_HEADER, PROXY_IMPORT_INDEX_HEADER,
     PROXY_IMPORT_REMOTE_HEADER, PROXY_IMPORT_TASK_KEY_HEADER, PROXY_IMPORT_TOTAL_INDEX_DOCS_HEADER,
@@ -41,7 +40,7 @@ pub enum MeilisearchHttpError {
     #[error("Using pagination options is not allowed in federated queries.\n - Hint: remove `{0}` from the query or remove `federation` from the request\n - Hint: pass `federation.limit` and `federation.offset` for pagination in federated search")]
     PaginationInFederatedQuery(&'static str),
     #[error("Using facet options is not allowed in federated queries.\n - Hint: remove `facets` from the query or remove `federation` from the request\n - Hint: pass `federation.facetsByIndex.{0}: {1:?}` for facets in federated search")]
-    FacetsInFederatedQuery(String, Vec<String>),
+    FacetsInFederatedQuery(String, AttributePatterns),
     #[error("Using `.personalize` is not allowed in federated queries.\n - Hint: remove `personalize` from the query or remove `federation` from the request\n - Hint: pass `federation.personalize` for personalization in federated search")]
     PersonalizationInFederatedQuery,
     #[error("Using `.showPerformanceDetails` is not allowed in federated queries.\n - Hint: remove `showPerformanceDetails` from the query or remove `federation` from the request")]

--- a/crates/meilisearch/src/routes/indexes/fields.rs
+++ b/crates/meilisearch/src/routes/indexes/fields.rs
@@ -16,7 +16,7 @@ use meilisearch_types::keys::actions;
 use meilisearch_types::milli::tokenizer::Language;
 use meilisearch_types::milli::{
     AttributePatterns, FieldSortOrder, FilterFeatures, FilterableAttributesFeatures,
-    FilterableAttributesRule, LocalizedAttributesRule, Metadata, MetadataBuilder, PatternMatch,
+    FilterableAttributesRule, LocalizedAttributesRule, Metadata, PatternMatch,
 };
 use serde::{Serialize, Serializer};
 use utoipa::ToSchema;
@@ -306,16 +306,17 @@ pub async fn post_index_fields(
 ) -> Result<HttpResponse, ResponseError> {
     let index = index_scheduler.user_index(index_uid.as_str())?;
     let rtxn = index.read_txn()?;
-    let builder = MetadataBuilder::from_index(&index, &rtxn)?;
-    let fields = builder
-        .fields_metadata()
+
+    let fidmap = index.fields_ids_map_with_metadata(&rtxn)?;
+
+    let fields = fidmap
         .iter()
-        .filter_map(|(name, metadata)| {
+        .filter_map(|(_, name, meta)| {
             let field = Field::new(
                 name,
-                metadata,
-                builder.filterable_attributes(),
-                builder.localized_attributes_rules(),
+                &meta,
+                fidmap.metadata_builder().filterable_attributes(),
+                fidmap.metadata_builder().localized_attributes_rules(),
             );
 
             if !body.0.apply_filter(&field) {

--- a/crates/meilisearch/src/routes/indexes/fields.rs
+++ b/crates/meilisearch/src/routes/indexes/fields.rs
@@ -309,7 +309,7 @@ pub async fn post_index_fields(
 
     let fidmap = index.fields_ids_map_with_metadata(&rtxn)?;
 
-    let fields = fidmap
+    let mut fields = fidmap
         .iter()
         .filter_map(|(_, name, meta)| {
             let field = Field::new(
@@ -327,6 +327,9 @@ pub async fn post_index_fields(
         })
         // collect into a vector to get the total length for pagination
         .collect::<Vec<_>>();
+
+    // keep existing alphabetical behavior
+    fields.sort_unstable_by_key(|field| field.name);
 
     let pagination = Pagination { offset: body.0.offset, limit: body.0.limit };
     let pagination_view = pagination.auto_paginate_sized(fields.into_iter());

--- a/crates/meilisearch/src/routes/indexes/search.rs
+++ b/crates/meilisearch/src/routes/indexes/search.rs
@@ -224,6 +224,7 @@ pub struct SearchQueryGet {
     ///
     /// The response includes `facetDistribution` and, for numeric facets, `facetStats` (min/max).
     ///
+    /// // TODO change the doc
     /// Use `["*"]` to request counts for all [filterableAttributes](https://www.meilisearch.com/docs/reference/api/settings/update-all-settings#body-filterable-attributes-one-of-0).
     ///
     /// The number of values returned per facet is limited by the index [maxValuesPerFacet](https://www.meilisearch.com/docs/reference/api/settings/update-faceting#body-max-values-per-facet-one-of-0) setting; attributes not in filterableAttributes are ignored.
@@ -435,7 +436,7 @@ impl TryFrom<SearchQueryGet> for SearchQuery {
             filter,
             sort: other.sort.map(|attr| fix_sort_query_parameters(&attr)),
             distinct: other.distinct,
-            facets: other.facets.map(|o| o.into_iter().collect()),
+            facets: other.facets.map(|o| o.into_iter().collect::<Vec<_>>().into()),
             highlight_pre_tag: other.highlight_pre_tag,
             highlight_post_tag: other.highlight_post_tag,
             matching_strategy: other.matching_strategy,

--- a/crates/meilisearch/src/routes/indexes/search.rs
+++ b/crates/meilisearch/src/routes/indexes/search.rs
@@ -224,8 +224,7 @@ pub struct SearchQueryGet {
     ///
     /// The response includes `facetDistribution` and, for numeric facets, `facetStats` (min/max).
     ///
-    /// // TODO change the doc
-    /// Use `["*"]` to request counts for all [filterableAttributes](https://www.meilisearch.com/docs/reference/api/settings/update-all-settings#body-filterable-attributes-one-of-0).
+    /// This route also supports patterns, i.e., "title", "dogs.*", "*", which can match over the [filterableAttributes](https://www.meilisearch.com/docs/reference/api/settings/update-all-settings#body-filterable-attributes-one-of-0).
     ///
     /// The number of values returned per facet is limited by the index [maxValuesPerFacet](https://www.meilisearch.com/docs/reference/api/settings/update-faceting#body-max-values-per-facet-one-of-0) setting; attributes not in filterableAttributes are ignored.
     ///

--- a/crates/meilisearch/src/search/federated/perform.rs
+++ b/crates/meilisearch/src/search/federated/perform.rs
@@ -20,8 +20,8 @@ use meilisearch_types::milli::score_details::{ScoreDetails, WeightedScoreValue};
 use meilisearch_types::milli::vector::Embedding;
 use meilisearch_types::milli::{
     self, merge_positioned_hits_into_page, serialize_index_filter_to_filter_string,
-    AttributePatterns, Deadline, DocumentId, FederatingResultsStep, OrderBy, PatternMatch,
-    DEFAULT_VALUES_PER_FACET,
+    AttributePatterns, Deadline, DocumentId, FederatingResultsStep, FieldsIdsMap, MetadataBuilder,
+    OrderBy, PatternMatch, DEFAULT_VALUES_PER_FACET,
 };
 use meilisearch_types::network::{Network, Remote, RemoteAvailability};
 use meilisearch_types::settings::DEFAULT_PAGINATION_MAX_TOTAL_HITS;
@@ -1370,13 +1370,23 @@ impl SearchByIndex {
 
         let required_hit_count = usize::min(params.required_hit_count, max_total_hits);
 
+        let fidmap = index.fields_ids_map(&rtxn).without_index()?;
+
         let mut degraded = false;
         let mut used_negative_operator = false;
         let mut candidates = RoaringBitmap::new();
+
+        let metadata_builder = MetadataBuilder::from_index(&index, &rtxn).without_index()?;
+
         let facet_patterns_by_index = self.federation.facets_by_index.remove(&index_uid).flatten();
-        if let Err(mut error) =
-            self.facet_order.check_facet_order(&index_uid, &facet_patterns_by_index, &index, &rtxn)
-        {
+        if let Err(mut error) = self.facet_order.check_facet_order(
+            &index_uid,
+            &facet_patterns_by_index,
+            &index,
+            &rtxn,
+            &fidmap,
+            &metadata_builder,
+        ) {
             if self.show_federation_info == ShowFederationInfo::Always {
                 error.message = format!("Inside `.federation.facetsByIndex.{index_uid}`: {error}");
             }
@@ -1387,19 +1397,24 @@ impl SearchByIndex {
         // all queries for an index share the same deadline
         let deadline = index.search_deadline(&rtxn).without_index()?;
 
-        let fidmap = index.fields_ids_map_with_metadata(&rtxn).without_index()?;
-        let filter_rules = index.filterable_attributes_rules(&rtxn).without_index()?;
-
         let mut extra_attributes_to_retrieve = BTreeSet::new();
         if let Some(distinct) = self.federation.distinct.as_ref().cloned() {
             extra_attributes_to_retrieve.insert(distinct);
             if let Some(facet_patterns) = facet_patterns_by_index.as_ref() {
-                for (_fid, fname, meta) in fidmap.iter() {
-                    if meta.filterable_attributes_features(&filter_rules).is_filterable()
-                        && facet_patterns.match_str(fname) == PatternMatch::Match
-                    {
-                        extra_attributes_to_retrieve.insert(fname.to_owned());
+                for (_fid, fname) in fidmap.iter() {
+                    if facet_patterns.match_str(fname) != PatternMatch::Match {
+                        continue;
                     }
+
+                    let (_, Some((_, rule))) = metadata_builder.filterable_rule_with_index(fname)
+                    else {
+                        continue;
+                    };
+
+                    if !rule.features().is_filterable() {
+                        continue;
+                    }
+                    extra_attributes_to_retrieve.insert(fname.to_owned());
                 }
             }
         }
@@ -1735,10 +1750,17 @@ impl SearchByIndex {
 
             // Important: this is the only transaction we'll use for this index during this federated search
             let rtxn = index.read_txn()?;
+            let fidmap = index.fields_ids_map(&rtxn)?;
+            let metadata_builder = MetadataBuilder::from_index(&index, &rtxn)?;
 
-            if let Err(mut error) =
-                self.facet_order.check_facet_order(&index_uid, &facets, &index, &rtxn)
-            {
+            if let Err(mut error) = self.facet_order.check_facet_order(
+                &index_uid,
+                &facets,
+                &index,
+                &rtxn,
+                &fidmap,
+                &metadata_builder,
+            ) {
                 if self.show_federation_info == ShowFederationInfo::Always {
                     error.message = format!(
                         "Inside `.federation.facetsByIndex.{index_uid}`: {error}\n - Note: index `{index_uid}` is not used in queries",
@@ -1802,33 +1824,43 @@ impl FacetOrder {
         facets_by_index: &Option<AttributePatterns>,
         index: &milli::Index,
         rtxn: &milli::heed::RoTxn<'_>,
+        fidmap: &FieldsIdsMap,
+        metadata_builder: &MetadataBuilder,
     ) -> Result<(), ResponseError> {
         match self {
             FacetOrder::ByFacet(facet_order) => {
                 if let Some(facet_patterns_by_index) = facets_by_index {
                     let index_facet_order = index.sort_facet_values_by(rtxn)?;
 
-                    let fidmap = index.fields_ids_map_with_metadata(rtxn)?;
-                    let filter_rules = index.filterable_attributes_rules(rtxn)?;
+                    for (_fid, fname) in fidmap.iter() {
+                        if facet_patterns_by_index.match_str(fname) != PatternMatch::Match {
+                            continue;
+                        }
 
-                    for (_fid, fname, meta) in fidmap.iter() {
-                        if meta.filterable_attributes_features(&filter_rules).is_filterable()
-                            && facet_patterns_by_index.match_str(fname) == PatternMatch::Match
-                        {
-                            let index_facet_order = index_facet_order.get(fname);
-                            let (previous_index, previous_facet_order) = facet_order
-                                .entry(fname.to_owned())
-                                .or_insert_with(|| (current_index.to_owned(), index_facet_order));
-                            if previous_facet_order != &index_facet_order {
-                                return Err(MeilisearchHttpError::InconsistentFacetOrder {
-                                    facet: fname.to_owned(),
-                                    previous_facet_order: *previous_facet_order,
-                                    previous_uid: previous_index.clone(),
-                                    current_uid: current_index.to_owned(),
-                                    index_facet_order,
-                                }
-                                .into());
+                        let (_, Some((_, rule))) =
+                            metadata_builder.filterable_rule_with_index(fname)
+                        else {
+                            continue;
+                        };
+
+                        if !rule.features().is_filterable() {
+                            continue;
+                        }
+
+                        let index_facet_order = index_facet_order.get(fname);
+
+                        let (previous_index, previous_facet_order) = facet_order
+                            .entry(fname.to_owned())
+                            .or_insert_with(|| (current_index.to_owned(), index_facet_order));
+                        if previous_facet_order != &index_facet_order {
+                            return Err(MeilisearchHttpError::InconsistentFacetOrder {
+                                facet: fname.to_owned(),
+                                previous_facet_order: *previous_facet_order,
+                                previous_uid: previous_index.clone(),
+                                current_uid: current_index.to_owned(),
+                                index_facet_order,
                             }
+                            .into());
                         }
                     }
                 }

--- a/crates/meilisearch/src/search/federated/perform.rs
+++ b/crates/meilisearch/src/search/federated/perform.rs
@@ -19,8 +19,9 @@ use meilisearch_types::milli::progress::Progress;
 use meilisearch_types::milli::score_details::{ScoreDetails, WeightedScoreValue};
 use meilisearch_types::milli::vector::Embedding;
 use meilisearch_types::milli::{
-    self, merge_positioned_hits_into_page, serialize_index_filter_to_filter_string, Deadline,
-    DocumentId, FederatingResultsStep, OrderBy, DEFAULT_VALUES_PER_FACET,
+    self, merge_positioned_hits_into_page, serialize_index_filter_to_filter_string,
+    AttributePatterns, Deadline, DocumentId, FederatingResultsStep, OrderBy, PatternMatch,
+    DEFAULT_VALUES_PER_FACET,
 };
 use meilisearch_types::network::{Network, Remote, RemoteAvailability};
 use meilisearch_types::settings::DEFAULT_PAGINATION_MAX_TOTAL_HITS;
@@ -1372,9 +1373,9 @@ impl SearchByIndex {
         let mut degraded = false;
         let mut used_negative_operator = false;
         let mut candidates = RoaringBitmap::new();
-        let facets_by_index = self.federation.facets_by_index.remove(&index_uid).flatten();
+        let facet_patterns_by_index = self.federation.facets_by_index.remove(&index_uid).flatten();
         if let Err(mut error) =
-            self.facet_order.check_facet_order(&index_uid, &facets_by_index, &index, &rtxn)
+            self.facet_order.check_facet_order(&index_uid, &facet_patterns_by_index, &index, &rtxn)
         {
             if self.show_federation_info == ShowFederationInfo::Always {
                 error.message = format!("Inside `.federation.facetsByIndex.{index_uid}`: {error}");
@@ -1386,14 +1387,22 @@ impl SearchByIndex {
         // all queries for an index share the same deadline
         let deadline = index.search_deadline(&rtxn).without_index()?;
 
-        let extra_attributes_to_retrieve: BTreeSet<_> =
-            if let Some(distinct) = self.federation.distinct.as_deref() {
-                std::iter::once(distinct.to_string())
-                    .chain(facets_by_index.iter().flatten().cloned())
-                    .collect()
-            } else {
-                Default::default()
-            };
+        let fidmap = index.fields_ids_map_with_metadata(&rtxn).without_index()?;
+        let filter_rules = index.filterable_attributes_rules(&rtxn).without_index()?;
+
+        let mut extra_attributes_to_retrieve = BTreeSet::new();
+        if let Some(distinct) = self.federation.distinct.as_ref().cloned() {
+            extra_attributes_to_retrieve.insert(distinct);
+            if let Some(facet_patterns) = facet_patterns_by_index.as_ref() {
+                for (_fid, fname, meta) in fidmap.iter() {
+                    if meta.filterable_attributes_features(&filter_rules).is_filterable()
+                        && facet_patterns.match_str(fname) == PatternMatch::Match
+                    {
+                        extra_attributes_to_retrieve.insert(fname.to_owned());
+                    }
+                }
+            }
+        }
 
         for QueryByIndex { query, weight, query_index } in queries {
             // use an immediately invoked lambda to capture the result without returning from the function
@@ -1675,7 +1684,7 @@ impl SearchByIndex {
                 .map(|(_, hit)| hit)
                 .collect();
         let estimated_total_hits = candidates.len() as usize;
-        let facets = facets_by_index
+        let facets = facet_patterns_by_index
             .map(|facets_by_index| {
                 compute_facet_distribution_stats(&facets_by_index, &index, &rtxn, candidates)
             })
@@ -1790,28 +1799,36 @@ impl FacetOrder {
     fn check_facet_order(
         &mut self,
         current_index: &str,
-        facets_by_index: &Option<Vec<String>>,
+        facets_by_index: &Option<AttributePatterns>,
         index: &milli::Index,
         rtxn: &milli::heed::RoTxn<'_>,
     ) -> Result<(), ResponseError> {
         match self {
             FacetOrder::ByFacet(facet_order) => {
-                if let Some(facets_by_index) = facets_by_index {
+                if let Some(facet_patterns_by_index) = facets_by_index {
                     let index_facet_order = index.sort_facet_values_by(rtxn)?;
-                    for facet in facets_by_index {
-                        let index_facet_order = index_facet_order.get(facet);
-                        let (previous_index, previous_facet_order) = facet_order
-                            .entry(facet.to_owned())
-                            .or_insert_with(|| (current_index.to_owned(), index_facet_order));
-                        if previous_facet_order != &index_facet_order {
-                            return Err(MeilisearchHttpError::InconsistentFacetOrder {
-                                facet: facet.clone(),
-                                previous_facet_order: *previous_facet_order,
-                                previous_uid: previous_index.clone(),
-                                current_uid: current_index.to_owned(),
-                                index_facet_order,
+
+                    let fidmap = index.fields_ids_map_with_metadata(rtxn)?;
+                    let filter_rules = index.filterable_attributes_rules(rtxn)?;
+
+                    for (_fid, fname, meta) in fidmap.iter() {
+                        if meta.filterable_attributes_features(&filter_rules).is_filterable()
+                            && facet_patterns_by_index.match_str(fname) == PatternMatch::Match
+                        {
+                            let index_facet_order = index_facet_order.get(fname);
+                            let (previous_index, previous_facet_order) = facet_order
+                                .entry(fname.to_owned())
+                                .or_insert_with(|| (current_index.to_owned(), index_facet_order));
+                            if previous_facet_order != &index_facet_order {
+                                return Err(MeilisearchHttpError::InconsistentFacetOrder {
+                                    facet: fname.to_owned(),
+                                    previous_facet_order: *previous_facet_order,
+                                    previous_uid: previous_index.clone(),
+                                    current_uid: current_index.to_owned(),
+                                    index_facet_order,
+                                }
+                                .into());
                             }
-                            .into());
                         }
                     }
                 }

--- a/crates/meilisearch/src/search/federated/types.rs
+++ b/crates/meilisearch/src/search/federated/types.rs
@@ -15,7 +15,7 @@ use meilisearch_types::error::deserr_codes::{
 use meilisearch_types::error::ResponseError;
 use meilisearch_types::index_uid::IndexUid;
 use meilisearch_types::milli::order_by_map::OrderByMap;
-use meilisearch_types::milli::OrderBy;
+use meilisearch_types::milli::{AttributePatterns, OrderBy};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use uuid::Uuid;
@@ -102,8 +102,9 @@ pub struct Federation {
     #[request(default, error = DeserrJsonError<InvalidSearchHitsPerPage>, skip_serializing_if = "Option::is_none")]
     pub hits_per_page: Option<usize>,
     /// Facets to retrieve per index
-    #[request(default, error = DeserrJsonError<InvalidMultiSearchFacetsByIndex>)]
-    pub facets_by_index: BTreeMap<IndexUid, Option<Vec<String>>>,
+    // We hide the fact that it's possible to define facets as null because utoipa::Schema doesn't support BTreeMap<_, Option<_>>.
+    #[request(default, schema_type = BTreeMap<IndexUid, AttributePatterns>, error = DeserrJsonError<InvalidMultiSearchFacetsByIndex>)]
+    pub facets_by_index: BTreeMap<IndexUid, Option<AttributePatterns>>,
     /// Options for merging facets from multiple indexes
     #[request(default, error = DeserrJsonError<InvalidMultiSearchMergeFacets>, skip_serializing_if = "Option::is_none")]
     pub merge_facets: Option<MergeFacets>,

--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -1,13 +1,13 @@
 use core::fmt;
 use std::cmp::min;
+use std::collections::HashMap;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::iter;
 use std::ops::Not as _;
 use std::rc::Rc;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Instant;
-use std::collections::HashMap;
-use std::iter;
 
 use deserr::Deserr;
 pub use federated::ProxyQuery;
@@ -2057,6 +2057,13 @@ fn compute_facet_distribution_stats(
     let sort_facet_values_by = index.sort_facet_values_by(rtxn).map_err(milli::Error::from)?;
     let filter_rules = index.filterable_attributes_rules(rtxn)?;
 
+    let fetch_valid_patterns = || {
+        filtered_matching_patterns(&filter_rules, &|features| features.is_filterable())
+            .into_iter()
+            .map(String::from)
+            .collect()
+    };
+
     'facet: for facet_pattern in &facet_patterns.patterns {
         for (rule_id, rule) in filter_rules.iter().enumerate() {
             if rule.features().is_filterable() {
@@ -2067,16 +2074,9 @@ fn compute_facet_distribution_stats(
                 }
             // field is subset of any filterable but current setting doesn't allow filterable
             } else if rule.match_str(facet_pattern) == Match {
-                // TODO do it in one place (a closure)
-                let valid_patterns =
-                    filtered_matching_patterns(&filter_rules, &|features| features.is_filterable())
-                        .into_iter()
-                        .map(String::from)
-                        .collect();
-
                 return Err(Error::UserError(UserError::InvalidFacetsDistribution {
                     invalid_facet_patterns: BTreeSet::from_iter(iter::once(facet_pattern.clone())),
-                    valid_patterns,
+                    valid_patterns: fetch_valid_patterns(),
                     // We found the rule matching our facet pattern but it's not filterable
                     matching_rule_indices: HashMap::from_iter(iter::once((
                         facet_pattern.clone(),
@@ -2087,16 +2087,9 @@ fn compute_facet_distribution_stats(
             }
         }
 
-        // TODO do it in one place (a closure)
-        let valid_patterns =
-            filtered_matching_patterns(&filter_rules, &|features| features.is_filterable())
-                .into_iter()
-                .map(String::from)
-                .collect();
-
         return Err(Error::UserError(UserError::InvalidFacetsDistribution {
             invalid_facet_patterns: BTreeSet::from_iter(iter::once(facet_pattern.clone())),
-            valid_patterns,
+            valid_patterns: fetch_valid_patterns(),
             // Not a single pattern matched our facet pattern
             matching_rule_indices: HashMap::new(),
         })

--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -48,7 +48,6 @@ use serde_json::{json, Value};
 mod mod_test;
 use utoipa::ToSchema;
 use uuid::Uuid;
-use PatternMatch::{Match, Parent};
 
 use crate::error::MeilisearchHttpError;
 
@@ -2065,12 +2064,12 @@ fn compute_facet_distribution_stats(
         for (rule_id, rule) in filter_rules.iter().enumerate() {
             if rule.features().is_filterable() {
                 // field is superset or subset of any filterable
-                if matches!(rule.rev_match_pattern(facet_pattern), Parent | Match) {
+                if rule.intersect_patterns(facet_pattern) {
                     // valid facet, check the next one
                     continue 'facet;
                 }
             // field is subset of any filterable but current setting doesn't allow filterable
-            } else if rule.match_str(facet_pattern) == Match {
+            } else if rule.match_str(facet_pattern) == PatternMatch::Match {
                 return Err(Error::UserError(UserError::InvalidFacetsDistribution {
                     invalid_facet_pattern: facet_pattern.clone(),
                     valid_patterns: fetch_valid_patterns(),

--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -235,8 +235,7 @@ pub struct SearchQuery {
     ///
     /// The response includes `facetDistribution` and, for numeric facets, `facetStats` (min/max).
     ///
-    /// // TODO change the doc
-    /// Use `["*"]` to request counts for all [filterableAttributes](https://www.meilisearch.com/docs/reference/api/settings/update-all-settings#body-filterable-attributes-one-of-0).
+    /// This route also supports patterns, i.e., "title", "dogs.*", "*", which can match over the [filterableAttributes](https://www.meilisearch.com/docs/reference/api/settings/update-all-settings#body-filterable-attributes-one-of-0).
     ///
     /// The number of values returned per facet is limited by the index [maxValuesPerFacet](https://www.meilisearch.com/docs/reference/api/settings/update-faceting#body-max-values-per-facet-one-of-0) setting; attributes not in filterableAttributes are ignored.
     ///

--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -28,8 +28,8 @@ use meilisearch_types::milli::score_details::{ScoreDetails, ScoringStrategy};
 use meilisearch_types::milli::vector::parsed_vectors::ExplicitVectors;
 use meilisearch_types::milli::vector::Embedder;
 use meilisearch_types::milli::{
-    filtered_universe, make_document, AttributeState, Deadline, FacetValueHit, Filter, IndexFilter,
-    InternalError, OrderBy, PatternMatch, SearchForFacetValues, SearchStep,
+    filtered_universe, make_document, AttributePatterns, AttributeState, Deadline, FacetValueHit,
+    Filter, IndexFilter, InternalError, OrderBy, PatternMatch, SearchForFacetValues, SearchStep,
 };
 use meilisearch_types::network::Network;
 use meilisearch_types::settings::DEFAULT_PAGINATION_MAX_TOTAL_HITS;
@@ -232,13 +232,14 @@ pub struct SearchQuery {
     ///
     /// The response includes `facetDistribution` and, for numeric facets, `facetStats` (min/max).
     ///
+    /// // TODO change the doc
     /// Use `["*"]` to request counts for all [filterableAttributes](https://www.meilisearch.com/docs/reference/api/settings/update-all-settings#body-filterable-attributes-one-of-0).
     ///
     /// The number of values returned per facet is limited by the index [maxValuesPerFacet](https://www.meilisearch.com/docs/reference/api/settings/update-faceting#body-max-values-per-facet-one-of-0) setting; attributes not in filterableAttributes are ignored.
     ///
     /// More info: [faceting](https://www.meilisearch.com/docs/learn/filtering_and_sorting/search_with_facet_filters).
     #[request(default, error = DeserrJsonError<InvalidSearchFacets>)]
-    pub facets: Option<Vec<String>>,
+    pub facets: Option<AttributePatterns>,
     /// How to match query terms when there are not enough results to satisfy `limit`.
     ///
     /// **`last`**: Returns documents containing all query terms first. If there are not enough such results, Meilisearch removes one query term at a time, starting from the end of the query (e.g. for "big fat cat", then "big fat", then "big").
@@ -849,7 +850,7 @@ pub struct SearchQueryWithIndex {
     pub distinct: Option<String>,
     /// Display the count of matches per facet
     #[request(default, error = DeserrJsonError<InvalidSearchFacets>)]
-    pub facets: Option<Vec<String>>,
+    pub facets: Option<AttributePatterns>,
     /// Strategy used to match query terms within documents
     #[request(default, error = DeserrJsonError<InvalidSearchMatchingStrategy>)]
     pub matching_strategy: MatchingStrategy,
@@ -924,8 +925,8 @@ impl SearchQueryWithIndex {
         }
     }
 
-    pub fn has_facets(&self) -> Option<&[String]> {
-        self.facets.as_deref().filter(|v| !v.is_empty())
+    pub fn has_facets(&self) -> Option<&AttributePatterns> {
+        self.facets.as_ref()
     }
 
     pub fn has_personalize(&self) -> bool {
@@ -2032,8 +2033,8 @@ pub enum Route {
     Similar,
 }
 
-fn compute_facet_distribution_stats<S: AsRef<str>>(
-    facets: &[S],
+fn compute_facet_distribution_stats(
+    attribute_patterns: &AttributePatterns,
     index: &Index,
     rtxn: &RoTxn,
     candidates: roaring::RoaringBitmap,
@@ -2050,12 +2051,19 @@ fn compute_facet_distribution_stats<S: AsRef<str>>(
 
     let sort_facet_values_by = index.sort_facet_values_by(rtxn).map_err(milli::Error::from)?;
 
-    // add specific facet if there is no placeholder
-    if facets.iter().all(|f| f.as_ref() != "*") {
-        let fields: Vec<_> =
-            facets.iter().map(|n| (n, sort_facet_values_by.get(n.as_ref()))).collect();
-        facet_distribution.facets(fields);
-    }
+    let fidmap = index.fields_ids_map_with_metadata(rtxn)?;
+    let filter_rules = index.filterable_attributes_rules(rtxn)?;
+    let fields = fidmap.iter().filter_map(|(_fid, fname, meta)| {
+        if meta.filterable_attributes_features(&filter_rules).is_filterable()
+            && attribute_patterns.match_str(fname) == PatternMatch::Match
+        {
+            Some((fname, sort_facet_values_by.get(fname)))
+        } else {
+            None
+        }
+    });
+
+    facet_distribution.facets(fields);
 
     let distribution = facet_distribution
         .candidates(candidates)
@@ -2063,6 +2071,7 @@ fn compute_facet_distribution_stats<S: AsRef<str>>(
         .execute()?;
     let stats = facet_distribution.compute_stats()?;
     let stats = stats.into_iter().map(|(k, (min, max))| (k, FacetStats { min, max })).collect();
+
     Ok(ComputedFacets { distribution, stats })
 }
 

--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -1,8 +1,6 @@
 use core::fmt;
 use std::cmp::min;
-use std::collections::HashMap;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
-use std::iter;
 use std::ops::Not as _;
 use std::rc::Rc;
 use std::str::FromStr;
@@ -2075,23 +2073,20 @@ fn compute_facet_distribution_stats(
             // field is subset of any filterable but current setting doesn't allow filterable
             } else if rule.match_str(facet_pattern) == Match {
                 return Err(Error::UserError(UserError::InvalidFacetsDistribution {
-                    invalid_facet_patterns: BTreeSet::from_iter(iter::once(facet_pattern.clone())),
+                    invalid_facet_pattern: facet_pattern.clone(),
                     valid_patterns: fetch_valid_patterns(),
                     // We found the rule matching our facet pattern but it's not filterable
-                    matching_rule_indices: HashMap::from_iter(iter::once((
-                        facet_pattern.clone(),
-                        rule_id,
-                    ))),
+                    matching_rule_index: Some(rule_id),
                 })
                 .into());
             }
         }
 
         return Err(Error::UserError(UserError::InvalidFacetsDistribution {
-            invalid_facet_patterns: BTreeSet::from_iter(iter::once(facet_pattern.clone())),
+            invalid_facet_pattern: facet_pattern.clone(),
             valid_patterns: fetch_valid_patterns(),
             // Not a single pattern matched our facet pattern
-            matching_rule_indices: HashMap::new(),
+            matching_rule_index: None,
         })
         .into());
     }

--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -6,6 +6,8 @@ use std::rc::Rc;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Instant;
+use std::collections::HashMap;
+use std::iter;
 
 use deserr::Deserr;
 pub use federated::ProxyQuery;
@@ -22,14 +24,16 @@ use meilisearch_types::error::{Code, ResponseError};
 use meilisearch_types::heed::RoTxn;
 use meilisearch_types::index_uid::IndexUid;
 use meilisearch_types::locales::Locale;
+use meilisearch_types::milli::filtered_matching_patterns;
 use meilisearch_types::milli::index::{self, EmbeddingsWithMetadata, SearchParameters};
 use meilisearch_types::milli::progress::Progress;
 use meilisearch_types::milli::score_details::{ScoreDetails, ScoringStrategy};
 use meilisearch_types::milli::vector::parsed_vectors::ExplicitVectors;
 use meilisearch_types::milli::vector::Embedder;
 use meilisearch_types::milli::{
-    filtered_universe, make_document, AttributePatterns, AttributeState, Deadline, FacetValueHit,
-    Filter, IndexFilter, InternalError, OrderBy, PatternMatch, SearchForFacetValues, SearchStep,
+    filtered_universe, make_document, AttributePatterns, AttributeState, Deadline, Error,
+    FacetValueHit, Filter, IndexFilter, InternalError, OrderBy, PatternMatch, SearchForFacetValues,
+    SearchStep, UserError,
 };
 use meilisearch_types::network::Network;
 use meilisearch_types::settings::DEFAULT_PAGINATION_MAX_TOTAL_HITS;
@@ -46,6 +50,7 @@ use serde_json::{json, Value};
 mod mod_test;
 use utoipa::ToSchema;
 use uuid::Uuid;
+use PatternMatch::{Match, Parent};
 
 use crate::error::MeilisearchHttpError;
 
@@ -2052,65 +2057,51 @@ fn compute_facet_distribution_stats(
     let sort_facet_values_by = index.sort_facet_values_by(rtxn).map_err(milli::Error::from)?;
     let filter_rules = index.filterable_attributes_rules(rtxn)?;
 
-    // 'facet for facet in facets {
-    //   for filterable in filterable_attributes {
-    //     if filterable.is_filterable() {
-    //     // field is superset or subset of any filterable
-    //       if filterable.patterns.iter().any(|filt| facet.match_str(filt) == Match | Parent) {
-    //         // valid facet, check the next one
-    //         continue 'facet;
-    //       }
-    //     // field is subset of any filterable but current setting doesn't allow filterable
-    //     } else if filterable.patterns.match_str(field) == Match {
-    //       return Err("pas filterable")
-    //     }
-    //   }
-
-    //   return Err("pas de pattern")
-    // }
-
-    use milli::FilterableAttributesRule::{Field, Pattern};
-
     'facet: for facet_pattern in &facet_patterns.patterns {
-        for rule in filter_rules {
+        for (rule_id, rule) in filter_rules.iter().enumerate() {
             if rule.features().is_filterable() {
-                // // field is superset or subset of any filterable
-                // match rule {
-                //     Field(pattern) => match_pattern(facet_pattern, pattern),
-                //     Pattern(patterns) => patterns.attribute_patterns,
-                // }
-
                 // field is superset or subset of any filterable
-                match facet_pattern.match_str(rule) {
+                if matches!(rule.rev_match_pattern(facet_pattern), Parent | Match) {
                     // valid facet, check the next one
-                    Pattern::Parent | Pattern::Match => continue 'facet,
-                    // field is subset of any filterable but current setting doesn't allow filterable
-                    Pattern::NoMatch => {
-                        if filterable.patterns.match_str(field) == Pattern::Match {
-                            // return Err("pas filterable");
-                            todo!("non filterable");
-                        }
-                    }
+                    continue 'facet;
                 }
+            // field is subset of any filterable but current setting doesn't allow filterable
+            } else if rule.match_str(facet_pattern) == Match {
+                // TODO do it in one place (a closure)
+                let valid_patterns =
+                    filtered_matching_patterns(&filter_rules, &|features| features.is_filterable())
+                        .into_iter()
+                        .map(String::from)
+                        .collect();
+
+                return Err(Error::UserError(UserError::InvalidFacetsDistribution {
+                    invalid_facet_patterns: BTreeSet::from_iter(iter::once(facet_pattern.clone())),
+                    valid_patterns,
+                    // We found the rule matching our facet pattern but it's not filterable
+                    matching_rule_indices: HashMap::from_iter(iter::once((
+                        facet_pattern.clone(),
+                        rule_id,
+                    ))),
+                })
+                .into());
             }
         }
 
-        todo!("no pattern found");
-        // return Err("pas de pattern")
-    }
+        // TODO do it in one place (a closure)
+        let valid_patterns =
+            filtered_matching_patterns(&filter_rules, &|features| features.is_filterable())
+                .into_iter()
+                .map(String::from)
+                .collect();
 
-    // let valid_patterns =
-    //     filtered_matching_patterns(filterable_attributes_rules, &|features| {
-    //         features.is_filterable()
-    //     })
-    //     .into_iter()
-    //     .map(String::from)
-    //     .collect();
-    // return Err(Error::UserError(UserError::InvalidFacetsDistribution {
-    //     invalid_facet_patterns: invalid_facets,
-    //     valid_patterns,
-    //     matching_rule_indices,
-    // }));
+        return Err(Error::UserError(UserError::InvalidFacetsDistribution {
+            invalid_facet_patterns: BTreeSet::from_iter(iter::once(facet_pattern.clone())),
+            valid_patterns,
+            // Not a single pattern matched our facet pattern
+            matching_rule_indices: HashMap::new(),
+        })
+        .into());
+    }
 
     let fidmap = index.fields_ids_map_with_metadata(rtxn)?;
     let fields = fidmap.iter().filter_map(|(_fid, fname, meta)| {

--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -22,16 +22,15 @@ use meilisearch_types::error::{Code, ResponseError};
 use meilisearch_types::heed::RoTxn;
 use meilisearch_types::index_uid::IndexUid;
 use meilisearch_types::locales::Locale;
-use meilisearch_types::milli::filtered_matching_patterns;
 use meilisearch_types::milli::index::{self, EmbeddingsWithMetadata, SearchParameters};
 use meilisearch_types::milli::progress::Progress;
 use meilisearch_types::milli::score_details::{ScoreDetails, ScoringStrategy};
 use meilisearch_types::milli::vector::parsed_vectors::ExplicitVectors;
 use meilisearch_types::milli::vector::Embedder;
 use meilisearch_types::milli::{
-    filtered_universe, make_document, AttributePatterns, AttributeState, Deadline, Error,
-    FacetValueHit, Filter, IndexFilter, InternalError, OrderBy, PatternMatch, SearchForFacetValues,
-    SearchStep, UserError,
+    filtered_matching_patterns, filtered_universe, make_document, AttributePatterns,
+    AttributeState, Deadline, Error, FacetValueHit, Filter, IndexFilter, InternalError,
+    MetadataBuilder, OrderBy, PatternMatch, SearchForFacetValues, SearchStep, UserError,
 };
 use meilisearch_types::network::Network;
 use meilisearch_types::settings::DEFAULT_PAGINATION_MAX_TOTAL_HITS;
@@ -2089,15 +2088,22 @@ fn compute_facet_distribution_stats(
         .into());
     }
 
-    let fidmap = index.fields_ids_map_with_metadata(rtxn)?;
-    let fields = fidmap.iter().filter_map(|(_fid, fname, meta)| {
-        if meta.filterable_attributes_features(&filter_rules).is_filterable()
-            && facet_patterns.match_str(fname) == PatternMatch::Match
-        {
-            Some((fname, sort_facet_values_by.get(fname)))
-        } else {
-            None
+    let fidmap = index.fields_ids_map(rtxn)?;
+    let metadata_builder = MetadataBuilder::from_index(index, rtxn)?;
+    let fields = fidmap.iter().filter_map(|(_fid, fname)| {
+        if facet_patterns.match_str(fname) != PatternMatch::Match {
+            return None;
         }
+
+        let (_, Some((_, rule))) = metadata_builder.filterable_rule_with_index(fname) else {
+            return None;
+        };
+
+        if !rule.features().is_filterable() {
+            return None;
+        }
+
+        Some((fname, sort_facet_values_by.get(fname)))
     });
 
     facet_distribution.facets(fields);

--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -2034,7 +2034,7 @@ pub enum Route {
 }
 
 fn compute_facet_distribution_stats(
-    attribute_patterns: &AttributePatterns,
+    facet_patterns: &AttributePatterns,
     index: &Index,
     rtxn: &RoTxn,
     candidates: roaring::RoaringBitmap,
@@ -2050,12 +2050,72 @@ fn compute_facet_distribution_stats(
     facet_distribution.max_values_per_facet(max_values_by_facet);
 
     let sort_facet_values_by = index.sort_facet_values_by(rtxn).map_err(milli::Error::from)?;
+    let filter_rules = index.filterable_attributes_rules(rtxn)?;
+
+    // 'facet for facet in facets {
+    //   for filterable in filterable_attributes {
+    //     if filterable.is_filterable() {
+    //     // field is superset or subset of any filterable
+    //       if filterable.patterns.iter().any(|filt| facet.match_str(filt) == Match | Parent) {
+    //         // valid facet, check the next one
+    //         continue 'facet;
+    //       }
+    //     // field is subset of any filterable but current setting doesn't allow filterable
+    //     } else if filterable.patterns.match_str(field) == Match {
+    //       return Err("pas filterable")
+    //     }
+    //   }
+
+    //   return Err("pas de pattern")
+    // }
+
+    use milli::FilterableAttributesRule::{Field, Pattern};
+
+    'facet: for facet_pattern in &facet_patterns.patterns {
+        for rule in filter_rules {
+            if rule.features().is_filterable() {
+                // // field is superset or subset of any filterable
+                // match rule {
+                //     Field(pattern) => match_pattern(facet_pattern, pattern),
+                //     Pattern(patterns) => patterns.attribute_patterns,
+                // }
+
+                // field is superset or subset of any filterable
+                match facet_pattern.match_str(rule) {
+                    // valid facet, check the next one
+                    Pattern::Parent | Pattern::Match => continue 'facet,
+                    // field is subset of any filterable but current setting doesn't allow filterable
+                    Pattern::NoMatch => {
+                        if filterable.patterns.match_str(field) == Pattern::Match {
+                            // return Err("pas filterable");
+                            todo!("non filterable");
+                        }
+                    }
+                }
+            }
+        }
+
+        todo!("no pattern found");
+        // return Err("pas de pattern")
+    }
+
+    // let valid_patterns =
+    //     filtered_matching_patterns(filterable_attributes_rules, &|features| {
+    //         features.is_filterable()
+    //     })
+    //     .into_iter()
+    //     .map(String::from)
+    //     .collect();
+    // return Err(Error::UserError(UserError::InvalidFacetsDistribution {
+    //     invalid_facet_patterns: invalid_facets,
+    //     valid_patterns,
+    //     matching_rule_indices,
+    // }));
 
     let fidmap = index.fields_ids_map_with_metadata(rtxn)?;
-    let filter_rules = index.filterable_attributes_rules(rtxn)?;
     let fields = fidmap.iter().filter_map(|(_fid, fname, meta)| {
         if meta.filterable_attributes_features(&filter_rules).is_filterable()
-            && attribute_patterns.match_str(fname) == PatternMatch::Match
+            && facet_patterns.match_str(fname) == PatternMatch::Match
         {
             Some((fname, sort_facet_values_by.get(fname)))
         } else {

--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -929,7 +929,7 @@ impl SearchQueryWithIndex {
     }
 
     pub fn has_facets(&self) -> Option<&AttributePatterns> {
-        self.facets.as_ref()
+        self.facets.as_ref().filter(|v| !v.is_empty())
     }
 
     pub fn has_personalize(&self) -> bool {

--- a/crates/meilisearch/tests/search/errors.rs
+++ b/crates/meilisearch/tests/search/errors.rs
@@ -435,7 +435,7 @@ async fn search_non_filterable_facets() {
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
-      "message": "Invalid facet distribution: Attribute `doggo` is not filterable. Available filterable attributes patterns are: `title`.",
+      "message": "Invalid facet distribution: Pattern `doggo` is not filterable. Available filterable attributes patterns are: `title`.",
       "code": "invalid_search_facets",
       "type": "invalid_request",
       "link": "https://docs.meilisearch.com/errors#invalid_search_facets"
@@ -446,7 +446,7 @@ async fn search_non_filterable_facets() {
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
-      "message": "Invalid facet distribution: Attribute `doggo` is not filterable. Available filterable attributes patterns are: `title`.",
+      "message": "Invalid facet distribution: Pattern `doggo` is not filterable. Available filterable attributes patterns are: `title`.",
       "code": "invalid_search_facets",
       "type": "invalid_request",
       "link": "https://docs.meilisearch.com/errors#invalid_search_facets"
@@ -466,7 +466,7 @@ async fn search_non_filterable_facets_multiple_filterable() {
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
-      "message": "Invalid facet distribution: Attribute `doggo` is not filterable. Available filterable attributes patterns are: `genres, title`.",
+      "message": "Invalid facet distribution: Pattern `doggo` is not filterable. Available filterable attributes patterns are: `genres, title`.",
       "code": "invalid_search_facets",
       "type": "invalid_request",
       "link": "https://docs.meilisearch.com/errors#invalid_search_facets"
@@ -477,7 +477,7 @@ async fn search_non_filterable_facets_multiple_filterable() {
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
-      "message": "Invalid facet distribution: Attribute `doggo` is not filterable. Available filterable attributes patterns are: `genres, title`.",
+      "message": "Invalid facet distribution: Pattern `doggo` is not filterable. Available filterable attributes patterns are: `genres, title`.",
       "code": "invalid_search_facets",
       "type": "invalid_request",
       "link": "https://docs.meilisearch.com/errors#invalid_search_facets"
@@ -496,7 +496,7 @@ async fn search_non_filterable_facets_no_filterable() {
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
-      "message": "Invalid facet distribution: Attribute `doggo` is not filterable. This index does not have configured filterable attributes.",
+      "message": "Invalid facet distribution: Pattern `doggo` is not filterable. This index does not have configured filterable attributes.",
       "code": "invalid_search_facets",
       "type": "invalid_request",
       "link": "https://docs.meilisearch.com/errors#invalid_search_facets"
@@ -507,7 +507,7 @@ async fn search_non_filterable_facets_no_filterable() {
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
-      "message": "Invalid facet distribution: Attribute `doggo` is not filterable. This index does not have configured filterable attributes.",
+      "message": "Invalid facet distribution: Pattern `doggo` is not filterable. This index does not have configured filterable attributes.",
       "code": "invalid_search_facets",
       "type": "invalid_request",
       "link": "https://docs.meilisearch.com/errors#invalid_search_facets"

--- a/crates/meilisearch/tests/search/errors.rs
+++ b/crates/meilisearch/tests/search/errors.rs
@@ -527,7 +527,7 @@ async fn search_non_filterable_facets_multiple_facets() {
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
-      "message": "Invalid facet distribution: Attributes `doggo, neko` are not filterable. Available filterable attributes patterns are: `genres, title`.",
+      "message": "Invalid facet distribution: Pattern `doggo` is not filterable. Available filterable attributes patterns are: `genres, title`.",
       "code": "invalid_search_facets",
       "type": "invalid_request",
       "link": "https://docs.meilisearch.com/errors#invalid_search_facets"
@@ -538,7 +538,7 @@ async fn search_non_filterable_facets_multiple_facets() {
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
-      "message": "Invalid facet distribution: Attributes `doggo, neko` are not filterable. Available filterable attributes patterns are: `genres, title`.",
+      "message": "Invalid facet distribution: Pattern `doggo` is not filterable. Available filterable attributes patterns are: `genres, title`.",
       "code": "invalid_search_facets",
       "type": "invalid_request",
       "link": "https://docs.meilisearch.com/errors#invalid_search_facets"

--- a/crates/meilisearch/tests/search/multi/mod.rs
+++ b/crates/meilisearch/tests/search/multi/mod.rs
@@ -917,7 +917,7 @@ async fn search_one_query_error() {
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
-      "message": "Inside `.queries[0]`: Invalid facet distribution: Attribute `color` is not filterable. Available filterable attributes patterns are: `id, title`.",
+      "message": "Inside `.queries[0]`: Invalid facet distribution: Pattern `color` is not filterable. Available filterable attributes patterns are: `id, title`.",
       "code": "invalid_search_facets",
       "type": "invalid_request",
       "link": "https://docs.meilisearch.com/errors#invalid_search_facets"

--- a/crates/meilisearch/tests/search/multi/mod.rs
+++ b/crates/meilisearch/tests/search/multi/mod.rs
@@ -987,7 +987,7 @@ async fn search_multiple_query_errors() {
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
-      "message": "Inside `.queries[0]`: Invalid facet distribution: Attribute `color` is not filterable. Available filterable attributes patterns are: `id, title`.",
+      "message": "Inside `.queries[0]`: Invalid facet distribution: Pattern `color` is not filterable. Available filterable attributes patterns are: `id, title`.",
       "code": "invalid_search_facets",
       "type": "invalid_request",
       "link": "https://docs.meilisearch.com/errors#invalid_search_facets"
@@ -3820,7 +3820,7 @@ async fn federation_non_faceted_for_an_index() {
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
-      "message": "Inside `.queries[1]`: Inside `.federation.facetsByIndex.fruits-no-name-[uuid]`: Invalid facet distribution: Attribute `name` is not filterable. Available filterable attributes patterns are: `BOOST, id`.",
+      "message": "Inside `.queries[1]`: Inside `.federation.facetsByIndex.fruits-no-name-[uuid]`: Invalid facet distribution: Pattern `name` is not filterable. Available filterable attributes patterns are: `BOOST, id`.",
       "code": "invalid_search_facets",
       "type": "invalid_request",
       "link": "https://docs.meilisearch.com/errors#invalid_search_facets"
@@ -3842,7 +3842,7 @@ async fn federation_non_faceted_for_an_index() {
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
-      "message": "Inside `.federation.facetsByIndex.fruits-no-name-[uuid]`: Invalid facet distribution: Attribute `name` is not filterable. Available filterable attributes patterns are: `BOOST, id`.\n - Note: index `fruits-no-name-[uuid]` is not used in queries",
+      "message": "Inside `.federation.facetsByIndex.fruits-no-name-[uuid]`: Invalid facet distribution: Pattern `name` is not filterable. Available filterable attributes patterns are: `BOOST, id`.\n - Note: index `fruits-no-name-[uuid]` is not used in queries",
       "code": "invalid_search_facets",
       "type": "invalid_request",
       "link": "https://docs.meilisearch.com/errors#invalid_search_facets"
@@ -3865,7 +3865,7 @@ async fn federation_non_faceted_for_an_index() {
     snapshot!(code, @"400 Bad Request");
     snapshot!(json_string!(response), @r###"
     {
-      "message": "Inside `.federation.facetsByIndex.fruits-no-facets-[uuid]`: Invalid facet distribution: Attributes `BOOST, id` are not filterable. This index does not have configured filterable attributes.\n - Note: index `fruits-no-facets-[uuid]` is not used in queries",
+      "message": "Inside `.federation.facetsByIndex.fruits-no-facets-[uuid]`: Invalid facet distribution: Pattern `BOOST` is not filterable. This index does not have configured filterable attributes.\n - Note: index `fruits-no-facets-[uuid]` is not used in queries",
       "code": "invalid_search_facets",
       "type": "invalid_request",
       "link": "https://docs.meilisearch.com/errors#invalid_search_facets"

--- a/crates/meilisearch/tests/search/multi/proxy.rs
+++ b/crates/meilisearch/tests/search/multi/proxy.rs
@@ -5,7 +5,7 @@ use meili_snap::{json_string, snapshot};
 use wiremock::matchers::{method, path, AnyMatcher};
 use wiremock::{Mock, MockServer, Request, ResponseTemplate};
 
-use crate::common::{Server, Value, SCORE_DOCUMENTS};
+use crate::common::{Server, Value, NESTED_DOCUMENTS, SCORE_DOCUMENTS};
 use crate::json;
 
 #[actix_rt::test]
@@ -419,6 +419,296 @@ async fn remote_sharding() {
       "limit": 20,
       "offset": 0,
       "estimatedTotalHits": 5,
+      "requestUid": "[uuid]",
+      "remoteErrors": {}
+    }
+    "###);
+}
+
+#[cfg(feature = "enterprise")]
+#[actix_rt::test]
+async fn remote_sharding_federated_pattern_facets() {
+    let ms0 = Server::new().await;
+    let ms1 = Server::new().await;
+    let ms2 = Server::new().await;
+
+    // enable feature
+
+    let (response, code) = ms0.set_features(json!({"network": true})).await;
+    snapshot!(code, @"200 OK");
+    snapshot!(json_string!(response["network"]), @"true");
+    let (response, code) = ms1.set_features(json!({"network": true})).await;
+    snapshot!(code, @"200 OK");
+    snapshot!(json_string!(response["network"]), @"true");
+    let (response, code) = ms2.set_features(json!({"network": true})).await;
+    snapshot!(code, @"200 OK");
+    snapshot!(json_string!(response["network"]), @"true");
+
+    // set self
+
+    let (response, code) = ms0.set_network(json!({"self": "ms0"})).await;
+    snapshot!(code, @"200 OK");
+    snapshot!(json_string!(response, {".version" => "[version]"}), @r###"
+    {
+      "self": "ms0",
+      "remotes": {},
+      "shards": {},
+      "leader": null,
+      "version": "[version]"
+    }
+    "###);
+    let (response, code) = ms1.set_network(json!({"self": "ms1"})).await;
+    snapshot!(code, @"200 OK");
+    snapshot!(json_string!(response, {".version" => "[version]"}), @r###"
+    {
+      "self": "ms1",
+      "remotes": {},
+      "shards": {},
+      "leader": null,
+      "version": "[version]"
+    }
+    "###);
+    let (response, code) = ms2.set_network(json!({"self": "ms2"})).await;
+    snapshot!(code, @"200 OK");
+    snapshot!(json_string!(response, {".version" => "[version]"}), @r###"
+    {
+      "self": "ms2",
+      "remotes": {},
+      "shards": {},
+      "leader": null,
+      "version": "[version]"
+    }
+    "###);
+
+    // wrap servers
+    let ms0 = Arc::new(ms0);
+    let ms1 = Arc::new(ms1);
+    let ms2 = Arc::new(ms2);
+
+    let rms0 = LocalMeili::new(ms0.clone()).await;
+    let rms1 = LocalMeili::new(ms1.clone()).await;
+    let rms2 = LocalMeili::new(ms2.clone()).await;
+
+    // set network
+    let network = json!({
+        "self": "ms0",
+        "leader": "ms0",
+        "remotes": {
+            "ms0": {
+                "url": rms0.url()
+            },
+            "ms1": {
+                "url": rms1.url()
+            },
+            "ms2": {
+                "url": rms2.url()
+            }
+        },
+        "shards": {
+            // Full replication
+            "shard1": { "remotes": ["ms0", "ms1", "ms2"] }
+        }
+    });
+
+    let (task, status_code) = ms0.set_network(network.clone()).await;
+    snapshot!(status_code, @"202 Accepted");
+    let t0 = task.uid();
+    let (t, _) = ms0.get_task(t0).await;
+
+    let t1 = t["network"]["remote_tasks"]["ms1"]["taskUid"].as_u64().unwrap();
+    let t2 = t["network"]["remote_tasks"]["ms2"]["taskUid"].as_u64().unwrap();
+
+    ms0.wait_task(t0).await.succeeded();
+    ms1.wait_task(t1).await.succeeded();
+    ms2.wait_task(t2).await.succeeded();
+
+    // list indexes
+    let index0 = ms0.index("test");
+
+    // update settings
+    let (task, code) = index0
+        .update_settings_filterable_attributes(json!([{
+            "attributePatterns": ["doggos.*"],
+            "features": {
+                "facetSearch": true,
+                "filter": { "equality": true, "comparison": true }
+            }
+        }]))
+        .await;
+    snapshot!(code, @"202 Accepted");
+    ms0.wait_task(task.uid()).await.succeeded();
+
+    // add documents
+    let documents = NESTED_DOCUMENTS.clone();
+    let documents = documents.as_array().unwrap();
+    let (task, code) = index0.add_documents(json!(documents), None).await;
+    snapshot!(code, @"202 Accepted");
+    ms0.wait_task(task.uid()).await.succeeded();
+
+    // Wait for all the tasks
+    let t0 = task.uid();
+    let (t, _) = ms0.get_task(task.uid()).await;
+
+    let t1 = t["network"]["remote_tasks"]["ms1"]["taskUid"].as_u64().unwrap();
+    let t2 = t["network"]["remote_tasks"]["ms2"]["taskUid"].as_u64().unwrap();
+
+    ms0.wait_task(t0).await.succeeded();
+    ms1.wait_task(t1).await.succeeded();
+    ms2.wait_task(t2).await.succeeded();
+
+    // perform multi-search
+    let request = json!({
+        "q": null,
+        "facets": ["doggos.name", "doggos.age"],
+        "useNetwork": true
+    });
+
+    let (response, code) = index0.search_post(request).await;
+    snapshot!(code, @"400 Bad Request");
+    snapshot!(json_string!(response, { ".processingTimeMs" => "[time]", ".requestUid" => "[uuid]" }), @r###"
+    {
+      "message": "Invalid facet distribution: Pattern `doggos.name` is not filterable. Available filterable attributes patterns are: `doggos.*`.",
+      "code": "invalid_search_facets",
+      "type": "invalid_request",
+      "link": "https://docs.meilisearch.com/errors#invalid_search_facets"
+    }
+    "###);
+
+    // update settings
+    let (task, code) = index0
+        .update_settings_filterable_attributes(json!([{
+            "attributePatterns": ["doggos.name", "doggos.age"],
+            "features": {
+                "facetSearch": true,
+                "filter": { "equality": true, "comparison": true }
+            }
+        }]))
+        .await;
+    snapshot!(code, @"202 Accepted");
+    ms0.wait_task(task.uid()).await.succeeded();
+
+    // perform multi-search
+    let request = json!({
+        "q": null,
+        "facets": ["doggos.*"],
+        "useNetwork": true
+    });
+
+    let (response, code) = index0.search_post(request).await;
+    snapshot!(code, @"200 OK");
+    snapshot!(json_string!(response, { ".processingTimeMs" => "[time]", ".requestUid" => "[uuid]" }), @r###"
+    {
+      "hits": [
+        {
+          "id": 852,
+          "father": "jean",
+          "mother": "michelle",
+          "doggos": [
+            {
+              "name": "bobby",
+              "age": 2
+            },
+            {
+              "name": "buddy",
+              "age": 4
+            }
+          ],
+          "cattos": "pésti",
+          "_federation": {
+            "indexUid": "test",
+            "queriesPosition": 0,
+            "weightedRankingScore": 1.0,
+            "remote": "ms0"
+          }
+        },
+        {
+          "id": 654,
+          "father": "pierre",
+          "mother": "sabine",
+          "doggos": [
+            {
+              "name": "gros bill",
+              "age": 8
+            }
+          ],
+          "cattos": [
+            "simba",
+            "pestiféré"
+          ],
+          "_federation": {
+            "indexUid": "test",
+            "queriesPosition": 0,
+            "weightedRankingScore": 1.0,
+            "remote": "ms0"
+          }
+        },
+        {
+          "id": 750,
+          "father": "romain",
+          "mother": "michelle",
+          "cattos": [
+            "enigma"
+          ],
+          "_federation": {
+            "indexUid": "test",
+            "queriesPosition": 0,
+            "weightedRankingScore": 1.0,
+            "remote": "ms0"
+          }
+        },
+        {
+          "id": 951,
+          "father": "jean-baptiste",
+          "mother": "sophie",
+          "doggos": [
+            {
+              "name": "turbo",
+              "age": 5
+            },
+            {
+              "name": "fast",
+              "age": 6
+            }
+          ],
+          "cattos": [
+            "moumoute",
+            "gomez"
+          ],
+          "_federation": {
+            "indexUid": "test",
+            "queriesPosition": 0,
+            "weightedRankingScore": 1.0,
+            "remote": "ms0"
+          }
+        }
+      ],
+      "query": "",
+      "processingTimeMs": "[time]",
+      "limit": 20,
+      "offset": 0,
+      "estimatedTotalHits": 4,
+      "facetDistribution": {
+        "doggos.age": {
+          "2": 1,
+          "4": 1,
+          "5": 1,
+          "6": 1,
+          "8": 1
+        },
+        "doggos.name": {
+          "bobby": 1,
+          "buddy": 1,
+          "fast": 1,
+          "gros bill": 1,
+          "turbo": 1
+        }
+      },
+      "facetStats": {
+        "doggos.age": {
+          "min": 2.0,
+          "max": 8.0
+        }
+      },
       "requestUid": "[uuid]",
       "remoteErrors": {}
     }

--- a/crates/meilisearch/tests/search/multi/proxy.rs
+++ b/crates/meilisearch/tests/search/multi/proxy.rs
@@ -3555,7 +3555,7 @@ async fn error_bad_request_facets_by_index_facet() {
       "requestUid": "[uuid]",
       "remoteErrors": {
         "ms1": {
-          "message": "remote host responded with code 400:\n  - response from remote: {\"message\":\"Inside `.queries[1]`: Inside `.federation.facetsByIndex.test`: Invalid facet distribution: Attribute `id` is not filterable. This index does not have configured filterable attributes.\",\"code\":\"invalid_search_facets\",\"type\":\"invalid_request\",\"link\":\"https://docs.meilisearch.com/errors#invalid_search_facets\"}\n  - hint: check that the remote instance has the correct index configuration for that request\n  - hint: check that the `network` experimental feature is enabled on the remote instance",
+          "message": "remote host responded with code 400:\n  - response from remote: {\"message\":\"Inside `.queries[1]`: Inside `.federation.facetsByIndex.test`: Invalid facet distribution: Pattern `id` is not filterable. This index does not have configured filterable attributes.\",\"code\":\"invalid_search_facets\",\"type\":\"invalid_request\",\"link\":\"https://docs.meilisearch.com/errors#invalid_search_facets\"}\n  - hint: check that the remote instance has the correct index configuration for that request\n  - hint: check that the `network` experimental feature is enabled on the remote instance",
           "code": "remote_bad_request",
           "type": "invalid_request",
           "link": "https://docs.meilisearch.com/errors#remote_bad_request"

--- a/crates/meilisearch/tests/search/multi/proxy.rs
+++ b/crates/meilisearch/tests/search/multi/proxy.rs
@@ -564,13 +564,122 @@ async fn remote_sharding_federated_pattern_facets() {
     });
 
     let (response, code) = index0.search_post(request).await;
-    snapshot!(code, @"400 Bad Request");
+    snapshot!(code, @"200 OK");
     snapshot!(json_string!(response, { ".processingTimeMs" => "[time]", ".requestUid" => "[uuid]" }), @r###"
     {
-      "message": "Invalid facet distribution: Pattern `doggos.name` is not filterable. Available filterable attributes patterns are: `doggos.*`.",
-      "code": "invalid_search_facets",
-      "type": "invalid_request",
-      "link": "https://docs.meilisearch.com/errors#invalid_search_facets"
+      "hits": [
+        {
+          "id": 852,
+          "father": "jean",
+          "mother": "michelle",
+          "doggos": [
+            {
+              "name": "bobby",
+              "age": 2
+            },
+            {
+              "name": "buddy",
+              "age": 4
+            }
+          ],
+          "cattos": "pésti",
+          "_federation": {
+            "indexUid": "test",
+            "queriesPosition": 0,
+            "weightedRankingScore": 1.0,
+            "remote": "ms0"
+          }
+        },
+        {
+          "id": 654,
+          "father": "pierre",
+          "mother": "sabine",
+          "doggos": [
+            {
+              "name": "gros bill",
+              "age": 8
+            }
+          ],
+          "cattos": [
+            "simba",
+            "pestiféré"
+          ],
+          "_federation": {
+            "indexUid": "test",
+            "queriesPosition": 0,
+            "weightedRankingScore": 1.0,
+            "remote": "ms0"
+          }
+        },
+        {
+          "id": 750,
+          "father": "romain",
+          "mother": "michelle",
+          "cattos": [
+            "enigma"
+          ],
+          "_federation": {
+            "indexUid": "test",
+            "queriesPosition": 0,
+            "weightedRankingScore": 1.0,
+            "remote": "ms0"
+          }
+        },
+        {
+          "id": 951,
+          "father": "jean-baptiste",
+          "mother": "sophie",
+          "doggos": [
+            {
+              "name": "turbo",
+              "age": 5
+            },
+            {
+              "name": "fast",
+              "age": 6
+            }
+          ],
+          "cattos": [
+            "moumoute",
+            "gomez"
+          ],
+          "_federation": {
+            "indexUid": "test",
+            "queriesPosition": 0,
+            "weightedRankingScore": 1.0,
+            "remote": "ms0"
+          }
+        }
+      ],
+      "query": "",
+      "processingTimeMs": "[time]",
+      "limit": 20,
+      "offset": 0,
+      "estimatedTotalHits": 4,
+      "facetDistribution": {
+        "doggos.age": {
+          "2": 1,
+          "4": 1,
+          "5": 1,
+          "6": 1,
+          "8": 1
+        },
+        "doggos.name": {
+          "bobby": 1,
+          "buddy": 1,
+          "fast": 1,
+          "gros bill": 1,
+          "turbo": 1
+        }
+      },
+      "facetStats": {
+        "doggos.age": {
+          "min": 2.0,
+          "max": 8.0
+        }
+      },
+      "requestUid": "[uuid]",
+      "remoteErrors": {}
     }
     "###);
 

--- a/crates/meilisearch/tests/search/multi/proxy.rs
+++ b/crates/meilisearch/tests/search/multi/proxy.rs
@@ -5,7 +5,7 @@ use meili_snap::{json_string, snapshot};
 use wiremock::matchers::{method, path, AnyMatcher};
 use wiremock::{Mock, MockServer, Request, ResponseTemplate};
 
-use crate::common::{Server, Value, NESTED_DOCUMENTS, SCORE_DOCUMENTS};
+use crate::common::{Server, Value, SCORE_DOCUMENTS};
 use crate::json;
 
 #[actix_rt::test]
@@ -428,6 +428,8 @@ async fn remote_sharding() {
 #[cfg(feature = "enterprise")]
 #[actix_rt::test]
 async fn remote_sharding_federated_pattern_facets() {
+    use crate::common::NESTED_DOCUMENTS;
+
     let ms0 = Server::new().await;
     let ms1 = Server::new().await;
     let ms2 = Server::new().await;

--- a/crates/milli/src/attribute_patterns.rs
+++ b/crates/milli/src/attribute_patterns.rs
@@ -15,7 +15,7 @@ pub struct AttributePatterns {
     /// An array of attribute name patterns. Each pattern can be an exact
     /// attribute name, or include wildcards (`*`) at the start, end, or
     /// both. Examples: `["title", "description_*", "*_date", "*content*"]`.
-    #[schema(value_type = Vec<String>, example = json!(["title", "overview_*", "release_date"]))]
+    #[schema(example = json!(["title", "overview_*", "release_date"]))]
     pub patterns: Vec<String>,
 }
 
@@ -50,6 +50,10 @@ impl AttributePatterns {
             }
         }
         pattern_match
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.patterns.is_empty()
     }
 }
 

--- a/crates/milli/src/attribute_patterns.rs
+++ b/crates/milli/src/attribute_patterns.rs
@@ -46,7 +46,19 @@ impl AttributePatterns {
             match match_pattern(pattern, str) {
                 PatternMatch::Match => return PatternMatch::Match,
                 PatternMatch::Parent => pattern_match = PatternMatch::Parent,
-                PatternMatch::NoMatch => {}
+                PatternMatch::NoMatch => (),
+            }
+        }
+        pattern_match
+    }
+
+    pub fn rev_match_pattern(&self, left_pattern: &str) -> PatternMatch {
+        let mut pattern_match = PatternMatch::NoMatch;
+        for pattern in &self.patterns {
+            match match_pattern(left_pattern, pattern) {
+                PatternMatch::Match => return PatternMatch::Match,
+                PatternMatch::Parent => pattern_match = PatternMatch::Parent,
+                PatternMatch::NoMatch => (),
             }
         }
         pattern_match

--- a/crates/milli/src/attribute_patterns.rs
+++ b/crates/milli/src/attribute_patterns.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use deserr::Deserr;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
@@ -8,7 +10,7 @@ use crate::is_faceted_by;
 /// include wildcards (`*`) for flexible matching. For example, `title`
 /// matches exactly, `overview_*` matches any attribute starting with
 /// `overview_`, and `*_date` matches any attribute ending with `_date`.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[repr(transparent)]
 #[serde(transparent)]
 pub struct AttributePatterns {
@@ -66,6 +68,12 @@ impl AttributePatterns {
 
     pub fn is_empty(&self) -> bool {
         self.patterns.is_empty()
+    }
+}
+
+impl fmt::Debug for AttributePatterns {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_list().entries(self.patterns.iter()).finish()
     }
 }
 

--- a/crates/milli/src/attribute_patterns.rs
+++ b/crates/milli/src/attribute_patterns.rs
@@ -54,16 +54,17 @@ impl AttributePatterns {
         pattern_match
     }
 
-    pub fn rev_match_pattern(&self, left_pattern: &str) -> PatternMatch {
-        let mut pattern_match = PatternMatch::NoMatch;
+    pub fn intersect_patterns(&self, other: &str) -> bool {
         for pattern in &self.patterns {
-            match match_pattern(left_pattern, pattern) {
-                PatternMatch::Match => return PatternMatch::Match,
-                PatternMatch::Parent => pattern_match = PatternMatch::Parent,
-                PatternMatch::NoMatch => (),
+            match match_pattern(other, pattern) {
+                PatternMatch::Match | PatternMatch::Parent => return true,
+                PatternMatch::NoMatch => match match_pattern(pattern, other) {
+                    PatternMatch::Match | PatternMatch::Parent => return true,
+                    PatternMatch::NoMatch => (),
+                },
             }
         }
-        pattern_match
+        false
     }
 
     pub fn is_empty(&self) -> bool {

--- a/crates/milli/src/error.rs
+++ b/crates/milli/src/error.rs
@@ -147,21 +147,21 @@ and can not be more than 511 bytes.", .document_id.to_string()
     )]
     InvalidDocumentId { document_id: Value },
     #[error("Invalid facet distribution: {}",
-        if .invalid_facets_name.len() == 1 {
-            let field = .invalid_facets_name.iter().next().unwrap();
+        if .invalid_facet_patterns.len() == 1 {
+            let field = .invalid_facet_patterns.iter().next().unwrap();
             match .matching_rule_indices.get(field) {
                 Some(rule_index) => format!("Attribute `{}` matched rule #{} in filterableAttributes, but this rule does not enable filtering.\nHint: enable filtering in rule #{} by modifying the features.filter object\nHint: prepend another rule matching `{}` with appropriate filter features before rule #{}",
                     field, rule_index, rule_index, field, rule_index),
                 None => match .valid_patterns.is_empty() {
-                    true => format!("Attribute `{}` is not filterable. This index does not have configured filterable attributes.", field),
-                    false => format!("Attribute `{}` is not filterable. Available filterable attributes patterns are: `{}`.",
+                    true => format!("Pattern `{}` is not filterable. This index does not have configured filterable attributes.", field),
+                    false => format!("Pattern `{}` is not filterable. Available filterable attributes patterns are: `{}`.",
                         field,
                         .valid_patterns.iter().map(AsRef::as_ref).collect::<Vec<&str>>().join(", ")),
                 }
             }
         } else {
             format!("Attributes `{}` are not filterable. {}",
-                .invalid_facets_name.iter().map(AsRef::as_ref).collect::<Vec<&str>>().join(", "),
+                .invalid_facet_patterns.iter().map(AsRef::as_ref).collect::<Vec<&str>>().join(", "),
                 match .valid_patterns.is_empty() {
                     true => "This index does not have configured filterable attributes.".to_string(),
                     false => format!("Available filterable attributes patterns are: `{}`.",
@@ -171,7 +171,7 @@ and can not be more than 511 bytes.", .document_id.to_string()
         }
     )]
     InvalidFacetsDistribution {
-        invalid_facets_name: BTreeSet<String>,
+        invalid_facet_patterns: BTreeSet<String>,
         valid_patterns: BTreeSet<String>,
         matching_rule_indices: HashMap<String, usize>,
     },

--- a/crates/milli/src/error.rs
+++ b/crates/milli/src/error.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeSet, HashMap};
+use std::collections::BTreeSet;
 use std::convert::Infallible;
 use std::fmt::Write;
 use std::{io, str};
@@ -147,9 +147,9 @@ and can not be more than 511 bytes.", .document_id.to_string()
     )]
     InvalidDocumentId { document_id: Value },
     #[error("Invalid facet distribution: {}",
-        if .invalid_facet_patterns.len() == 1 {
-            let field = .invalid_facet_patterns.iter().next().unwrap();
-            match .matching_rule_indices.get(field) {
+        {
+            let field = .invalid_facet_pattern;
+            match .matching_rule_index {
                 Some(rule_index) => format!("Attribute `{}` matched rule #{} in filterableAttributes, but this rule does not enable filtering.\nHint: enable filtering in rule #{} by modifying the features.filter object\nHint: prepend another rule matching `{}` with appropriate filter features before rule #{}",
                     field, rule_index, rule_index, field, rule_index),
                 None => match .valid_patterns.is_empty() {
@@ -159,21 +159,12 @@ and can not be more than 511 bytes.", .document_id.to_string()
                         .valid_patterns.iter().map(AsRef::as_ref).collect::<Vec<&str>>().join(", ")),
                 }
             }
-        } else {
-            format!("Attributes `{}` are not filterable. {}",
-                .invalid_facet_patterns.iter().map(AsRef::as_ref).collect::<Vec<&str>>().join(", "),
-                match .valid_patterns.is_empty() {
-                    true => "This index does not have configured filterable attributes.".to_string(),
-                    false => format!("Available filterable attributes patterns are: `{}`.",
-                        .valid_patterns.iter().map(AsRef::as_ref).collect::<Vec<&str>>().join(", ")),
-                }
-            )
         }
     )]
     InvalidFacetsDistribution {
-        invalid_facet_patterns: BTreeSet<String>,
+        invalid_facet_pattern: String,
         valid_patterns: BTreeSet<String>,
-        matching_rule_indices: HashMap<String, usize>,
+        matching_rule_index: Option<usize>,
     },
     #[error(transparent)]
     InvalidGeoField(#[from] Box<GeoError>),

--- a/crates/milli/src/fields_ids_map/metadata.rs
+++ b/crates/milli/src/fields_ids_map/metadata.rs
@@ -296,7 +296,6 @@ pub struct MetadataBuilder {
     distinct_attribute: Option<String>,
     asc_desc_attributes: HashMap<String, FieldSortOrder>,
     displayed_attributes: Option<HashSet<String>>,
-    fields_metadata: BTreeMap<String, Metadata>,
     order_by_map: OrderByMap,
 }
 
@@ -325,7 +324,7 @@ impl MetadataBuilder {
             .displayed_fields(rtxn)?
             .map(|fields| fields.into_iter().map(String::from).collect());
 
-        let mut this = Self {
+        Ok(Self {
             searchable_attributes,
             exact_searchable_attributes,
             filterable_attributes,
@@ -334,15 +333,8 @@ impl MetadataBuilder {
             distinct_attribute,
             asc_desc_attributes,
             displayed_attributes,
-            fields_metadata: BTreeMap::default(),
             order_by_map: index.sort_facet_values_by(rtxn)?,
-        };
-
-        for field_name in index.fields_ids_map(rtxn)?.names() {
-            this.fields_metadata.insert(field_name.to_owned(), this.metadata_for_field(field_name));
-        }
-
-        Ok(this)
+        })
     }
 
     /// Build a new `MetadataBuilder` from the given parameters.
@@ -372,7 +364,6 @@ impl MetadataBuilder {
             distinct_attribute,
             asc_desc_attributes,
             displayed_attributes: None,
-            fields_metadata: BTreeMap::default(),
             order_by_map: OrderByMap::default(),
         }
     }
@@ -387,7 +378,6 @@ impl MetadataBuilder {
             distinct_attribute: None,
             asc_desc_attributes: Default::default(),
             displayed_attributes: None,
-            fields_metadata: Default::default(),
             order_by_map: OrderByMap::default(),
         }
     }
@@ -693,9 +683,5 @@ impl MetadataBuilder {
 
     pub fn localized_attributes_rules(&self) -> Option<&[LocalizedAttributesRule]> {
         self.localized_attributes.as_deref()
-    }
-
-    pub fn fields_metadata(&self) -> &BTreeMap<String, Metadata> {
-        &self.fields_metadata
     }
 }

--- a/crates/milli/src/fields_ids_map/metadata.rs
+++ b/crates/milli/src/fields_ids_map/metadata.rs
@@ -152,10 +152,17 @@ impl Metadata {
         &self,
         rules: &'rules [LocalizedAttributesRule],
     ) -> Option<&'rules [Language]> {
+        self.localized_attributes_rule_with_index(rules).map(|(_, rule)| rule.locales())
+    }
+
+    fn localized_attributes_rule_with_index<'rules>(
+        &self,
+        rules: &'rules [LocalizedAttributesRule],
+    ) -> Option<(usize, &'rules LocalizedAttributesRule)> {
         let localized_attributes_rule_id = self.localized_attributes_rule_id?.get();
         // - 1: `localized_attributes_rule_id` is NonZero
         let rule = rules.get((localized_attributes_rule_id - 1) as usize).unwrap();
-        Some(rule.locales())
+        Some((localized_attributes_rule_id.into(), rule))
     }
 
     pub fn filterable_attributes<'rules>(
@@ -385,10 +392,44 @@ impl MetadataBuilder {
         }
     }
 
+    /// Computes the full metadata for a field
+    ///
+    /// Use when you need the full metadata, otherwise consider using one of the intermediate functions
     pub fn metadata_for_field(&self, field: &str) -> Metadata {
-        if is_faceted_by(field, RESERVED_VECTORS_FIELD_NAME) {
+        if let Some(metadata) = self.has_reserved_field_metadata(field) {
+            return metadata;
+        }
+
+        let localized_attributes_rule_id =
+            self.localized_rule_with_index_not_reserved(field).map(|(id, _)| {
+                NonZeroU16::new(id.saturating_add(1).try_into().unwrap())
+                    // saturating_add(1): make `id` `NonZero`
+                    .unwrap()
+            });
+
+        Metadata {
+            searchable: self.is_searchable_not_reserved(field),
+            exact: self.is_exact_not_reserved(field),
+            sortable: self.is_sortable_not_reserved(field),
+            distinct: self.is_distinct_not_reserved(field),
+            asc_desc: self.is_asc_desc_not_reserved(field),
+            geo: PatternMatch::NoMatch,
+            geo_json: PatternMatch::NoMatch,
+            localized_attributes_rule_id,
+            filterable_attributes_rule_id: self.filterable_attribute_rules_not_reserved(field),
+            displayed: self.is_displayed(field),
+            sort_by: self.order_by_map.get(field),
+        }
+    }
+
+    // Partial metadata
+
+    /// `Some` if the field is faceted by the reserved vector field name, otherwise `None`
+    pub fn has_vector_metadata(&self, field: &str) -> Option<Metadata> {
+        // Vectors fields are not searchable, filterable, distinct or asc_desc
+        is_faceted_by(field, RESERVED_VECTORS_FIELD_NAME).then_some(
             // Vectors fields are not searchable, filterable, distinct or asc_desc
-            return Metadata {
+            Metadata {
                 searchable: (PatternMatch::NoMatch, None),
                 exact: PatternMatch::NoMatch,
                 sortable: PatternMatch::NoMatch,
@@ -398,67 +439,147 @@ impl MetadataBuilder {
                 geo_json: PatternMatch::NoMatch,
                 localized_attributes_rule_id: None,
                 filterable_attributes_rule_id: (PatternMatch::NoMatch, None),
-                displayed: self.is_field_displayed(field),
+                displayed: self.is_displayed(field),
                 sort_by: OrderBy::default(),
-            };
-        }
+            },
+        )
+    }
 
-        // A field is sortable if it is faceted by a sortable attribute
-        let sortable = field_match_any_patterns_legacy(&self.sortable_attributes, field);
-
-        let mut matching_filterable = PatternMatch::NoMatch;
-        let filterable_attributes_rule_id = self
-            .filterable_attributes
-            .iter()
-            .position(|attribute| match attribute.match_str(field) {
-                PatternMatch::Match => {
-                    matching_filterable = PatternMatch::Match;
-                    true
-                }
-                PatternMatch::Parent => {
-                    matching_filterable = PatternMatch::Parent;
-                    false
-                }
-                PatternMatch::NoMatch => false,
-            })
-            // saturating_add(1): make `id` `NonZero`
-            .map(|id| NonZeroU16::new(id.saturating_add(1).try_into().unwrap()).unwrap());
-        let filterable_attributes_rule_id = (matching_filterable, filterable_attributes_rule_id);
-
-        if match_field_legacy(RESERVED_GEO_FIELD_NAME, field) == PatternMatch::Match {
+    /// `Some` if the field is matching legacy the reserved geo field name, otherwise `None`
+    pub fn has_geo_metadata(&self, field: &str) -> Option<Metadata> {
+        (match_field_legacy(RESERVED_GEO_FIELD_NAME, field) == PatternMatch::Match).then_some(
             // Geo fields are not searchable, distinct or asc_desc
-            return Metadata {
+            Metadata {
                 searchable: (PatternMatch::NoMatch, None),
                 exact: PatternMatch::NoMatch,
-                sortable,
+                sortable: self.is_sortable_not_reserved(field),
                 distinct: PatternMatch::NoMatch,
                 asc_desc: (PatternMatch::NoMatch, None),
                 geo: PatternMatch::Match,
                 geo_json: PatternMatch::NoMatch,
                 localized_attributes_rule_id: None,
-                filterable_attributes_rule_id,
-                displayed: self.is_field_displayed(field),
+                filterable_attributes_rule_id: self.filterable_attribute_rules_not_reserved(field),
+                displayed: self.is_displayed(field),
                 sort_by: self.order_by_map.get(field),
-            };
-        }
-        if match_field_legacy(RESERVED_GEOJSON_FIELD_NAME, field) == PatternMatch::Match {
-            debug_assert!(sortable != PatternMatch::Match, "geojson fields should not be sortable");
-            return Metadata {
+            },
+        )
+    }
+
+    /// `Some` if the field is matching legacy the reserved geojson field name, otherwise `None`
+    pub fn has_geo_json_metadata(&self, field: &str) -> Option<Metadata> {
+        (match_field_legacy(RESERVED_GEOJSON_FIELD_NAME, field) == PatternMatch::Match).then_some(
+            Metadata {
                 searchable: (PatternMatch::NoMatch, None),
                 exact: PatternMatch::NoMatch,
-                sortable,
+                // geojson field should not be sortable
+                sortable: PatternMatch::NoMatch,
                 distinct: PatternMatch::NoMatch,
                 asc_desc: (PatternMatch::NoMatch, None),
                 geo: PatternMatch::NoMatch,
                 geo_json: PatternMatch::Match,
                 localized_attributes_rule_id: None,
-                filterable_attributes_rule_id,
-                displayed: self.is_field_displayed(field),
+                filterable_attributes_rule_id: self.filterable_attribute_rules_not_reserved(field),
+                displayed: self.is_displayed(field),
                 sort_by: self.order_by_map.get(field),
-            };
-        }
+            },
+        )
+    }
 
-        let searchable = match &self.searchable_attributes {
+    /// `Some` if the field is any of the reserved fields with special metadata, `None` otherwise.
+    pub fn has_reserved_field_metadata(&self, field: &str) -> Option<Metadata> {
+        self.has_vector_metadata(field)
+            .or_else(|| self.has_geo_metadata(field))
+            .or_else(|| self.has_geo_json_metadata(field))
+    }
+
+    /// Whether the field is a displayable attribute.
+    pub fn is_displayed(&self, field: &str) -> PatternMatch {
+        match self.displayed_attributes.as_ref() {
+            Some(attrs) => field_match_any_patterns_legacy(attrs, field),
+            None => PatternMatch::Match,
+        }
+    }
+
+    /// Whether the field is a searchable attribute.
+    pub fn is_searchable(&self, field: &str) -> (PatternMatch, Option<Weight>) {
+        if let Some(Metadata { searchable, .. }) = self.has_reserved_field_metadata(field) {
+            searchable
+        } else {
+            self.is_searchable_not_reserved(field)
+        }
+    }
+
+    /// Whether the field is an exact attribute.
+    pub fn is_exact(&self, field: &str) -> PatternMatch {
+        if let Some(Metadata { exact, .. }) = self.has_reserved_field_metadata(field) {
+            exact
+        } else {
+            self.is_exact_not_reserved(field)
+        }
+    }
+
+    /// Whether the field is a sortable attribute.
+    pub fn is_sortable(&self, field: &str) -> PatternMatch {
+        if let Some(Metadata { sortable, .. }) = self.has_reserved_field_metadata(field) {
+            sortable
+        } else {
+            self.is_sortable_not_reserved(field)
+        }
+    }
+
+    /// Whether the field is the distinct field.
+    pub fn is_distinct(&self, field: &str) -> PatternMatch {
+        if let Some(Metadata { distinct, .. }) = self.has_reserved_field_metadata(field) {
+            distinct
+        } else {
+            self.is_distinct_not_reserved(field)
+        }
+    }
+
+    /// Whether the field matches any filterable rule, and if so the matching rule and its index.
+    pub fn filterable_rule_with_index<'rules>(
+        &'rules self,
+        field: &str,
+    ) -> (PatternMatch, Option<(usize, &'rules FilterableAttributesRule)>) {
+        if let Some(metadata) = self.has_reserved_field_metadata(field) {
+            (
+                metadata.filterable_attributes_rule_id.0,
+                metadata
+                    .filterable_attributes_with_rule_index(self.filterable_attributes.as_slice()),
+            )
+        } else {
+            self.filterable_rule_with_index_not_reserved(field)
+        }
+    }
+
+    /// Whether the field matches any localized rule, and if so the matching rule and its index.
+    pub fn localized_rule_with_index<'rules>(
+        &'rules self,
+        field: &str,
+    ) -> Option<(usize, &'rules LocalizedAttributesRule)> {
+        let localized_attributes_rules = self.localized_attributes.as_deref()?;
+
+        if let Some(metadata) = self.has_reserved_field_metadata(field) {
+            metadata.localized_attributes_rule_with_index(localized_attributes_rules)
+        } else {
+            self.localized_rule_with_index_not_reserved(field)
+        }
+    }
+
+    /// Whether the field matches any asc desc custom rule, and if so the field sort order.
+    pub fn is_asc_desc(&self, field: &str) -> (PatternMatch, Option<FieldSortOrder>) {
+        if let Some(Metadata { asc_desc, .. }) = self.has_reserved_field_metadata(field) {
+            asc_desc
+        } else {
+            self.is_asc_desc_not_reserved(field)
+        }
+    }
+
+    // partial metadata implementation
+    // the following functions assume that callers already checked whether the field is a reserved field with a special metadata
+
+    fn is_searchable_not_reserved(&self, field: &str) -> (PatternMatch, Option<Weight>) {
+        match &self.searchable_attributes {
             // A field is searchable if it is faceted by a searchable attribute
             Some(attributes) => {
                 let mut matching_searchable = PatternMatch::NoMatch;
@@ -479,13 +600,71 @@ impl MetadataBuilder {
                 (matching_searchable, weight)
             }
             None => (PatternMatch::Match, Some(0)),
-        };
+        }
+    }
 
-        let exact = field_match_any_patterns_legacy(&self.exact_searchable_attributes, field);
+    fn is_exact_not_reserved(&self, field: &str) -> PatternMatch {
+        field_match_any_patterns_legacy(&self.exact_searchable_attributes, field)
+    }
 
-        let distinct = match_distinct_field(self.distinct_attribute.as_deref(), field);
-        let asc_desc = match field_match_any_patterns_legacy(self.asc_desc_attributes.keys(), field)
-        {
+    fn is_sortable_not_reserved(&self, field: &str) -> PatternMatch {
+        // A field is sortable if it is faceted by a sortable attribute
+        field_match_any_patterns_legacy(&self.sortable_attributes, field)
+    }
+
+    fn is_distinct_not_reserved(&self, field: &str) -> PatternMatch {
+        match_distinct_field(self.distinct_attribute.as_deref(), field)
+    }
+
+    fn filterable_rule_with_index_not_reserved<'rules>(
+        &'rules self,
+        field: &str,
+    ) -> (PatternMatch, Option<(usize, &'rules FilterableAttributesRule)>) {
+        let mut matching_filterable = PatternMatch::NoMatch;
+        let filterable_attributes_rule_id =
+            self.filterable_attributes.iter().enumerate().find(|(_rule_id, attribute)| {
+                match attribute.match_str(field) {
+                    PatternMatch::Match => {
+                        matching_filterable = PatternMatch::Match;
+                        true
+                    }
+                    PatternMatch::Parent => {
+                        matching_filterable = PatternMatch::Parent;
+                        false
+                    }
+                    PatternMatch::NoMatch => false,
+                }
+            });
+        (matching_filterable, filterable_attributes_rule_id)
+    }
+
+    fn filterable_attribute_rules_not_reserved(
+        &self,
+        field: &str,
+    ) -> (PatternMatch, Option<NonZeroU16>) {
+        let (matching_filterable, filterable_attributes_rule) =
+            self.filterable_rule_with_index_not_reserved(field);
+        let filterable_attributes_rule_id = filterable_attributes_rule.map(|(rule_id, _)| {
+            NonZeroU16::new(rule_id.saturating_add(1).try_into().unwrap())
+                // saturating_add(1): make `id` `NonZero`
+                .unwrap()
+        });
+        (matching_filterable, filterable_attributes_rule_id)
+    }
+
+    fn localized_rule_with_index_not_reserved<'rules>(
+        &'rules self,
+        field: &str,
+    ) -> Option<(usize, &'rules LocalizedAttributesRule)> {
+        self.localized_attributes
+            .iter()
+            .flat_map(|v| v.iter())
+            .enumerate()
+            .find(|(_rule_id, rule)| rule.match_str(field) == PatternMatch::Match)
+    }
+
+    fn is_asc_desc_not_reserved(&self, field: &str) -> (PatternMatch, Option<FieldSortOrder>) {
+        match field_match_any_patterns_legacy(self.asc_desc_attributes.keys(), field) {
             PatternMatch::Match => {
                 // If the field matches an asc_desc attribute, return the order
                 match self.asc_desc_attributes.get(field) {
@@ -495,37 +674,10 @@ impl MetadataBuilder {
             }
             PatternMatch::Parent => (PatternMatch::Parent, None),
             PatternMatch::NoMatch => (PatternMatch::NoMatch, None),
-        };
-
-        let localized_attributes_rule_id = self
-            .localized_attributes
-            .iter()
-            .flat_map(|v| v.iter())
-            .position(|rule| rule.match_str(field) == PatternMatch::Match)
-            // saturating_add(1): make `id` `NonZero`
-            .map(|id| NonZeroU16::new(id.saturating_add(1).try_into().unwrap()).unwrap());
-
-        Metadata {
-            searchable,
-            exact,
-            sortable,
-            distinct,
-            asc_desc,
-            geo: PatternMatch::NoMatch,
-            geo_json: PatternMatch::NoMatch,
-            localized_attributes_rule_id,
-            filterable_attributes_rule_id,
-            displayed: self.is_field_displayed(field),
-            sort_by: self.order_by_map.get(field),
         }
     }
 
-    fn is_field_displayed(&self, field: &str) -> PatternMatch {
-        match self.displayed_attributes.as_ref() {
-            Some(attrs) => field_match_any_patterns_legacy(attrs, field),
-            None => PatternMatch::Match,
-        }
-    }
+    // Accessors
 
     pub fn searchable_attributes(&self) -> Option<&[String]> {
         self.searchable_attributes.as_deref()

--- a/crates/milli/src/filterable_attributes_rules.rs
+++ b/crates/milli/src/filterable_attributes_rules.rs
@@ -29,12 +29,15 @@ impl FilterableAttributesRule {
         }
     }
 
-    pub fn rev_match_pattern(&self, left_pattern: &str) -> PatternMatch {
+    pub fn intersect_patterns(&self, other: &str) -> bool {
         match self {
             // If the rule is a field, match the field against the provided pattern using the legacy behavior
-            FilterableAttributesRule::Field(field) => match_field_legacy(left_pattern, field),
+            FilterableAttributesRule::Field(field) => matches!(
+                match_field_legacy(other, field),
+                PatternMatch::Parent | PatternMatch::Match
+            ),
             // If the rule is a pattern, match each one of them against the provided pattern using the new behavior
-            FilterableAttributesRule::Pattern(patterns) => patterns.rev_match_pattern(left_pattern),
+            FilterableAttributesRule::Pattern(patterns) => patterns.intersect_patterns(other),
         }
     }
 
@@ -87,8 +90,8 @@ impl FilterableAttributesPatterns {
         self.attribute_patterns.match_str(field)
     }
 
-    pub fn rev_match_pattern(&self, left_pattern: &str) -> PatternMatch {
-        self.attribute_patterns.rev_match_pattern(left_pattern)
+    pub fn intersect_patterns(&self, other: &str) -> bool {
+        self.attribute_patterns.intersect_patterns(other)
     }
 
     pub fn features(&self) -> FilterableAttributesFeatures {

--- a/crates/milli/src/filterable_attributes_rules.rs
+++ b/crates/milli/src/filterable_attributes_rules.rs
@@ -29,6 +29,15 @@ impl FilterableAttributesRule {
         }
     }
 
+    pub fn rev_match_pattern(&self, left_pattern: &str) -> PatternMatch {
+        match self {
+            // If the rule is a field, match the field against the provided pattern using the legacy behavior
+            FilterableAttributesRule::Field(field) => match_field_legacy(left_pattern, field),
+            // If the rule is a pattern, match each one of them against the provided pattern using the new behavior
+            FilterableAttributesRule::Pattern(patterns) => patterns.rev_match_pattern(left_pattern),
+        }
+    }
+
     /// Check if the rule is a geo field.
     ///
     /// prefer using `index.is_geo_enabled`, `index.is_geo_filtering_enabled`
@@ -76,6 +85,10 @@ pub struct FilterableAttributesPatterns {
 impl FilterableAttributesPatterns {
     pub fn match_str(&self, field: &str) -> PatternMatch {
         self.attribute_patterns.match_str(field)
+    }
+
+    pub fn rev_match_pattern(&self, left_pattern: &str) -> PatternMatch {
+        self.attribute_patterns.rev_match_pattern(left_pattern)
     }
 
     pub fn features(&self) -> FilterableAttributesFeatures {

--- a/crates/milli/src/filterable_attributes_rules.rs
+++ b/crates/milli/src/filterable_attributes_rules.rs
@@ -64,13 +64,13 @@ pub struct FilterableAttributesPatterns {
     /// characters. For example, `["price_*", "stock"]` matches `price_usd`,
     /// `price_eur`, and `stock`.
     #[schema(value_type = Vec<String>)]
-    pub attribute_patterns: AttributePatterns,
+    pub attribute_patterns: AttributePatterns, // try match
     /// The filtering and faceting features enabled for attributes matching
     /// these patterns. If not specified, defaults to equality filtering
     /// enabled.
     #[serde(default)]
     #[deserr(default)]
-    pub features: FilterableAttributesFeatures,
+    pub features: FilterableAttributesFeatures, // if ok, check is_filterable, if nobody matches it's an error
 }
 
 impl FilterableAttributesPatterns {

--- a/crates/milli/src/filterable_attributes_rules.rs
+++ b/crates/milli/src/filterable_attributes_rules.rs
@@ -73,13 +73,13 @@ pub struct FilterableAttributesPatterns {
     /// characters. For example, `["price_*", "stock"]` matches `price_usd`,
     /// `price_eur`, and `stock`.
     #[schema(value_type = Vec<String>)]
-    pub attribute_patterns: AttributePatterns, // try match
+    pub attribute_patterns: AttributePatterns,
     /// The filtering and faceting features enabled for attributes matching
     /// these patterns. If not specified, defaults to equality filtering
     /// enabled.
     #[serde(default)]
     #[deserr(default)]
-    pub features: FilterableAttributesFeatures, // if ok, check is_filterable, if nobody matches it's an error
+    pub features: FilterableAttributesFeatures,
 }
 
 impl FilterableAttributesPatterns {

--- a/crates/milli/src/index.rs
+++ b/crates/milli/src/index.rs
@@ -641,7 +641,7 @@ impl Index {
 
     /// Returns the fields ids map with metadata.
     ///
-    /// This structure is not yet stored in the index, and is generated on the fly.
+    /// This structure is not yet stored in the index, and is generated on the fly, which can be costly.
     pub fn fields_ids_map_with_metadata(&self, rtxn: &RoTxn<'_>) -> Result<FieldIdMapWithMetadata> {
         Ok(FieldIdMapWithMetadata::new(
             self.fields_ids_map(rtxn)?,

--- a/crates/milli/src/lib.rs
+++ b/crates/milli/src/lib.rs
@@ -78,8 +78,8 @@ pub use self::fields_ids_map::{
     FieldIdMapWithMetadata, FieldSortOrder, FieldsIdsMap, GlobalFieldsIdsMap, MetadataBuilder,
 };
 pub use self::filterable_attributes_rules::{
-    FilterFeatures, FilterableAttributesFeatures, FilterableAttributesPatterns,
-    FilterableAttributesRule,
+    filtered_matching_patterns, FilterFeatures, FilterableAttributesFeatures,
+    FilterableAttributesPatterns, FilterableAttributesRule,
 };
 pub use self::foreign_key::ForeignKey;
 pub use self::heed_codec::{

--- a/crates/milli/src/search/facet/facet_distribution.rs
+++ b/crates/milli/src/search/facet/facet_distribution.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, HashMap};
 use std::fmt::Display;
 use std::ops::ControlFlow;
 use std::{fmt, mem};
@@ -377,39 +377,29 @@ impl<'a> FacetDistribution<'a> {
         &self,
         filterable_attributes_rules: &[FilterableAttributesRule],
     ) -> Result<()> {
-        let mut invalid_facets = BTreeSet::new();
-        let mut matching_rule_indices = HashMap::new();
-
         if let Some(facets) = &self.facets {
             for field in facets.keys() {
                 let matched_rule = matching_features(field, filterable_attributes_rules);
                 let is_filterable = matched_rule.is_some_and(|(_, f)| f.is_filterable());
 
                 if !is_filterable {
-                    invalid_facets.insert(field.to_string());
+                    let valid_patterns =
+                        filtered_matching_patterns(filterable_attributes_rules, &|features| {
+                            features.is_filterable()
+                        })
+                        .into_iter()
+                        .map(String::from)
+                        .collect();
 
-                    // If the field matched a rule but that rule doesn't enable filtering,
-                    // store the rule index for better error messages
-                    if let Some((rule_index, _)) = matched_rule {
-                        matching_rule_indices.insert(field.to_string(), rule_index);
-                    }
+                    return Err(Error::UserError(UserError::InvalidFacetsDistribution {
+                        invalid_facet_pattern: field.to_string(),
+                        valid_patterns,
+                        // If the field matched a rule but that rule doesn't enable filtering,
+                        // store the rule index for better error messages
+                        matching_rule_index: matched_rule.map(|(rule_index, _)| rule_index),
+                    }));
                 }
             }
-        }
-
-        if !invalid_facets.is_empty() {
-            let valid_patterns =
-                filtered_matching_patterns(filterable_attributes_rules, &|features| {
-                    features.is_filterable()
-                })
-                .into_iter()
-                .map(String::from)
-                .collect();
-            return Err(Error::UserError(UserError::InvalidFacetsDistribution {
-                invalid_facet_patterns: invalid_facets,
-                valid_patterns,
-                matching_rule_indices,
-            }));
         }
 
         Ok(())

--- a/crates/milli/src/search/facet/facet_distribution.rs
+++ b/crates/milli/src/search/facet/facet_distribution.rs
@@ -406,7 +406,7 @@ impl<'a> FacetDistribution<'a> {
                 .map(String::from)
                 .collect();
             return Err(Error::UserError(UserError::InvalidFacetsDistribution {
-                invalid_facets_name: invalid_facets,
+                invalid_facet_patterns: invalid_facets,
                 valid_patterns,
                 matching_rule_indices,
             }));


### PR DESCRIPTION
## Changelog

The `facets` parameter in search and federated search now supports more wildcards. Previously, only the single wildcard `"*"` was supported, requesting all filterable fields.

Now, patterns *containing* `*`  are supported with the same matching rules as in `filterableAttributes.attributePatterns` and `localizedAttributes.attributePatterns`, such as `dogs.*`, which will add to the facet distribution all filterable fields that match the pattern (such as `dogs.intel`, `dogs.kefir`, etc.).

---


This PR enables providing patterns when requesting the facet distribution of certain fields. Before, it was only possible to provide either a whole attribute name, i.e., `title`, `dogs.intel`, or everything through the `*` special pattern. Now, a user can provide patterns, i.e., `title`, `dogs.*`, `*` and retrieve all of the facets that are filterable. An error is still thrown if a pattern is found to match a non-filterable pattern or matches nothing in the filterable attributes list.

## To Do

- [x] Update the documentation
- [x] Support attribute patterns on the search route
- [x] Support attribute patterns on the multi-search/federation route
- [x] Make sure it works with sharding