### PR TITLE
View the target state of index settings

### DIFF
--- a/crates/index-scheduler/src/lib.rs
+++ b/crates/index-scheduler/src/lib.rs
@@ -74,6 +74,7 @@ use meilisearch_types::milli::vector::{
 use meilisearch_types::milli::{self, Index};
 use meilisearch_types::network::route::Status;
 use meilisearch_types::network::{Network, RemoteAvailability};
+use meilisearch_types::settings::{SecretPolicy, SettingsTarget};
 use meilisearch_types::task_view::TaskView;
 use meilisearch_types::tasks::network::{
     DbTaskNetwork, NetworkTopologyChange, Origin, TaskNetwork,
@@ -1303,6 +1304,127 @@ impl IndexScheduler {
         let deleted = self.chat_settings.delete(&mut wtxn, uid)?;
         wtxn.commit()?;
         Ok(deleted)
+    }
+
+    pub fn user_index_settings_target(
+        &self,
+        uid: &str,
+        secret_policy: SecretPolicy,
+    ) -> Result<SettingsTarget> {
+        let uid = UserIndex::try_from_uid(uid)?;
+        let err = |err| Error::from_milli(err, Some(uid.uid().to_string()));
+        let rtxn = self.env.read_txn()?;
+        let current = match self.index_mapper.index(&rtxn, uid) {
+            Ok(index) => {
+                let rtxn = index.read_txn()?;
+                Some(
+                    meilisearch_types::settings::settings(&index, &rtxn, secret_policy)
+                        .map_err(err)?,
+                )
+            }
+            Err(Error::IndexNotFound(_)) => None,
+            Err(err) => return Err(err),
+        };
+
+        let tasks_by_status =
+            self.queue.tasks.get_status(&rtxn, meilisearch_types::tasks::Status::Enqueued)?;
+
+        let tasks_by_index = self.queue.tasks.index_tasks(&rtxn, uid.uid())?;
+
+        let mut tasks = tasks_by_index & tasks_by_status;
+
+        // error if the index doesn't currently exist and no pending task will change this
+        if tasks.is_empty() && current.is_none() {
+            return Err(Error::IndexNotFound(uid.uid().to_string()));
+        }
+
+        let tasks_by_kind = self
+            .queue
+            .tasks
+            .get_kind(&rtxn, meilisearch_types::tasks::Kind::SettingsUpdate)?
+            | self.queue.tasks.get_kind(&rtxn, meilisearch_types::tasks::Kind::IndexDeletion)?;
+
+        tasks &= tasks_by_kind;
+
+        if tasks.is_empty() {
+            let target = current.as_ref().map(|current| {
+                let mut target = current.clone();
+                target.difference(current);
+                target
+            });
+
+            return Ok(SettingsTarget {
+                current,
+                target,
+                task_ids: Default::default(),
+                needs_processing: false,
+            });
+        }
+
+        let mut target = current.clone().map(|settings| settings.into_unchecked());
+
+        for task_id in &tasks {
+            let task = self
+                .queue
+                .tasks
+                .get_task(&rtxn, task_id)
+                .and_then(|task| task.ok_or(Error::CorruptedTaskQueue))?;
+            match task.kind {
+                KindWithContent::SettingsUpdate {
+                    index_uid: _,
+                    new_settings,
+                    is_deletion: _,
+                    allow_index_creation: _,
+                } => {
+                    target = Some(match target.take() {
+                        Some(mut target) => {
+                            target.merge(&new_settings);
+                            target
+                        }
+                        None => *new_settings,
+                    });
+                }
+                KindWithContent::IndexDeletion { index_uid: _ } => target = None,
+                KindWithContent::DocumentAdditionOrUpdate { .. }
+                | KindWithContent::DocumentDeletion { .. }
+                | KindWithContent::DocumentDeletionByFilter { .. }
+                | KindWithContent::DocumentEdition { .. }
+                | KindWithContent::DocumentClear { .. }
+                | KindWithContent::IndexCreation { .. }
+                | KindWithContent::IndexUpdate { .. }
+                | KindWithContent::IndexSwap { .. }
+                | KindWithContent::TaskCancelation { .. }
+                | KindWithContent::TaskDeletion { .. }
+                | KindWithContent::DumpCreation { .. }
+                | KindWithContent::SnapshotCreation
+                | KindWithContent::Export { .. }
+                | KindWithContent::UpgradeDatabase { .. }
+                | KindWithContent::IndexCompaction { .. }
+                | KindWithContent::NetworkTopologyChange(_)
+                | KindWithContent::DsrUpdate(_)
+                | KindWithContent::DsrClear => (),
+            }
+        }
+
+        let mut target = target.map(|settings| {
+            let mut settings = settings.check();
+
+            if let SecretPolicy::HideSecrets = secret_policy {
+                settings.hide_secrets();
+            }
+            settings
+        });
+
+        if let (Some(current), Some(target)) = (current.as_ref(), target.as_mut()) {
+            target.difference(current);
+        }
+
+        Ok(SettingsTarget {
+            current,
+            target,
+            task_ids: tasks.into_iter().collect(),
+            needs_processing: true,
+        })
     }
 }
 

--- a/crates/meilisearch-types/src/settings.rs
+++ b/crates/meilisearch-types/src/settings.rs
@@ -25,6 +25,7 @@ use crate::deserr::DeserrJsonError;
 use crate::error::deserr_codes::*;
 use crate::facet_values_sort::FacetValuesSort;
 use crate::locales::LocalizedAttributesRuleView;
+use crate::tasks::TaskId;
 
 /// The maximum number of results that the engine
 /// will be able to return in one search call.
@@ -507,6 +508,66 @@ impl Settings<Checked> {
         }
     }
 
+    pub fn difference(&mut self, other: &Self) {
+        let Self {
+            displayed_attributes,
+            searchable_attributes,
+            filterable_attributes,
+            foreign_keys,
+            sortable_attributes,
+            ranking_rules,
+            stop_words,
+            synonyms,
+            non_separator_tokens,
+            separator_tokens,
+            dictionary,
+            distinct_attribute,
+            proximity_precision,
+            typo_tolerance,
+            faceting,
+            pagination,
+            embedders,
+            search_cutoff_ms,
+            localized_attributes,
+            facet_search,
+            prefix_search,
+            chat,
+            _kind,
+        } = self;
+
+        displayed_attributes.difference(&other.displayed_attributes);
+        searchable_attributes.difference(&other.searchable_attributes);
+        filterable_attributes.difference(&other.filterable_attributes);
+        foreign_keys.difference(&other.foreign_keys);
+        sortable_attributes.difference(&other.sortable_attributes);
+        ranking_rules.difference(&other.ranking_rules);
+        stop_words.difference(&other.stop_words);
+        synonyms.difference(&other.synonyms);
+        non_separator_tokens.difference(&other.non_separator_tokens);
+        separator_tokens.difference(&other.separator_tokens);
+        dictionary.difference(&other.dictionary);
+        distinct_attribute.difference(&other.distinct_attribute);
+        proximity_precision.difference(&other.proximity_precision);
+        typo_tolerance.difference(&other.typo_tolerance);
+        faceting.difference(&other.faceting);
+        pagination.difference(&other.pagination);
+        embedders.difference(&other.embedders);
+        if let (Setting::Set(embedders), Setting::Set(other_embedders)) =
+            (embedders, &other.embedders)
+        {
+            for (embedder_name, embedder) in embedders {
+                if let Some(other_embedder) = other_embedders.get(embedder_name) {
+                    embedder.inner.difference(&other_embedder.inner);
+                }
+            }
+        }
+        search_cutoff_ms.difference(&other.search_cutoff_ms);
+        localized_attributes.difference(&other.localized_attributes);
+        facet_search.difference(&other.facet_search);
+        prefix_search.difference(&other.prefix_search);
+        chat.difference(&other.chat);
+    }
+
     pub fn into_unchecked(self) -> Settings<Unchecked> {
         let Self {
             displayed_attributes,
@@ -974,6 +1035,7 @@ pub fn apply_settings_to_builder(
     }
 }
 
+#[derive(Debug, Clone, Copy)]
 pub enum SecretPolicy {
     RevealSecrets,
     HideSecrets,
@@ -1308,6 +1370,12 @@ impl std::ops::Deref for WildcardSetting {
     }
 }
 
+impl std::ops::DerefMut for WildcardSetting {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
 #[routes::request(setting, override_error = DeserrJsonError<InvalidSettingsPrefixSearch>)]
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PrefixSearchSettings {
@@ -1331,6 +1399,26 @@ impl From<PrefixSearchSettings> for PrefixSearch {
             PrefixSearchSettings::Disabled => PrefixSearch::Disabled,
         }
     }
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+#[schema(rename_all = "camelCase")]
+pub struct SettingsTarget {
+    /// Settings object representing the currently processed state of the settings.
+    ///
+    /// `null` if the index doesn't currently exist.
+    pub current: Option<Settings<Checked>>,
+    /// Settings object representing the target processing state of the settings, as obtained by processed all related tasks.
+    ///
+    /// Only contains the fields that will be modified by the related tasks.
+    ///
+    /// `null` if the index will not exist after processing all related tasks.
+    pub target: Option<Settings<Checked>>,
+    /// List of the ids of the pending tasks related to the settings of this index.
+    pub task_ids: Vec<TaskId>,
+    /// Set to `true` if there is at least one task that will update the settings of this index.
+    pub needs_processing: bool,
 }
 
 #[cfg(test)]

--- a/crates/meilisearch/src/routes/indexes/settings.rs
+++ b/crates/meilisearch/src/routes/indexes/settings.rs
@@ -42,6 +42,7 @@ macro_rules! make_setting_routes {
         #[routes::routes(
             routes(
                 "" => [patch(update_all), get(get_all), delete(delete_all)],
+                "target" =>  [get(get_all_target)],
                 $( $route => [get($attr::get), $update_verb($attr::update), delete($attr::delete)]),*
             ),
             tag = "Settings",
@@ -753,6 +754,137 @@ pub async fn get_all(
     debug!(returns = ?new_settings, "Get all settings");
     Ok(HttpResponse::Ok().json(new_settings))
 }
+
+#[routes::path(
+    security(("Bearer" = ["settings.get", "settings.*", "*"])),
+    params(("index_uid" = String, example = "movies", description = "Unique identifier of the index.", nullable = false)),
+    responses(
+        (status = 200, description = "Returns the current and target settings.", body = SettingsTarget, content_type = "application/json", example = json!({
+            "current": {
+                "displayedAttributes": [
+                    "*"
+                ],
+                "searchableAttributes": [
+                    "*"
+                ],
+                "filterableAttributes": [],
+                "sortableAttributes": [],
+                "rankingRules": [
+                    "words",
+                    "typo",
+                    "proximity",
+                    "attributeRank",
+                    "sort",
+                    "wordPosition",
+                    "exactness"
+                    ],
+                    "stopWords": [],
+                    "nonSeparatorTokens": [],
+                    "separatorTokens": [],
+                    "dictionary": [],
+                    "synonyms": {},
+                    "distinctAttribute": null,
+                    "proximityPrecision": "byWord",
+                    "typoTolerance": {
+                        "enabled": true,
+                        "minWordSizeForTypos": {
+                            "oneTypo": 5,
+                            "twoTypos": 9
+                        },
+                        "disableOnWords": [],
+                        "disableOnAttributes": [],
+                        "disableOnNumbers": false
+                    },
+                    "faceting": {
+                        "maxValuesPerFacet": 100,
+                        "sortFacetValuesBy": {
+                            "*": "alpha"
+                        }
+                    },
+                    "pagination": {
+                        "maxTotalHits": 1000
+                    },
+                    "embedders": {},
+                    "searchCutoffMs": null,
+                    "localizedAttributes": null,
+                    "facetSearch": true,
+                    "prefixSearch": "indexingTime"
+                },
+                "target": {
+                    "searchableAttributes": [
+                        "title",
+                        "overview"
+                        ],
+                    "filterableAttributes": [
+                        "release_date"
+                        ],
+                    "sortableAttributes": [
+                        "release_date"
+                        ],
+                    "facetSearch": false
+                },
+                "taskIds": [
+                    10,
+                    11
+                ],
+                "needsProcessing": true
+        })),
+        (status = 401, description = "The authorization header is missing.", body = ResponseError, content_type = "application/json", example = json!(
+            {
+                "message": "The Authorization header is missing. It must use the bearer authorization method.",
+                "code": "missing_authorization_header",
+                "type": "auth",
+                "link": "https://docs.meilisearch.com/errors#missing_authorization_header"
+            }
+        )),
+        (status = 404, description = "Index not found.", body = ResponseError, content_type = "application/json", example = json!(
+            {
+                "message": "Index `movies` not found.",
+                "code": "index_not_found",
+                "type": "invalid_request",
+                "link": "https://docs.meilisearch.com/errors#index_not_found"
+            }
+        )),
+    )
+)]
+/// Compare current and target settings
+///
+/// Retrieve all settings of an index in a single request. Returns every configurable option and its current or default value, as
+/// well as the values that will be set after processing all pending tasks.
+pub async fn get_all_target(
+    index_scheduler: GuardedData<ActionPolicy<{ actions::SETTINGS_GET }>, Data<IndexScheduler>>,
+    index_uid: web::Path<String>,
+) -> Result<HttpResponse, ResponseError> {
+    let index_uid = IndexUid::try_from(index_uid.into_inner())?;
+
+    let mut target =
+        index_scheduler.user_index_settings_target(&index_uid, SecretPolicy::HideSecrets)?;
+
+    let features = index_scheduler.features();
+
+    if features.check_chat_completions("showing index `chat` settings").is_err() {
+        if let Some(setting) = target.current.as_mut() {
+            setting.chat = Setting::NotSet;
+        }
+        if let Some(setting) = target.target.as_mut() {
+            setting.chat = Setting::NotSet;
+        }
+    }
+
+    if features.check_foreign_keys_setting("showing index `foreignKeys` settings").is_err() {
+        if let Some(setting) = target.current.as_mut() {
+            setting.foreign_keys = Setting::NotSet;
+        }
+        if let Some(setting) = target.target.as_mut() {
+            setting.foreign_keys = Setting::NotSet;
+        }
+    }
+
+    debug!(returns = ?target, "Get all settings target");
+    Ok(HttpResponse::Ok().json(target))
+}
+
+use meilisearch_types::settings::SettingsTarget;
 
 #[routes::path(
     summary = "Reset all settings",

--- a/crates/milli/src/update/settings.rs
+++ b/crates/milli/src/update/settings.rs
@@ -136,6 +136,15 @@ impl<T> Setting<T> {
         *self = new;
         true
     }
+
+    pub fn difference(&mut self, other: &Self)
+    where
+        T: PartialEq,
+    {
+        if self == other {
+            *self = Setting::NotSet
+        }
+    }
 }
 
 impl<T: Serialize> Serialize for Setting<T> {


### PR DESCRIPTION
# Changelog

Adds a new route `GET /indexes/{:indexId}/settings/target`

Calling this route returns an object with the following fields:

- `current`: settings object representing the currently processed state of the settings. `null` if the index does not currently exist
- `target`: settings object representing the target processing state of the settings, as obtained by processing all related tasks. `null` if the index will be deleted after processing all related tasks.
- `taskIds`: list of task IDs that will modify the setting of the index or delete the index.
- `needsProcessing`: set to `true` if there is at least one task that will update the settings of this index.

Returns 404 `index_not_found` if called on an index that doesn't currently exist **and** no tasks related to this index are pending (enqueued or processing).

<details>

<summary>Response when no change is planned</summary>

```jsonc
// GET /indexes/movies/settings/target
{
  "current": {
    "displayedAttributes": [
      "*"
    ],
    "searchableAttributes": [
      "title",
      "overview"
    ],
    "filterableAttributes": [
      "release_date"
    ],
    "sortableAttributes": [
      "release_date"
    ],
    "rankingRules": [
      "words",
      "typo",
      "proximity",
      "attributeRank",
      "sort",
      "wordPosition",
      "exactness"
    ],
    "stopWords": [],
    "nonSeparatorTokens": [],
    "separatorTokens": [],
    "dictionary": [],
    "synonyms": {},
    "distinctAttribute": null,
    "proximityPrecision": "byWord",
    "typoTolerance": {
      "enabled": true,
      "minWordSizeForTypos": {
        "oneTypo": 5,
        "twoTypos": 9
      },
      "disableOnWords": [],
      "disableOnAttributes": [],
      "disableOnNumbers": false
    },
    "faceting": {
      "maxValuesPerFacet": 100,
      "sortFacetValuesBy": {
        "*": "alpha"
      }
    },
    "pagination": {
      "maxTotalHits": 1000
    },
    "embedders": {},
    "searchCutoffMs": null,
    "localizedAttributes": null,
    "facetSearch": false,
    "prefixSearch": "indexingTime"
  },
  "target": {},
  "taskIds": [],
  "needsProcessing": false
}
```

</details>

<details>

<summary>Response when there are pending tasks for the index settings</summary>

```jsonc
// GET /indexes/movies/settings/target
{
  "current": {
    "displayedAttributes": [
      "*"
    ],
    "searchableAttributes": [
      "*"
    ],
    "filterableAttributes": [],
    "sortableAttributes": [],
    "rankingRules": [
      "words",
      "typo",
      "proximity",
      "attributeRank",
      "sort",
      "wordPosition",
      "exactness"
    ],
    "stopWords": [],
    "nonSeparatorTokens": [],
    "separatorTokens": [],
    "dictionary": [],
    "synonyms": {},
    "distinctAttribute": null,
    "proximityPrecision": "byWord",
    "typoTolerance": {
      "enabled": true,
      "minWordSizeForTypos": {
        "oneTypo": 5,
        "twoTypos": 9
      },
      "disableOnWords": [],
      "disableOnAttributes": [],
      "disableOnNumbers": false
    },
    "faceting": {
      "maxValuesPerFacet": 100,
      "sortFacetValuesBy": {
        "*": "alpha"
      }
    },
    "pagination": {
      "maxTotalHits": 1000
    },
    "embedders": {},
    "searchCutoffMs": null,
    "localizedAttributes": null,
    "facetSearch": true,
    "prefixSearch": "indexingTime"
  },
  "target": {
    "searchableAttributes": [
      "title",
      "overview"
    ],
    "filterableAttributes": [
      "release_date"
    ],
    "sortableAttributes": [
      "release_date"
    ],
    "facetSearch": false
  },
  "taskIds": [
    10,
    11
  ],
  "needsProcessing": true
}
```

</details>

## Related issue

Fixes [linear issue (internal)](https://linear.app/meilisearch/issue/ENGPROD-2643/view-the-target-state-of-index-settings)

## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respect the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - *list of used tools and what they were used for*
