### PR TITLE
docs(security): Fix stale pre-v1.0 supported versions statement

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ If you believe you have found a security vulnerability in any Meilisearch-owned 
 
 ## Supported versions
 
-As long as we are pre-v1.0, only the latest version of Meilisearch will be supported with security updates.
+Only the latest stable release of Meilisearch is supported with security updates.
 
 ## Reporting security issues
 


### PR DESCRIPTION
## Related issue

Fixes #6516

## Generative AI tools

- [x] This PR uses generative AI tooling and respect the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - Claude Code was used to draft the diff and this PR description. I verified the current text of `SECURITY.md`, the workspace version in `Cargo.toml` (`1.50.0`), and the latest GitHub release (`v1.49.0`) against the repository myself before opening this PR.

## Requirements

⚠️ Ensure the following requirements before merging ⚠️
- [x] Automated tests have been added. — N/A, this is a documentation-only wording fix with no testable behavior.
- [x] If some tests cannot be automated, manual rigorous tests should be applied. — N/A, docs-only change; verified by reading the rendered file.
- [ ] ⚠️ If there is any change in the DB: — N/A, no DB changes.
- [ ] If necessary, the feature have been tested in the Cloud production environment — N/A.
- [ ] If necessary, the documentation related to the implemented feature in the PR is ready. — N/A, this PR *is* the documentation fix.
- [ ] If necessary, the integrations related to the implemented feature in the PR are ready. — N/A.

---

### What

`SECURITY.md`'s "Supported versions" section still read:

> As long as we are pre-v1.0, only the latest version of Meilisearch will be supported with security updates.

Meilisearch has been past v1.0 for a long time (workspace `Cargo.toml` currently declares `version = "1.50.0"`; the latest published GitHub release is `v1.49.0`), so the policy statement was gated on a condition (`pre-v1.0`) that's no longer true. A reader couldn't tell from `SECURITY.md` which versions actually receive security updates.

This PR makes the minimal wording fix, stating the actual current policy without pinning a specific version number (so it won't go stale again on the next release):

> Only the latest stable release of Meilisearch is supported with security updates.

### Why this wording

- Avoids re-introducing a hardcoded version/condition that will drift out of date again (the root cause of this issue).
- Matches the substance of what the reporter (@kobihikri) suggested in the issue: state that the latest stable release line is supported.

Thanks to @kobihikri for filing #6516 with a clear repro of the staleness (issue text, `Cargo.toml`, and latest release cross-checked).
