### PR TITLE
Add missing route descriptions for documentation

### DIFF
--- a/.github/workflows/check-openapi-file.yml
+++ b/.github/workflows/check-openapi-file.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Check all routes have summaries
         run: cargo run --release -p openapi-generator -- --check-summaries
 
+      - name: Check all routes have descriptions
+        run: cargo run --release -p openapi-generator -- --check-descriptions
+
       - name: Check for duplicate or malformed paths
         run: cargo run --release -p openapi-generator -- --check-paths
 

--- a/crates/meilisearch/src/routes/chats/chat_completions.rs
+++ b/crates/meilisearch/src/routes/chats/chat_completions.rs
@@ -66,6 +66,12 @@ use crate::search::{add_search_rules, elapsed, prepare_search, search_from_kind,
 use crate::search_queue::SearchQueue;
 
 /// Request a chat completion
+///
+/// Answer a conversational question with the OpenAI-compatible chat completions API,
+/// using the documents of the authorized indexes as context.
+/// Only streamed responses (`stream: true`) are supported.
+///
+/// This route is only available when the `chatCompletions` [experimental feature](https://www.meilisearch.com/docs/resources/help/experimental_features_overview) is enabled.
 #[routes::path(
     params(
         ("workspace_uid" = String, Path, example = "my-workspace", description = "The unique identifier of the chat workspace.", nullable = false),

--- a/crates/meilisearch/src/routes/chats/mod.rs
+++ b/crates/meilisearch/src/routes/chats/mod.rs
@@ -67,6 +67,10 @@ pub struct ChatsParam {
 }
 
 /// Get a chat workspace
+///
+/// Get the details of a chat workspace by its unique identifier.
+///
+/// This route is only available when the `chatCompletions` [experimental feature](https://www.meilisearch.com/docs/resources/help/experimental_features_overview) is enabled.
 #[routes::path(
     security(("Bearer" = ["chats.get", "*"])),
     params(
@@ -111,6 +115,10 @@ pub async fn get_chat(
 }
 
 /// Delete a chat workspace
+///
+/// Delete a chat workspace and its settings by its unique identifier.
+///
+/// This route is only available when the `chatCompletions` [experimental feature](https://www.meilisearch.com/docs/resources/help/experimental_features_overview) is enabled.
 #[routes::path(
     security(("Bearer" = ["chats.delete", "*"])),
     params(
@@ -180,6 +188,10 @@ pub struct ChatWorkspaceView {
 }
 
 /// List chat workspaces
+///
+/// List all chat workspaces registered on the instance, with pagination.
+///
+/// This route is only available when the `chatCompletions` [experimental feature](https://www.meilisearch.com/docs/resources/help/experimental_features_overview) is enabled.
 #[routes::path(
     security(("Bearer" = ["chats.get", "*"])),
     responses(

--- a/crates/meilisearch/src/routes/chats/settings.rs
+++ b/crates/meilisearch/src/routes/chats/settings.rs
@@ -19,6 +19,11 @@ use crate::extractors::authentication::policies::ActionPolicy;
 use crate::extractors::authentication::GuardedData;
 
 /// Get settings of a chat workspace
+///
+/// Get the settings of a chat workspace, such as the LLM source, the base prompts,
+/// and the search parameters. The API key is never returned.
+///
+/// This route is only available when the `chatCompletions` [experimental feature](https://www.meilisearch.com/docs/resources/help/experimental_features_overview) is enabled.
 #[routes::path(
     security(("Bearer" = ["chats.settings.get", "*"])),
     params(
@@ -82,6 +87,12 @@ pub async fn get_settings(
 }
 
 /// Update settings of a chat workspace
+///
+/// Partially update the settings of a chat workspace, such as the LLM source, the base prompts,
+/// and the search parameters. Fields set to `null` are reset to their default value,
+/// and missing fields are left unchanged.
+///
+/// This route is only available when the `chatCompletions` [experimental feature](https://www.meilisearch.com/docs/resources/help/experimental_features_overview) is enabled.
 #[routes::path(
     security(("Bearer" = ["chats.settings.update", "*"])),
     request_body = ChatWorkspaceSettings,
@@ -224,6 +235,10 @@ pub async fn patch_settings(
 }
 
 /// Reset the settings of a chat workspace
+///
+/// Reset all the settings of a chat workspace to their default value.
+///
+/// This route is only available when the `chatCompletions` [experimental feature](https://www.meilisearch.com/docs/resources/help/experimental_features_overview) is enabled.
 #[routes::path(
     security(("Bearer" = ["chats.settings.update", "*"])),
     params(

--- a/crates/meilisearch/src/routes/render.rs
+++ b/crates/meilisearch/src/routes/render.rs
@@ -49,7 +49,16 @@ pub fn configure(cfg: &mut web::ServiceConfig) {
     cfg.service(web::resource("").route(web::post().to(SeqHandler(render_post))));
 }
 
-/// Render documents with POST
+/// Render template
+///
+/// Render a template, either fetched from the settings of an index (embedder document template,
+/// chat document template, indexing or search fragment) or provided inline, by injecting the
+/// given input (a document from an index, an inline document, or a search query).
+///
+/// Returns the template and the rendered result, allowing to preview how Meilisearch renders
+/// templates without indexing any document.
+///
+/// This route is only available when the `renderRoute` [experimental feature](https://www.meilisearch.com/docs/resources/help/experimental_features_overview) is enabled.
 #[routes::path(
     security(("Bearer" = ["settings.get,documents.get", "*.get", "*"])),
     request_body = RenderQuery,

--- a/crates/openapi-generator/src/main.rs
+++ b/crates/openapi-generator/src/main.rs
@@ -30,6 +30,10 @@ struct Cli {
     #[arg(long)]
     check_summaries: bool,
 
+    /// Check that all routes have a description (useful for CI)
+    #[arg(long)]
+    check_descriptions: bool,
+
     /// Check for duplicate routes and path issues (useful for CI)
     #[arg(long)]
     check_paths: bool,
@@ -55,6 +59,11 @@ fn main() -> Result<()> {
     // Check that all routes have summaries if requested
     if cli.check_summaries {
         check_all_routes_have_summaries(&openapi_value)?;
+    }
+
+    // Check that all routes have descriptions if requested
+    if cli.check_descriptions {
+        check_all_routes_have_descriptions(&openapi_value)?;
     }
 
     // Check for path issues (duplicates, malformed paths) if requested
@@ -95,21 +104,19 @@ fn get_paths_object(openapi: &Value) -> Result<&JsonObject> {
     openapi.get("paths").and_then(Value::as_object).context("OpenAPI spec missing 'paths' object")
 }
 
-/// Checks that all routes have a summary field.
-///
-/// Returns an error if any route is missing a summary.
-fn check_all_routes_have_summaries(openapi: &Value) -> Result<()> {
-    let paths = get_paths_object(openapi)?;
-
-    let mut missing_summaries: Vec<String> = paths
+/// Returns the routes whose operation is missing a non-empty string `field` (e.g. "summary" or "description").
+fn routes_missing_operation_field(paths: &JsonObject, field: &str) -> Vec<String> {
+    let mut missing: Vec<String> = paths
         .iter()
         .flat_map(|(path, path_item)| {
             path_item.as_object().map(|path_item| {
                 HTTP_METHODS.iter().filter_map(move |method| {
                     let op = path_item.get(*method)?;
-                    let has_summary =
-                        op.get("summary").and_then(Value::as_str).is_some_and(|s| !s.is_empty());
-                    if has_summary {
+                    let has_field = op
+                        .get(field)
+                        .and_then(Value::as_str)
+                        .is_some_and(|s| !s.trim().is_empty());
+                    if has_field {
                         None
                     } else {
                         Some(format!("{} {}", method.to_uppercase(), path))
@@ -119,8 +126,29 @@ fn check_all_routes_have_summaries(openapi: &Value) -> Result<()> {
         })
         .flatten()
         .collect();
-    missing_summaries.sort_unstable();
-    missing_summaries.dedup();
+    missing.sort_unstable();
+    missing.dedup();
+    missing
+}
+
+/// Prints the doc-comment example shared by the summary and description checks.
+fn print_doc_comment_help() {
+    eprintln!("\nTo fix this, add a doc-comment (///) above the route handler function.");
+    eprintln!("The first line becomes the summary, subsequent lines become the description.");
+    eprintln!("\nExample:");
+    eprintln!("  /// List webhooks");
+    eprintln!("  ///");
+    eprintln!("  /// Get the list of all registered webhooks.");
+    eprintln!("  #[utoipa::path(...)]");
+    eprintln!("  async fn get_webhooks(...) {{ ... }}");
+}
+
+/// Checks that all routes have a summary field.
+///
+/// Returns an error if any route is missing a summary.
+fn check_all_routes_have_summaries(openapi: &Value) -> Result<()> {
+    let paths = get_paths_object(openapi)?;
+    let missing_summaries = routes_missing_operation_field(paths, "summary");
 
     if missing_summaries.is_empty() {
         println!("All routes have summaries.");
@@ -131,15 +159,28 @@ fn check_all_routes_have_summaries(openapi: &Value) -> Result<()> {
     for route in &missing_summaries {
         eprintln!("  - {}", route);
     }
-    eprintln!("\nTo fix this, add a doc-comment (///) above the route handler function.");
-    eprintln!("The first line becomes the summary, subsequent lines become the description.");
-    eprintln!("\nExample:");
-    eprintln!("  /// List webhooks");
-    eprintln!("  ///");
-    eprintln!("  /// Get the list of all registered webhooks.");
-    eprintln!("  #[utoipa::path(...)]");
-    eprintln!("  async fn get_webhooks(...) {{ ... }}");
+    print_doc_comment_help();
     anyhow::bail!("{} route(s) missing summary", missing_summaries.len());
+}
+
+/// Checks that all routes have a description field.
+///
+/// Returns an error if any route is missing a description.
+fn check_all_routes_have_descriptions(openapi: &Value) -> Result<()> {
+    let paths = get_paths_object(openapi)?;
+    let missing_descriptions = routes_missing_operation_field(paths, "description");
+
+    if missing_descriptions.is_empty() {
+        println!("All routes have descriptions.");
+        return Ok(());
+    }
+
+    eprintln!("The following routes are missing a description:");
+    for route in &missing_descriptions {
+        eprintln!("  - {}", route);
+    }
+    print_doc_comment_help();
+    anyhow::bail!("{} route(s) missing description", missing_descriptions.len());
 }
 
 /// Checks for path issues in the OpenAPI specification.
@@ -768,6 +809,28 @@ mod tests {
         assert_eq!(normalize_path("indexes//{indexUid}"), "indexes/{indexUid}");
         assert_eq!(normalize_path("/indexes//{indexUid}/compact"), "indexes/{indexUid}/compact");
         assert_eq!(normalize_path("//indexes///compact//"), "indexes/compact");
+    }
+
+    #[test]
+    fn test_routes_missing_operation_field() {
+        let openapi = json!({
+            "paths": {
+                "/indexes": {
+                    "get": { "summary": "List indexes", "description": "List all indexes." },
+                    "post": { "summary": "Create an index" }
+                },
+                "/health": {
+                    "get": { "summary": "Get health", "description": "  " }
+                }
+            }
+        });
+        let paths = get_paths_object(&openapi).unwrap();
+
+        assert!(routes_missing_operation_field(paths, "summary").is_empty());
+        assert_eq!(
+            routes_missing_operation_field(paths, "description"),
+            vec!["GET /health", "POST /indexes"]
+        );
     }
 
     #[test]

--- a/crates/openapi-generator/src/main.rs
+++ b/crates/openapi-generator/src/main.rs
@@ -112,10 +112,8 @@ fn routes_missing_operation_field(paths: &JsonObject, field: &str) -> Vec<String
             path_item.as_object().map(|path_item| {
                 HTTP_METHODS.iter().filter_map(move |method| {
                     let op = path_item.get(*method)?;
-                    let has_field = op
-                        .get(field)
-                        .and_then(Value::as_str)
-                        .is_some_and(|s| !s.trim().is_empty());
+                    let has_field =
+                        op.get(field).and_then(Value::as_str).is_some_and(|s| !s.trim().is_empty());
                     if has_field {
                         None
                     } else {


### PR DESCRIPTION
## Related issue

Improves docs with missing route description + fixes route wrong naming

<img width="1420" height="615" alt="Capture d’écran 2026-07-07 à 11 54 26" src="https://github.com/user-attachments/assets/0cf30bea-1819-4a9c-b2b4-13cc59229815" />


## Generative AI tools

- [ ] This PR does not use generative AI tooling
- [X] This PR uses generative AI tooling and respect the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
  - To find all missing descriptions
  - To improve the CI script

## Requirements

⚠️ Ensure the following requirements before merging ⚠️
- [ ] Automated tests have been added.
- [ ] If some tests cannot be automated, manual rigorous tests should be applied.
- [ ] ⚠️ If there is any change in the DB:
    - [ ] Test that any impacted DB still works as expected after using `--experimental-dumpless-upgrade` on a DB created with the last released Meilisearch
    - [ ] Test that during the upgrade, **search is still available** (artificially make the upgrade longer if needed)
    - [ ] Set the `db change` label.
- [ ] If necessary, the feature have been tested in the Cloud production environment (with [prototypes](./documentation/prototypes.md)) and the Cloud UI is ready.
- [ ] If necessary, the [documentation](https://github.com/meilisearch/documentation) related to the implemented feature in the PR is ready.
- [ ] If necessary, the [integrations](https://github.com/meilisearch/integration-guides) related to the implemented feature in the PR are ready.
