### PR TITLE
simplify partitioning step

### DIFF
--- a/crates/meilisearch/src/search/federated/network.rs
+++ b/crates/meilisearch/src/search/federated/network.rs
@@ -109,17 +109,6 @@ impl Partition {
         })
     }
 
-    pub fn to_query_partition(
-        &self,
-        federation: &mut Federation,
-        query: &SearchQuery,
-        federation_options: Option<FederationOptions>,
-        index_uid: &IndexUid,
-    ) -> Result<impl Iterator<Item = SearchQueryWithIndex> + '_, ResponseError> {
-        let query = fixup_query_federation(federation, query, federation_options, index_uid);
-        self.to_partition(query)
-    }
-
     pub fn into_query_partition(
         self,
         federation: &mut Federation,

--- a/crates/meilisearch/src/search/federated/perform.rs
+++ b/crates/meilisearch/src/search/federated/perform.rs
@@ -1071,18 +1071,11 @@ impl PartitionedQueries {
             return Err(MeilisearchHttpError::DistinctInFederatedQueryAndFederation.into());
         }
 
-        let (index_uid, query, federation_options);
         let queries = if federated_query.must_use_network(network, &features)? {
             let partition = partition
                 .get_or_insert_with(|| super::Partition::new(network.clone(), remote_availability));
-            (index_uid, query, federation_options) = federated_query.into_index_query_federation();
 
-            either::Left(partition.to_query_partition(
-                federation,
-                &query,
-                federation_options,
-                &index_uid,
-            )?)
+            either::Left(partition.to_partition(federated_query)?)
         } else {
             either::Right(std::iter::once(federated_query))
         };


### PR DESCRIPTION
This PR simplifies the partitioning step in the federated search.

Before, the federated query was destructured into a tuple containing:
- simple query
- the extracted federation option
- the extracted index uid

Then this tuple was directly used to reconstruct the federated query before calling `to_partition`.

This PR removes that intermediate transformation.

I may be missing something, so that's why I created a dedicated PR for it.

@dureuill, let me know if this intermediate transformation must be kept. 🤔 