### PR TITLE
Own parsed filters structure

### DIFF
--- a/crates/filter-parser/src/condition.rs
+++ b/crates/filter-parser/src/condition.rs
@@ -14,7 +14,9 @@ use Condition::*;
 
 use crate::error::IResultExt;
 use crate::value::{parse_vector_value, parse_vector_value_cut};
-use crate::{parse_value, Error, ErrorKind, FilterCondition, IResult, Span, Token, VectorFilter};
+use crate::{
+    parse_value, Error, ErrorKind, FilterCondition, IResult, Span, Token, TokenLike, VectorFilter,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Condition {
@@ -153,7 +155,7 @@ fn parse_vectors(input: Span) -> IResult<(Token, Option<Token>, VectorFilter)> {
     ))(input)?;
 
     if let Ok((input, point)) = tag::<_, _, ()>(".")(input) {
-        let opt_value = parse_vector_value(input).ok().map(|(_, v)| v);
+        let opt_value: Option<Token> = parse_vector_value(input).ok().map(|(_, v)| v);
         let value = opt_value
             .as_ref()
             .map(|v| v.fragment().to_owned())

--- a/crates/filter-parser/src/condition.rs
+++ b/crates/filter-parser/src/condition.rs
@@ -17,22 +17,22 @@ use crate::value::{parse_vector_value, parse_vector_value_cut};
 use crate::{parse_value, Error, ErrorKind, FilterCondition, IResult, Span, Token, VectorFilter};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Condition<'a> {
-    GreaterThan(Token<'a>),
-    GreaterThanOrEqual(Token<'a>),
-    Equal(Token<'a>),
-    NotEqual(Token<'a>),
+pub enum Condition {
+    GreaterThan(Token),
+    GreaterThanOrEqual(Token),
+    Equal(Token),
+    NotEqual(Token),
     Null,
     Empty,
     Exists,
-    LowerThan(Token<'a>),
-    LowerThanOrEqual(Token<'a>),
-    Between { from: Token<'a>, to: Token<'a> },
-    Contains { keyword: Token<'a>, word: Token<'a> },
-    StartsWith { keyword: Token<'a>, word: Token<'a> },
+    LowerThan(Token),
+    LowerThanOrEqual(Token),
+    Between { from: Token, to: Token },
+    Contains { keyword: Token, word: Token },
+    StartsWith { keyword: Token, word: Token },
 }
 
-impl Condition<'_> {
+impl Condition {
     pub fn operator(&self) -> &str {
         match self {
             Condition::GreaterThan(_) => ">",
@@ -47,31 +47,6 @@ impl Condition<'_> {
             Condition::Between { .. } => "TO",
             Condition::Contains { .. } => "CONTAINS",
             Condition::StartsWith { .. } => "STARTS WITH",
-        }
-    }
-
-    pub fn into_owned(self) -> Condition<'static> {
-        match self {
-            Condition::GreaterThan(token) => Condition::GreaterThan(token.into_owned()),
-            Condition::GreaterThanOrEqual(token) => {
-                Condition::GreaterThanOrEqual(token.into_owned())
-            }
-            Condition::Equal(token) => Condition::Equal(token.into_owned()),
-            Condition::NotEqual(token) => Condition::NotEqual(token.into_owned()),
-            Condition::Null => Condition::Null,
-            Condition::Empty => Condition::Empty,
-            Condition::Exists => Condition::Exists,
-            Condition::LowerThan(token) => Condition::LowerThan(token.into_owned()),
-            Condition::LowerThanOrEqual(token) => Condition::LowerThanOrEqual(token.into_owned()),
-            Condition::Between { from, to } => {
-                Condition::Between { from: from.into_owned(), to: to.into_owned() }
-            }
-            Condition::Contains { keyword, word } => {
-                Condition::Contains { keyword: keyword.into_owned(), word: word.into_owned() }
-            }
-            Condition::StartsWith { keyword, word } => {
-                Condition::StartsWith { keyword: keyword.into_owned(), word: word.into_owned() }
-            }
         }
     }
 }

--- a/crates/filter-parser/src/error.rs
+++ b/crates/filter-parser/src/error.rs
@@ -3,7 +3,7 @@ use std::fmt::Display;
 use nom::error::{self, ParseError};
 use nom::Parser;
 
-use crate::{CowSpan, IResult, Span};
+use crate::{IResult, OwnedSpan, Span};
 
 pub trait NomErrorExt<E> {
     fn is_failure(&self) -> bool;
@@ -33,22 +33,22 @@ impl<E> NomErrorExt<E> for nom::Err<E> {
 
 /// cut a parser and map the error
 pub fn cut_with_err<'a, O>(
-    mut parser: impl FnMut(Span<'a>) -> IResult<'a, O>,
-    mut with: impl FnMut(Error<'a>) -> Error<'a>,
-) -> impl FnMut(Span<'a>) -> IResult<'a, O> {
+    mut parser: impl FnMut(Span<'a>) -> IResult<O>,
+    mut with: impl FnMut(Error) -> Error,
+) -> impl FnMut(Span<'a>) -> IResult<O> {
     move |input| match parser.parse(input) {
         Err(nom::Err::Error(e)) => Err(nom::Err::Failure(with(e))),
         rest => rest,
     }
 }
 
-pub trait IResultExt<'a> {
-    fn map_cut(self, kind: ErrorKind<'a>) -> Self;
+pub trait IResultExt {
+    fn map_cut(self, kind: ErrorKind) -> Self;
 }
 
-impl<'a, T> IResultExt<'a> for IResult<'a, T> {
-    fn map_cut(self, kind: ErrorKind<'a>) -> Self {
-        self.map_err(move |e: nom::Err<Error<'a>>| {
+impl<'a, T> IResultExt for IResult<'a, T> {
+    fn map_cut(self, kind: ErrorKind) -> Self {
+        self.map_err(move |e: nom::Err<Error>| {
             let input = match e {
                 nom::Err::Incomplete(_) => return e,
                 nom::Err::Error(e) => e.context().clone(),
@@ -60,9 +60,9 @@ impl<'a, T> IResultExt<'a> for IResult<'a, T> {
 }
 
 #[derive(Debug)]
-pub struct Error<'a> {
-    context: CowSpan<'a>,
-    kind: ErrorKind<'a>,
+pub struct Error {
+    context: OwnedSpan,
+    kind: ErrorKind,
 }
 
 #[derive(Debug)]
@@ -72,9 +72,9 @@ pub enum ExpectedValueKind {
 }
 
 #[derive(Debug)]
-pub enum ErrorKind<'a> {
+pub enum ErrorKind {
     Foreign,
-    ReservedGeo(&'a str),
+    ReservedGeo(&'static str),
     GeoRadius,
     GeoRadiusArgumentCount(usize),
     GeoBoundingBox,
@@ -109,24 +109,24 @@ pub enum ErrorKind<'a> {
     External(String),
 }
 
-impl<'a> Error<'a> {
-    pub fn kind(&self) -> &ErrorKind<'a> {
+impl Error {
+    pub fn kind(&self) -> &ErrorKind {
         &self.kind
     }
 
-    pub fn context(&self) -> &CowSpan<'a> {
+    pub fn context(&self) -> &OwnedSpan {
         &self.context
     }
 
-    pub fn new_from_kind(context: CowSpan<'a>, kind: ErrorKind<'a>) -> Self {
+    pub fn new_from_kind(context: OwnedSpan, kind: ErrorKind) -> Self {
         Self { context, kind }
     }
 
-    pub fn failure_from_kind(context: CowSpan<'a>, kind: ErrorKind<'a>) -> nom::Err<Self> {
+    pub fn failure_from_kind(context: OwnedSpan, kind: ErrorKind) -> nom::Err<Self> {
         nom::Err::Failure(Self::new_from_kind(context, kind))
     }
 
-    pub fn new_from_external(context: CowSpan<'a>, error: impl std::error::Error) -> Self {
+    pub fn new_from_external(context: OwnedSpan, error: impl std::error::Error) -> Self {
         Self::new_from_kind(context, ErrorKind::External(error.to_string()))
     }
 
@@ -138,8 +138,8 @@ impl<'a> Error<'a> {
     }
 }
 
-impl<'a> ParseError<Span<'a>> for Error<'a> {
-    fn from_error_kind(input: Span<'a>, kind: error::ErrorKind) -> Self {
+impl ParseError<Span<'_>> for Error {
+    fn from_error_kind(input: Span, kind: error::ErrorKind) -> Self {
         let kind = match kind {
             error::ErrorKind::Eof => ErrorKind::ExpectedEof,
             kind => ErrorKind::InternalError(kind),
@@ -147,17 +147,17 @@ impl<'a> ParseError<Span<'a>> for Error<'a> {
         Self { context: input.into(), kind }
     }
 
-    fn append(_input: Span<'a>, _kind: error::ErrorKind, other: Self) -> Self {
+    fn append(_input: Span, _kind: error::ErrorKind, other: Self) -> Self {
         other
     }
 
-    fn from_char(input: Span<'a>, c: char) -> Self {
+    fn from_char(input: Span, c: char) -> Self {
         Self { context: input.into(), kind: ErrorKind::Char(c) }
     }
 }
 
-impl Display for Error<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let input = self.context.fragment();
         // When printing our error message we want to escape all `\n` to be sure we keep our format with the
         // first line being the diagnostic and the second line being the incriminated filter.
@@ -303,11 +303,8 @@ impl Display for Error<'_> {
             ErrorKind::External(ref error) => writeln!(f, "{}", error)?,
             ErrorKind::Foreign => writeln!(f, "Was expecting a field name and an condition inside `_foreign(..)` filter but instead found `{escaped_input}`.")?,
         }
-        if let Some(base_column) = self.context.get_utf8_column() {
-            let size = self.context.fragment().chars().count();
-            write!(f, "{}:{} {}", base_column, base_column + size, self.context.extra())
-        } else {
-            write!(f, "{}", self.context.extra())
-        }
+        let base_column = self.context.get_utf8_column();
+        let size = self.context.fragment().chars().count();
+        write!(f, "{}:{} {}", base_column, base_column + size, self.context.extra())
     }
 }

--- a/crates/filter-parser/src/lib.rs
+++ b/crates/filter-parser/src/lib.rs
@@ -69,99 +69,71 @@ use crate::condition::parse_vectors_exists;
 use crate::error::IResultExt;
 
 pub type Span<'a> = LocatedSpan<&'a str, &'a str>;
-pub type OwnedSpan = LocatedSpan<String, String>;
 
-type IResult<'a, Ret> = nom::IResult<Span<'a>, Ret, Error<'a>>;
+type IResult<'a, Ret> = nom::IResult<Span<'a>, Ret, Error>;
 
 const MAX_FILTER_DEPTH: usize = 150;
 
-/// Copy the Cow<str> behaviour because span doesn't support `LocatedSpan<Cow<str>, Cow<str>>`.
 #[derive(Debug, Clone)]
-pub enum CowSpan<'a> {
-    Borrowed(Span<'a>),
-    Owned(OwnedSpan),
+pub struct OwnedSpan {
+    span: LocatedSpan<String, String>,
+    utf8_column: usize,
 }
 
-impl<'a> CowSpan<'a> {
+impl OwnedSpan {
     pub fn fragment(&self) -> &str {
-        match self {
-            CowSpan::Borrowed(span) => span.fragment(),
-            CowSpan::Owned(span) => span.fragment(),
-        }
+        self.span.fragment()
     }
 
     pub fn extra(&self) -> &str {
-        match self {
-            CowSpan::Borrowed(span) => span.extra,
-            CowSpan::Owned(span) => &span.extra,
-        }
+        self.span.extra.as_str()
     }
 
-    pub fn into_owned(self) -> CowSpan<'static> {
-        match self {
-            CowSpan::Borrowed(span) => {
-                let fragment = span.fragment().to_string();
-                let extra = span.extra.to_string();
-
-                CowSpan::Owned(OwnedSpan::new_extra(fragment, extra))
-            }
-            CowSpan::Owned(span) => CowSpan::Owned(span),
-        }
-    }
-
-    pub fn get_utf8_column(&self) -> Option<usize> {
-        match self {
-            CowSpan::Borrowed(span) => Some(span.get_utf8_column()),
-            // When owning a span, we don't know the original column because we lost the reference to the original input.
-            CowSpan::Owned(_) => None,
-        }
+    pub fn get_utf8_column(&self) -> usize {
+        self.utf8_column
     }
 }
 
-impl<'a> From<Span<'a>> for CowSpan<'a> {
-    fn from(span: Span<'a>) -> Self {
-        CowSpan::Borrowed(span)
-    }
-}
-
-impl From<OwnedSpan> for CowSpan<'_> {
-    fn from(span: OwnedSpan) -> Self {
-        CowSpan::Owned(span)
+impl From<Span<'_>> for OwnedSpan {
+    fn from(span: Span) -> Self {
+        let utf8_column = span.get_utf8_column();
+        let span = LocatedSpan::new_extra(span.fragment().to_string(), span.extra.to_string());
+        OwnedSpan { span, utf8_column }
     }
 }
 
 /// Allow [CowSpan] to be constructed from &[str]
-impl<'a> From<&'a str> for CowSpan<'a> {
-    fn from(s: &'a str) -> Self {
-        CowSpan::from(Span::new_extra(s, s))
+impl From<&str> for OwnedSpan {
+    fn from(s: &str) -> Self {
+        OwnedSpan::from(Span::new_extra(s, s))
     }
 }
 
 /// Allow [CowSpan] to be constructed from String
-impl From<String> for CowSpan<'_> {
+impl From<String> for OwnedSpan {
     fn from(s: String) -> Self {
-        CowSpan::from(OwnedSpan::new_extra(s.clone(), s))
+        OwnedSpan::from(Span::new_extra(&s, &s))
     }
 }
 
 #[derive(Debug, Clone)]
-pub struct Token<'a> {
+pub struct Token {
     /// The token in the original input, it should be used when possible.
-    span: CowSpan<'a>,
+    span: OwnedSpan,
     /// If you need to modify the original input you can use the `modified_fragment` field
     /// to store your modified input.
     modified_fragment: Option<String>,
 }
 
-impl PartialEq for Token<'_> {
+impl PartialEq for Token {
     fn eq(&self, other: &Self) -> bool {
         self.original_fragment() == other.original_fragment()
     }
 }
 
-impl Eq for Token<'_> {}
+impl Eq for Token {}
 
-impl<'a> Token<'a> {
+impl Token {
     /// Returns the original fragment of the token.
     pub fn original_fragment(&self) -> &str {
         self.span.fragment()
@@ -199,11 +171,11 @@ impl<'a> Token<'a> {
         Self { span: self.span, modified_fragment }
     }
 
-    pub fn to_external_error(&self, error: impl std::error::Error) -> Error<'a> {
+    pub fn to_external_error(&self, error: impl std::error::Error) -> Error {
         Error::new_from_external(self.span.clone(), error)
     }
 
-    pub fn parse_finite_float(&self) -> Result<f64, Error<'a>> {
+    pub fn parse_finite_float(&self) -> Result<f64, Error> {
         let value: f64 = self.fragment().parse().map_err(|e| self.to_external_error(e))?;
         if value.is_finite() {
             Ok(value)
@@ -212,34 +184,30 @@ impl<'a> Token<'a> {
         }
     }
 
-    pub fn get_utf8_column(&self) -> Option<usize> {
+    pub fn get_utf8_column(&self) -> usize {
         self.span.get_utf8_column()
-    }
-
-    pub fn into_owned(self) -> Token<'static> {
-        Token { span: self.span.into_owned(), modified_fragment: self.modified_fragment }
     }
 }
 
-impl<'a, T: Into<CowSpan<'a>>> From<T> for Token<'a> {
+impl<T: Into<OwnedSpan>> From<T> for Token {
     fn from(span: T) -> Self {
         Token { span: span.into(), modified_fragment: None }
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum VectorFilter<'a> {
-    Fragment(Token<'a>),
+pub enum VectorFilter {
+    Fragment(Token),
     DocumentTemplate,
     UserProvided,
     Regenerate,
     None,
 }
 
-impl<'a> VectorFilter<'a> {
-    pub fn into_owned(self) -> VectorFilter<'static> {
+impl VectorFilter {
+    pub fn into_owned(self) -> VectorFilter {
         match self {
-            Self::Fragment(token) => VectorFilter::Fragment(token.into_owned()),
+            Self::Fragment(token) => VectorFilter::Fragment(token),
             Self::DocumentTemplate => VectorFilter::DocumentTemplate,
             Self::UserProvided => VectorFilter::UserProvided,
             Self::Regenerate => VectorFilter::Regenerate,
@@ -249,94 +217,45 @@ impl<'a> VectorFilter<'a> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum IndexFilterCondition<'a> {
+pub enum IndexFilterCondition {
     Not(Box<Self>),
-    Condition { fid: Token<'a>, op: Condition<'a> },
-    In { fid: Token<'a>, els: Vec<Token<'a>> },
+    Condition { fid: Token, op: Condition },
+    In { fid: Token, els: Vec<Token> },
     Or(Vec<Self>),
     And(Vec<Self>),
-    VectorExists { fid: Token<'a>, embedder: Option<Token<'a>>, filter: VectorFilter<'a> },
-    GeoLowerThan { point: [Token<'a>; 2], radius: Token<'a>, resolution: Option<Token<'a>> },
-    GeoBoundingBox { top_right_point: [Token<'a>; 2], bottom_left_point: [Token<'a>; 2] },
-    GeoPolygon { points: Vec<[Token<'a>; 2]> },
+    VectorExists { fid: Token, embedder: Option<Token>, filter: VectorFilter },
+    GeoLowerThan { point: [Token; 2], radius: Token, resolution: Option<Token> },
+    GeoBoundingBox { top_right_point: [Token; 2], bottom_left_point: [Token; 2] },
+    GeoPolygon { points: Vec<[Token; 2]> },
 }
 
-impl<'a> IndexFilterCondition<'a> {
-    pub fn fids(&self, depth: usize) -> impl Iterator<Item = &Token<'a>> {
+impl IndexFilterCondition {
+    pub fn fids(&self, depth: usize) -> impl Iterator<Item = &Token> {
         FidIter { stack: vec![(depth, self)] }
     }
 }
 
-impl IndexFilterCondition<'_> {
-    pub fn into_owned(self) -> IndexFilterCondition<'static> {
-        match self {
-            Self::Not(condition) => IndexFilterCondition::Not(Box::new((*condition).into_owned())),
-            Self::Condition { fid, op } => {
-                IndexFilterCondition::Condition { fid: fid.into_owned(), op: op.into_owned() }
-            }
-            Self::In { fid, els } => IndexFilterCondition::In {
-                fid: fid.into_owned(),
-                els: els.into_iter().map(|el| el.into_owned()).collect(),
-            },
-            Self::Or(subfilters) => IndexFilterCondition::Or(
-                subfilters.into_iter().map(|filter| filter.into_owned()).collect(),
-            ),
-            Self::And(subfilters) => IndexFilterCondition::And(
-                subfilters.into_iter().map(|filter| filter.into_owned()).collect(),
-            ),
-            Self::VectorExists { fid, embedder, filter } => IndexFilterCondition::VectorExists {
-                fid: fid.into_owned(),
-                embedder: embedder.map(|embedder| embedder.into_owned()),
-                filter: filter.into_owned(),
-            },
-            Self::GeoLowerThan { point: [point0, point1], radius, resolution } => {
-                IndexFilterCondition::GeoLowerThan {
-                    point: [point0.into_owned(), point1.into_owned()],
-                    radius: radius.into_owned(),
-                    resolution: resolution.map(|resolution| resolution.into_owned()),
-                }
-            }
-            Self::GeoBoundingBox {
-                top_right_point: [top_right_point0, top_right_point1],
-                bottom_left_point: [bottom_left_point0, bottom_left_point1],
-            } => IndexFilterCondition::GeoBoundingBox {
-                top_right_point: [top_right_point0.into_owned(), top_right_point1.into_owned()],
-                bottom_left_point: [
-                    bottom_left_point0.into_owned(),
-                    bottom_left_point1.into_owned(),
-                ],
-            },
-            Self::GeoPolygon { points } => IndexFilterCondition::GeoPolygon {
-                points: points
-                    .into_iter()
-                    .map(|[point0, point1]| [point0.into_owned(), point1.into_owned()])
-                    .collect(),
-            },
-        }
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum FilterCondition<'a> {
+pub enum FilterCondition {
     Not(Box<Self>),
-    Condition { fid: Token<'a>, op: Condition<'a> },
-    In { fid: Token<'a>, els: Vec<Token<'a>> },
+    Condition { fid: Token, op: Condition },
+    In { fid: Token, els: Vec<Token> },
     Or(Vec<Self>),
     And(Vec<Self>),
-    VectorExists { fid: Token<'a>, embedder: Option<Token<'a>>, filter: VectorFilter<'a> },
-    GeoLowerThan { point: [Token<'a>; 2], radius: Token<'a>, resolution: Option<Token<'a>> },
-    GeoBoundingBox { top_right_point: [Token<'a>; 2], bottom_left_point: [Token<'a>; 2] },
-    GeoPolygon { points: Vec<[Token<'a>; 2]> },
-    Foreign { fid: Token<'a>, op: Box<Self> },
+    VectorExists { fid: Token, embedder: Option<Token>, filter: VectorFilter },
+    GeoLowerThan { point: [Token; 2], radius: Token, resolution: Option<Token> },
+    GeoBoundingBox { top_right_point: [Token; 2], bottom_left_point: [Token; 2] },
+    GeoPolygon { points: Vec<[Token; 2]> },
+    Foreign { fid: Token, op: Box<Self> },
 }
 
 pub enum TraversedElement<'a> {
-    FilterCondition(&'a FilterCondition<'a>),
-    Condition(&'a Condition<'a>),
+    FilterCondition(&'a FilterCondition),
+    Condition(&'a Condition),
 }
 
-impl<'a> FilterCondition<'a> {
-    pub fn use_contains_operator(&self) -> Option<&Token<'a>> {
+impl FilterCondition {
+    pub fn use_contains_operator(&self) -> Option<&Token> {
         match self {
             FilterCondition::Condition { fid: _, op } => match op {
                 Condition::GreaterThan(_)
@@ -365,7 +284,7 @@ impl<'a> FilterCondition<'a> {
         }
     }
 
-    pub fn use_vector_filter(&self) -> Option<&Token<'a>> {
+    pub fn use_vector_filter(&self) -> Option<&Token> {
         match self {
             FilterCondition::Condition { .. } => None,
             FilterCondition::Not(this) => this.use_vector_filter(),
@@ -381,7 +300,7 @@ impl<'a> FilterCondition<'a> {
         }
     }
 
-    pub fn use_field(&self, field: &str) -> Option<&Token<'a>> {
+    pub fn use_field(&self, field: &str) -> Option<&Token> {
         match self {
             FilterCondition::Condition { fid, .. } | FilterCondition::In { fid, .. } => {
                 (fid.fragment() == field).then_some(fid)
@@ -400,7 +319,7 @@ impl<'a> FilterCondition<'a> {
         }
     }
 
-    pub fn use_foreign_operator(&self) -> Option<&Token<'a>> {
+    pub fn use_foreign_operator(&self) -> Option<&Token> {
         ForeignFilterIter { stack: vec![(MAX_FILTER_DEPTH, self)] }.next().and_then(|filter| {
             match filter {
                 FilterCondition::Foreign { fid, .. } => Some(fid),
@@ -409,16 +328,16 @@ impl<'a> FilterCondition<'a> {
         })
     }
 
-    pub fn list_foreign_filters(&self) -> impl Iterator<Item = &FilterCondition<'a>> {
+    pub fn list_foreign_filters(&self) -> impl Iterator<Item = &FilterCondition> {
         ForeignFilterIter { stack: vec![(MAX_FILTER_DEPTH, self)] }
     }
 
-    pub fn fids(&self, depth: usize) -> impl Iterator<Item = &Token<'a>> {
+    pub fn fids(&self, depth: usize) -> impl Iterator<Item = &Token> {
         FidIter { stack: vec![(depth, self)] }
     }
 
     /// Returns the first token found at the specified depth, `None` if no token at this depth.
-    pub fn token_at_depth(&self, depth: usize) -> Option<&Token<'a>> {
+    pub fn token_at_depth(&self, depth: usize) -> Option<&Token> {
         match self {
             FilterCondition::Condition { fid, .. } if depth == 0 => Some(fid),
             FilterCondition::Or(subfilters) => {
@@ -444,7 +363,7 @@ impl<'a> FilterCondition<'a> {
         }
     }
 
-    pub fn parse(input: &'a str) -> Result<Option<Self>, Error<'a>> {
+    pub fn parse(input: &str) -> Result<Option<Self>, Error> {
         if input.trim().is_empty() {
             return Ok(None);
         }
@@ -460,12 +379,12 @@ impl<'a> FilterCondition<'a> {
 }
 
 /// Iterator listing the `Foreign` filters of a filter condition.
-struct ForeignFilterIter<'a, 'b> {
-    stack: Vec<(usize, &'a FilterCondition<'b>)>,
+struct ForeignFilterIter<'a> {
+    stack: Vec<(usize, &'a FilterCondition)>,
 }
 
-impl<'a, 'b> Iterator for ForeignFilterIter<'a, 'b> {
-    type Item = &'a FilterCondition<'b>;
+impl<'a> Iterator for ForeignFilterIter<'a> {
+    type Item = &'a FilterCondition;
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
@@ -493,8 +412,8 @@ struct FidIter<'a, T> {
     stack: Vec<(usize, &'a T)>,
 }
 
-impl<'a, 'b> Iterator for FidIter<'a, FilterCondition<'b>> {
-    type Item = &'a Token<'b>;
+impl<'a> Iterator for FidIter<'a, FilterCondition> {
+    type Item = &'a Token;
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
@@ -521,8 +440,8 @@ impl<'a, 'b> Iterator for FidIter<'a, FilterCondition<'b>> {
     }
 }
 
-impl<'a, 'b> Iterator for FidIter<'a, IndexFilterCondition<'b>> {
-    type Item = &'a Token<'b>;
+impl<'a> Iterator for FidIter<'a, IndexFilterCondition> {
+    type Item = &'a Token;
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
@@ -549,9 +468,7 @@ impl<'a, 'b> Iterator for FidIter<'a, IndexFilterCondition<'b>> {
 }
 
 /// remove OPTIONAL whitespaces before AND after the provided parser.
-fn ws<'a, O>(
-    inner: impl FnMut(Span<'a>) -> IResult<'a, O>,
-) -> impl FnMut(Span<'a>) -> IResult<'a, O> {
+fn ws<'a, O>(inner: impl FnMut(Span<'a>) -> IResult<O>) -> impl FnMut(Span<'a>) -> IResult<O> {
     delimited(multispace0, inner, multispace0)
 }
 
@@ -925,7 +842,7 @@ pub fn parse_filter(input: Span) -> IResult<FilterCondition> {
     terminated(|input| parse_expression(input, 0), eof)(input)
 }
 
-impl std::fmt::Display for IndexFilterCondition<'_> {
+impl std::fmt::Display for IndexFilterCondition {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             IndexFilterCondition::Not(filter) => {
@@ -1001,7 +918,7 @@ impl std::fmt::Display for IndexFilterCondition<'_> {
     }
 }
 
-impl std::fmt::Display for FilterCondition<'_> {
+impl std::fmt::Display for FilterCondition {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             FilterCondition::Not(filter) => {
@@ -1080,7 +997,7 @@ impl std::fmt::Display for FilterCondition<'_> {
     }
 }
 
-impl std::fmt::Display for Condition<'_> {
+impl std::fmt::Display for Condition {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Condition::GreaterThan(token) => write!(f, "> {token}"),
@@ -1099,7 +1016,7 @@ impl std::fmt::Display for Condition<'_> {
     }
 }
 
-impl std::fmt::Display for Token<'_> {
+impl std::fmt::Display for Token {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{{{}}}", self.fragment())
     }
@@ -1112,7 +1029,7 @@ pub mod tests {
     use super::*;
 
     /// Create a raw [Token]. You must specify the string that appear BEFORE your element followed by your element
-    pub fn rtok<'a>(before: &'a str, value: &'a str) -> Token<'a> {
+    pub fn rtok<'a>(before: &'a str, value: &'a str) -> Token {
         // if the string is empty we still need to return 1 for the line number
         let lines = if before.is_empty() { 1 } else { before.lines().count() };
         let offset = before.chars().count();

--- a/crates/filter-parser/src/lib.rs
+++ b/crates/filter-parser/src/lib.rs
@@ -80,6 +80,74 @@ pub struct OwnedSpan {
     utf8_column: usize,
 }
 
+pub trait TokenLike {
+    /// The fragment of the token.
+    fn fragment(&self) -> &str;
+    /// Returns a new token with the modified fragment.
+    fn with_modified_fragment(self, modified_fragment: Option<String>) -> Self;
+    /// Modifies the fragment of the token.
+    fn modify_fragment(&mut self, new: String);
+    /// Returns the span of the token.
+    fn span(&self) -> OwnedSpan;
+
+    /// The fragment with escaped double quotes.
+    fn escaped_fragment(&self) -> String {
+        serde_json::to_string(self.fragment()).unwrap()
+    }
+}
+
+/// Light version of a token.
+/// This kind of token doesn't keep the context of the original input.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LightToken {
+    fragment: String,
+    utf8_column: usize,
+    /// If you need to modify the original input you can use the `modified_fragment` field
+    /// to store your modified input.
+    modified_fragment: Option<String>,
+}
+
+impl From<LightToken> for Token {
+    fn from(light_token: LightToken) -> Self {
+        Token { span: light_token.span(), modified_fragment: light_token.modified_fragment }
+    }
+}
+
+impl From<&str> for LightToken {
+    fn from(fragment: &str) -> Self {
+        LightToken { fragment: fragment.to_string(), utf8_column: 0, modified_fragment: None }
+    }
+}
+
+impl TokenLike for LightToken {
+    fn fragment(&self) -> &str {
+        self.modified_fragment.as_ref().unwrap_or(&self.fragment)
+    }
+
+    fn with_modified_fragment(self, modified_fragment: Option<String>) -> Self {
+        Self { fragment: self.fragment, utf8_column: self.utf8_column, modified_fragment }
+    }
+
+    fn modify_fragment(&mut self, new: String) {
+        self.modified_fragment = Some(new);
+    }
+
+    fn span(&self) -> OwnedSpan {
+        let span = LocatedSpan::new_extra(self.fragment.to_string(), String::new());
+        OwnedSpan { span, utf8_column: self.utf8_column }
+    }
+}
+
+impl From<Span<'_>> for LightToken {
+    fn from(span: Span) -> Self {
+        LightToken {
+            fragment: span.fragment().to_string(),
+            utf8_column: span.get_utf8_column(),
+            modified_fragment: None,
+        }
+    }
+}
+
 impl OwnedSpan {
     pub fn fragment(&self) -> &str {
         self.span.fragment()
@@ -133,21 +201,30 @@ impl PartialEq for Token {
 
 impl Eq for Token {}
 
+impl TokenLike for Token {
+    /// Return the fragment of the token.
+    /// If the token has been modified, the modified value is returned.
+    fn fragment(&self) -> &str {
+        self.modified_fragment.as_ref().map_or(self.span.fragment(), |v| v)
+    }
+
+    fn with_modified_fragment(self, modified_fragment: Option<String>) -> Self {
+        Self { span: self.span, modified_fragment }
+    }
+
+    fn modify_fragment(&mut self, new: String) {
+        self.modified_fragment = Some(new);
+    }
+
+    fn span(&self) -> OwnedSpan {
+        self.span.clone()
+    }
+}
+
 impl Token {
     /// Returns the original fragment of the token.
     pub fn original_fragment(&self) -> &str {
         self.span.fragment()
-    }
-
-    /// Return the fragment of the token.
-    /// If the token has been modified, the modified value is returned.
-    pub fn fragment(&self) -> &str {
-        self.modified_fragment.as_ref().map_or(self.span.fragment(), |v| v)
-    }
-
-    /// The fragment with escaped double quotes.
-    pub fn escaped_fragment(&self) -> String {
-        serde_json::to_string(self.fragment()).unwrap()
     }
 
     /// Returns the extra fragment of the token.
@@ -161,14 +238,6 @@ impl Token {
     #[cfg(test)]
     pub fn modified_fragment(&self) -> Option<&str> {
         self.modified_fragment.as_deref()
-    }
-
-    pub fn modify_fragment(&mut self, new: String) {
-        self.modified_fragment = Some(new);
-    }
-
-    pub fn with_modified_fragment(self, modified_fragment: Option<String>) -> Self {
-        Self { span: self.span, modified_fragment }
     }
 
     pub fn to_external_error(&self, error: impl std::error::Error) -> Error {
@@ -220,7 +289,7 @@ impl VectorFilter {
 pub enum IndexFilterCondition {
     Not(Box<Self>),
     Condition { fid: Token, op: Condition },
-    In { fid: Token, els: Vec<Token> },
+    In { fid: Token, els: Vec<LightToken> },
     Or(Vec<Self>),
     And(Vec<Self>),
     VectorExists { fid: Token, embedder: Option<Token>, filter: VectorFilter },
@@ -239,7 +308,7 @@ impl IndexFilterCondition {
 pub enum FilterCondition {
     Not(Box<Self>),
     Condition { fid: Token, op: Condition },
-    In { fid: Token, els: Vec<Token> },
+    In { fid: Token, els: Vec<LightToken> },
     Or(Vec<Self>),
     And(Vec<Self>),
     VectorExists { fid: Token, embedder: Option<Token>, filter: VectorFilter },
@@ -473,7 +542,10 @@ fn ws<'a, O>(inner: impl FnMut(Span<'a>) -> IResult<O>) -> impl FnMut(Span<'a>) 
 }
 
 /// value_list = (value ("," value)* ","?)?
-fn parse_value_list(input: Span) -> IResult<Vec<Token>> {
+fn parse_value_list<'a, T>(input: Span<'a>) -> IResult<'a, Vec<T>>
+where
+    T: From<Span<'a>> + TokenLike,
+{
     let (input, first_value) = opt(parse_value)(input)?;
     if let Some(first_value) = first_value {
         let value_list_el_parser = preceded(ws(tag(",")), parse_value);
@@ -489,7 +561,7 @@ fn parse_value_list(input: Span) -> IResult<Vec<Token>> {
 }
 
 /// "IN" WS* "[" value_list "]"
-fn parse_in_body(input: Span) -> IResult<Vec<Token>> {
+fn parse_in_body(input: Span) -> IResult<Vec<LightToken>> {
     let (input, _) = ws(word_exact("IN"))(input)?;
 
     // everything after `IN` can be a failure
@@ -502,7 +574,7 @@ fn parse_in_body(input: Span) -> IResult<Vec<Token>> {
         if eof::<_, ()>(input).is_ok() {
             Error::new_from_kind(input.into(), ErrorKind::InClosingBracket)
         } else {
-            let expected_value_kind = match parse_value(input) {
+            let expected_value_kind = match parse_value::<LightToken>(input) {
                 Err(nom::Err::Error(e)) => match e.kind() {
                     ErrorKind::ReservedKeyword(_) => ExpectedValueKind::ReservedKeyword,
                     _ => ExpectedValueKind::Other,
@@ -1017,6 +1089,12 @@ impl std::fmt::Display for Condition {
 }
 
 impl std::fmt::Display for Token {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{{{}}}", self.fragment())
+    }
+}
+
+impl std::fmt::Display for LightToken {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{{{}}}", self.fragment())
     }

--- a/crates/filter-parser/src/value.rs
+++ b/crates/filter-parser/src/value.rs
@@ -8,7 +8,7 @@ use nom::{InputIter, InputLength, InputTake, Slice};
 use crate::error::{ExpectedValueKind, NomErrorExt};
 use crate::{
     parse_geo, parse_geo_bounding_box, parse_geo_distance, parse_geo_point, parse_geo_radius,
-    Error, ErrorKind, IResult, Span, Token,
+    Error, ErrorKind, IResult, Span, Token, TokenLike,
 };
 
 /// This function goes through all characters in the [Span] if it finds any escaped character (`\`).
@@ -19,7 +19,10 @@ fn unescape(buf: Span, char_to_escape: char) -> String {
 }
 
 /// Parse a value in quote. If it encounter an escaped quote it'll unescape it.
-fn quoted_by(quote: char, input: Span) -> IResult<Token> {
+fn quoted_by<'a, T>(quote: char, input: Span<'a>) -> IResult<'a, T>
+where
+    T: From<Span<'a>> + crate::TokenLike,
+{
     // empty fields / values are valid in json
     if input.is_empty() {
         return Ok((input.slice(input.input_len()..), input.into()));
@@ -31,7 +34,7 @@ fn quoted_by(quote: char, input: Span) -> IResult<Token> {
     while let Some((idx, c)) = i.next() {
         if c == quote {
             let (rem, output) = input.take_split(idx);
-            let mut token = Token::from(output);
+            let mut token = T::from(output);
             if let Some(value) = escaped.then(|| unescape(output, quote)) {
                 token.modify_fragment(value);
             }
@@ -49,7 +52,7 @@ fn quoted_by(quote: char, input: Span) -> IResult<Token> {
         // if it was preceded by a `\` or if it was anything else we can continue to advance
     }
 
-    let mut token = Token::from(input);
+    let mut token = T::from(input);
     if let Some(value) = escaped.then(|| unescape(input, quote)) {
         token.modify_fragment(value);
     }
@@ -58,13 +61,16 @@ fn quoted_by(quote: char, input: Span) -> IResult<Token> {
 }
 
 // word           = (alphanumeric | _ | - | .)+    except for reserved keywords
-pub fn word_not_keyword<'a>(input: Span<'a>) -> IResult<'a, Token> {
-    let (input, word): (_, Token) =
-        take_while1(is_value_component)(input).map(|(s, t)| (s, t.into()))?;
+pub fn word_not_keyword<'a, T>(input: Span<'a>) -> IResult<'a, T>
+where
+    T: From<Span<'a>> + crate::TokenLike,
+{
+    let (input, word): (_, _) = take_while1(is_value_component)(input)?;
+    let word = T::from(word);
     if is_keyword(word.fragment()) {
         return Err(nom::Err::Error(Error::new_from_kind(
             input.into(),
-            ErrorKind::ReservedKeyword(word.fragment().to_owned()),
+            ErrorKind::ReservedKeyword(word.fragment().to_string()),
         )));
     }
     Ok((input, word))
@@ -87,13 +93,19 @@ pub fn word_exact<'a, 'b: 'a>(tag: &'b str) -> impl Fn(Span<'a>) -> IResult<'a, 
 }
 
 /// vector_value          = ( non_dot_word | singleQuoted | doubleQuoted)
-pub fn parse_vector_value(input: Span) -> IResult<Token> {
-    pub fn non_dot_word(input: Span) -> IResult<Token> {
+pub fn parse_vector_value<'a, T>(input: Span<'a>) -> IResult<'a, T>
+where
+    T: From<Span<'a>> + crate::TokenLike,
+{
+    pub fn non_dot_word<'a, T>(input: Span<'a>) -> IResult<'a, T>
+    where
+        T: From<Span<'a>> + crate::TokenLike,
+    {
         let (input, word) = take_while1(|c| is_value_component(c) && c != '.')(input)?;
         Ok((input, word.into()))
     }
 
-    let (input, value) = alt((
+    let (input, value): (_, T) = alt((
         delimited(char('\''), cut(|input| quoted_by('\'', input)), cut(char('\''))),
         delimited(char('"'), cut(|input| quoted_by('"', input)), cut(char('"'))),
         non_dot_word,
@@ -108,11 +120,12 @@ pub fn parse_vector_value(input: Span) -> IResult<Token> {
             }
         }
         Err(unescaper::Error::IncompleteStr(_)) => Err(nom::Err::Incomplete(nom::Needed::Unknown)),
-        Err(unescaper::Error::ParseIntError { .. }) => {
-            Err(nom::Err::Error(Error::new_from_kind(value.span, ErrorKind::InvalidEscapedNumber)))
-        }
+        Err(unescaper::Error::ParseIntError { .. }) => Err(nom::Err::Error(Error::new_from_kind(
+            input.into(),
+            ErrorKind::InvalidEscapedNumber,
+        ))),
         Err(unescaper::Error::InvalidChar { .. }) => {
-            Err(nom::Err::Error(Error::new_from_kind(value.span, ErrorKind::MalformedValue)))
+            Err(nom::Err::Error(Error::new_from_kind(input.into(), ErrorKind::MalformedValue)))
         }
     }
 }
@@ -130,7 +143,10 @@ pub fn parse_vector_value_cut<'a>(input: Span<'a>, kind: ErrorKind) -> IResult<'
 }
 
 /// value          = WS* ( word | singleQuoted | doubleQuoted) WS+
-pub fn parse_value(input: Span) -> IResult<Token> {
+pub fn parse_value<'a, T>(input: Span<'a>) -> IResult<'a, T>
+where
+    T: From<Span<'a>> + crate::TokenLike,
+{
     // to get better diagnostic message we are going to strip the left whitespaces from the input right now
     let (input, _) = take_while(char::is_whitespace)(input)?;
 
@@ -178,7 +194,7 @@ pub fn parse_value(input: Span) -> IResult<Token> {
     // when we create the errors from the output of the alt we have spaces everywhere
     let error_word = take_till::<_, _, Error>(is_syntax_component);
 
-    let (input, value) = terminated(
+    let (input, value): (_, T) = terminated(
         alt((
             delimited(char('\''), cut(|input| quoted_by('\'', input)), cut(char('\''))),
             delimited(char('"'), cut(|input| quoted_by('"', input)), cut(char('"'))),
@@ -224,11 +240,12 @@ pub fn parse_value(input: Span) -> IResult<Token> {
             }
         }
         Err(unescaper::Error::IncompleteStr(_)) => Err(nom::Err::Incomplete(nom::Needed::Unknown)),
-        Err(unescaper::Error::ParseIntError { .. }) => {
-            Err(nom::Err::Error(Error::new_from_kind(value.span, ErrorKind::InvalidEscapedNumber)))
-        }
+        Err(unescaper::Error::ParseIntError { .. }) => Err(nom::Err::Error(Error::new_from_kind(
+            value.span(),
+            ErrorKind::InvalidEscapedNumber,
+        ))),
         Err(unescaper::Error::InvalidChar { .. }) => {
-            Err(nom::Err::Error(Error::new_from_kind(value.span, ErrorKind::MalformedValue)))
+            Err(nom::Err::Error(Error::new_from_kind(value.span(), ErrorKind::MalformedValue)))
         }
     }
 }
@@ -295,7 +312,7 @@ pub mod test {
 
         for (input, expected) in test_case {
             let input = Span::new_extra(input, input);
-            let result = parse_value(input);
+            let result = parse_value::<Token>(input);
 
             assert!(
                 result.is_ok(),
@@ -323,7 +340,7 @@ pub mod test {
 
         for (input, remaining, expected_tok, expected_val) in test_case {
             let span = Span::new_extra(input, "");
-            let result = quoted_by('"', span);
+            let result = quoted_by::<Token>('"', span);
             assert!(result.is_ok());
 
             let (rem, output) = result.unwrap();
@@ -397,7 +414,7 @@ pub mod test {
 
         for (input, expected, escaped) in test_case {
             let input = Span::new_extra(input, input);
-            let result = parse_value(input);
+            let result = parse_value::<Token>(input);
 
             assert!(
                 result.is_ok(),
@@ -435,7 +452,7 @@ pub mod test {
 
         for (input, expected) in test_case {
             let input = Span::new_extra(input, input);
-            let result = parse_value(input);
+            let result = parse_value::<Token>(input);
 
             assert!(
                 result.is_err(),

--- a/crates/filter-parser/src/value.rs
+++ b/crates/filter-parser/src/value.rs
@@ -58,8 +58,8 @@ fn quoted_by(quote: char, input: Span) -> IResult<Token> {
 }
 
 // word           = (alphanumeric | _ | - | .)+    except for reserved keywords
-pub fn word_not_keyword<'a>(input: Span<'a>) -> IResult<'a, Token<'a>> {
-    let (input, word): (_, Token<'a>) =
+pub fn word_not_keyword<'a>(input: Span<'a>) -> IResult<'a, Token> {
+    let (input, word): (_, Token) =
         take_while1(is_value_component)(input).map(|(s, t)| (s, t.into()))?;
     if is_keyword(word.fragment()) {
         return Err(nom::Err::Error(Error::new_from_kind(
@@ -71,9 +71,9 @@ pub fn word_not_keyword<'a>(input: Span<'a>) -> IResult<'a, Token<'a>> {
 }
 
 // word           = {tag}
-pub fn word_exact<'a, 'b: 'a>(tag: &'b str) -> impl Fn(Span<'a>) -> IResult<'a, Token<'a>> {
+pub fn word_exact<'a, 'b: 'a>(tag: &'b str) -> impl Fn(Span<'a>) -> IResult<'a, Token> {
     move |input| {
-        let (input, word): (_, Token<'a>) =
+        let (input, word): (_, Token) =
             take_while1(is_value_component)(input).map(|(s, t)| (s, t.into()))?;
         if word.fragment() == tag {
             Ok((input, word))
@@ -117,7 +117,7 @@ pub fn parse_vector_value(input: Span) -> IResult<Token> {
     }
 }
 
-pub fn parse_vector_value_cut<'a>(input: Span<'a>, kind: ErrorKind<'a>) -> IResult<'a, Token<'a>> {
+pub fn parse_vector_value_cut<'a>(input: Span<'a>, kind: ErrorKind) -> IResult<'a, Token> {
     parse_vector_value(input).map_err(|e| match e {
         nom::Err::Failure(e) => match e.kind() {
             ErrorKind::Char(c) if *c == '"' || *c == '\'' => {

--- a/crates/index-scheduler/src/filter.rs
+++ b/crates/index-scheduler/src/filter.rs
@@ -63,14 +63,14 @@ pub type ForeignKeysPerIndex = HashMap<SourceIndexUid, Vec<(ForeignIndexUid, Sou
 /// Convert a filter into an index filter by evaluating the foreign filters
 ///
 /// this function is a wrapper around the `filters_into_index_filters`.
-pub fn filter_into_index_filter<'a>(
-    filter: Filter<'a>,
+pub fn filter_into_index_filter(
+    filter: Filter,
     index: &Index,
     rtxn: &RoTxn,
     index_scheduler: &IndexScheduler,
     progress: &Progress,
     index_uid: &str,
-) -> Result<IndexFilter<'a>> {
+) -> Result<IndexFilter> {
     let foreign_keys = index
         .foreign_keys(rtxn)
         .map_err(|err| Error::from_milli(milli::Error::from(err), Some(index_uid.to_string())))?;
@@ -104,11 +104,11 @@ pub fn filter_into_index_filter<'a>(
 ///
 /// This function will open each foreign index once and process the filters.
 pub fn filters_into_index_filters<'a>(
-    filters: Vec<(SourceIndexUid, Option<Filter<'a>>)>,
+    filters: Vec<(SourceIndexUid, Option<Filter>)>,
     foreign_keys_per_index: &ForeignKeysPerIndex,
     index_scheduler: &IndexScheduler,
     progress: &Progress,
-) -> Result<Vec<Option<IndexFilter<'a>>>> {
+) -> Result<Vec<Option<IndexFilter>>> {
     // list all the foreign filters and check their validity
     let mut foreign_filters = Vec::new();
     for (index_uid, filter) in filters.iter() {
@@ -243,8 +243,8 @@ pub fn filters_into_index_filters<'a>(
 ///
 /// This function will not open any foreign index but will panic if a foreign filter is encountered.
 pub fn filters_into_index_filters_unchecked<'a>(
-    filters: Vec<Option<Filter<'a>>>,
-) -> Result<Vec<Option<IndexFilter<'a>>>> {
+    filters: Vec<Option<Filter>>,
+) -> Result<Vec<Option<IndexFilter>>> {
     filters
         .into_iter()
         .map(|filter| {
@@ -255,12 +255,12 @@ pub fn filters_into_index_filters_unchecked<'a>(
         .collect::<Result<_>>()
 }
 
-fn condition_to_index_condition<'a, F>(
-    filter: FilterCondition<'a>,
+fn condition_to_index_condition<F>(
+    filter: FilterCondition,
     foreign_filter: &mut F,
-) -> Result<IndexFilterCondition<'a>>
+) -> Result<IndexFilterCondition>
 where
-    F: FnMut(FilterCondition<'a>) -> Result<IndexFilterCondition<'a>>,
+    F: FnMut(FilterCondition) -> Result<IndexFilterCondition>,
 {
     match filter {
         FilterCondition::Not(filter) => condition_to_index_condition(*filter, foreign_filter)
@@ -329,7 +329,7 @@ pub fn parse_filter<'a>(
     filter_parsing_error_code: Code,
     features: RoFeatures,
     index_uid: Option<&str>,
-) -> Result<Option<Filter<'a>>> {
+) -> Result<Option<Filter>> {
     let filter = match facets {
         Value::String(expr) => Filter::from_str(expr).map_err(|e| {
             Error::Milli { error: e, index_uid: index_uid.map(String::from) }
@@ -348,10 +348,10 @@ pub fn parse_filter<'a>(
 }
 
 fn check_filter_experimental_features<'a>(
-    filter: Option<Filter<'a>>,
+    filter: Option<Filter>,
     features: RoFeatures,
     index_uid: Option<&str>,
-) -> Result<Option<Filter<'a>>> {
+) -> Result<Option<Filter>> {
     if let Some(ref filter) = filter {
         // If the contains operator is used while the contains filter feature is not enabled, errors out
         if let Some((token, error)) =
@@ -406,7 +406,7 @@ fn parse_filter_array<'a>(
     arr: &'a [Value],
     code: Code,
     index_uid: Option<&str>,
-) -> Result<Option<Filter<'a>>> {
+) -> Result<Option<Filter>> {
     let mut ands = Vec::new();
     for value in arr {
         match value {
@@ -459,7 +459,7 @@ fn invalid_filter_syntax_error(
 }
 
 fn unsupported_foreign_filter_error(
-    filter: FilterCondition<'_>,
+    filter: FilterCondition,
     code: Code,
     index_uid: Option<&str>,
 ) -> Error {
@@ -486,7 +486,7 @@ pub fn parse_local_index_filter<'a>(
     index_uid: Option<&str>,
     features: RoFeatures,
     code: Code,
-) -> Result<Option<IndexFilter<'a>>> {
+) -> Result<Option<IndexFilter>> {
     let Some(Filter { condition }) = parse_filter(filter, code, features, index_uid)? else {
         return Ok(None);
     };

--- a/crates/index-scheduler/src/filter.rs
+++ b/crates/index-scheduler/src/filter.rs
@@ -6,7 +6,7 @@ use meilisearch_types::error::Code;
 use meilisearch_types::heed::RoTxn;
 use meilisearch_types::milli::progress::Progress;
 use meilisearch_types::milli::{
-    self, filtered_universe, Filter, FilterCondition, IndexFilter, IndexFilterCondition,
+    self, filtered_universe, Filter, FilterCondition, IndexFilter, IndexFilterCondition, TokenLike,
 };
 use meilisearch_types::Index;
 use serde_json::Value;
@@ -217,7 +217,7 @@ pub fn filters_into_index_filters(
             let mut inner = Vec::new();
             for internal in docids.iter() {
                 if let Some(external) = internal_to_external_docids.get(&internal) {
-                    inner.push(external.to_string().into());
+                    inner.push(external.as_str().into());
                 }
             }
 

--- a/crates/index-scheduler/src/filter.rs
+++ b/crates/index-scheduler/src/filter.rs
@@ -103,7 +103,7 @@ pub fn filter_into_index_filter(
 /// Convert a vector of filters into a vector of index filters by evaluating the foreign filters
 ///
 /// This function will open each foreign index once and process the filters.
-pub fn filters_into_index_filters<'a>(
+pub fn filters_into_index_filters(
     filters: Vec<(SourceIndexUid, Option<Filter>)>,
     foreign_keys_per_index: &ForeignKeysPerIndex,
     index_scheduler: &IndexScheduler,
@@ -242,7 +242,7 @@ pub fn filters_into_index_filters<'a>(
 /// Convert a vector of filters into a vector of index filters without evaluating the foreign filters
 ///
 /// This function will not open any foreign index but will panic if a foreign filter is encountered.
-pub fn filters_into_index_filters_unchecked<'a>(
+pub fn filters_into_index_filters_unchecked(
     filters: Vec<Option<Filter>>,
 ) -> Result<Vec<Option<IndexFilter>>> {
     filters
@@ -324,8 +324,8 @@ pub fn retrieve_foreign_keys_settings<'a>(
     Ok(foreign_keys_settings)
 }
 
-pub fn parse_filter<'a>(
-    facets: &'a Value,
+pub fn parse_filter(
+    facets: &Value,
     filter_parsing_error_code: Code,
     features: RoFeatures,
     index_uid: Option<&str>,
@@ -347,7 +347,7 @@ pub fn parse_filter<'a>(
     check_filter_experimental_features(filter, features, index_uid)
 }
 
-fn check_filter_experimental_features<'a>(
+fn check_filter_experimental_features(
     filter: Option<Filter>,
     features: RoFeatures,
     index_uid: Option<&str>,
@@ -402,8 +402,8 @@ fn check_filter_experimental_features<'a>(
     Ok(filter)
 }
 
-fn parse_filter_array<'a>(
-    arr: &'a [Value],
+fn parse_filter_array(
+    arr: &[Value],
     code: Code,
     index_uid: Option<&str>,
 ) -> Result<Option<Filter>> {
@@ -481,8 +481,8 @@ fn unsupported_foreign_filter_error(
 /// - Check the experimental features
 /// - Parse the filter
 /// - if a foreign filter is encountered, return an error "Unsupported foreign filter"
-pub fn parse_local_index_filter<'a>(
-    filter: &'a Value,
+pub fn parse_local_index_filter(
+    filter: &Value,
     index_uid: Option<&str>,
     features: RoFeatures,
     code: Code,

--- a/crates/meilisearch/src/routes/chats/chat_completions.rs
+++ b/crates/meilisearch/src/routes/chats/chat_completions.rs
@@ -415,8 +415,6 @@ async fn process_search_request(
                     }
                 })
                 .transpose()?
-                // we need to own the filter because it's sent to spawn_blocking
-                .map(|f| f.into_owned())
         }
         None => None,
     };

--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -1624,7 +1624,7 @@ pub fn prepare_search<'t>(
     index_uid: &'t str,
     before_search: time::OffsetDateTime,
     query: &'t SearchQuery,
-    filter: Option<IndexFilter<'t>>,
+    filter: Option<IndexFilter>,
     search_kind: &SearchKind,
     deadline: Deadline,
     features: RoFeatures,
@@ -2679,13 +2679,13 @@ pub fn perform_similar(
     Ok(result)
 }
 
-fn extract_filters<'a>(
+fn extract_filters(
     index_scheduler: &IndexScheduler,
     index_uid: IndexUid,
     progress: &Progress,
-    docid_filter: Option<Filter<'a>>,
-    candidates_filter: Option<Filter<'a>>,
-) -> Result<(Option<IndexFilter<'a>>, Option<IndexFilter<'a>>), ResponseError> {
+    docid_filter: Option<Filter>,
+    candidates_filter: Option<Filter>,
+) -> Result<(Option<IndexFilter>, Option<IndexFilter>), ResponseError> {
     let source_index_uid = SourceIndexUid(Rc::from(&*index_uid));
     let foreign_keys_settings =
         retrieve_foreign_keys_settings(index_scheduler, std::iter::once(&source_index_uid))?;

--- a/crates/milli/src/lib.rs
+++ b/crates/milli/src/lib.rs
@@ -50,7 +50,7 @@ use std::hash::BuildHasherDefault;
 
 use charabia::normalizer::{CharNormalizer, CompatibilityDecompositionNormalizer};
 pub use documents::GeoSortStrategy;
-pub use filter_parser::{Condition, FilterCondition, IndexFilterCondition, Span, Token};
+pub use filter_parser::{Condition, FilterCondition, IndexFilterCondition, Span, Token, TokenLike};
 use fxhash::{FxHasher32, FxHasher64};
 pub use grenad::CompressionType;
 pub use must_stop_processing::MustStopProcessing;

--- a/crates/milli/src/search/facet/filter/index_filter.rs
+++ b/crates/milli/src/search/facet/filter/index_filter.rs
@@ -28,23 +28,17 @@ use crate::{
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct IndexFilter<'a> {
-    pub condition: IndexFilterCondition<'a>,
+pub struct IndexFilter {
+    pub condition: IndexFilterCondition,
 }
 
-impl<'a> From<IndexFilterCondition<'a>> for IndexFilter<'a> {
-    fn from(condition: IndexFilterCondition<'a>) -> Self {
+impl From<IndexFilterCondition> for IndexFilter {
+    fn from(condition: IndexFilterCondition) -> Self {
         IndexFilter { condition }
     }
 }
 
-impl IndexFilter<'_> {
-    pub fn into_owned(self) -> IndexFilter<'static> {
-        IndexFilter { condition: self.condition.into_owned() }
-    }
-}
-
-impl<'a> IndexFilter<'a> {
+impl IndexFilter {
     pub fn evaluate(&self, rtxn: &heed::RoTxn<'_>, index: &Index) -> Result<RoaringBitmap> {
         // to avoid doing this for each recursive call we're going to do it ONCE ahead of time
         let fields_ids_map = index.fields_ids_map(rtxn)?;
@@ -78,7 +72,7 @@ impl<'a> IndexFilter<'a> {
         index: &Index,
         field_id: FieldId,
         universe_hint: Option<&RoaringBitmap>,
-        operator: &Condition<'a>,
+        operator: &Condition,
         features: &FilterableAttributesFeatures,
         rule_index: usize,
     ) -> Result<RoaringBitmap> {
@@ -330,7 +324,7 @@ impl<'a> IndexFilter<'a> {
         rtxn: &heed::RoTxn<'_>,
         index: &Index,
         universe_hint: Option<&RoaringBitmap>,
-        operator: &Condition<'a>,
+        operator: &Condition,
     ) -> Result<RoaringBitmap> {
         Ok(match operator {
             Condition::Equal(token) => {
@@ -810,7 +804,7 @@ fn generate_filter_error(
     rtxn: &heed::RoTxn<'_>,
     index: &Index,
     field_id: FieldId,
-    operator: &Condition<'_>,
+    operator: &Condition,
     features: &FilterableAttributesFeatures,
     rule_index: usize,
 ) -> Error {
@@ -828,7 +822,7 @@ fn generate_filter_error(
     }
 }
 
-pub fn serialize_index_filter_to_filter_string(filter: &IndexFilter<'_>) -> Result<String> {
+pub fn serialize_index_filter_to_filter_string(filter: &IndexFilter) -> Result<String> {
     let mut s = String::new();
     serialize_index_filter_condition(&mut s, &filter.condition)
         .map_err(|_| SerializationError::FailedToSerializeFilter)?;
@@ -837,7 +831,7 @@ pub fn serialize_index_filter_to_filter_string(filter: &IndexFilter<'_>) -> Resu
 
 fn serialize_index_filter_condition(
     f: &mut impl FmtWrite,
-    condition: &IndexFilterCondition<'_>,
+    condition: &IndexFilterCondition,
 ) -> std::fmt::Result {
     match condition {
         IndexFilterCondition::Not(filter) => {
@@ -942,7 +936,7 @@ fn serialize_index_filter_condition(
     Ok(())
 }
 
-fn serialize_condition(f: &mut impl FmtWrite, condition: &Condition<'_>) -> std::fmt::Result {
+fn serialize_condition(f: &mut impl FmtWrite, condition: &Condition) -> std::fmt::Result {
     match condition {
         Condition::GreaterThan(token) => write!(f, "> {}", token.escaped_fragment()),
         Condition::GreaterThanOrEqual(token) => write!(f, ">= {}", token.escaped_fragment()),

--- a/crates/milli/src/search/facet/filter/index_filter.rs
+++ b/crates/milli/src/search/facet/filter/index_filter.rs
@@ -3,7 +3,7 @@ use std::fmt::{Debug, Write as FmtWrite};
 use std::ops::Bound::{self, Excluded, Included, Unbounded};
 
 pub use filter_parser::Condition;
-use filter_parser::{IndexFilterCondition, VectorFilter};
+use filter_parser::{IndexFilterCondition, TokenLike, VectorFilter};
 use heed::types::LazyDecode;
 use heed::BytesEncode;
 use memchr::memmem::Finder;
@@ -430,7 +430,7 @@ impl IndexFilter {
             }
             IndexFilterCondition::In { fid, els } if fid.fragment() == SHARD_FIELD => els
                 .iter()
-                .map(|el| Condition::Equal(el.clone()))
+                .map(|el| Condition::Equal(el.clone().into()))
                 .map(|op| Self::evaluate_shard_operator(rtxn, index, universe_hint, &op))
                 .union(),
             IndexFilterCondition::In { fid, els } => {
@@ -444,7 +444,7 @@ impl IndexFilter {
                 };
 
                 els.iter()
-                    .map(|el| Condition::Equal(el.clone()))
+                    .map(|el| Condition::Equal(el.clone().into()))
                     .map(|op| {
                         Self::evaluate_operator(
                             rtxn,

--- a/crates/milli/src/search/facet/filter/mod.rs
+++ b/crates/milli/src/search/facet/filter/mod.rs
@@ -20,8 +20,8 @@ const MAX_FILTER_DEPTH: usize = 2000;
 pub const SHARD_FIELD: &str = "_shard";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Filter<'a> {
-    pub condition: FilterCondition<'a>,
+pub struct Filter {
+    pub condition: FilterCondition,
 }
 
 #[derive(Debug)]
@@ -106,20 +106,20 @@ impl Display for FilterError<'_> {
     }
 }
 
-impl<'a> From<FPError<'a>> for Error {
-    fn from(error: FPError<'a>) -> Self {
+impl From<FPError> for Error {
+    fn from(error: FPError) -> Self {
         Self::UserError(UserError::InvalidFilter(error.to_string()))
     }
 }
 
-impl<'a> From<Filter<'a>> for FilterCondition<'a> {
-    fn from(f: Filter<'a>) -> Self {
+impl From<Filter> for FilterCondition {
+    fn from(f: Filter) -> Self {
         f.condition
     }
 }
 
-impl<'a> From<FilterCondition<'a>> for Filter<'a> {
-    fn from(fc: FilterCondition<'a>) -> Self {
+impl From<FilterCondition> for Filter {
+    fn from(fc: FilterCondition) -> Self {
         Self { condition: fc }
     }
 }

--- a/crates/milli/src/search/facet/filter/parser.rs
+++ b/crates/milli/src/search/facet/filter/parser.rs
@@ -8,8 +8,8 @@ use crate::Result;
 
 use crate::{search::facet::filter::MAX_FILTER_DEPTH, Filter, SHARD_FIELD};
 
-impl<'a> Filter<'a> {
-    pub fn from_json(facets: &'a Value) -> Result<Option<Self>> {
+impl Filter {
+    pub fn from_json(facets: &Value) -> Result<Option<Self>> {
         match facets {
             Value::String(expr) => {
                 let condition = Self::from_str(expr)?;
@@ -23,7 +23,7 @@ impl<'a> Filter<'a> {
         }
     }
 
-    fn parse_filter_array(arr: &'a [Value]) -> Result<Option<Self>> {
+    fn parse_filter_array(arr: &[Value]) -> Result<Option<Self>> {
         let mut ands = Vec::new();
         for value in arr {
             match value {
@@ -55,7 +55,7 @@ impl<'a> Filter<'a> {
         Self::from_array(ands)
     }
 
-    pub fn from_array<I, J>(array: I) -> Result<Option<Self>>
+    pub fn from_array<'a, I, J>(array: I) -> Result<Option<Self>>
     where
         I: IntoIterator<Item = Either<J, &'a str>>,
         J: IntoIterator<Item = &'a str>,
@@ -101,7 +101,7 @@ impl<'a> Filter<'a> {
     }
 
     #[allow(clippy::should_implement_trait)]
-    pub fn from_str(expression: &'a str) -> Result<Option<Self>> {
+    pub fn from_str(expression: &str) -> Result<Option<Self>> {
         let condition = match FilterCondition::parse(expression) {
             Ok(Some(fc)) => Ok(fc),
             Ok(None) => return Ok(None),
@@ -115,19 +115,19 @@ impl<'a> Filter<'a> {
         Ok(Some(Self { condition }))
     }
 
-    pub fn use_contains_operator(&self) -> Option<&Token<'_>> {
+    pub fn use_contains_operator(&self) -> Option<&Token> {
         self.condition.use_contains_operator()
     }
 
-    pub fn use_vector_filter(&self) -> Option<&Token<'_>> {
+    pub fn use_vector_filter(&self) -> Option<&Token> {
         self.condition.use_vector_filter()
     }
 
-    pub fn use_shard_filter(&self) -> Option<&Token<'_>> {
+    pub fn use_shard_filter(&self) -> Option<&Token> {
         self.condition.use_field(SHARD_FIELD)
     }
 
-    pub fn use_foreign_filter(&self) -> Option<&Token<'_>> {
+    pub fn use_foreign_filter(&self) -> Option<&Token> {
         self.condition.use_foreign_operator()
     }
 }

--- a/crates/milli/src/search/facet/filter/tests.rs
+++ b/crates/milli/src/search/facet/filter/tests.rs
@@ -14,8 +14,8 @@ use crate::{Filter, FilterableAttributesRule};
 
 /// Convert a Filter to an IndexFilter
 /// this is only available for tests, in production we must ensure that the foreign filters have been preprocessed.
-impl<'a> From<Filter<'a>> for IndexFilter<'a> {
-    fn from(filter: Filter<'a>) -> Self {
+impl From<Filter> for IndexFilter {
+    fn from(filter: Filter) -> Self {
         IndexFilter { condition: condition_to_index_condition(filter.condition) }
     }
 }

--- a/crates/milli/src/search/facet/filter/vector.rs
+++ b/crates/milli/src/search/facet/filter/vector.rs
@@ -18,7 +18,7 @@ pub enum VectorFilterError<'a> {
             format!("Available embedders are: {}.{did_you_mean}", available.iter().map(|e| format!("`{e}`")).collect::<Vec<_>>().join(", "))
         }
     })]
-    EmbedderDoesNotExist { embedder: &'a Token<'a>, available: Vec<String> },
+    EmbedderDoesNotExist { embedder: &'a Token, available: Vec<String> },
 
     #[error("The fragment `{}` does not exist on embedder `{}`. {}", fragment.fragment(), embedder.fragment(), {
         if available.is_empty() {
@@ -30,11 +30,7 @@ pub enum VectorFilterError<'a> {
             format!("Available fragments on this embedder are: {}.{did_you_mean}", available.iter().map(|f| format!("`{f}`")).collect::<Vec<_>>().join(", "))
         }
     })]
-    FragmentDoesNotExist {
-        embedder: &'a Token<'a>,
-        fragment: &'a Token<'a>,
-        available: Vec<String>,
-    },
+    FragmentDoesNotExist { embedder: &'a Token, fragment: &'a Token, available: Vec<String> },
 }
 
 use VectorFilterError::*;
@@ -54,8 +50,8 @@ pub(super) fn evaluate(
     rtxn: &heed::RoTxn<'_>,
     index: &Index,
     universe: Option<&RoaringBitmap>,
-    embedder: Option<Token<'_>>,
-    filter: &VectorFilter<'_>,
+    embedder: Option<Token>,
+    filter: &VectorFilter,
 ) -> crate::Result<RoaringBitmap> {
     let index_embedding_configs = index.embedding_configs();
     let embedding_configs = index_embedding_configs.embedding_configs(rtxn)?;
@@ -80,9 +76,9 @@ pub(super) fn evaluate(
 fn evaluate_inner(
     rtxn: &heed::RoTxn<'_>,
     index: &Index,
-    embedder: &Token<'_>,
+    embedder: &Token,
     embedding_configs: &[IndexEmbeddingConfig],
-    filter: &VectorFilter<'_>,
+    filter: &VectorFilter,
 ) -> crate::Result<RoaringBitmap> {
     let backend = index.get_vector_store(rtxn)?.unwrap_or_default();
     let embedder_name = embedder.fragment();

--- a/crates/milli/src/search/facet/filter/vector.rs
+++ b/crates/milli/src/search/facet/filter/vector.rs
@@ -1,4 +1,4 @@
-use filter_parser::{Token, VectorFilter};
+use filter_parser::{Token, TokenLike, VectorFilter};
 use roaring::{MultiOps, RoaringBitmap};
 
 use crate::error::{DidYouMean, Error};

--- a/crates/milli/src/search/mod.rs
+++ b/crates/milli/src/search/mod.rs
@@ -58,7 +58,7 @@ pub struct PinDoc {
 pub struct Search<'a> {
     query: Option<String>,
     // this should be linked to the String in the query
-    filter: Option<IndexFilter<'a>>,
+    filter: Option<IndexFilter>,
     offset: usize,
     limit: usize,
     sort_criteria: Option<Vec<AscDesc>>,
@@ -178,7 +178,7 @@ impl<'a> Search<'a> {
         self
     }
 
-    pub fn filter(&mut self, condition: Option<IndexFilter<'a>>) -> &mut Search<'a> {
+    pub fn filter(&mut self, condition: Option<IndexFilter>) -> &mut Search<'a> {
         self.filter = condition;
         self
     }

--- a/crates/milli/src/search/new/mod.rs
+++ b/crates/milli/src/search/new/mod.rs
@@ -666,7 +666,7 @@ fn resolve_sort_criteria<'ctx, Query: RankingRuleQueryTrait>(
 pub fn filtered_universe(
     index: &Index,
     txn: &RoTxn<'_>,
-    filters: &Option<IndexFilter<'_>>,
+    filters: &Option<IndexFilter>,
     candidates: Option<&RoaringBitmap>,
     progress: &Progress,
 ) -> Result<RoaringBitmap> {

--- a/crates/milli/src/search/similar.rs
+++ b/crates/milli/src/search/similar.rs
@@ -11,7 +11,7 @@ use crate::{filtered_universe, DocumentId, Index, Result, SearchResult};
 pub struct Similar<'a> {
     id: DocumentId,
     // this should be linked to the String in the query
-    filter: Option<IndexFilter<'a>>,
+    filter: Option<IndexFilter>,
     offset: usize,
     limit: usize,
     rtxn: &'a heed::RoTxn<'a>,
@@ -51,7 +51,7 @@ impl<'a> Similar<'a> {
         }
     }
 
-    pub fn filter(&mut self, filter: IndexFilter<'a>) -> &mut Self {
+    pub fn filter(&mut self, filter: IndexFilter) -> &mut Self {
         self.filter = Some(filter);
         self
     }


### PR DESCRIPTION


## Related

Fixes: https://linear.app/meilisearch/issue/ENGPROD-2617

This work is related to the document join filtering.

The goal here is to parse the filter in a preprocessing step, which implies storing the parsed value in an intermediate struct.

This PR removes the reference to the filter string in the parsed filter structure in order to own it completely.
