### PR TITLE
Make sure not to store empty or long synonym keys

### DIFF
--- a/crates/milli/src/update/settings.rs
+++ b/crates/milli/src/update/settings.rs
@@ -48,7 +48,7 @@ use crate::vector::{
 };
 use crate::{
     ChannelCongestion, FieldId, FilterableAttributesRule, ForeignKey, Index,
-    LocalizedAttributesRule, MustStopProcessing, Result,
+    LocalizedAttributesRule, MustStopProcessing, Result, MAX_LMDB_KEY_LENGTH,
 };
 
 #[derive(Default, Debug, Clone, PartialEq, Eq, Copy)]
@@ -758,7 +758,11 @@ impl<'a, 't, 'i> Settings<'a, 't, 'i> {
 
                 self.index.synonyms.clear(self.wtxn)?;
                 for (key, synonyms) in new_synonyms {
-                    self.index.synonyms.put(self.wtxn, &key, &synonyms)?;
+                    // length of all words + count of delimiters
+                    let total_length = key.iter().map(String::len).sum::<usize>() + key.len();
+                    if total_length < MAX_LMDB_KEY_LENGTH && total_length != 0 {
+                        self.index.synonyms.put(self.wtxn, &key, &synonyms)?;
+                    }
                 }
 
                 self.index.put_user_defined_synonyms(self.wtxn, user_synonyms)?;

--- a/crates/milli/src/update/upgrade/v1_49.rs
+++ b/crates/milli/src/update/upgrade/v1_49.rs
@@ -5,7 +5,9 @@ use heed::types::Str;
 use heed::RwTxn;
 
 use super::{UpgradeIndex, UpgradeParams};
-use crate::{index::AssociatedSynonyms, update::settings::normalize, Index, Result};
+use crate::index::AssociatedSynonyms;
+use crate::update::settings::normalize;
+use crate::{Index, Result, MAX_LMDB_KEY_LENGTH};
 
 pub const SYNONYMS_KEY: &str = "synonyms";
 
@@ -47,6 +49,10 @@ impl UpgradeIndex for MigrateSynonymsToDedicatedDatabase {
         let mut entries = BTreeMap::new();
         for (original_key, synonyms) in user_defined_synonyms {
             let normalized = normalize(&tokenizer, &original_key);
+            if normalized.is_empty() {
+                continue;
+            }
+
             let synonyms = AssociatedSynonyms::new(synonyms);
             if synonyms.synonyms(&tokenizer).is_empty() {
                 continue;
@@ -56,7 +62,11 @@ impl UpgradeIndex for MigrateSynonymsToDedicatedDatabase {
         }
 
         for (key, synonyms) in entries {
-            index.synonyms.put(wtxn, &key, &synonyms)?;
+            // length of all words + count of delimiters
+            let total_length = key.iter().map(String::len).sum::<usize>() + key.len();
+            if total_length < MAX_LMDB_KEY_LENGTH && total_length != 0 {
+                index.synonyms.put(wtxn, &key, &synonyms)?;
+            }
         }
 
         Ok(false)


### PR DESCRIPTION
This PR makes sure we do not store empty synonym keys in LMDB and simply ignore them. Note that, as before, we keep the original user synonyms unchanged.