### PR TITLE
Fix yet another filter round-trip serialization error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2274,6 +2274,7 @@ dependencies = [
  "levenshtein_automata",
  "nom",
  "nom_locate",
+ "serde_json",
  "unescaper",
 ]
 

--- a/crates/filter-parser/Cargo.toml
+++ b/crates/filter-parser/Cargo.toml
@@ -16,6 +16,7 @@ nom = "7.1.3"
 nom_locate = "4.2.0"
 unescaper = "0.1.6"
 levenshtein_automata = { version = "0.2.1", features = ["fst_automaton"] }
+serde_json = { version = "1.0.150", features = ["preserve_order"] }
 
 [dev-dependencies]
 # fixed version due to format breakages in v1.40

--- a/crates/filter-parser/src/lib.rs
+++ b/crates/filter-parser/src/lib.rs
@@ -175,7 +175,7 @@ impl<'a> Token<'a> {
 
     /// The fragment with escaped double quotes.
     pub fn escaped_fragment(&self) -> String {
-        self.fragment().replace('"', r#"\""#)
+        serde_json::to_string(self.fragment()).unwrap()
     }
 
     /// Returns the extra fragment of the token.

--- a/crates/milli/src/search/facet/filter/index_filter.rs
+++ b/crates/milli/src/search/facet/filter/index_filter.rs
@@ -846,16 +846,16 @@ fn serialize_index_filter_condition(
             write!(f, ")")?;
         }
         IndexFilterCondition::Condition { fid, op } => {
-            write!(f, "\"{}\" ", fid.escaped_fragment())?;
+            write!(f, "{} ", fid.escaped_fragment())?;
             serialize_condition(f, op)?;
         }
         IndexFilterCondition::In { fid, els } => {
-            write!(f, "\"{}\" IN [", fid.escaped_fragment())?;
+            write!(f, "{} IN [", fid.escaped_fragment())?;
             for (i, el) in els.iter().enumerate() {
                 if i > 0 {
                     write!(f, ", ")?;
                 }
-                write!(f, "\"{}\"", el.escaped_fragment())?;
+                write!(f, "{}", el.escaped_fragment())?;
             }
             write!(f, "]")?;
         }
@@ -882,11 +882,11 @@ fn serialize_index_filter_condition(
         IndexFilterCondition::VectorExists { fid: _, embedder, filter: inner } => {
             write!(f, "_vectors")?;
             if let Some(embedder) = embedder {
-                write!(f, ".\"{}\"", embedder.escaped_fragment())?;
+                write!(f, ".{}", embedder.escaped_fragment())?;
             }
             match inner {
                 VectorFilter::Fragment(fragment) => {
-                    write!(f, ".fragments.\"{}\"", fragment.escaped_fragment())?
+                    write!(f, ".fragments.{}", fragment.escaped_fragment())?
                 }
                 VectorFilter::DocumentTemplate => write!(f, ".documentTemplate")?,
                 VectorFilter::UserProvided => write!(f, ".userProvided")?,
@@ -944,23 +944,23 @@ fn serialize_index_filter_condition(
 
 fn serialize_condition(f: &mut impl FmtWrite, condition: &Condition<'_>) -> std::fmt::Result {
     match condition {
-        Condition::GreaterThan(token) => write!(f, "> \"{}\"", token.escaped_fragment()),
-        Condition::GreaterThanOrEqual(token) => write!(f, ">= \"{}\"", token.escaped_fragment()),
-        Condition::Equal(token) => write!(f, "= \"{}\"", token.escaped_fragment()),
-        Condition::NotEqual(token) => write!(f, "!= \"{}\"", token.escaped_fragment()),
+        Condition::GreaterThan(token) => write!(f, "> {}", token.escaped_fragment()),
+        Condition::GreaterThanOrEqual(token) => write!(f, ">= {}", token.escaped_fragment()),
+        Condition::Equal(token) => write!(f, "= {}", token.escaped_fragment()),
+        Condition::NotEqual(token) => write!(f, "!= {}", token.escaped_fragment()),
         Condition::Null => write!(f, "IS NULL"),
         Condition::Empty => write!(f, "IS EMPTY"),
         Condition::Exists => write!(f, "EXISTS"),
-        Condition::LowerThan(token) => write!(f, "< \"{}\"", token.escaped_fragment()),
-        Condition::LowerThanOrEqual(token) => write!(f, "<= \"{}\"", token.escaped_fragment()),
+        Condition::LowerThan(token) => write!(f, "< {}", token.escaped_fragment()),
+        Condition::LowerThanOrEqual(token) => write!(f, "<= {}", token.escaped_fragment()),
         Condition::Between { from, to } => {
-            write!(f, "\"{}\" TO \"{}\"", from.escaped_fragment(), to.escaped_fragment())
+            write!(f, "{} TO {}", from.escaped_fragment(), to.escaped_fragment())
         }
         Condition::Contains { word, keyword: _ } => {
-            write!(f, "CONTAINS \"{}\"", word.escaped_fragment())
+            write!(f, "CONTAINS {}", word.escaped_fragment())
         }
         Condition::StartsWith { word, keyword: _ } => {
-            write!(f, "STARTS WITH \"{}\"", word.escaped_fragment())
+            write!(f, "STARTS WITH {}", word.escaped_fragment())
         }
     }
 }


### PR DESCRIPTION
## Changelog

Fix a bug where some filters containing escaped characters (such as `\\`) would cause search requests to fail with `invalid_search_filter`

## Related issue

Fixes #6493 

## Implementation

The bug stems from the fact that we're manually escaping `"` to `\"`, which leaves out other escaped characters such as `\`.

To fix this issue I added  `serde-json` and use it to escape the filter fragments as a serde-json string, which makes sense when serializing them and should take care of all escaped characters.

## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respect the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - *list of used tools and what they were used for*