### PR TITLE
Remove legacy search pipeline

### DIFF
--- a/crates/index-scheduler/src/features.rs
+++ b/crates/index-scheduler/src/features.rs
@@ -48,10 +48,6 @@ impl RoFeatures {
         self.runtime
     }
 
-    pub fn legacy_search(&self) -> bool {
-        self.runtime.legacy_search.unwrap_or(false)
-    }
-
     pub fn queue_documents_fetch(&self) -> bool {
         !self.runtime.disable_documents_fetch_queue
     }
@@ -241,17 +237,11 @@ impl FeatureData {
 
         let persisted_features: RuntimeTogglableFeatures =
             runtime_features_db.get(wtxn, db_keys::EXPERIMENTAL_FEATURES)?.unwrap_or_default();
-        let InstanceTogglableFeatures {
-            metrics,
-            logs_route,
-            contains_filter,
-            legacy_search_as_default: legacy_search,
-        } = instance_features;
+        let InstanceTogglableFeatures { metrics, logs_route, contains_filter } = instance_features;
         let runtime = Arc::new(RwLock::new(RuntimeTogglableFeatures {
             metrics: metrics || persisted_features.metrics,
             logs_route: logs_route || persisted_features.logs_route,
             contains_filter: contains_filter || persisted_features.contains_filter,
-            legacy_search: persisted_features.legacy_search.or(Some(legacy_search)),
             ..persisted_features
         }));
 

--- a/crates/meilisearch-types/src/features.rs
+++ b/crates/meilisearch-types/src/features.rs
@@ -24,7 +24,6 @@ pub struct RuntimeTogglableFeatures {
     pub multimodal: bool,
     pub foreign_keys: bool,
     pub disable_documents_fetch_queue: bool,
-    pub legacy_search: Option<bool>,
     pub render_route: bool,
 }
 
@@ -33,7 +32,6 @@ pub struct InstanceTogglableFeatures {
     pub metrics: bool,
     pub logs_route: bool,
     pub contains_filter: bool,
-    pub legacy_search_as_default: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]

--- a/crates/meilisearch/src/analytics/segment_analytics.rs
+++ b/crates/meilisearch/src/analytics/segment_analytics.rs
@@ -214,7 +214,6 @@ struct Infos {
     experimental_no_edition_2024_for_settings: bool,
     experimental_foreign_keys: bool,
     experimental_queue_documents_fetch: bool,
-    experimental_legacy_search: bool,
     experimental_personalization: bool,
     experimental_allowed_ip_networks: bool,
     experimental_render_route: bool,
@@ -256,7 +255,6 @@ impl Infos {
             db_path,
             experimental_contains_filter,
             experimental_enable_metrics,
-            experimental_legacy_search_default,
             experimental_search_queue_size,
             experimental_drop_search_after,
             experimental_nb_searches_per_core,
@@ -329,7 +327,6 @@ impl Infos {
             multimodal,
             foreign_keys,
             disable_documents_fetch_queue,
-            legacy_search,
             render_route,
         } = features;
 
@@ -361,7 +358,6 @@ impl Infos {
             experimental_allowed_ip_networks: !experimental_allowed_ip_networks.is_empty(),
             experimental_foreign_keys: foreign_keys,
             experimental_queue_documents_fetch: !disable_documents_fetch_queue,
-            experimental_legacy_search: legacy_search.unwrap_or(experimental_legacy_search_default),
             experimental_render_route: render_route,
             gpu_enabled: meilisearch_types::milli::vector::is_cuda_enabled(),
             db_path: db_path != Path::new("./data.ms"),

--- a/crates/meilisearch/src/option.rs
+++ b/crates/meilisearch/src/option.rs
@@ -58,7 +58,6 @@ const MEILI_EXPERIMENTAL_CONTAINS_FILTER: &str = "MEILI_EXPERIMENTAL_CONTAINS_FI
 const MEILI_EXPERIMENTAL_NO_EDITION_2024_FOR_SETTINGS: &str =
     "MEILI_EXPERIMENTAL_NO_EDITION_2024_FOR_SETTINGS";
 const MEILI_EXPERIMENTAL_ENABLE_METRICS: &str = "MEILI_EXPERIMENTAL_ENABLE_METRICS";
-const MEILI_EXPERIMENTAL_LEGACY_SEARCH_DEFAULT: &str = "MEILI_EXPERIMENTAL_LEGACY_SEARCH";
 const MEILI_EXPERIMENTAL_SEARCH_QUEUE_SIZE: &str = "MEILI_EXPERIMENTAL_SEARCH_QUEUE_SIZE";
 const MEILI_EXPERIMENTAL_DROP_SEARCH_AFTER: &str = "MEILI_EXPERIMENTAL_DROP_SEARCH_AFTER";
 const MEILI_EXPERIMENTAL_NB_SEARCHES_PER_CORE: &str = "MEILI_EXPERIMENTAL_NB_SEARCHES_PER_CORE";
@@ -397,13 +396,6 @@ pub struct Opt {
     #[serde(default)]
     pub experimental_enable_metrics: bool,
 
-    /// Experimental legacy search feature.
-    ///
-    /// Enables the legacy search pipeline by default.
-    #[clap(long, env = MEILI_EXPERIMENTAL_LEGACY_SEARCH_DEFAULT)]
-    #[serde(default)]
-    pub experimental_legacy_search_default: bool,
-
     /// Experimental search queue size. For more information,
     /// see: <https://github.com/orgs/meilisearch/discussions/729>
     ///
@@ -619,7 +611,6 @@ impl Opt {
             no_analytics,
             experimental_contains_filter,
             experimental_enable_metrics,
-            experimental_legacy_search_default: experimental_legacy_search,
             experimental_search_queue_size,
             experimental_drop_search_after,
             experimental_nb_searches_per_core,
@@ -686,10 +677,6 @@ impl Opt {
         export_to_env_if_not_present(
             MEILI_EXPERIMENTAL_ENABLE_METRICS,
             experimental_enable_metrics.to_string(),
-        );
-        export_to_env_if_not_present(
-            MEILI_EXPERIMENTAL_LEGACY_SEARCH_DEFAULT,
-            experimental_legacy_search.to_string(),
         );
         export_to_env_if_not_present(
             MEILI_EXPERIMENTAL_SEARCH_QUEUE_SIZE,
@@ -818,7 +805,6 @@ impl Opt {
     pub(crate) fn to_instance_features(&self) -> InstanceTogglableFeatures {
         InstanceTogglableFeatures {
             metrics: self.experimental_enable_metrics,
-            legacy_search_as_default: self.experimental_legacy_search_default,
             logs_route: self.experimental_enable_logs_route,
             contains_filter: self.experimental_contains_filter,
         }

--- a/crates/meilisearch/src/routes/features.rs
+++ b/crates/meilisearch/src/routes/features.rs
@@ -46,7 +46,6 @@ pub struct ExperimentalFeaturesApi;
             multimodal: Some(false),
             foreign_keys: Some(false),
             disable_documents_fetch_queue: Some(false),
-            legacy_search: Some(false),
             render_route: Some(false),
         })),
         (status = 401, description = "The authorization header is missing.", body = ResponseError, content_type = "application/json", example = json!(
@@ -116,9 +115,6 @@ pub struct RuntimeTogglableFeatures {
     /// Disable documents fetch queue
     #[request(default)]
     pub disable_documents_fetch_queue: Option<bool>,
-    /// Enable legacy search pipeline
-    #[request(default)]
-    pub legacy_search: Option<bool>,
     /// Enable the `POST /render-template` route
     #[request(default)]
     pub render_route: Option<bool>,
@@ -140,7 +136,6 @@ impl From<meilisearch_types::features::RuntimeTogglableFeatures> for RuntimeTogg
             multimodal,
             foreign_keys,
             disable_documents_fetch_queue,
-            legacy_search,
             render_route,
         } = value;
 
@@ -158,7 +153,6 @@ impl From<meilisearch_types::features::RuntimeTogglableFeatures> for RuntimeTogg
             multimodal: Some(multimodal),
             foreign_keys: Some(foreign_keys),
             disable_documents_fetch_queue: Some(disable_documents_fetch_queue),
-            legacy_search,
             render_route: Some(render_route),
         }
     }
@@ -179,7 +173,6 @@ pub struct PatchExperimentalFeatureAnalytics {
     multimodal: bool,
     foreign_keys: bool,
     disable_documents_fetch_queue: bool,
-    legacy_search: bool,
     render_route: bool,
 }
 
@@ -203,7 +196,6 @@ impl Aggregate for PatchExperimentalFeatureAnalytics {
             multimodal: new.multimodal,
             foreign_keys: new.foreign_keys,
             disable_documents_fetch_queue: new.disable_documents_fetch_queue,
-            legacy_search: new.legacy_search,
             render_route: new.render_route,
         })
     }
@@ -234,7 +226,6 @@ impl Aggregate for PatchExperimentalFeatureAnalytics {
             multimodal: Some(false),
             foreign_keys: Some(false),
             disable_documents_fetch_queue: Some(false),
-            legacy_search: Some(false),
             render_route: Some(false),
          })),
         (status = 401, description = "The authorization header is missing.", body = ResponseError, content_type = "application/json", example = json!(
@@ -292,7 +283,6 @@ async fn patch_features(
             .0
             .disable_documents_fetch_queue
             .unwrap_or(old_features.disable_documents_fetch_queue),
-        legacy_search: new_features.0.legacy_search.or(old_features.legacy_search),
         render_route: new_features.0.render_route.unwrap_or(old_features.render_route),
     };
 
@@ -313,7 +303,6 @@ async fn patch_features(
         multimodal,
         foreign_keys,
         disable_documents_fetch_queue,
-        legacy_search,
         render_route,
     } = new_features;
 
@@ -332,7 +321,6 @@ async fn patch_features(
             multimodal,
             foreign_keys,
             disable_documents_fetch_queue,
-            legacy_search: legacy_search.unwrap_or(false),
             render_route,
         },
         &req,

--- a/crates/meilisearch/src/routes/indexes/search.rs
+++ b/crates/meilisearch/src/routes/indexes/search.rs
@@ -26,10 +26,8 @@ use crate::personalization::PersonalizationService;
 use crate::routes::indexes::search_analytics::{SearchAggregator, SearchGET, SearchPOST};
 use crate::routes::parse_include_metadata_header;
 use crate::search::{
-    add_search_rules, perform_federated_search, perform_search, Federation, HybridQuery,
-    MatchingStrategy, NetworkableQuery as _, Partition, Personalize, RankingScoreThreshold,
-    RetrieveVectors, SearchKind, SearchParams, SearchQuery, SearchQueryWithIndex, SearchResult,
-    SemanticRatio, ShowFederationInfo, DEFAULT_CROP_LENGTH, DEFAULT_CROP_MARKER,
+    HybridQuery, MatchingStrategy, Personalize, RankingScoreThreshold, SearchKind, SearchQuery,
+    SearchQueryWithIndex, SearchResult, SemanticRatio, DEFAULT_CROP_LENGTH, DEFAULT_CROP_MARKER,
     DEFAULT_HIGHLIGHT_POST_TAG, DEFAULT_HIGHLIGHT_PRE_TAG, DEFAULT_SEARCH_LIMIT,
     DEFAULT_SEARCH_OFFSET, DEFAULT_SEMANTIC_RATIO,
 };
@@ -549,89 +547,6 @@ pub async fn search_with_url_query(
     req: HttpRequest,
     analytics: web::Data<Analytics>,
 ) -> Result<HttpResponse, ResponseError> {
-    let use_documents_retrieval = !index_scheduler.features().legacy_search();
-    if use_documents_retrieval {
-        let request_uid = Uuid::now_v7();
-        debug!(request_uid = ?request_uid, parameters = ?params, "Search get");
-        let progress = Progress::default();
-        progress.update_progress(TotalProcessingTimeStep::WaitInQueue);
-        let permit = search_queue.try_get_search_permit().await?;
-        progress.update_progress(TotalProcessingTimeStep::Search);
-        let index_uid = IndexUid::try_from(index_uid.into_inner())?;
-
-        let query: SearchQuery = params.into_inner().try_into()?;
-
-        let mut aggregate = SearchAggregator::<SearchGET>::from_query(&query);
-
-        let include_metadata = parse_include_metadata_header(&req);
-        let is_proxy = false;
-        let document_retrieval = DocumentSearch {
-            request_uid,
-            queries: vec![SearchQueryWithIndex::from_index_query_federation(
-                index_uid.clone(),
-                query,
-                None,
-            )],
-            federation: None,
-            is_proxy,
-            include_metadata,
-            personalization_service: (*personalization_service).clone(),
-        };
-
-        let search_result = document_retrieval
-            .execute(index_scheduler, &progress)
-            .await
-            .map(|result| {
-                let DocumentSearchResult::Multi(mut search_results) = result else {
-                    unreachable!()
-                };
-
-                search_results.pop().unwrap().result
-            })
-            .map_err(|(mut err, _)| match err.error_code.as_str() {
-                "index_not_found" => {
-                    // If the index is not found, return a 404 status code
-                    err.code = StatusCode::NOT_FOUND;
-                    err
-                }
-                _ => err,
-            });
-
-        permit.drop().await;
-
-        if let Ok(search_result) = search_result.as_ref() {
-            aggregate.succeed(search_result);
-        }
-        analytics.publish(aggregate, &req);
-
-        let search_result = search_result?;
-
-        debug!(request_uid = ?request_uid, returns = ?search_result, progress = ?progress.accumulated_durations(), "Search get");
-
-        Ok(HttpResponse::Ok().json(search_result))
-    } else {
-        legacy_search_with_url_query(
-            index_scheduler,
-            search_queue,
-            personalization_service,
-            index_uid,
-            params,
-            req,
-            analytics,
-        )
-        .await
-    }
-}
-
-pub async fn legacy_search_with_url_query(
-    index_scheduler: GuardedData<ActionPolicy<{ actions::SEARCH }>, Data<IndexScheduler>>,
-    search_queue: web::Data<SearchQueue>,
-    personalization_service: web::Data<PersonalizationService>,
-    index_uid: web::Path<String>,
-    params: AwebQueryParameter<SearchQueryGet, DeserrQueryParamError>,
-    req: HttpRequest,
-    analytics: web::Data<Analytics>,
-) -> Result<HttpResponse, ResponseError> {
     let request_uid = Uuid::now_v7();
     debug!(request_uid = ?request_uid, parameters = ?params, "Search get");
     let progress = Progress::default();
@@ -640,28 +555,41 @@ pub async fn legacy_search_with_url_query(
     progress.update_progress(TotalProcessingTimeStep::Search);
     let index_uid = IndexUid::try_from(index_uid.into_inner())?;
 
-    let mut query: SearchQuery = params.into_inner().try_into()?;
-
-    // Tenant token search_rules.
-    if let Some(search_rules) = index_scheduler.filters().get_index_search_rules(&index_uid) {
-        add_search_rules(&mut query.filter, search_rules);
-    }
+    let query: SearchQuery = params.into_inner().try_into()?;
 
     let mut aggregate = SearchAggregator::<SearchGET>::from_query(&query);
 
     let include_metadata = parse_include_metadata_header(&req);
-
-    let search_result = search(
-        query,
-        index_scheduler.clone(),
-        index_uid,
+    let is_proxy = false;
+    let document_retrieval = DocumentSearch {
         request_uid,
+        queries: vec![SearchQueryWithIndex::from_index_query_federation(
+            index_uid.clone(),
+            query,
+            None,
+        )],
+        federation: None,
+        is_proxy,
         include_metadata,
-        &progress,
-        &personalization_service,
-        StatusCode::NOT_FOUND,
-    )
-    .await;
+        personalization_service: (*personalization_service).clone(),
+    };
+
+    let search_result = document_retrieval
+        .execute(index_scheduler, &progress)
+        .await
+        .map(|result| {
+            let DocumentSearchResult::Multi(mut search_results) = result else { unreachable!() };
+
+            search_results.pop().unwrap().result
+        })
+        .map_err(|(mut err, _)| match err.error_code.as_str() {
+            "index_not_found" => {
+                // If the index is not found, return a 404 status code
+                err.code = StatusCode::NOT_FOUND;
+                err
+            }
+            _ => err,
+        });
 
     permit.drop().await;
 
@@ -675,111 +603,6 @@ pub async fn legacy_search_with_url_query(
     debug!(request_uid = ?request_uid, returns = ?search_result, progress = ?progress.accumulated_durations(), "Search get");
 
     Ok(HttpResponse::Ok().json(search_result))
-}
-
-#[allow(clippy::too_many_arguments)]
-pub(crate) async fn search(
-    mut query: SearchQuery,
-    index_scheduler: Data<IndexScheduler>,
-    index_uid: IndexUid,
-    request_uid: Uuid,
-    include_metadata: bool,
-    progress: &Progress,
-    service: &PersonalizationService,
-    index_not_found_http_code: StatusCode,
-) -> Result<SearchResult, ResponseError> {
-    // Extract personalization and query string before moving query
-    let personalize = query.personalize.take();
-    // Save the query string for personalization if requested
-    let personalize_query = personalize.is_some().then(|| query.q.clone()).flatten();
-
-    let features = index_scheduler.features();
-    let network = index_scheduler.network();
-    let remote_availability = index_scheduler.remote_availability();
-
-    if query.must_use_network(&network, &features)? {
-        let mut federation = Federation::default();
-        let queries = Partition::new(network, remote_availability)
-            .into_query_partition(&mut federation, &query, None, &index_uid)?
-            .collect();
-
-        let search_result = perform_federated_search(
-            index_scheduler,
-            queries,
-            federation,
-            features,
-            false,
-            request_uid,
-            include_metadata,
-            ShowFederationInfo::OnNetworkOnly,
-            service,
-            progress,
-        )
-        .await
-        .map_err(|(err, _)| err);
-
-        let (search_result, _deadline) = search_result?;
-        let search_result =
-            search_result.into_search_result(query.q.unwrap_or_default(), index_uid.as_str());
-
-        Ok(search_result)
-    } else {
-        let index = index_scheduler.user_index(&index_uid).map_err(|err| match &err {
-            index_scheduler::Error::IndexNotFound(_) => {
-                let mut err = ResponseError::from(err);
-                err.code = index_not_found_http_code;
-                err
-            }
-            _ => ResponseError::from(err),
-        })?;
-
-        let search_kind = search_kind(&query, &index_scheduler, index_uid.to_string(), &index)?;
-        let retrieve_vector = RetrieveVectors::new(query.retrieve_vectors);
-
-        let progress_clone = progress.clone();
-        let show_performance_details = query.show_performance_details;
-        let search_result = tokio::task::spawn_blocking(move || {
-            perform_search(
-                SearchParams {
-                    index_uid: index_uid.to_string(),
-                    query,
-                    search_kind,
-                    retrieve_vectors: retrieve_vector,
-                    features,
-                    request_uid,
-                    include_metadata,
-                },
-                &index_scheduler,
-                &index,
-                &progress_clone,
-            )
-        })
-        .await;
-
-        let (mut search_result, deadline) = search_result??;
-
-        // Apply personalization if requested
-        // in the legacy search, personalization is applied after pinning hits,
-        // the new implementation applies personalization before pinning hits.
-        if let Some(personalize) = personalize {
-            search_result.hits = service
-                .rerank_search_results(
-                    std::mem::take(&mut search_result.hits),
-                    &personalize,
-                    personalize_query.as_deref(),
-                    &deadline,
-                    progress,
-                )
-                .await?;
-        }
-
-        // Add performance details at the end if requested
-        if show_performance_details {
-            search_result.performance_details = Some(progress.accumulated_durations());
-        }
-
-        Ok(search_result)
-    }
 }
 
 /// Search with POST
@@ -848,90 +671,6 @@ pub async fn search_with_post(
     req: HttpRequest,
     analytics: web::Data<Analytics>,
 ) -> Result<HttpResponse, ResponseError> {
-    let use_documents_retrieval = !index_scheduler.features().legacy_search();
-    if use_documents_retrieval {
-        let index_uid = IndexUid::try_from(index_uid.into_inner())?;
-        let request_uid = Uuid::now_v7();
-
-        let progress = Progress::default();
-        progress.update_progress(TotalProcessingTimeStep::WaitInQueue);
-        let permit = search_queue.try_get_search_permit().await?;
-        progress.update_progress(TotalProcessingTimeStep::Search);
-
-        let query = params.into_inner();
-        debug!(request_uid = ?request_uid, parameters = ?query, "Search post");
-
-        let mut aggregate = SearchAggregator::<SearchPOST>::from_query(&query);
-
-        let include_metadata = parse_include_metadata_header(&req);
-        let is_proxy = false;
-        let document_retrieval = DocumentSearch {
-            request_uid,
-            queries: vec![SearchQueryWithIndex::from_index_query_federation(
-                index_uid.clone(),
-                query,
-                None,
-            )],
-            federation: None,
-            is_proxy,
-            include_metadata,
-            personalization_service: (*personalization_service).clone(),
-        };
-
-        let search_result = document_retrieval
-            .execute(index_scheduler, &progress)
-            .await
-            .map(|result| {
-                let DocumentSearchResult::Multi(mut search_results) = result else {
-                    unreachable!()
-                };
-
-                search_results.pop().unwrap().result
-            })
-            .map_err(|(mut err, _)| match err.error_code.as_str() {
-                "index_not_found" => {
-                    // If the index is not found, return a 404 status code
-                    err.code = StatusCode::NOT_FOUND;
-                    err
-                }
-                _ => err,
-            });
-
-        permit.drop().await;
-
-        if let Ok(search_result) = search_result.as_ref() {
-            aggregate.succeed(search_result);
-        }
-        analytics.publish(aggregate, &req);
-
-        let search_result = search_result?;
-
-        debug!(request_uid = ?request_uid, returns = ?search_result, progress = ?progress.accumulated_durations(), "Search post");
-
-        Ok(HttpResponse::Ok().json(search_result))
-    } else {
-        legacy_search_with_post(
-            index_scheduler,
-            search_queue,
-            personalization_service,
-            index_uid,
-            params,
-            req,
-            analytics,
-        )
-        .await
-    }
-}
-
-pub async fn legacy_search_with_post(
-    index_scheduler: GuardedData<ActionPolicy<{ actions::SEARCH }>, Data<IndexScheduler>>,
-    search_queue: web::Data<SearchQueue>,
-    personalization_service: web::Data<crate::personalization::PersonalizationService>,
-    index_uid: web::Path<String>,
-    params: AwebJson<SearchQuery, DeserrJsonError>,
-    req: HttpRequest,
-    analytics: web::Data<Analytics>,
-) -> Result<HttpResponse, ResponseError> {
     let index_uid = IndexUid::try_from(index_uid.into_inner())?;
     let request_uid = Uuid::now_v7();
 
@@ -940,29 +679,42 @@ pub async fn legacy_search_with_post(
     let permit = search_queue.try_get_search_permit().await?;
     progress.update_progress(TotalProcessingTimeStep::Search);
 
-    let mut query = params.into_inner();
+    let query = params.into_inner();
     debug!(request_uid = ?request_uid, parameters = ?query, "Search post");
-
-    // Tenant token search_rules.
-    if let Some(search_rules) = index_scheduler.filters().get_index_search_rules(&index_uid) {
-        add_search_rules(&mut query.filter, search_rules);
-    }
 
     let mut aggregate = SearchAggregator::<SearchPOST>::from_query(&query);
 
     let include_metadata = parse_include_metadata_header(&req);
-
-    let search_result = search(
-        query,
-        index_scheduler.clone(),
-        index_uid,
+    let is_proxy = false;
+    let document_retrieval = DocumentSearch {
         request_uid,
+        queries: vec![SearchQueryWithIndex::from_index_query_federation(
+            index_uid.clone(),
+            query,
+            None,
+        )],
+        federation: None,
+        is_proxy,
         include_metadata,
-        &progress,
-        &personalization_service,
-        StatusCode::NOT_FOUND,
-    )
-    .await;
+        personalization_service: (*personalization_service).clone(),
+    };
+
+    let search_result = document_retrieval
+        .execute(index_scheduler, &progress)
+        .await
+        .map(|result| {
+            let DocumentSearchResult::Multi(mut search_results) = result else { unreachable!() };
+
+            search_results.pop().unwrap().result
+        })
+        .map_err(|(mut err, _)| match err.error_code.as_str() {
+            "index_not_found" => {
+                // If the index is not found, return a 404 status code
+                err.code = StatusCode::NOT_FOUND;
+                err
+            }
+            _ => err,
+        });
 
     permit.drop().await;
 

--- a/crates/meilisearch/src/routes/multi_search.rs
+++ b/crates/meilisearch/src/routes/multi_search.rs
@@ -1,4 +1,3 @@
-use actix_http::StatusCode;
 use actix_web::web::{self, Data};
 use actix_web::{HttpRequest, HttpResponse};
 use deserr::actix_web::AwebJson;
@@ -9,23 +8,18 @@ use meilisearch_types::keys::actions;
 use meilisearch_types::milli::progress::Progress;
 use meilisearch_types::milli::TotalProcessingTimeStep;
 use serde::Serialize;
-use tracing::debug;
 use utoipa::ToSchema;
 use uuid::Uuid;
 
 use super::multi_search_analytics::MultiSearchAggregator;
 use crate::analytics::Analytics;
 use crate::documents_retrieval::{DocumentSearch, DocumentSearchResult};
-use crate::error::MeilisearchHttpError;
 use crate::extractors::authentication::policies::ActionPolicy;
-use crate::extractors::authentication::{AuthenticationError, GuardedData};
+use crate::extractors::authentication::GuardedData;
 use crate::personalization::PersonalizationService;
 use crate::routes::parse_include_metadata_header;
 use crate::search::proxy::{PROXY_SEARCH_HEADER, PROXY_SEARCH_HEADER_VALUE};
-use crate::search::{
-    add_search_rules, perform_federated_search, FederatedSearch, FederatedSearchResult,
-    SearchQueryWithIndex, SearchResultWithIndex, ShowFederationInfo,
-};
+use crate::search::{FederatedSearch, FederatedSearchResult, SearchResultWithIndex};
 use crate::search_queue::SearchQueue;
 
 #[routes::routes(
@@ -154,86 +148,6 @@ pub async fn multi_search_with_post(
     req: HttpRequest,
     analytics: web::Data<Analytics>,
 ) -> Result<HttpResponse, ResponseError> {
-    let use_documents_retrieval = !index_scheduler.features().legacy_search();
-    if use_documents_retrieval {
-        // Since we don't want to process half of the search requests and then get a permit refused
-        // we're going to get one permit for the whole duration of the multi-search request.
-        let progress = Progress::default();
-        progress.update_progress(TotalProcessingTimeStep::WaitInQueue);
-        let permit = search_queue.try_get_search_permit().await?;
-        progress.update_progress(TotalProcessingTimeStep::Search);
-        let request_uid = Uuid::now_v7();
-
-        let federated_search = params.into_inner();
-
-        let mut multi_aggregate = MultiSearchAggregator::from_federated_search(&federated_search);
-
-        let FederatedSearch { queries, federation } = federated_search;
-
-        // check remote header
-        let is_proxy = req
-            .headers()
-            .get(PROXY_SEARCH_HEADER)
-            .is_some_and(|value| value.as_bytes() == PROXY_SEARCH_HEADER_VALUE.as_bytes());
-
-        let include_metadata = parse_include_metadata_header(&req);
-        let document_retrieval = DocumentSearch {
-            request_uid,
-            queries,
-            federation,
-            is_proxy,
-            include_metadata,
-            personalization_service: (*personalization_service).clone(),
-        };
-
-        let search_results = document_retrieval.execute(index_scheduler, &progress).await;
-
-        if search_results.is_ok() {
-            multi_aggregate.succeed();
-        }
-
-        permit.drop().await;
-        analytics.publish(multi_aggregate, &req);
-
-        let search_results = search_results.map_err(|(mut err, query_index)| {
-            // Add the query index that failed as context for the error message.
-            // We're doing it only here and not directly in the `WithIndex` trait so that the `with_index` function returns a different type
-            // of result and we can benefit from static typing.
-            if let Some(query_index) = query_index {
-                err.message = format!("Inside `.queries[{query_index}]`: {}", err.message);
-            }
-            err
-        })?;
-
-        match search_results {
-            DocumentSearchResult::Federated(search_result) => {
-                Ok(HttpResponse::Ok().json(search_result))
-            }
-            DocumentSearchResult::Multi(search_results) => {
-                Ok(HttpResponse::Ok().json(SearchResults { results: search_results }))
-            }
-        }
-    } else {
-        legacy_multi_search_with_post(
-            index_scheduler,
-            search_queue,
-            personalization_service,
-            params,
-            req,
-            analytics,
-        )
-        .await
-    }
-}
-
-pub async fn legacy_multi_search_with_post(
-    index_scheduler: GuardedData<ActionPolicy<{ actions::SEARCH }>, Data<IndexScheduler>>,
-    search_queue: Data<SearchQueue>,
-    personalization_service: Data<PersonalizationService>,
-    params: AwebJson<FederatedSearch, DeserrJsonError>,
-    req: HttpRequest,
-    analytics: web::Data<Analytics>,
-) -> Result<HttpResponse, ResponseError> {
     // Since we don't want to process half of the search requests and then get a permit refused
     // we're going to get one permit for the whole duration of the multi-search request.
     let progress = Progress::default();
@@ -246,176 +160,49 @@ pub async fn legacy_multi_search_with_post(
 
     let mut multi_aggregate = MultiSearchAggregator::from_federated_search(&federated_search);
 
-    let FederatedSearch { mut queries, federation } = federated_search;
+    let FederatedSearch { queries, federation } = federated_search;
 
-    let features = index_scheduler.features();
+    // check remote header
+    let is_proxy = req
+        .headers()
+        .get(PROXY_SEARCH_HEADER)
+        .is_some_and(|value| value.as_bytes() == PROXY_SEARCH_HEADER_VALUE.as_bytes());
 
-    // regardless of federation, check authorization and apply search rules
-    let auth = 'check_authorization: {
-        for (query_index, federated_query) in queries.iter_mut().enumerate() {
-            let index_uid = federated_query.index_uid.as_str();
-            // Check index from API key
-            if !index_scheduler.filters().is_index_authorized(index_uid) {
-                break 'check_authorization Err(AuthenticationError::InvalidToken)
-                    .with_index(query_index);
-            }
-            // Apply search rules from tenant token
-            if let Some(search_rules) = index_scheduler.filters().get_index_search_rules(index_uid)
-            {
-                add_search_rules(&mut federated_query.filter, search_rules);
-            }
-        }
-        Ok(())
+    let include_metadata = parse_include_metadata_header(&req);
+    let document_retrieval = DocumentSearch {
+        request_uid,
+        queries,
+        federation,
+        is_proxy,
+        include_metadata,
+        personalization_service: (*personalization_service).clone(),
     };
 
-    auth.map_err(|(mut err, query_index)| {
+    let search_results = document_retrieval.execute(index_scheduler, &progress).await;
+
+    if search_results.is_ok() {
+        multi_aggregate.succeed();
+    }
+
+    permit.drop().await;
+    analytics.publish(multi_aggregate, &req);
+
+    let search_results = search_results.map_err(|(mut err, query_index)| {
         // Add the query index that failed as context for the error message.
         // We're doing it only here and not directly in the `WithIndex` trait so that the `with_index` function returns a different type
         // of result and we can benefit from static typing.
-        err.message = format!("Inside `.queries[{query_index}]`: {}", err.message);
+        if let Some(query_index) = query_index {
+            err.message = format!("Inside `.queries[{query_index}]`: {}", err.message);
+        }
         err
     })?;
 
-    let include_metadata = parse_include_metadata_header(&req);
-    let response = match federation {
-        Some(federation) => {
-            debug!(
-                request_uid = ?request_uid,
-                federation = ?federation,
-                parameters = ?queries,
-                "Federated-search"
-            );
-
-            // check remote header
-            let is_proxy = req
-                .headers()
-                .get(PROXY_SEARCH_HEADER)
-                .is_some_and(|value| value.as_bytes() == PROXY_SEARCH_HEADER_VALUE.as_bytes());
-            let search_result = perform_federated_search(
-                index_scheduler.clone(),
-                queries,
-                federation,
-                features,
-                is_proxy,
-                request_uid,
-                include_metadata,
-                ShowFederationInfo::Always,
-                &personalization_service,
-                &progress,
-            )
-            .await;
-            permit.drop().await;
-
-            if search_result.is_ok() {
-                multi_aggregate.succeed();
-            }
-
-            analytics.publish(multi_aggregate, &req);
-
-            debug!(
-                request_uid = ?request_uid,
-                returns = ?search_result,
-                progress = ?progress.accumulated_durations(),
-                "Federated-search"
-            );
-
-            let (search_result, _) = search_result.map_err(|(mut err, query_index)| {
-                // Add the query index that failed as context for the error message.
-                // We're doing it only here and not directly in the `WithIndex` trait so that the `with_index` function returns a different type
-                // of result and we can benefit from static typing.
-                if let Some(query_index) = query_index {
-                    err.message = format!("Inside `.queries[{query_index}]`: {}", err.message);
-                }
-                err
-            })?;
-            HttpResponse::Ok().json(search_result)
+    match search_results {
+        DocumentSearchResult::Federated(search_result) => {
+            Ok(HttpResponse::Ok().json(search_result))
         }
-        None => {
-            // Explicitly expect a `(ResponseError, usize)` for the error type rather than `ResponseError` only,
-            // so that `?` doesn't work if it doesn't use `with_index`, ensuring that it is not forgotten in case of code
-            // changes.
-            let search_results: Result<_, (ResponseError, usize)> = async {
-                let mut search_results = Vec::with_capacity(queries.len());
-                for (query_index, (index_uid, query, federation_options)) in queries
-                    .into_iter()
-                    .map(SearchQueryWithIndex::into_index_query_federation)
-                    .enumerate()
-                {
-                    debug!(
-                        request_uid = ?request_uid,
-                        on_index = query_index,
-                        parameters = ?query,
-                        "Multi-search"
-                    );
-
-                    if federation_options.is_some() {
-                        return Err((
-                            MeilisearchHttpError::FederationOptionsInNonFederatedRequest.into(),
-                            query_index,
-                        ));
-                    }
-
-                    let search_result = crate::routes::indexes::search::search(
-                        query,
-                        index_scheduler.clone(),
-                        index_uid.clone(),
-                        request_uid,
-                        include_metadata,
-                        &progress,
-                        &personalization_service,
-                        StatusCode::BAD_REQUEST,
-                    )
-                    .await
-                    .with_index(query_index)?;
-
-                    search_results.push(SearchResultWithIndex {
-                        index_uid: index_uid.into_inner(),
-                        result: search_result,
-                    });
-                }
-                Ok(search_results)
-            }
-            .await;
-            permit.drop().await;
-
-            if search_results.is_ok() {
-                multi_aggregate.succeed();
-            }
-            analytics.publish(multi_aggregate, &req);
-
-            let search_results = search_results.map_err(|(mut err, query_index)| {
-                // Add the query index that failed as context for the error message.
-                // We're doing it only here and not directly in the `WithIndex` trait so that the `with_index` function returns a different type
-                // of result and we can benefit from static typing.
-                err.message = format!("Inside `.queries[{query_index}]`: {}", err.message);
-                err
-            })?;
-
-            debug!(
-                request_uid = ?request_uid,
-                returns = ?search_results,
-                progress = ?progress.accumulated_durations(),
-                "Multi-search"
-            );
-
-            HttpResponse::Ok().json(SearchResults { results: search_results })
+        DocumentSearchResult::Multi(search_results) => {
+            Ok(HttpResponse::Ok().json(SearchResults { results: search_results }))
         }
-    };
-
-    Ok(response)
-}
-
-/// Local `Result` extension trait to avoid `map_err` boilerplate.
-trait WithIndex {
-    type T;
-    /// convert the error type inside of the `Result` to a `ResponseError`, and
-    /// return a couple of it + the usize.
-    fn with_index(self, index: usize) -> Result<Self::T, (ResponseError, usize)>;
-}
-
-impl<T, E: Into<ResponseError>> WithIndex for Result<T, E> {
-    type T = T;
-    fn with_index(self, index: usize) -> Result<T, (ResponseError, usize)> {
-        self.map_err(|err| (err.into(), index))
     }
 }

--- a/crates/meilisearch/tests/dumps/mod.rs
+++ b/crates/meilisearch/tests/dumps/mod.rs
@@ -2194,7 +2194,6 @@ async fn import_dump_v6_containing_experimental_features() {
       "multimodal": false,
       "foreignKeys": false,
       "disableDocumentsFetchQueue": false,
-      "legacySearch": null,
       "renderRoute": false
     }
     "###);
@@ -2327,7 +2326,6 @@ async fn import_dump_v6_containing_batches_and_enqueued_tasks() {
       "multimodal": false,
       "foreignKeys": false,
       "disableDocumentsFetchQueue": false,
-      "legacySearch": null,
       "renderRoute": false
     }
     "###);
@@ -2440,7 +2438,6 @@ async fn generate_and_import_dump_containing_vectors() {
       "multimodal": false,
       "foreignKeys": false,
       "disableDocumentsFetchQueue": false,
-      "legacySearch": false,
       "renderRoute": false
     }
     "###);

--- a/crates/meilisearch/tests/features/mod.rs
+++ b/crates/meilisearch/tests/features/mod.rs
@@ -31,7 +31,6 @@ async fn experimental_features() {
       "multimodal": false,
       "foreignKeys": false,
       "disableDocumentsFetchQueue": false,
-      "legacySearch": false,
       "renderRoute": false
     }
     "###);
@@ -54,7 +53,6 @@ async fn experimental_features() {
       "multimodal": false,
       "foreignKeys": false,
       "disableDocumentsFetchQueue": false,
-      "legacySearch": false,
       "renderRoute": false
     }
     "###);
@@ -77,7 +75,6 @@ async fn experimental_features() {
       "multimodal": false,
       "foreignKeys": false,
       "disableDocumentsFetchQueue": false,
-      "legacySearch": false,
       "renderRoute": false
     }
     "###);
@@ -101,7 +98,6 @@ async fn experimental_features() {
       "multimodal": false,
       "foreignKeys": false,
       "disableDocumentsFetchQueue": false,
-      "legacySearch": false,
       "renderRoute": false
     }
     "###);
@@ -125,7 +121,6 @@ async fn experimental_features() {
       "multimodal": false,
       "foreignKeys": false,
       "disableDocumentsFetchQueue": false,
-      "legacySearch": false,
       "renderRoute": false
     }
     "###);
@@ -156,7 +151,6 @@ async fn experimental_feature_metrics() {
       "multimodal": false,
       "foreignKeys": false,
       "disableDocumentsFetchQueue": false,
-      "legacySearch": false,
       "renderRoute": false
     }
     "###);
@@ -204,7 +198,7 @@ async fn errors() {
     meili_snap::snapshot!(code, @"400 Bad Request");
     meili_snap::snapshot!(meili_snap::json_string!(response), @r###"
     {
-      "message": "Unknown field `NotAFeature`: expected one of `metrics`, `logsRoute`, `editDocumentsByFunction`, `containsFilter`, `dynamicSearchRules`, `network`, `getTaskDocumentsRoute`, `taskQueueCompactionRoute`, `compositeEmbedders`, `chatCompletions`, `multimodal`, `foreignKeys`, `disableDocumentsFetchQueue`, `legacySearch`, `renderRoute`",
+      "message": "Unknown field `NotAFeature`: expected one of `metrics`, `logsRoute`, `editDocumentsByFunction`, `containsFilter`, `dynamicSearchRules`, `network`, `getTaskDocumentsRoute`, `taskQueueCompactionRoute`, `compositeEmbedders`, `chatCompletions`, `multimodal`, `foreignKeys`, `disableDocumentsFetchQueue`, `renderRoute`",
       "code": "bad_request",
       "type": "invalid_request",
       "link": "https://docs.meilisearch.com/errors#bad_request"


### PR DESCRIPTION
## Generative AI tools

- [x] This PR does not use generative AI tooling

## Changelog

Remove the experimental feature allowing the use of the legacy search pipeline and remove the related dead code.
The experimental feature `legacySearch` will not be available anymore.
