### PR TITLE
Speed up search requests by reducing the number of deserializations

### DIFF
--- a/crates/fuzzers/src/bin/fuzz-indexing.rs
+++ b/crates/fuzzers/src/bin/fuzz-indexing.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -165,7 +164,7 @@ fn main() {
                                 .search(
                                     &wtxn,
                                     "test",
-                                    Cow::Borrowed(&fields_ids_map),
+                                    &fields_ids_map,
                                     time::OffsetDateTime::now_utc(),
                                     &progress,
                                 )

--- a/crates/fuzzers/src/bin/fuzz-indexing.rs
+++ b/crates/fuzzers/src/bin/fuzz-indexing.rs
@@ -159,8 +159,15 @@ fn main() {
 
                             // after executing a batch we check if the database is corrupted
                             let progress = Progress::default();
+                            let fields_ids_map = index.fields_ids_map(&wtxn).unwrap();
                             let res = index
-                                .search(&wtxn, "test", time::OffsetDateTime::now_utc(), &progress)
+                                .search(
+                                    &wtxn,
+                                    "test",
+                                    &fields_ids_map,
+                                    time::OffsetDateTime::now_utc(),
+                                    &progress,
+                                )
                                 .execute()
                                 .unwrap();
                             index.documents(&wtxn, res.documents_ids).unwrap();

--- a/crates/fuzzers/src/bin/fuzz-indexing.rs
+++ b/crates/fuzzers/src/bin/fuzz-indexing.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -164,7 +165,7 @@ fn main() {
                                 .search(
                                     &wtxn,
                                     "test",
-                                    &fields_ids_map,
+                                    Cow::Borrowed(&fields_ids_map),
                                     time::OffsetDateTime::now_utc(),
                                     &progress,
                                 )

--- a/crates/index-scheduler/src/filter.rs
+++ b/crates/index-scheduler/src/filter.rs
@@ -171,6 +171,7 @@ pub fn filters_into_index_filters(
     for (foreign_index_uid, filter_indices) in filters_per_foreign_index.iter() {
         let foreign_index = index_scheduler.user_index(foreign_index_uid.as_ref())?;
         let foreign_rtxn = foreign_index.read_txn()?;
+        let foreign_fields_ids_map = foreign_index.fields_ids_map(&foreign_rtxn).unwrap();
         let foreign_external_docids = foreign_index.external_documents_ids();
 
         // Gather the internal docids for each filter
@@ -179,11 +180,15 @@ pub fn filters_into_index_filters(
             let (_, foreign_index_uid, _, index_filter, _) = &foreign_filters[*filter_index];
 
             // filter the foreign index
-            let docids =
-                filtered_universe(&foreign_index, &foreign_rtxn, index_filter, None, progress)
-                    .map_err(|err| {
-                        Error::from_milli(err, Some(foreign_index_uid.as_ref().to_string()))
-                    })?;
+            let docids = filtered_universe(
+                &foreign_index,
+                &foreign_rtxn,
+                &foreign_fields_ids_map,
+                index_filter,
+                None,
+                progress,
+            )
+            .map_err(|err| Error::from_milli(err, Some(foreign_index_uid.as_ref().to_string())))?;
 
             filters_internal_docids.push(docids);
         }

--- a/crates/index-scheduler/src/scheduler/process_dump_creation.rs
+++ b/crates/index-scheduler/src/scheduler/process_dump_creation.rs
@@ -202,7 +202,11 @@ impl IndexScheduler {
                                 milli::Error::UserError(milli::UserError::InvalidVectorsMapType {
                                     document_id: {
                                         if let Ok(Some(Ok(index))) = index
-                                            .external_id_of(&rtxn, std::iter::once(id))
+                                            .external_id_of(
+                                                &rtxn,
+                                                &fields_ids_map,
+                                                std::iter::once(id),
+                                            )
                                             .map(|it| it.into_iter().next())
                                         {
                                             index

--- a/crates/index-scheduler/src/scheduler/process_export.rs
+++ b/crates/index-scheduler/src/scheduler/process_export.rs
@@ -87,6 +87,7 @@ impl IndexScheduler {
 
             let index = self.user_index(uid)?;
             let index_rtxn = index.read_txn()?;
+            let fields_ids_map = index.fields_ids_map(&index_rtxn)?;
             let filter = filter
                 .as_ref()
                 .map(|f| {
@@ -96,8 +97,10 @@ impl IndexScheduler {
                 .transpose()?
                 .flatten();
 
-            let filter_universe =
-                filter.map(|f| f.evaluate(&index_rtxn, &index)).transpose().map_err(err)?;
+            let filter_universe = filter
+                .map(|f| f.evaluate(&index_rtxn, &index, &fields_ids_map))
+                .transpose()
+                .map_err(err)?;
             let whole_universe =
                 index.documents_ids(&index_rtxn).map_err(milli::Error::from).map_err(err)?;
             let universe = filter_universe.unwrap_or(whole_universe);
@@ -324,7 +327,11 @@ impl IndexScheduler {
                                     document_id: {
                                         if let Ok(Some(Ok(index))) = ctx
                                             .index
-                                            .external_id_of(&index_rtxn, std::iter::once(docid))
+                                            .external_id_of(
+                                                &index_rtxn,
+                                                &fields_ids_map,
+                                                std::iter::once(docid),
+                                            )
                                             .map(|it| it.into_iter().next())
                                         {
                                             index

--- a/crates/index-scheduler/src/scheduler/process_index_operation.rs
+++ b/crates/index-scheduler/src/scheduler/process_index_operation.rs
@@ -138,8 +138,9 @@ impl IndexScheduler {
                                 Code::InvalidDocumentFilter,
                             )?;
                             if let Some(filter) = filter {
-                                let candidates =
-                                    filter.evaluate(index_wtxn, index).map_err(|err| {
+                                let candidates = filter
+                                    .evaluate(index_wtxn, index, &db_fields_ids_map)
+                                    .map_err(|err| {
                                         Error::from_milli(err, Some(index_uid.clone()))
                                     })?;
                                 indexer.delete_documents_by_internal_ids(candidates);
@@ -266,9 +267,12 @@ impl IndexScheduler {
                     })
                     .transpose()?
                 {
-                    Some(filter) => filter
-                        .evaluate(index_wtxn, index)
-                        .map_err(|err| Error::from_milli(err, Some(index_uid.clone())))?,
+                    Some(filter) => {
+                        let db_fields_ids_map = index.fields_ids_map(index_wtxn)?;
+                        filter
+                            .evaluate(index_wtxn, index, &db_fields_ids_map)
+                            .map_err(|err| Error::from_milli(err, Some(index_uid.clone())))?
+                    }
                     None => index.documents_ids(index_wtxn)?,
                 };
 
@@ -427,8 +431,9 @@ impl IndexScheduler {
                                 }
                             };
                             if let Some(filter) = filter {
+                                let db_fields_ids_map = index.fields_ids_map(index_wtxn)?;
                                 let candidates = filter
-                                    .evaluate(index_wtxn, index)
+                                    .evaluate(index_wtxn, index, &db_fields_ids_map)
                                     .map_err(|err| Error::from_milli(err, Some(index_uid.clone())));
                                 match candidates {
                                     Ok(candidates) => to_delete |= candidates,

--- a/crates/meilisearch/src/routes/chats/chat_completions.rs
+++ b/crates/meilisearch/src/routes/chats/chat_completions.rs
@@ -424,9 +424,11 @@ async fn process_search_request(
             .search_deadline(&rtxn)
             .map_err(|e| MeilisearchHttpError::from_milli(e, Some(index_uid.clone())))?;
 
+        let fields_ids_map = index_cloned.fields_ids_map(&rtxn)?;
         let (search, _is_finite_pagination, _max_total_hits, _offset) = prepare_search(
             &index_cloned,
             &rtxn,
+            &fields_ids_map,
             &index_uid,
             start_time,
             &query,

--- a/crates/meilisearch/src/routes/chats/chat_completions.rs
+++ b/crates/meilisearch/src/routes/chats/chat_completions.rs
@@ -35,7 +35,8 @@ use meilisearch_types::keys::actions;
 use meilisearch_types::milli::index::ChatConfig;
 use meilisearch_types::milli::progress::Progress;
 use meilisearch_types::milli::{
-    all_obkv_to_json, obkv_to_json, Filter, OrderBy, PatternMatch, TotalProcessingTimeStep,
+    all_obkv_to_json, obkv_to_json, FieldsIdsMap, Filter, OrderBy, PatternMatch,
+    TotalProcessingTimeStep,
 };
 use meilisearch_types::{Document, Index};
 use serde::Deserialize;
@@ -254,6 +255,7 @@ fn setup_search_tool(
         let search_rules = filters.get_index_search_rules(name.uid());
 
         let rtxn = index.read_txn()?;
+        let fields_ids_map = index.fields_ids_map(&rtxn)?;
         let chat_config = index.chat_config(&rtxn)?;
         let index_description = chat_config.description;
         let _ = writeln!(
@@ -266,6 +268,7 @@ fn setup_search_tool(
             index_scheduler,
             index,
             &rtxn,
+            &fields_ids_map,
             10,
             search_rules,
             name.uid(),
@@ -359,6 +362,7 @@ async fn process_search_request(
     let index = index_scheduler.user_index(&index_uid)?;
     let progress = Progress::default();
     let rtxn = index.static_read_txn()?;
+    let fields_ids_map = index.fields_ids_map(&rtxn)?;
     let ChatConfig { description: _, prompt: _, search_parameters } = index.chat_config(&rtxn)?;
     let mut query = SearchQuery {
         q,
@@ -464,7 +468,7 @@ async fn process_search_request(
         }
 
         let fields_ids_map = index.fields_ids_map(rtxn)?;
-        let displayed_fields = index.displayed_fields_ids(rtxn)?;
+        let displayed_fields = index.displayed_fields_ids(rtxn, &fields_ids_map)?;
         for &document_id in &search_result.documents_ids {
             let obkv = index.document(rtxn, document_id)?;
             let document = match displayed_fields {
@@ -477,7 +481,13 @@ async fn process_search_request(
 
     let (rtxn, search_result) = output?;
     let render_alloc = Bump::new();
-    let formatted = format_documents(&rtxn, &index, &render_alloc, search_result.documents_ids)?;
+    let formatted = format_documents(
+        &rtxn,
+        &index,
+        &fields_ids_map,
+        &render_alloc,
+        search_result.documents_ids,
+    )?;
     let text = formatted.join("\n");
     drop(rtxn);
 
@@ -991,10 +1001,12 @@ struct SearchInIndexParameters {
     filter: Option<String>,
 }
 
+#[allow(clippy::too_many_arguments)]
 fn format_facet_distributions(
     index_scheduler: &IndexScheduler,
     index: &Index,
     rtxn: &RoTxn,
+    fields_ids_map: &FieldsIdsMap,
     max_values_per_facet: usize,
     search_rules: Option<IndexSearchRules>,
     index_uid: &str,
@@ -1011,16 +1023,15 @@ fn format_facet_distributions(
         };
         let filter =
             filter_into_index_filter(filter, index, rtxn, index_scheduler, progress, index_uid)?;
-        filter.evaluate(rtxn, index).map_err(from_milli)?
+        filter.evaluate(rtxn, index, fields_ids_map).map_err(from_milli)?
     };
     let rules = index.filterable_attributes_rules(rtxn)?;
-    let fields_ids_map = index.fields_ids_map(rtxn)?;
     let filterable_attributes = fields_ids_map
         .names()
         .filter(|name| rules.iter().any(|rule| matches!(rule.match_str(name), PatternMatch::Match)))
         .map(|name| (name, OrderBy::Count));
     let facets_distribution = index
-        .facets_distribution(rtxn)
+        .facets_distribution(rtxn, fields_ids_map)
         .max_values_per_facet(max_values_per_facet)
         .candidates(universe)
         .facets(filterable_attributes)

--- a/crates/meilisearch/src/routes/chats/utils.rs
+++ b/crates/meilisearch/src/routes/chats/utils.rs
@@ -15,7 +15,7 @@ use meilisearch_types::milli::index::ChatConfig;
 use meilisearch_types::milli::prompt::{Prompt, PromptData};
 use meilisearch_types::milli::update::new::document::DocumentFromDb;
 use meilisearch_types::milli::{
-    DocumentId, FieldIdMapWithMetadata, GlobalFieldsIdsMap, MetadataBuilder,
+    DocumentId, FieldIdMapWithMetadata, FieldsIdsMap, GlobalFieldsIdsMap, MetadataBuilder,
 };
 use meilisearch_types::{Document, Index};
 use serde::Serialize;
@@ -214,6 +214,7 @@ impl SseEventSender {
 pub fn format_documents<'doc>(
     rtxn: &RoTxn<'_>,
     index: &Index,
+    fields_ids_map: &FieldsIdsMap,
     doc_alloc: &'doc Bump,
     internal_docids: Vec<DocumentId>,
 ) -> Result<Vec<&'doc str>, ResponseError> {
@@ -223,20 +224,19 @@ pub fn format_documents<'doc>(
         ResponseError::from_msg(e.to_string(), Code::InvalidChatSettingDocumentTemplate)
     })?;
 
-    let fid_map = index.fields_ids_map(rtxn)?;
     let metadata_builder = MetadataBuilder::from_index(index, rtxn)?;
-    let fid_map_with_meta = FieldIdMapWithMetadata::new(fid_map.clone(), metadata_builder);
+    let fid_map_with_meta = FieldIdMapWithMetadata::new(fields_ids_map.clone(), metadata_builder);
     let global = RwLock::new(fid_map_with_meta);
     let gfid_map = RefCell::new(GlobalFieldsIdsMap::new(&global));
 
     let external_ids: Vec<String> = index
-        .external_id_of(rtxn, internal_docids.iter().copied())?
+        .external_id_of(rtxn, fields_ids_map, internal_docids.iter().copied())?
         .into_iter()
         .collect::<Result<_, _>>()?;
 
     let mut renders = Vec::new();
     for (docid, external_docid) in internal_docids.into_iter().zip(external_ids) {
-        let document = match DocumentFromDb::new(docid, rtxn, index, &fid_map)? {
+        let document = match DocumentFromDb::new(docid, rtxn, index, fields_ids_map)? {
             Some(doc) => doc,
             None => unreachable!("Document with internal ID {docid} not found"),
         };

--- a/crates/meilisearch/src/routes/indexes/documents.rs
+++ b/crates/meilisearch/src/routes/indexes/documents.rs
@@ -29,7 +29,9 @@ use meilisearch_types::milli::progress::Progress;
 use meilisearch_types::milli::score_details::{GeoSort, WeightedScoreValue};
 use meilisearch_types::milli::update::{IndexDocumentsMethod, MissingDocumentPolicy};
 use meilisearch_types::milli::vector::parsed_vectors::ExplicitVectors;
-use meilisearch_types::milli::{make_document, AscDesc, DocumentId, IndexFilter, Member};
+use meilisearch_types::milli::{
+    make_document, AscDesc, DocumentId, FieldsIdsMap, IndexFilter, Member,
+};
 use meilisearch_types::network::Network;
 use meilisearch_types::serde_cs::vec::CS;
 use meilisearch_types::star_or::OptionStarOrList;
@@ -1130,6 +1132,7 @@ async fn retrieve_documents_local(
 
         let index = index_scheduler.user_index(&index_uid)?;
         let rtxn = index.read_txn()?;
+        let fields_ids_map = index.fields_ids_map(&rtxn)?;
         let progress = Progress::default();
 
         let filter = &filter;
@@ -1159,6 +1162,7 @@ async fn retrieve_documents_local(
         let (total, documents) = retrieve_documents(
             &index,
             &rtxn,
+            &fields_ids_map,
             offset,
             limit,
             ids,
@@ -2242,6 +2246,7 @@ pub async fn clear_all_documents(
 fn some_documents<'a, 't: 'a, 'i, I1, I2, S1, S2>(
     index: &'a Index,
     rtxn: &'t RoTxn,
+    fields_ids_map: &'a FieldsIdsMap,
     doc_ids: impl IntoIterator<Item = DocumentId> + 'a,
     retrieve_vectors: RetrieveVectors,
     attributes_to_retrieve: Option<I1>,
@@ -2253,8 +2258,6 @@ where
     S1: AsRef<str> + 'i,
     S2: AsRef<str> + 'i,
 {
-    let fields_ids_map = index.fields_ids_map(rtxn)?;
-
     let attributes_to_retrieve: BTreeSet<_> = match attributes_to_retrieve {
         Some(attributes) => attributes
             .into_iter()
@@ -2284,10 +2287,10 @@ where
 
     Ok(index.iter_documents(rtxn, doc_ids)?.map(move |ret| {
         ret.map_err(ResponseError::from).and_then(|(key, obkv)| -> Result<_, ResponseError> {
-            let mut document = make_document(obkv, &fields_ids_map, &attributes_to_retrieve)?;
+            let mut document = make_document(obkv, fields_ids_map, &attributes_to_retrieve)?;
             let extra_document = extra_attributes_to_retrieve
                 .as_ref()
-                .map(|extra_attributes| make_document(obkv, &fields_ids_map, extra_attributes))
+                .map(|extra_attributes| make_document(obkv, fields_ids_map, extra_attributes))
                 .transpose()?;
             match retrieve_vectors {
                 RetrieveVectors::Hide => {
@@ -2323,6 +2326,7 @@ where
 fn retrieve_documents<S: AsRef<str>>(
     index: &Index,
     rtxn: &RoTxn,
+    fields_ids_map: &FieldsIdsMap,
     offset: usize,
     limit: usize,
     ids: Option<Vec<ExternalDocumentId>>,
@@ -2347,7 +2351,7 @@ fn retrieve_documents<S: AsRef<str>>(
     };
 
     if let Some(filter) = filter {
-        candidates &= filter.evaluate(rtxn, index).map_err(|err| match err {
+        candidates &= filter.evaluate(rtxn, index, fields_ids_map).map_err(|err| match err {
             milli::Error::UserError(milli::UserError::InvalidFilter(_)) => {
                 ResponseError::from_msg(err.to_string(), Code::InvalidDocumentFilter)
             }
@@ -2357,7 +2361,7 @@ fn retrieve_documents<S: AsRef<str>>(
 
     let (it, number_of_documents) = if let Some(sort) = sort_criteria.as_ref() {
         let number_of_documents = candidates.len();
-        let facet_sort = recursive_sort(index, rtxn, sort, &candidates)?;
+        let facet_sort = recursive_sort(index, rtxn, fields_ids_map, sort, &candidates)?;
         let iter = facet_sort.iter()?;
         let mut documents = Vec::with_capacity(limit);
         for result in iter.skip(offset).take(limit) {
@@ -2375,6 +2379,7 @@ fn retrieve_documents<S: AsRef<str>>(
             itertools::Either::Left(some_documents(
                 index,
                 rtxn,
+                fields_ids_map,
                 documents.into_iter(),
                 retrieve_vectors,
                 attributes_to_retrieve,
@@ -2389,6 +2394,7 @@ fn retrieve_documents<S: AsRef<str>>(
             itertools::Either::Right(some_documents(
                 index,
                 rtxn,
+                fields_ids_map,
                 candidates.into_iter().skip(offset).take(limit),
                 retrieve_vectors,
                 attributes_to_retrieve,
@@ -2504,6 +2510,7 @@ fn retrieve_document<S: AsRef<str>>(
     retrieve_vectors: RetrieveVectors,
 ) -> Result<Document, ResponseError> {
     let txn = index.read_txn()?;
+    let fields_ids_map = index.fields_ids_map(&txn)?;
 
     let internal_id = index
         .external_documents_ids()
@@ -2514,6 +2521,7 @@ fn retrieve_document<S: AsRef<str>>(
     let (document, _extra_document) = some_documents(
         index,
         &txn,
+        &fields_ids_map,
         Some(internal_id),
         retrieve_vectors,
         attributes_to_retrieve,

--- a/crates/meilisearch/src/routes/indexes/facet_search.rs
+++ b/crates/meilisearch/src/routes/indexes/facet_search.rs
@@ -507,6 +507,7 @@ async fn search_multi_local(
     let search_result = tokio::task::spawn_blocking(move || {
         let index = index_scheduler.user_index(&index_uid)?;
         let rtxn = index.read_txn()?;
+        let fields_ids_map = index.fields_ids_map(&rtxn)?;
         let deadline = index.search_deadline(&rtxn)?;
         let search_kind =
             search_kind(&search_query, &index_scheduler, index_uid.to_string(), &index)?;
@@ -539,6 +540,7 @@ async fn search_multi_local(
         let (search, _, _, _) = prepare_search(
             &index,
             &rtxn,
+            &fields_ids_map,
             index_uid.as_str(),
             before_search,
             &search_query,
@@ -549,7 +551,16 @@ async fn search_multi_local(
             &progress_clone,
         )?;
 
-        perform_facet_search(&index, &rtxn, search, facet_query, facet_name, search_kind, locales)
+        perform_facet_search(
+            &index,
+            &rtxn,
+            &fields_ids_map,
+            search,
+            facet_query,
+            facet_name,
+            search_kind,
+            locales,
+        )
     })
     .await;
     search_result?
@@ -573,6 +584,7 @@ async fn search_local(
         let index = index_scheduler.user_index(&index_uid)?;
         let rtxn = index.read_txn()?;
         let deadline = index.search_deadline(&rtxn)?;
+        let fields_ids_map = index.fields_ids_map(&rtxn)?;
         let search_kind =
             search_kind(&search_query, &index_scheduler, index_uid.to_string(), &index)?;
         let filter = match &search_query.filter {
@@ -597,6 +609,7 @@ async fn search_local(
         let (search, _, _, _) = prepare_search(
             &index,
             &rtxn,
+            &fields_ids_map,
             index_uid.as_str(),
             before_search,
             &search_query,
@@ -607,8 +620,17 @@ async fn search_local(
             &progress_clone,
         )?;
 
-        perform_facet_search(&index, &rtxn, search, facet_query, facet_name, search_kind, locales)
-            .map(|(results, _)| results)
+        perform_facet_search(
+            &index,
+            &rtxn,
+            &fields_ids_map,
+            search,
+            facet_query,
+            facet_name,
+            search_kind,
+            locales,
+        )
+        .map(|(results, _)| results)
     })
     .await;
     search_result?

--- a/crates/meilisearch/src/search/federated/perform.rs
+++ b/crates/meilisearch/src/search/federated/perform.rs
@@ -1707,7 +1707,13 @@ impl SearchByIndex {
         let estimated_total_hits = candidates.len() as usize;
         let facets = facet_patterns_by_index
             .map(|facets_by_index| {
-                compute_facet_distribution_stats(&facets_by_index, &index, &rtxn, candidates)
+                compute_facet_distribution_stats(
+                    &facets_by_index,
+                    &index,
+                    &rtxn,
+                    &fidmap,
+                    candidates,
+                )
             })
             .transpose()
             .map_err(|mut error| {
@@ -1776,9 +1782,13 @@ impl SearchByIndex {
             }
 
             if let Some(facets) = facets {
-                if let Err(mut error) =
-                    compute_facet_distribution_stats(&facets, &index, &rtxn, Default::default())
-                {
+                if let Err(mut error) = compute_facet_distribution_stats(
+                    &facets,
+                    &index,
+                    &rtxn,
+                    &fidmap,
+                    Default::default(),
+                ) {
                     if self.show_federation_info == ShowFederationInfo::Always {
                         error.message = format!(
                             "Inside `.federation.facetsByIndex.{index_uid}`: {}\n - Note: index `{index_uid}` is not used in queries",

--- a/crates/meilisearch/src/search/federated/perform.rs
+++ b/crates/meilisearch/src/search/federated/perform.rs
@@ -21,7 +21,7 @@ use meilisearch_types::milli::vector::Embedding;
 use meilisearch_types::milli::{
     self, merge_positioned_hits_into_page, serialize_index_filter_to_filter_string,
     AttributePatterns, Deadline, DocumentId, FederatingResultsStep, FieldsIdsMap, MetadataBuilder,
-    OrderBy, PatternMatch, DEFAULT_VALUES_PER_FACET,
+    OrderBy, PatternMatch, SearchStep, DEFAULT_VALUES_PER_FACET,
 };
 use meilisearch_types::network::{Network, Remote, RemoteAvailability};
 use meilisearch_types::settings::DEFAULT_PAGINATION_MAX_TOTAL_HITS;
@@ -1370,7 +1370,10 @@ impl SearchByIndex {
 
         let required_hit_count = usize::min(params.required_hit_count, max_total_hits);
 
-        let fidmap = index.fields_ids_map(&rtxn).without_index()?;
+        let fidmap = {
+            let _step = progress.update_progress_scoped(SearchStep::LoadFieldIdsMap);
+            index.fields_ids_map(&rtxn).without_index()?
+        };
 
         let mut degraded = false;
         let mut used_negative_operator = false;

--- a/crates/meilisearch/src/search/federated/perform.rs
+++ b/crates/meilisearch/src/search/federated/perform.rs
@@ -1503,6 +1503,7 @@ impl SearchByIndex {
                 let (mut search, _is_finite_pagination, _max_total_hits, _offset) = prepare_search(
                     &index,
                     &rtxn,
+                    &fidmap,
                     &index_uid,
                     before_search,
                     &query,
@@ -1583,8 +1584,8 @@ impl SearchByIndex {
 
                 let formatter_builder = HitMaker::formatter_builder(matching_words, tokenizer);
 
-                let hit_maker =
-                    HitMaker::new(&index, &rtxn, format, formatter_builder).map_err(|e| {
+                let hit_maker = HitMaker::new(&index, &rtxn, &fidmap, format, formatter_builder)
+                    .map_err(|e| {
                         MeilisearchHttpError::from_milli(e, Some(index_uid.to_string()))
                     })?;
 

--- a/crates/meilisearch/src/search/federated/perform.rs
+++ b/crates/meilisearch/src/search/federated/perform.rs
@@ -1429,7 +1429,9 @@ impl SearchByIndex {
                     (SearchKind::SemanticOnly { .. }, _) => {
                         ranking_rules::CanonicalizationKind::Vector
                     }
-                    (_, Some(q)) if !q.is_empty() => ranking_rules::CanonicalizationKind::Keyword,
+                    (_, Some(q)) if !q.trim().is_empty() => {
+                        ranking_rules::CanonicalizationKind::Keyword
+                    }
                     _ => ranking_rules::CanonicalizationKind::Placeholder,
                 };
 

--- a/crates/meilisearch/src/search/hydration.rs
+++ b/crates/meilisearch/src/search/hydration.rs
@@ -32,7 +32,9 @@ pub fn hydrate_documents(
     for (foreign_index_uid, field_names) in foreign_keys_by_index_uid {
         let index = index_scheduler.user_index(foreign_index_uid)?;
         let rtxn = index.read_txn()?;
-        let formatter = HydrationFormatter::new(&index, &rtxn, field_names.as_slice())?;
+        let fields_ids_map = index.fields_ids_map(&rtxn)?;
+        let formatter =
+            HydrationFormatter::new(&index, &rtxn, &fields_ids_map, field_names.as_slice())?;
 
         for document in documents.iter_mut() {
             formatter.hydrate_document(&mut document.document)?;
@@ -52,9 +54,10 @@ impl<'a> HydrationFormatter<'a> {
     fn new(
         index: &'a Index,
         rtxn: &'a RoTxn<'a>,
+        fields_ids_map: &'a FieldsIdsMap,
         field_names: &'a [&'a str],
     ) -> milli::Result<Self> {
-        let document_maker = IndexDocumentMaker::new(index, rtxn)?;
+        let document_maker = IndexDocumentMaker::new(index, rtxn, fields_ids_map)?;
 
         Ok(Self { document_maker, field_names })
     }
@@ -94,16 +97,19 @@ struct IndexDocumentMaker<'a> {
     rtxn: &'a RoTxn<'a>,
     external_documents_ids: ExternalDocumentsIds,
     displayed_ids: BTreeSet<FieldId>,
-    fields_ids_map: FieldsIdsMap,
+    fields_ids_map: &'a FieldsIdsMap,
 }
 
 impl<'a> IndexDocumentMaker<'a> {
-    fn new(index: &'a Index, rtxn: &'a RoTxn<'a>) -> milli::Result<Self> {
+    fn new(
+        index: &'a Index,
+        rtxn: &'a RoTxn<'a>,
+        fields_ids_map: &'a FieldsIdsMap,
+    ) -> milli::Result<Self> {
         let external_documents_ids = index.external_documents_ids();
-        let fields_ids_map = index.fields_ids_map(rtxn)?;
 
         // If displayed_fields_ids is None, we use all the fields ids present in the fields_ids_map
-        let displayed_ids = index.displayed_fields_ids(rtxn)?.map_or_else(
+        let displayed_ids = index.displayed_fields_ids(rtxn, fields_ids_map)?.map_or_else(
             || fields_ids_map.iter().map(|(id, _)| id).collect(),
             |fields| fields.into_iter().collect::<BTreeSet<_>>(),
         );
@@ -130,7 +136,7 @@ impl<'a> IndexDocumentMaker<'a> {
             .map(|&fid| self.fields_ids_map.name(fid).expect("Missing field name"))
             .collect();
 
-        make_document(obkv, &self.fields_ids_map, &selectors).map_err(ResponseError::from)
+        make_document(obkv, self.fields_ids_map, &selectors).map_err(ResponseError::from)
     }
 }
 
@@ -219,7 +225,8 @@ impl FederatedHydrationFormatter {
         for (index_uid, docids) in hydration_docids {
             let index = index_scheduler.user_index(index_uid.as_ref())?;
             let rtxn = index.read_txn()?;
-            let document_maker = IndexDocumentMaker::new(&index, &rtxn)?;
+            let fields_ids_map = index.fields_ids_map(&rtxn)?;
+            let document_maker = IndexDocumentMaker::new(&index, &rtxn, &fields_ids_map)?;
             for docid in docids {
                 let document = document_maker.make_document(&docid)?;
                 hydration_documents.insert((index_uid.clone(), docid), document);

--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -1,4 +1,5 @@
 use core::fmt;
+use std::borrow::Cow;
 use std::cmp::min;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::ops::Not as _;
@@ -1635,7 +1636,8 @@ pub fn prepare_search<'t>(
     if query.media.is_some() {
         features.check_multimodal("passing `media` in a search query")?;
     }
-    let mut search = index.search(rtxn, index_uid, fields_ids_map, before_search, progress);
+    let mut search =
+        index.search(rtxn, index_uid, Cow::Borrowed(fields_ids_map), before_search, progress);
     search.deadline(deadline.clone());
     if let Some(ranking_score_threshold) = query.ranking_score_threshold {
         search.ranking_score_threshold(ranking_score_threshold.0);

--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -1,5 +1,4 @@
 use core::fmt;
-use std::borrow::Cow;
 use std::cmp::min;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::ops::Not as _;
@@ -1636,8 +1635,7 @@ pub fn prepare_search<'t>(
     if query.media.is_some() {
         features.check_multimodal("passing `media` in a search query")?;
     }
-    let mut search =
-        index.search(rtxn, index_uid, Cow::Borrowed(fields_ids_map), before_search, progress);
+    let mut search = index.search(rtxn, index_uid, fields_ids_map, before_search, progress);
     search.deadline(deadline.clone());
     if let Some(ranking_score_threshold) = query.ranking_score_threshold {
         search.ranking_score_threshold(ranking_score_threshold.0);

--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -1622,6 +1622,7 @@ pub fn fuse_filters(left: Option<Value>, right: Option<Value>) -> Option<Value> 
 pub fn prepare_search<'t>(
     index: &'t Index,
     rtxn: &'t RoTxn,
+    fields_ids_map: &'t FieldsIdsMap,
     index_uid: &'t str,
     before_search: time::OffsetDateTime,
     query: &'t SearchQuery,
@@ -1634,7 +1635,7 @@ pub fn prepare_search<'t>(
     if query.media.is_some() {
         features.check_multimodal("passing `media` in a search query")?;
     }
-    let mut search = index.search(rtxn, index_uid, before_search, progress);
+    let mut search = index.search(rtxn, index_uid, fields_ids_map, before_search, progress);
     search.deadline(deadline.clone());
     if let Some(ranking_score_threshold) = query.ranking_score_threshold {
         search.ranking_score_threshold(ranking_score_threshold.0);
@@ -1791,6 +1792,8 @@ pub fn perform_search(
     let rtxn = index.read_txn()?;
     let deadline = index.search_deadline(&rtxn)?;
 
+    let fields_ids_map = index.fields_ids_map(&rtxn)?;
+
     let filter = match &query.filter {
         Some(filter) => {
             let filter = parse_filter(filter, Code::InvalidSearchFilter, features, None)?;
@@ -1806,6 +1809,7 @@ pub fn perform_search(
     let (mut search, is_finite_pagination, max_total_hits, offset) = prepare_search(
         index,
         &rtxn,
+        &fields_ids_map,
         &index_uid,
         before_search,
         &query,
@@ -1907,6 +1911,7 @@ pub fn perform_search(
     let mut documents = make_hits(
         index,
         &rtxn,
+        &fields_ids_map,
         format,
         matching_words,
         documents_ids.iter().copied().zip(document_scores.iter()),
@@ -2201,7 +2206,7 @@ impl RetrieveVectors {
 struct HitMaker<'a> {
     index: &'a Index,
     rtxn: &'a RoTxn<'a>,
-    fields_ids_map: FieldsIdsMap,
+    fields_ids_map: &'a FieldsIdsMap,
     displayed_ids: BTreeSet<FieldId>,
     vectors_fid: Option<FieldId>,
     retrieve_vectors: RetrieveVectors,
@@ -2248,6 +2253,7 @@ impl<'a> HitMaker<'a> {
     pub fn new(
         index: &'a Index,
         rtxn: &'a RoTxn<'a>,
+        fields_ids_map: &'a FieldsIdsMap,
         format: AttributesFormat,
         mut formatter_builder: MatcherBuilder<'a>,
     ) -> milli::Result<Self> {
@@ -2255,7 +2261,6 @@ impl<'a> HitMaker<'a> {
         formatter_builder.highlight_prefix(format.highlight_pre_tag);
         formatter_builder.highlight_suffix(format.highlight_post_tag);
 
-        let fields_ids_map = index.fields_ids_map(rtxn)?;
         let displayed_ids = index
             .displayed_fields_ids(rtxn)?
             .map(|fields| fields.into_iter().collect::<BTreeSet<_>>());
@@ -2334,7 +2339,7 @@ impl<'a> HitMaker<'a> {
             &attr_to_crop,
             format.crop_length,
             &to_retrieve_ids,
-            &fields_ids_map,
+            fields_ids_map,
             &displayed_ids,
         );
 
@@ -2391,13 +2396,13 @@ impl<'a> HitMaker<'a> {
             .collect();
 
         // Generate a document with all the attributes to retrieve
-        let mut document = make_document(obkv, &self.fields_ids_map, &attributes_to_retrieve)?;
+        let mut document = make_document(obkv, self.fields_ids_map, &attributes_to_retrieve)?;
 
         let extra_document = self
             .extra_ids
             .is_empty()
             .not()
-            .then(|| make_document(obkv, &self.fields_ids_map, &self.extra_ids))
+            .then(|| make_document(obkv, self.fields_ids_map, &self.extra_ids))
             .transpose()?
             .unwrap_or_default();
 
@@ -2438,11 +2443,11 @@ impl<'a> HitMaker<'a> {
                 self.formatted_options.keys().map(extract_field).collect()
             };
 
-            let document = make_document(obkv, &self.fields_ids_map, &selectors)?;
+            let document = make_document(obkv, self.fields_ids_map, &selectors)?;
 
             format_fields(
                 document,
-                &self.fields_ids_map,
+                self.fields_ids_map,
                 &self.formatter_builder,
                 &self.formatted_options,
                 self.show_matches_position,
@@ -2478,6 +2483,7 @@ impl<'a> HitMaker<'a> {
 fn make_hits<'a>(
     index: &Index,
     rtxn: &RoTxn<'_>,
+    fields_ids_map: &FieldsIdsMap,
     format: AttributesFormat,
     matching_words: milli::MatchingWords,
     documents_ids_scores: impl Iterator<Item = (u32, &'a Vec<ScoreDetails>)> + 'a,
@@ -2496,7 +2502,7 @@ fn make_hits<'a>(
 
     let formatter_builder = HitMaker::formatter_builder(matching_words, tokenizer);
 
-    let hit_maker = HitMaker::new(index, rtxn, format, formatter_builder)?;
+    let hit_maker = HitMaker::new(index, rtxn, fields_ids_map, format, formatter_builder)?;
 
     for (id, score) in documents_ids_scores {
         documents.push(hit_maker.make_hit(id, score, progress)?);
@@ -2504,9 +2510,11 @@ fn make_hits<'a>(
     Ok(documents)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn perform_facet_search<'a>(
     index: &Index,
     rtxn: &RoTxn,
+    fields_ids_map: &FieldsIdsMap,
     search: milli::Search<'a>,
     facet_query: Option<String>,
     facet_name: String,
@@ -2540,7 +2548,7 @@ pub fn perform_facet_search<'a>(
     let candidates =
         search.execute_for_candidates(matches!(search_kind, SearchKind::Hybrid { .. }))?;
 
-    let mut facet_search = SearchForFacetValues::new(facet_name, index, rtxn);
+    let mut facet_search = SearchForFacetValues::new(facet_name, index, rtxn, fields_ids_map);
     if let Some(facet_query) = &facet_query {
         facet_search.query(facet_query);
     }
@@ -2577,6 +2585,7 @@ pub fn perform_similar(
     let features = index_scheduler.features();
     let index = index_scheduler.user_index(&index_uid)?;
     let rtxn = index.read_txn()?;
+    let fields_ids_map = index.fields_ids_map(&rtxn)?;
 
     let SimilarQuery {
         id,
@@ -2704,6 +2713,7 @@ pub fn perform_similar(
     let hits = make_hits(
         &index,
         &rtxn,
+        &fields_ids_map,
         format,
         Default::default(),
         documents_ids.iter().copied().zip(document_scores.iter()),

--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -1947,7 +1947,7 @@ pub fn perform_search(
     let (facet_distribution, facet_stats) = facets
         .map(move |facets| {
             let _step = progress.update_progress_scoped(SearchStep::FacetDistribution);
-            compute_facet_distribution_stats(&facets, index, &rtxn, candidates)
+            compute_facet_distribution_stats(&facets, index, &rtxn, &fields_ids_map, candidates)
         })
         .transpose()?
         .map(|ComputedFacets { distribution, stats }| (distribution, stats))
@@ -2044,9 +2044,10 @@ fn compute_facet_distribution_stats(
     facet_patterns: &AttributePatterns,
     index: &Index,
     rtxn: &RoTxn,
+    fields_ids_map: &FieldsIdsMap,
     candidates: roaring::RoaringBitmap,
 ) -> Result<ComputedFacets, ResponseError> {
-    let mut facet_distribution = index.facets_distribution(rtxn);
+    let mut facet_distribution = index.facets_distribution(rtxn, fields_ids_map);
 
     let max_values_by_facet = index
         .max_values_per_facet(rtxn)
@@ -2095,9 +2096,8 @@ fn compute_facet_distribution_stats(
         .into());
     }
 
-    let fidmap = index.fields_ids_map(rtxn)?;
     let metadata_builder = MetadataBuilder::from_index(index, rtxn)?;
-    let fields = fidmap.iter().filter_map(|(_fid, fname)| {
+    let fields = fields_ids_map.iter().filter_map(|(_fid, fname)| {
         if facet_patterns.match_str(fname) != PatternMatch::Match {
             return None;
         }
@@ -2264,7 +2264,7 @@ impl<'a> HitMaker<'a> {
         formatter_builder.highlight_suffix(format.highlight_post_tag);
 
         let displayed_ids = index
-            .displayed_fields_ids(rtxn)?
+            .displayed_fields_ids(rtxn, fields_ids_map)?
             .map(|fields| fields.into_iter().collect::<BTreeSet<_>>());
 
         let vectors_fid = fields_ids_map.id(milli::constants::RESERVED_VECTORS_FIELD_NAME);
@@ -2652,7 +2652,8 @@ pub fn perform_similar(
         ));
     };
 
-    let docid_universe = filtered_universe(&index, &rtxn, &docid_filter, None, progress)?;
+    let docid_universe =
+        filtered_universe(&index, &rtxn, &fields_ids_map, &docid_filter, None, progress)?;
     if docid_universe.contains(internal_id).not() {
         return Err(ResponseError::from_msg(
             MeilisearchHttpError::DocumentNotFound(id.into_inner()).to_string(),
@@ -2666,6 +2667,7 @@ pub fn perform_similar(
         limit,
         &index,
         &rtxn,
+        &fields_ids_map,
         embedder_name,
         embedder,
         quantized,

--- a/crates/meilitool/src/main.rs
+++ b/crates/meilitool/src/main.rs
@@ -595,7 +595,11 @@ fn export_documents(
                                 meilisearch_types::milli::UserError::InvalidVectorsMapType {
                                     document_id: {
                                         if let Ok(Some(Ok(index))) = index
-                                            .external_id_of(&rtxn, std::iter::once(id))
+                                            .external_id_of(
+                                                &rtxn,
+                                                &fields_ids_map,
+                                                std::iter::once(id),
+                                            )
                                             .map(|it| it.into_iter().next())
                                         {
                                             index

--- a/crates/milli/src/documents/sort.rs
+++ b/crates/milli/src/documents/sort.rs
@@ -11,7 +11,7 @@ use crate::documents::GeoSortParameter;
 use crate::heed_codec::facet::{FacetGroupKeyCodec, FacetGroupValueCodec};
 use crate::heed_codec::BytesRefCodec;
 use crate::search::facet::{ascending_facet_sort, descending_facet_sort};
-use crate::{is_faceted, AscDesc, DocumentId, Member, UserError};
+use crate::{is_faceted, AscDesc, DocumentId, FieldsIdsMap, Member, UserError};
 
 #[derive(Debug, Clone, Copy)]
 enum AscDescId {
@@ -412,11 +412,11 @@ impl<'ctx> SortedDocuments<'ctx> {
 pub fn recursive_sort<'ctx>(
     index: &'ctx crate::Index,
     rtxn: &'ctx heed::RoTxn<'ctx>,
+    fields_ids_map: &FieldsIdsMap,
     sort: &[AscDesc],
     candidates: &'ctx RoaringBitmap,
 ) -> crate::Result<SortedDocuments<'ctx>> {
     let sortable_fields: BTreeSet<_> = index.sortable_fields(rtxn)?.into_iter().collect();
-    let fields_ids_map = index.fields_ids_map(rtxn)?;
 
     // Retrieve the field ids that are used for sorting
     let mut fields = Vec::new();

--- a/crates/milli/src/dynamic_search_rules.rs
+++ b/crates/milli/src/dynamic_search_rules.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::ops::{Bound, ControlFlow};
 
 use heed::{RoTxn, WithoutTls};
@@ -139,7 +138,7 @@ impl<'a> DynamicSearchRulesView<'a> {
         let mut search = self.index.search(
             self.rtxn,
             "",
-            Cow::Borrowed(self.db_fields_ids_map),
+            self.db_fields_ids_map,
             OffsetDateTime::now_utc(),
             &progress,
         );

--- a/crates/milli/src/dynamic_search_rules.rs
+++ b/crates/milli/src/dynamic_search_rules.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::ops::{Bound, ControlFlow};
 
 use heed::{RoTxn, WithoutTls};
@@ -138,7 +139,7 @@ impl<'a> DynamicSearchRulesView<'a> {
         let mut search = self.index.search(
             self.rtxn,
             "",
-            self.db_fields_ids_map,
+            Cow::Borrowed(self.db_fields_ids_map),
             OffsetDateTime::now_utc(),
             &progress,
         );

--- a/crates/milli/src/dynamic_search_rules.rs
+++ b/crates/milli/src/dynamic_search_rules.rs
@@ -135,7 +135,13 @@ impl<'a> DynamicSearchRulesView<'a> {
         offset: usize,
     ) -> Result<SearchResult> {
         let progress = Default::default();
-        let mut search = self.index.search(self.rtxn, "", OffsetDateTime::now_utc(), &progress);
+        let mut search = self.index.search(
+            self.rtxn,
+            "",
+            self.db_fields_ids_map,
+            OffsetDateTime::now_utc(),
+            &progress,
+        );
 
         if let Some(query) = query {
             search.query(query);

--- a/crates/milli/src/index.rs
+++ b/crates/milli/src/index.rs
@@ -1496,7 +1496,7 @@ impl Index {
         &'a self,
         rtxn: &'a RoTxn<'a>,
         index_uid: &'a str,
-        fields_ids_map: &'a FieldsIdsMap,
+        fields_ids_map: Cow<'a, FieldsIdsMap>,
         before_search: time::OffsetDateTime,
         progress: &'a Progress,
     ) -> Search<'a> {

--- a/crates/milli/src/index.rs
+++ b/crates/milli/src/index.rs
@@ -845,10 +845,13 @@ impl Index {
     }
 
     /// Identical to `displayed_fields`, but returns the ids instead.
-    pub fn displayed_fields_ids(&self, rtxn: &RoTxn<'_>) -> Result<Option<Vec<FieldId>>> {
+    pub fn displayed_fields_ids(
+        &self,
+        rtxn: &RoTxn<'_>,
+        fields_ids_map: &FieldsIdsMap,
+    ) -> Result<Option<Vec<FieldId>>> {
         match self.displayed_fields(rtxn)? {
             Some(fields) => {
-                let fields_ids_map = self.fields_ids_map(rtxn)?;
                 let mut fields_ids = Vec::new();
                 for name in fields.into_iter() {
                     if let Some(field_id) = fields_ids_map.id(name) {
@@ -1001,10 +1004,10 @@ impl Index {
     pub fn user_defined_searchable_fields_ids(
         &self,
         rtxn: &RoTxn<'_>,
+        fields_ids_map: &FieldsIdsMap,
     ) -> Result<Option<Vec<FieldId>>> {
         match self.user_defined_searchable_fields(rtxn)? {
             Some(fields) => {
-                let fields_ids_map = self.fields_ids_map(rtxn)?;
                 let mut fields_ids = Vec::new();
                 for name in fields {
                     if let Some(field_id) = fields_ids_map.id(name) {
@@ -1082,9 +1085,12 @@ impl Index {
     }
 
     /// Identical to `sortable_fields`, but returns ids instead.
-    pub fn sortable_fields_ids(&self, rtxn: &RoTxn<'_>) -> Result<HashSet<FieldId>> {
+    pub fn sortable_fields_ids(
+        &self,
+        rtxn: &RoTxn<'_>,
+        fields_ids_map: &FieldsIdsMap,
+    ) -> Result<HashSet<FieldId>> {
         let fields = self.sortable_fields(rtxn)?;
-        let fields_ids_map = self.fields_ids_map(rtxn)?;
         Ok(fields.into_iter().filter_map(|name| fields_ids_map.id(&name)).collect())
     }
 
@@ -1461,16 +1467,15 @@ impl Index {
     pub fn external_id_of<'a, 't: 'a>(
         &'a self,
         rtxn: &'t RoTxn<'t>,
+        fields_ids_map: &'a FieldsIdsMap,
         ids: impl IntoIterator<Item = DocumentId> + 'a,
     ) -> Result<impl IntoIterator<Item = Result<String>> + 'a> {
-        let fields = self.fields_ids_map(rtxn)?;
-
         // uses precondition "never called on an empty index"
         let primary_key = self.primary_key(rtxn)?.ok_or(InternalError::DatabaseMissingEntry {
             db_name: db_name::MAIN,
             key: Some(main_key::PRIMARY_KEY_KEY),
         })?;
-        let primary_key = PrimaryKey::new(primary_key, &fields).ok_or_else(|| {
+        let primary_key = PrimaryKey::new(primary_key, &fields_ids_map).ok_or_else(|| {
             InternalError::FieldIdMapMissingEntry(crate::FieldIdMapMissingEntry::FieldName {
                 field_name: primary_key.to_owned(),
                 process: "external_id_of",
@@ -1478,7 +1483,7 @@ impl Index {
         })?;
         Ok(self.iter_documents(rtxn, ids)?.map(move |entry| -> Result<_> {
             let (_docid, obkv) = entry?;
-            match primary_key.document_id(obkv, &fields)? {
+            match primary_key.document_id(obkv, &fields_ids_map)? {
                 Ok(document_id) => Ok(document_id),
                 Err(_) => Err(InternalError::DocumentsError(
                     crate::documents::Error::InvalidDocumentFormat,
@@ -1488,8 +1493,12 @@ impl Index {
         }))
     }
 
-    pub fn facets_distribution<'a>(&'a self, rtxn: &'a RoTxn<'a>) -> FacetDistribution<'a> {
-        FacetDistribution::new(rtxn, self)
+    pub fn facets_distribution<'a>(
+        &'a self,
+        rtxn: &'a RoTxn<'a>,
+        fields_ids_map: &'a FieldsIdsMap,
+    ) -> FacetDistribution<'a> {
+        FacetDistribution::new(rtxn, self, fields_ids_map)
     }
 
     pub fn search<'a>(

--- a/crates/milli/src/index.rs
+++ b/crates/milli/src/index.rs
@@ -667,15 +667,17 @@ impl Index {
     }
 
     /// Get the fieldids weights map which associates the field ids to their weights
-    pub fn fieldids_weights_map(&self, rtxn: &RoTxn<'_>) -> heed::Result<FieldidsWeightsMap> {
+    pub fn fieldids_weights_map(
+        &self,
+        rtxn: &RoTxn<'_>,
+        fields_ids_map: &FieldsIdsMap,
+    ) -> heed::Result<FieldidsWeightsMap> {
         self.main
             .remap_types::<Str, SerdeJson<_>>()
             .get(rtxn, main_key::FIELDIDS_WEIGHTS_MAP_KEY)?
             .map(Ok)
             .unwrap_or_else(|| {
-                Ok(FieldidsWeightsMap::from_field_id_map_without_searchable(
-                    &self.fields_ids_map(rtxn)?,
-                ))
+                Ok(FieldidsWeightsMap::from_field_id_map_without_searchable(fields_ids_map))
             })
     }
 
@@ -698,18 +700,19 @@ impl Index {
     pub fn searchable_fields_and_weights<'a>(
         &self,
         rtxn: &'a RoTxn<'a>,
+        fields_ids_map: &FieldsIdsMap,
     ) -> Result<Vec<(Cow<'a, str>, FieldId, Weight)>> {
-        let fid_map = self.fields_ids_map(rtxn)?;
-        let weight_map = self.fieldids_weights_map(rtxn)?;
-        let searchable = self.searchable_fields(rtxn)?;
+        let weight_map = self.fieldids_weights_map(rtxn, fields_ids_map)?;
+        let searchable = self.searchable_fields(rtxn, fields_ids_map)?;
 
         searchable
             .into_iter()
             .map(|field| -> Result<_> {
-                let fid = fid_map.id(&field).ok_or_else(|| FieldIdMapMissingEntry::FieldName {
-                    field_name: field.to_string(),
-                    process: "searchable_fields_and_weights",
-                })?;
+                let fid =
+                    fields_ids_map.id(&field).ok_or_else(|| FieldIdMapMissingEntry::FieldName {
+                        field_name: field.to_string(),
+                        process: "searchable_fields_and_weights",
+                    })?;
                 let weight = weight_map
                     .weight(fid)
                     .ok_or(InternalError::FieldidsWeightsMapMissingEntry { key: fid })?;
@@ -929,14 +932,17 @@ impl Index {
     }
 
     /// Returns the searchable fields, those are the fields that are indexed,
-    pub fn searchable_fields<'t>(&self, rtxn: &'t RoTxn<'_>) -> heed::Result<Vec<Cow<'t, str>>> {
+    pub fn searchable_fields<'t>(
+        &self,
+        rtxn: &'t RoTxn<'_>,
+        fields_ids_map: &FieldsIdsMap,
+    ) -> heed::Result<Vec<Cow<'t, str>>> {
         self.main
             .remap_types::<Str, SerdeBincode<Vec<&'t str>>>()
             .get(rtxn, main_key::SEARCHABLE_FIELDS_KEY)?
             .map(|fields| Ok(fields.into_iter().map(Cow::Borrowed).collect()))
             .unwrap_or_else(|| {
-                Ok(self
-                    .fields_ids_map(rtxn)?
+                Ok(fields_ids_map
                     .names()
                     .filter(|name| !crate::is_faceted_by(name, RESERVED_VECTORS_FIELD_NAME))
                     .map(|field| Cow::Owned(field.to_string()))
@@ -945,9 +951,12 @@ impl Index {
     }
 
     /// Identical to `searchable_fields`, but returns the ids instead.
-    pub fn searchable_fields_ids(&self, rtxn: &RoTxn<'_>) -> Result<Vec<FieldId>> {
-        let fields = self.searchable_fields(rtxn)?;
-        let fields_ids_map = self.fields_ids_map(rtxn)?;
+    pub fn searchable_fields_ids(
+        &self,
+        rtxn: &RoTxn<'_>,
+        fields_ids_map: &FieldsIdsMap,
+    ) -> Result<Vec<FieldId>> {
+        let fields = self.searchable_fields(rtxn, fields_ids_map)?;
         let mut fields_ids = Vec::new();
         for name in fields {
             if let Some(field_id) = fields_ids_map.id(&name) {
@@ -1487,10 +1496,11 @@ impl Index {
         &'a self,
         rtxn: &'a RoTxn<'a>,
         index_uid: &'a str,
+        fields_ids_map: &'a FieldsIdsMap,
         before_search: time::OffsetDateTime,
         progress: &'a Progress,
     ) -> Search<'a> {
-        Search::new(rtxn, self, index_uid, before_search, progress)
+        Search::new(rtxn, self, fields_ids_map, index_uid, before_search, progress)
     }
 
     /// Returns the index creation time.
@@ -1627,10 +1637,13 @@ impl Index {
     }
 
     /// Returns the list of exact attributes field ids.
-    pub fn exact_attributes_ids(&self, txn: &RoTxn<'_>) -> Result<HashSet<FieldId>> {
+    pub fn exact_attributes_ids(
+        &self,
+        txn: &RoTxn<'_>,
+        fields_ids_map: &FieldsIdsMap,
+    ) -> Result<HashSet<FieldId>> {
         let attrs = self.exact_attributes(txn)?;
-        let fid_map = self.fields_ids_map(txn)?;
-        Ok(attrs.iter().filter_map(|attr| fid_map.id(attr)).collect())
+        Ok(attrs.iter().filter_map(|attr| fields_ids_map.id(attr)).collect())
     }
 
     /// Writes the exact attributes to the database.

--- a/crates/milli/src/index.rs
+++ b/crates/milli/src/index.rs
@@ -1505,7 +1505,7 @@ impl Index {
         &'a self,
         rtxn: &'a RoTxn<'a>,
         index_uid: &'a str,
-        fields_ids_map: Cow<'a, FieldsIdsMap>,
+        fields_ids_map: &'a FieldsIdsMap,
         before_search: time::OffsetDateTime,
         progress: &'a Progress,
     ) -> Search<'a> {

--- a/crates/milli/src/search/facet/facet_distribution.rs
+++ b/crates/milli/src/search/facet/facet_distribution.rs
@@ -19,7 +19,9 @@ use crate::heed_codec::{BytesRefCodec, StrRefCodec};
 use crate::search::facet::facet_distribution_iter::{
     count_iterate_over_facet_distribution, lexicographically_iterate_over_facet_distribution,
 };
-use crate::{Error, FieldId, FilterableAttributesRule, Index, PatternMatch, Result, UserError};
+use crate::{
+    Error, FieldId, FieldsIdsMap, FilterableAttributesRule, Index, PatternMatch, Result, UserError,
+};
 
 /// The default number of values by facets that will
 /// be fetched from the key-value store.
@@ -55,10 +57,15 @@ pub struct FacetDistribution<'a> {
     default_order_by: OrderBy,
     rtxn: &'a heed::RoTxn<'a>,
     index: &'a Index,
+    fields_ids_map: &'a FieldsIdsMap,
 }
 
 impl<'a> FacetDistribution<'a> {
-    pub fn new(rtxn: &'a heed::RoTxn<'a>, index: &'a Index) -> FacetDistribution<'a> {
+    pub fn new(
+        rtxn: &'a heed::RoTxn<'a>,
+        index: &'a Index,
+        fields_ids_map: &'a FieldsIdsMap,
+    ) -> FacetDistribution<'a> {
         FacetDistribution {
             facets: None,
             candidates: None,
@@ -66,6 +73,7 @@ impl<'a> FacetDistribution<'a> {
             default_order_by: OrderBy::default(),
             rtxn,
             index,
+            fields_ids_map,
         }
     }
 
@@ -294,12 +302,11 @@ impl<'a> FacetDistribution<'a> {
             return Ok(Default::default());
         };
 
-        let fields_ids_map = self.index.fields_ids_map(self.rtxn)?;
         let filterable_attributes_rules = self.index.filterable_attributes_rules(self.rtxn)?;
         self.check_faceted_fields(&filterable_attributes_rules)?;
 
         let mut distribution = BTreeMap::new();
-        for (fid, name) in fields_ids_map.iter() {
+        for (fid, name) in self.fields_ids_map.iter() {
             if self.select_field(name, &filterable_attributes_rules) {
                 let min_value = if let Some(min_value) = crate::search::facet::facet_min_value(
                     self.index,
@@ -330,12 +337,11 @@ impl<'a> FacetDistribution<'a> {
     }
 
     pub fn execute(&self) -> Result<BTreeMap<String, IndexMap<String, u64>>> {
-        let fields_ids_map = self.index.fields_ids_map(self.rtxn)?;
         let filterable_attributes_rules = self.index.filterable_attributes_rules(self.rtxn)?;
         self.check_faceted_fields(&filterable_attributes_rules)?;
 
         let mut distribution = BTreeMap::new();
-        for (fid, name) in fields_ids_map.iter() {
+        for (fid, name) in self.fields_ids_map.iter() {
             if self.select_field(name, &filterable_attributes_rules) {
                 let order_by = self
                     .facets
@@ -415,6 +421,7 @@ impl fmt::Debug for FacetDistribution<'_> {
             default_order_by,
             rtxn: _,
             index: _,
+            fields_ids_map: _,
         } = self;
 
         f.debug_struct("FacetDistribution")
@@ -458,15 +465,16 @@ mod tests {
         index.add_documents(documents).unwrap();
 
         let txn = index.read_txn().unwrap();
+        let fields_ids_map = index.fields_ids_map(&txn).unwrap();
 
-        let map = FacetDistribution::new(&txn, &index)
+        let map = FacetDistribution::new(&txn, &index, &fields_ids_map)
             .facets(iter::once(("colour", OrderBy::default())))
             .execute()
             .unwrap();
 
         milli_snap!(format!("{map:?}"), @r###"{"colour": {"Blue": 2, "RED": 1}}"###);
 
-        let map = FacetDistribution::new(&txn, &index)
+        let map = FacetDistribution::new(&txn, &index, &fields_ids_map)
             .facets(iter::once(("colour", OrderBy::default())))
             .candidates([0, 1, 2].iter().copied().collect())
             .execute()
@@ -474,7 +482,7 @@ mod tests {
 
         milli_snap!(format!("{map:?}"), @r###"{"colour": {"Blue": 2, "RED": 1}}"###);
 
-        let map = FacetDistribution::new(&txn, &index)
+        let map = FacetDistribution::new(&txn, &index, &fields_ids_map)
             .facets(iter::once(("colour", OrderBy::default())))
             .candidates([1, 2].iter().copied().collect())
             .execute()
@@ -485,7 +493,7 @@ mod tests {
         // the candidates
         milli_snap!(format!("{map:?}"), @r###"{"colour": {"  blue": 1, "RED": 1}}"###);
 
-        let map = FacetDistribution::new(&txn, &index)
+        let map = FacetDistribution::new(&txn, &index, &fields_ids_map)
             .facets(iter::once(("colour", OrderBy::default())))
             .candidates([2].iter().copied().collect())
             .execute()
@@ -493,7 +501,7 @@ mod tests {
 
         milli_snap!(format!("{map:?}"), @r###"{"colour": {"RED": 1}}"###);
 
-        let map = FacetDistribution::new(&txn, &index)
+        let map = FacetDistribution::new(&txn, &index, &fields_ids_map)
             .facets(iter::once(("colour", OrderBy::default())))
             .candidates([0, 1, 2].iter().copied().collect())
             .max_values_per_facet(1)
@@ -502,7 +510,7 @@ mod tests {
 
         milli_snap!(format!("{map:?}"), @r###"{"colour": {"Blue": 2}}"###);
 
-        let map = FacetDistribution::new(&txn, &index)
+        let map = FacetDistribution::new(&txn, &index, &fields_ids_map)
             .facets(iter::once(("colour", OrderBy::Count)))
             .candidates([0, 1, 2].iter().copied().collect())
             .max_values_per_facet(1)
@@ -540,15 +548,16 @@ mod tests {
         index.add_documents(documents).unwrap();
 
         let txn = index.read_txn().unwrap();
+        let fields_ids_map = index.fields_ids_map(&txn).unwrap();
 
-        let map = FacetDistribution::new(&txn, &index)
+        let map = FacetDistribution::new(&txn, &index, &fields_ids_map)
             .facets(iter::once(("colour", OrderBy::default())))
             .execute()
             .unwrap();
 
         milli_snap!(format!("{map:?}"), @r###"{"colour": {"Blue": 4000, "Red": 6000}}"###);
 
-        let map = FacetDistribution::new(&txn, &index)
+        let map = FacetDistribution::new(&txn, &index, &fields_ids_map)
             .facets(iter::once(("colour", OrderBy::default())))
             .max_values_per_facet(1)
             .execute()
@@ -556,7 +565,7 @@ mod tests {
 
         milli_snap!(format!("{map:?}"), @r###"{"colour": {"Blue": 4000}}"###);
 
-        let map = FacetDistribution::new(&txn, &index)
+        let map = FacetDistribution::new(&txn, &index, &fields_ids_map)
             .facets(iter::once(("colour", OrderBy::default())))
             .candidates((0..10_000).collect())
             .execute()
@@ -564,7 +573,7 @@ mod tests {
 
         milli_snap!(format!("{map:?}"), @r###"{"colour": {"Blue": 4000, "Red": 6000}}"###);
 
-        let map = FacetDistribution::new(&txn, &index)
+        let map = FacetDistribution::new(&txn, &index, &fields_ids_map)
             .facets(iter::once(("colour", OrderBy::default())))
             .candidates((0..5_000).collect())
             .execute()
@@ -572,7 +581,7 @@ mod tests {
 
         milli_snap!(format!("{map:?}"), @r###"{"colour": {"Blue": 2000, "Red": 3000}}"###);
 
-        let map = FacetDistribution::new(&txn, &index)
+        let map = FacetDistribution::new(&txn, &index, &fields_ids_map)
             .facets(iter::once(("colour", OrderBy::default())))
             .candidates((0..5_000).collect())
             .execute()
@@ -580,7 +589,7 @@ mod tests {
 
         milli_snap!(format!("{map:?}"), @r###"{"colour": {"Blue": 2000, "Red": 3000}}"###);
 
-        let map = FacetDistribution::new(&txn, &index)
+        let map = FacetDistribution::new(&txn, &index, &fields_ids_map)
             .facets(iter::once(("colour", OrderBy::default())))
             .candidates((0..5_000).collect())
             .max_values_per_facet(1)
@@ -589,7 +598,7 @@ mod tests {
 
         milli_snap!(format!("{map:?}"), @r###"{"colour": {"Blue": 2000}}"###);
 
-        let map = FacetDistribution::new(&txn, &index)
+        let map = FacetDistribution::new(&txn, &index, &fields_ids_map)
             .facets(iter::once(("colour", OrderBy::Count)))
             .candidates((0..5_000).collect())
             .max_values_per_facet(1)
@@ -627,15 +636,16 @@ mod tests {
         index.add_documents(documents).unwrap();
 
         let txn = index.read_txn().unwrap();
+        let fields_ids_map = index.fields_ids_map(&txn).unwrap();
 
-        let map = FacetDistribution::new(&txn, &index)
+        let map = FacetDistribution::new(&txn, &index, &fields_ids_map)
             .facets(iter::once(("colour", OrderBy::default())))
             .execute()
             .unwrap();
 
         milli_snap!(format!("{map:?}"), "no_candidates", @"ac9229ed5964d893af96a7076e2f8af5");
 
-        let map = FacetDistribution::new(&txn, &index)
+        let map = FacetDistribution::new(&txn, &index, &fields_ids_map)
             .facets(iter::once(("colour", OrderBy::default())))
             .max_values_per_facet(2)
             .execute()
@@ -643,7 +653,7 @@ mod tests {
 
         milli_snap!(format!("{map:?}"), "no_candidates_with_max_2", @r###"{"colour": {"0": 10, "1": 10}}"###);
 
-        let map = FacetDistribution::new(&txn, &index)
+        let map = FacetDistribution::new(&txn, &index, &fields_ids_map)
             .facets(iter::once(("colour", OrderBy::default())))
             .candidates((0..10_000).collect())
             .execute()
@@ -651,7 +661,7 @@ mod tests {
 
         milli_snap!(format!("{map:?}"), "candidates_0_10_000", @"ac9229ed5964d893af96a7076e2f8af5");
 
-        let map = FacetDistribution::new(&txn, &index)
+        let map = FacetDistribution::new(&txn, &index, &fields_ids_map)
             .facets(iter::once(("colour", OrderBy::default())))
             .candidates((0..5_000).collect())
             .execute()
@@ -688,15 +698,16 @@ mod tests {
         index.add_documents(documents).unwrap();
 
         let txn = index.read_txn().unwrap();
+        let fields_ids_map = index.fields_ids_map(&txn).unwrap();
 
-        let map = FacetDistribution::new(&txn, &index)
+        let map = FacetDistribution::new(&txn, &index, &fields_ids_map)
             .facets(iter::once(("colour", OrderBy::default())))
             .compute_stats()
             .unwrap();
 
         milli_snap!(format!("{map:?}"), "no_candidates", @"{}");
 
-        let map = FacetDistribution::new(&txn, &index)
+        let map = FacetDistribution::new(&txn, &index, &fields_ids_map)
             .facets(iter::once(("colour", OrderBy::default())))
             .candidates((0..1000).collect())
             .compute_stats()
@@ -704,7 +715,7 @@ mod tests {
 
         milli_snap!(format!("{map:?}"), "candidates_0_1000", @r###"{"colour": (0.0, 999.0)}"###);
 
-        let map = FacetDistribution::new(&txn, &index)
+        let map = FacetDistribution::new(&txn, &index, &fields_ids_map)
             .facets(iter::once(("colour", OrderBy::default())))
             .candidates((217..777).collect())
             .compute_stats()
@@ -741,15 +752,16 @@ mod tests {
         index.add_documents(documents).unwrap();
 
         let txn = index.read_txn().unwrap();
+        let fields_ids_map = index.fields_ids_map(&txn).unwrap();
 
-        let map = FacetDistribution::new(&txn, &index)
+        let map = FacetDistribution::new(&txn, &index, &fields_ids_map)
             .facets(iter::once(("colour", OrderBy::default())))
             .compute_stats()
             .unwrap();
 
         milli_snap!(format!("{map:?}"), "no_candidates", @"{}");
 
-        let map = FacetDistribution::new(&txn, &index)
+        let map = FacetDistribution::new(&txn, &index, &fields_ids_map)
             .facets(iter::once(("colour", OrderBy::default())))
             .candidates((0..1000).collect())
             .compute_stats()
@@ -757,7 +769,7 @@ mod tests {
 
         milli_snap!(format!("{map:?}"), "candidates_0_1000", @r###"{"colour": (0.0, 1999.0)}"###);
 
-        let map = FacetDistribution::new(&txn, &index)
+        let map = FacetDistribution::new(&txn, &index, &fields_ids_map)
             .facets(iter::once(("colour", OrderBy::default())))
             .candidates((217..777).collect())
             .compute_stats()
@@ -794,15 +806,16 @@ mod tests {
         index.add_documents(documents).unwrap();
 
         let txn = index.read_txn().unwrap();
+        let fields_ids_map = index.fields_ids_map(&txn).unwrap();
 
-        let map = FacetDistribution::new(&txn, &index)
+        let map = FacetDistribution::new(&txn, &index, &fields_ids_map)
             .facets(iter::once(("colour", OrderBy::default())))
             .compute_stats()
             .unwrap();
 
         milli_snap!(format!("{map:?}"), "no_candidates", @"{}");
 
-        let map = FacetDistribution::new(&txn, &index)
+        let map = FacetDistribution::new(&txn, &index, &fields_ids_map)
             .facets(iter::once(("colour", OrderBy::default())))
             .candidates((0..1000).collect())
             .compute_stats()
@@ -810,7 +823,7 @@ mod tests {
 
         milli_snap!(format!("{map:?}"), "candidates_0_1000", @r###"{"colour": (0.0, 999.0)}"###);
 
-        let map = FacetDistribution::new(&txn, &index)
+        let map = FacetDistribution::new(&txn, &index, &fields_ids_map)
             .facets(iter::once(("colour", OrderBy::default())))
             .candidates((217..777).collect())
             .compute_stats()
@@ -852,15 +865,16 @@ mod tests {
         index.add_documents(documents).unwrap();
 
         let txn = index.read_txn().unwrap();
+        let fields_ids_map = index.fields_ids_map(&txn).unwrap();
 
-        let map = FacetDistribution::new(&txn, &index)
+        let map = FacetDistribution::new(&txn, &index, &fields_ids_map)
             .facets(iter::once(("colour", OrderBy::default())))
             .compute_stats()
             .unwrap();
 
         milli_snap!(format!("{map:?}"), "no_candidates", @"{}");
 
-        let map = FacetDistribution::new(&txn, &index)
+        let map = FacetDistribution::new(&txn, &index, &fields_ids_map)
             .facets(iter::once(("colour", OrderBy::default())))
             .candidates((0..1000).collect())
             .compute_stats()
@@ -868,7 +882,7 @@ mod tests {
 
         milli_snap!(format!("{map:?}"), "candidates_0_1000", @r###"{"colour": (0.0, 1998.0)}"###);
 
-        let map = FacetDistribution::new(&txn, &index)
+        let map = FacetDistribution::new(&txn, &index, &fields_ids_map)
             .facets(iter::once(("colour", OrderBy::default())))
             .candidates((217..777).collect())
             .compute_stats()

--- a/crates/milli/src/search/facet/filter/index_filter.rs
+++ b/crates/milli/src/search/facet/filter/index_filter.rs
@@ -39,9 +39,13 @@ impl From<IndexFilterCondition> for IndexFilter {
 }
 
 impl IndexFilter {
-    pub fn evaluate(&self, rtxn: &heed::RoTxn<'_>, index: &Index) -> Result<RoaringBitmap> {
+    pub fn evaluate(
+        &self,
+        rtxn: &heed::RoTxn<'_>,
+        index: &Index,
+        fields_ids_map: &FieldsIdsMap,
+    ) -> Result<RoaringBitmap> {
         // to avoid doing this for each recursive call we're going to do it ONCE ahead of time
-        let fields_ids_map = index.fields_ids_map(rtxn)?;
         let filterable_attributes_rules = index.filterable_attributes_rules(rtxn)?;
 
         for fid in self.condition.fids(MAX_FILTER_DEPTH) {
@@ -64,7 +68,7 @@ impl IndexFilter {
             }))?;
         }
 
-        self.inner_evaluate(rtxn, index, &fields_ids_map, &filterable_attributes_rules, None)
+        self.inner_evaluate(rtxn, index, fields_ids_map, &filterable_attributes_rules, None)
     }
 
     fn evaluate_operator(

--- a/crates/milli/src/search/facet/filter/tests.rs
+++ b/crates/milli/src/search/facet/filter/tests.rs
@@ -61,13 +61,14 @@ fn empty_db() {
         .unwrap();
 
     let rtxn = index.read_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
 
     let filter = Filter::from_str("PrIcE < 1000").unwrap().unwrap();
-    let bitmap = IndexFilter::from(filter).evaluate(&rtxn, &index).unwrap();
+    let bitmap = IndexFilter::from(filter).evaluate(&rtxn, &index, &fields_ids_map).unwrap();
     assert!(bitmap.is_empty());
 
     let filter = Filter::from_str("NOT PrIcE >= 1000").unwrap().unwrap();
-    let bitmap = IndexFilter::from(filter).evaluate(&rtxn, &index).unwrap();
+    let bitmap = IndexFilter::from(filter).evaluate(&rtxn, &index, &fields_ids_map).unwrap();
     assert!(bitmap.is_empty());
 }
 
@@ -136,22 +137,23 @@ fn not_filterable() {
     let index = TempIndex::new();
 
     let rtxn = index.read_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
     let filter = Filter::from_str("_geoRadius(42, 150, 10)").unwrap().unwrap();
-    let error = IndexFilter::from(filter).evaluate(&rtxn, &index).unwrap_err();
+    let error = IndexFilter::from(filter).evaluate(&rtxn, &index, &fields_ids_map).unwrap_err();
     snapshot!(error.to_string(), @r"
         Attribute `_geo/_geojson` is not filterable. This index does not have configured filterable attributes.
         12:14 _geoRadius(42, 150, 10)
         ");
 
     let filter = Filter::from_str("_geoBoundingBox([42, 150], [30, 10])").unwrap().unwrap();
-    let error = IndexFilter::from(filter).evaluate(&rtxn, &index).unwrap_err();
+    let error = IndexFilter::from(filter).evaluate(&rtxn, &index, &fields_ids_map).unwrap_err();
     snapshot!(error.to_string(), @r"
         Attribute `_geo/_geojson` is not filterable. This index does not have configured filterable attributes.
         18:20 _geoBoundingBox([42, 150], [30, 10])
         ");
 
     let filter = Filter::from_str("dog = \"bernese mountain\"").unwrap().unwrap();
-    let error = IndexFilter::from(filter).evaluate(&rtxn, &index).unwrap_err();
+    let error = IndexFilter::from(filter).evaluate(&rtxn, &index, &fields_ids_map).unwrap_err();
     snapshot!(error.to_string(), @r###"
         Attribute `dog` is not filterable. This index does not have configured filterable attributes.
         1:4 dog = "bernese mountain"
@@ -169,42 +171,42 @@ fn not_filterable() {
     let rtxn = index.read_txn().unwrap();
 
     let filter = Filter::from_str("_geoRadius(-90, 150, 10)").unwrap().unwrap();
-    let error = IndexFilter::from(filter).evaluate(&rtxn, &index).unwrap_err();
+    let error = IndexFilter::from(filter).evaluate(&rtxn, &index, &fields_ids_map).unwrap_err();
     snapshot!(error.to_string(), @r"
         Attribute `_geo/_geojson` is not filterable. Available filterable attribute patterns are: `title`.
         12:15 _geoRadius(-90, 150, 10)
         ");
 
     let filter = Filter::from_str("_geoBoundingBox([42, 150], [30, 10])").unwrap().unwrap();
-    let error = IndexFilter::from(filter).evaluate(&rtxn, &index).unwrap_err();
+    let error = IndexFilter::from(filter).evaluate(&rtxn, &index, &fields_ids_map).unwrap_err();
     snapshot!(error.to_string(), @r"
         Attribute `_geo/_geojson` is not filterable. Available filterable attribute patterns are: `title`.
         18:20 _geoBoundingBox([42, 150], [30, 10])
         ");
 
     let filter = Filter::from_str("name = 12").unwrap().unwrap();
-    let error = IndexFilter::from(filter).evaluate(&rtxn, &index).unwrap_err();
+    let error = IndexFilter::from(filter).evaluate(&rtxn, &index, &fields_ids_map).unwrap_err();
     snapshot!(error.to_string(), @r###"
         Attribute `name` is not filterable. Available filterable attribute patterns are: `title`.
         1:5 name = 12
         "###);
 
     let filter = Filter::from_str("title = \"test\" AND name = 12").unwrap().unwrap();
-    let error = IndexFilter::from(filter).evaluate(&rtxn, &index).unwrap_err();
+    let error = IndexFilter::from(filter).evaluate(&rtxn, &index, &fields_ids_map).unwrap_err();
     snapshot!(error.to_string(), @r###"
         Attribute `name` is not filterable. Available filterable attribute patterns are: `title`.
         20:24 title = "test" AND name = 12
         "###);
 
     let filter = Filter::from_str("title = \"test\" AND name IN [12]").unwrap().unwrap();
-    let error = IndexFilter::from(filter).evaluate(&rtxn, &index).unwrap_err();
+    let error = IndexFilter::from(filter).evaluate(&rtxn, &index, &fields_ids_map).unwrap_err();
     snapshot!(error.to_string(), @r###"
         Attribute `name` is not filterable. Available filterable attribute patterns are: `title`.
         20:24 title = "test" AND name IN [12]
         "###);
 
     let filter = Filter::from_str("title = \"test\" AND name != 12").unwrap().unwrap();
-    let error = IndexFilter::from(filter).evaluate(&rtxn, &index).unwrap_err();
+    let error = IndexFilter::from(filter).evaluate(&rtxn, &index, &fields_ids_map).unwrap_err();
     snapshot!(error.to_string(), @r###"
         Attribute `name` is not filterable. Available filterable attribute patterns are: `title`.
         20:24 title = "test" AND name != 12
@@ -329,10 +331,11 @@ fn geo_radius_error() {
         .unwrap();
 
     let rtxn = index.read_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
 
     // georadius have a bad latitude
     let filter = Filter::from_str("_geoRadius(-100, 150, 10)").unwrap().unwrap();
-    let error = IndexFilter::from(filter).evaluate(&rtxn, &index).unwrap_err();
+    let error = IndexFilter::from(filter).evaluate(&rtxn, &index, &fields_ids_map).unwrap_err();
     snapshot!(error.to_string(), @r"
         Bad latitude `-100`. Latitude must be contained between -90 and 90 degrees.
         12:16 _geoRadius(-100, 150, 10)
@@ -340,7 +343,7 @@ fn geo_radius_error() {
 
     // georadius have a bad latitude
     let filter = Filter::from_str("_geoRadius(-90.0000001, 150, 10)").unwrap().unwrap();
-    let error = IndexFilter::from(filter).evaluate(&rtxn, &index).unwrap_err();
+    let error = IndexFilter::from(filter).evaluate(&rtxn, &index, &fields_ids_map).unwrap_err();
     snapshot!(error.to_string(), @r"
         Bad latitude `-90.0000001`. Latitude must be contained between -90 and 90 degrees.
         12:23 _geoRadius(-90.0000001, 150, 10)
@@ -348,7 +351,7 @@ fn geo_radius_error() {
 
     // georadius have a bad longitude
     let filter = Filter::from_str("_geoRadius(-10, 250, 10)").unwrap().unwrap();
-    let error = IndexFilter::from(filter).evaluate(&rtxn, &index).unwrap_err();
+    let error = IndexFilter::from(filter).evaluate(&rtxn, &index, &fields_ids_map).unwrap_err();
     snapshot!(error.to_string(), @r"
         Bad longitude `250`. Longitude must be contained between -180 and 180 degrees. Hint: try using `-110` instead.
         17:20 _geoRadius(-10, 250, 10)
@@ -356,7 +359,7 @@ fn geo_radius_error() {
 
     // georadius have a bad longitude
     let filter = Filter::from_str("_geoRadius(-10, 180.000001, 10)").unwrap().unwrap();
-    let error = IndexFilter::from(filter).evaluate(&rtxn, &index).unwrap_err();
+    let error = IndexFilter::from(filter).evaluate(&rtxn, &index, &fields_ids_map).unwrap_err();
     snapshot!(error.to_string(), @r"
         Bad longitude `180.000001`. Longitude must be contained between -180 and 180 degrees. Hint: try using `-179.999999` instead.
         17:27 _geoRadius(-10, 180.000001, 10)
@@ -378,11 +381,12 @@ fn geo_bounding_box_error() {
         .unwrap();
 
     let rtxn = index.read_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
 
     // geoboundingbox top left coord have a bad latitude
     let filter =
         Filter::from_str("_geoBoundingBox([-90.0000001, 150], [30, 10])").unwrap().unwrap();
-    let error = IndexFilter::from(filter).evaluate(&rtxn, &index).unwrap_err();
+    let error = IndexFilter::from(filter).evaluate(&rtxn, &index, &fields_ids_map).unwrap_err();
     snapshot!(error.to_string(), @r"
         Bad latitude `-90.0000001`. Latitude must be contained between -90 and 90 degrees.
         18:29 _geoBoundingBox([-90.0000001, 150], [30, 10])
@@ -390,7 +394,7 @@ fn geo_bounding_box_error() {
 
     // geoboundingbox top left coord have a bad latitude
     let filter = Filter::from_str("_geoBoundingBox([90.0000001, 150], [30, 10])").unwrap().unwrap();
-    let error = IndexFilter::from(filter).evaluate(&rtxn, &index).unwrap_err();
+    let error = IndexFilter::from(filter).evaluate(&rtxn, &index, &fields_ids_map).unwrap_err();
     snapshot!(error.to_string(), @r"
         Bad latitude `90.0000001`. Latitude must be contained between -90 and 90 degrees.
         18:28 _geoBoundingBox([90.0000001, 150], [30, 10])
@@ -399,7 +403,7 @@ fn geo_bounding_box_error() {
     // geoboundingbox bottom right coord have a bad latitude
     let filter =
         Filter::from_str("_geoBoundingBox([30, 10], [-90.0000001, 150])").unwrap().unwrap();
-    let error = IndexFilter::from(filter).evaluate(&rtxn, &index).unwrap_err();
+    let error = IndexFilter::from(filter).evaluate(&rtxn, &index, &fields_ids_map).unwrap_err();
     snapshot!(error.to_string(), @r"
         Bad latitude `-90.0000001`. Latitude must be contained between -90 and 90 degrees.
         28:39 _geoBoundingBox([30, 10], [-90.0000001, 150])
@@ -407,7 +411,7 @@ fn geo_bounding_box_error() {
 
     // geoboundingbox bottom right coord have a bad latitude
     let filter = Filter::from_str("_geoBoundingBox([30, 10], [90.0000001, 150])").unwrap().unwrap();
-    let error = IndexFilter::from(filter).evaluate(&rtxn, &index).unwrap_err();
+    let error = IndexFilter::from(filter).evaluate(&rtxn, &index, &fields_ids_map).unwrap_err();
     snapshot!(error.to_string(), @r"
         Bad latitude `90.0000001`. Latitude must be contained between -90 and 90 degrees.
         28:38 _geoBoundingBox([30, 10], [90.0000001, 150])
@@ -415,7 +419,7 @@ fn geo_bounding_box_error() {
 
     // geoboundingbox top left coord have a bad longitude
     let filter = Filter::from_str("_geoBoundingBox([-10, 180.000001], [30, 10])").unwrap().unwrap();
-    let error = IndexFilter::from(filter).evaluate(&rtxn, &index).unwrap_err();
+    let error = IndexFilter::from(filter).evaluate(&rtxn, &index, &fields_ids_map).unwrap_err();
     snapshot!(error.to_string(), @r"
         Bad longitude `180.000001`. Longitude must be contained between -180 and 180 degrees. Hint: try using `-179.999999` instead.
         23:33 _geoBoundingBox([-10, 180.000001], [30, 10])
@@ -424,7 +428,7 @@ fn geo_bounding_box_error() {
     // geoboundingbox top left coord have a bad longitude
     let filter =
         Filter::from_str("_geoBoundingBox([-10, -180.000001], [30, 10])").unwrap().unwrap();
-    let error = IndexFilter::from(filter).evaluate(&rtxn, &index).unwrap_err();
+    let error = IndexFilter::from(filter).evaluate(&rtxn, &index, &fields_ids_map).unwrap_err();
     snapshot!(error.to_string(), @r"
         Bad longitude `-180.000001`. Longitude must be contained between -180 and 180 degrees. Hint: try using `179.999999` instead.
         23:34 _geoBoundingBox([-10, -180.000001], [30, 10])
@@ -433,7 +437,7 @@ fn geo_bounding_box_error() {
     // geoboundingbox bottom right coord have a bad longitude
     let filter =
         Filter::from_str("_geoBoundingBox([30, 10], [-10, -180.000001])").unwrap().unwrap();
-    let error = IndexFilter::from(filter).evaluate(&rtxn, &index).unwrap_err();
+    let error = IndexFilter::from(filter).evaluate(&rtxn, &index, &fields_ids_map).unwrap_err();
     snapshot!(error.to_string(), @r"
         Bad longitude `-180.000001`. Longitude must be contained between -180 and 180 degrees. Hint: try using `179.999999` instead.
         33:44 _geoBoundingBox([30, 10], [-10, -180.000001])
@@ -441,7 +445,7 @@ fn geo_bounding_box_error() {
 
     // geoboundingbox bottom right coord have a bad longitude
     let filter = Filter::from_str("_geoBoundingBox([30, 10], [-10, 180.000001])").unwrap().unwrap();
-    let error = IndexFilter::from(filter).evaluate(&rtxn, &index).unwrap_err();
+    let error = IndexFilter::from(filter).evaluate(&rtxn, &index, &fields_ids_map).unwrap_err();
     snapshot!(error.to_string(), @r"
         Bad longitude `180.000001`. Longitude must be contained between -180 and 180 degrees. Hint: try using `-179.999999` instead.
         33:43 _geoBoundingBox([30, 10], [-10, 180.000001])
@@ -501,26 +505,27 @@ fn non_finite_float() {
         .unwrap();
 
     let rtxn = index.read_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
     let filter = Filter::from_str("price = inf").unwrap().unwrap();
-    let result = IndexFilter::from(filter).evaluate(&rtxn, &index).unwrap();
+    let result = IndexFilter::from(filter).evaluate(&rtxn, &index, &fields_ids_map).unwrap();
     assert!(result.contains(0));
     let filter = Filter::from_str("price < inf").unwrap().unwrap();
-    let result = IndexFilter::from(filter).evaluate(&rtxn, &index).unwrap();
+    let result = IndexFilter::from(filter).evaluate(&rtxn, &index, &fields_ids_map).unwrap();
     // this is allowed due to filters with strings
     assert!(result.contains(1));
 
     let filter = Filter::from_str("price = NaN").unwrap().unwrap();
-    let result = IndexFilter::from(filter).evaluate(&rtxn, &index).unwrap();
+    let result = IndexFilter::from(filter).evaluate(&rtxn, &index, &fields_ids_map).unwrap();
     assert!(result.is_empty());
     let filter = Filter::from_str("price < NaN").unwrap().unwrap();
-    let result = IndexFilter::from(filter).evaluate(&rtxn, &index).unwrap();
+    let result = IndexFilter::from(filter).evaluate(&rtxn, &index, &fields_ids_map).unwrap();
     assert!(result.contains(1));
 
     let filter = Filter::from_str("price = infinity").unwrap().unwrap();
-    let result = IndexFilter::from(filter).evaluate(&rtxn, &index).unwrap();
+    let result = IndexFilter::from(filter).evaluate(&rtxn, &index, &fields_ids_map).unwrap();
     assert!(result.contains(2));
     let filter = Filter::from_str("price < infinity").unwrap().unwrap();
-    let result = IndexFilter::from(filter).evaluate(&rtxn, &index).unwrap();
+    let result = IndexFilter::from(filter).evaluate(&rtxn, &index, &fields_ids_map).unwrap();
     assert!(result.contains(0));
     assert!(result.contains(1));
 }
@@ -548,57 +553,60 @@ fn filter_number() {
     index.add_documents(documents!(docs)).unwrap();
 
     let rtxn = index.read_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
     for i in 0..100 {
         let filter_str = format!("id = {i}");
         let filter = Filter::from_str(&filter_str).unwrap().unwrap();
-        let result = IndexFilter::from(filter).evaluate(&rtxn, &index).unwrap();
+        let result = IndexFilter::from(filter).evaluate(&rtxn, &index, &fields_ids_map).unwrap();
         assert_eq!(result, RoaringBitmap::from_iter([i]));
     }
     for i in 0..100 {
         let filter_str = format!("id > {i}");
         let filter = Filter::from_str(&filter_str).unwrap().unwrap();
-        let result = IndexFilter::from(filter).evaluate(&rtxn, &index).unwrap();
+        let result = IndexFilter::from(filter).evaluate(&rtxn, &index, &fields_ids_map).unwrap();
         assert_eq!(result, RoaringBitmap::from_iter((i + 1)..100));
     }
     for i in 0..100 {
         let filter_str = format!("id < {i}");
         let filter = Filter::from_str(&filter_str).unwrap().unwrap();
-        let result = IndexFilter::from(filter).evaluate(&rtxn, &index).unwrap();
+        let result = IndexFilter::from(filter).evaluate(&rtxn, &index, &fields_ids_map).unwrap();
         assert_eq!(result, RoaringBitmap::from_iter(0..i));
     }
     for i in 0..100 {
         let filter_str = format!("id <= {i}");
         let filter = Filter::from_str(&filter_str).unwrap().unwrap();
-        let result = IndexFilter::from(filter).evaluate(&rtxn, &index).unwrap();
+        let result = IndexFilter::from(filter).evaluate(&rtxn, &index, &fields_ids_map).unwrap();
         assert_eq!(result, RoaringBitmap::from_iter(0..=i));
     }
     for i in 0..100 {
         let filter_str = format!("id >= {i}");
         let filter = Filter::from_str(&filter_str).unwrap().unwrap();
-        let result = IndexFilter::from(filter).evaluate(&rtxn, &index).unwrap();
+        let result = IndexFilter::from(filter).evaluate(&rtxn, &index, &fields_ids_map).unwrap();
         assert_eq!(result, RoaringBitmap::from_iter(i..100));
     }
     for i in 0..100 {
         for j in i..100 {
             let filter_str = format!("id {i} TO {j}");
             let filter = Filter::from_str(&filter_str).unwrap().unwrap();
-            let result = IndexFilter::from(filter).evaluate(&rtxn, &index).unwrap();
+            let result =
+                IndexFilter::from(filter).evaluate(&rtxn, &index, &fields_ids_map).unwrap();
             assert_eq!(result, RoaringBitmap::from_iter(i..=j));
         }
     }
     let filter = Filter::from_str("one >= 0 OR one <= 0").unwrap().unwrap();
-    let result = IndexFilter::from(filter).evaluate(&rtxn, &index).unwrap();
+    let result = IndexFilter::from(filter).evaluate(&rtxn, &index, &fields_ids_map).unwrap();
     assert_eq!(result, RoaringBitmap::default());
 
     let filter = Filter::from_str("one = 0").unwrap().unwrap();
-    let result = IndexFilter::from(filter).evaluate(&rtxn, &index).unwrap();
+    let result = IndexFilter::from(filter).evaluate(&rtxn, &index, &fields_ids_map).unwrap();
     assert_eq!(result, RoaringBitmap::default());
 
     for i in 0..10 {
         for j in i..10 {
             let filter_str = format!("two {i} TO {j}");
             let filter = Filter::from_str(&filter_str).unwrap().unwrap();
-            let result = IndexFilter::from(filter).evaluate(&rtxn, &index).unwrap();
+            let result =
+                IndexFilter::from(filter).evaluate(&rtxn, &index, &fields_ids_map).unwrap();
             assert_eq!(
                 result,
                 RoaringBitmap::from_iter((0..100).filter(|x| (i..=j).contains(&(x % 10))))
@@ -606,7 +614,7 @@ fn filter_number() {
         }
     }
     let filter = Filter::from_str("two != 0").unwrap().unwrap();
-    let result = IndexFilter::from(filter).evaluate(&rtxn, &index).unwrap();
+    let result = IndexFilter::from(filter).evaluate(&rtxn, &index, &fields_ids_map).unwrap();
     assert_eq!(result, RoaringBitmap::from_iter((0..100).filter(|x| x % 10 != 0)));
 }
 

--- a/crates/milli/src/search/facet/filter/tests.rs
+++ b/crates/milli/src/search/facet/filter/tests.rs
@@ -243,8 +243,9 @@ fn escaped_quote_in_filter_value_2380() {
         .unwrap();
 
     let rtxn = index.read_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
 
-    let mut search = index.search(&rtxn);
+    let mut search = index.search(&rtxn, &fields_ids_map);
     // this filter is copy pasted from #2380 with the exact same espace sequence
     let filter = Filter::from_str("monitor_diagonal = '27\" to 30\\''").unwrap().unwrap();
     search.filter(Some(IndexFilter::from(filter)));
@@ -307,8 +308,9 @@ fn zero_radius() {
         .unwrap();
 
     let rtxn = index.read_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
 
-    let mut search = index.search(&rtxn);
+    let mut search = index.search(&rtxn, &fields_ids_map);
 
     let filter = Filter::from_str("_geoRadius(45.4777599, 9.1967508, 0)").unwrap().unwrap();
     search.filter(Some(IndexFilter::from(filter)));

--- a/crates/milli/src/search/facet/search.rs
+++ b/crates/milli/src/search/facet/search.rs
@@ -14,7 +14,7 @@ use crate::error::UserError;
 use crate::filterable_attributes_rules::{filtered_matching_patterns, matching_features};
 use crate::heed_codec::facet::{FacetGroupKey, FacetGroupValue};
 use crate::search::build_dfa;
-use crate::{DocumentId, FieldId, Index, OrderBy, Result};
+use crate::{DocumentId, FieldId, FieldsIdsMap, Index, OrderBy, Result};
 
 /// The maximum number of values per facet returned by the facet search route.
 const DEFAULT_MAX_NUMBER_OF_VALUES_PER_FACET: usize = 100;
@@ -23,18 +23,25 @@ pub struct SearchForFacetValues<'a> {
     query: Option<String>,
     facet: String,
     index: &'a Index,
+    fields_ids_map: &'a FieldsIdsMap,
     rtxn: &'a RoTxn<'a>,
     max_values: usize,
     locales: Option<Vec<Language>>,
 }
 
 impl<'a> SearchForFacetValues<'a> {
-    pub fn new(facet: String, index: &'a Index, rtxn: &'a RoTxn<'a>) -> SearchForFacetValues<'a> {
+    pub fn new(
+        facet: String,
+        index: &'a Index,
+        rtxn: &'a RoTxn<'a>,
+        fields_ids_map: &'a FieldsIdsMap,
+    ) -> SearchForFacetValues<'a> {
         SearchForFacetValues {
             query: None,
             facet,
             index,
             rtxn,
+            fields_ids_map,
             max_values: DEFAULT_MAX_NUMBER_OF_VALUES_PER_FACET,
             locales: None,
         }
@@ -95,8 +102,7 @@ impl<'a> SearchForFacetValues<'a> {
             .into());
         };
 
-        let fields_ids_map = index.fields_ids_map(rtxn)?;
-        let Some(fid) = fields_ids_map.id(&self.facet) else {
+        let Some(fid) = self.fields_ids_map.id(&self.facet) else {
             return Ok((Vec::new(), order));
         };
 
@@ -129,7 +135,8 @@ impl<'a> SearchForFacetValues<'a> {
                 let query = query.as_ref();
 
                 let authorize_typos = index.authorize_typos(rtxn)?;
-                let field_authorizes_typos = !index.exact_attributes_ids(rtxn)?.contains(&fid);
+                let field_authorizes_typos =
+                    !index.exact_attributes_ids(rtxn, self.fields_ids_map)?.contains(&fid);
 
                 if authorize_typos && field_authorizes_typos {
                     let exact_words_fst = index.exact_words(rtxn)?;

--- a/crates/milli/src/search/hybrid.rs
+++ b/crates/milli/src/search/hybrid.rs
@@ -278,7 +278,7 @@ impl Search<'_> {
             max_total_hits: self.max_total_hits,
             rtxn: self.rtxn,
             index: self.index,
-            fields_ids_map: self.fields_ids_map,
+            fields_ids_map: self.fields_ids_map.clone(),
             index_uid: self.index_uid,
             before_search: self.before_search,
             semantic: self.semantic.clone(),

--- a/crates/milli/src/search/hybrid.rs
+++ b/crates/milli/src/search/hybrid.rs
@@ -10,7 +10,8 @@ use crate::search::steps::SearchStep;
 use crate::search::SemanticSearch;
 use crate::vector::{Embedding, SearchQuery};
 use crate::{
-    merge_positioned_hits_into_page, Index, MatchingWords, PinDoc, Result, Search, SearchResult,
+    merge_positioned_hits_into_page, FieldsIdsMap, Index, MatchingWords, PinDoc, Result, Search,
+    SearchResult,
 };
 
 struct ScoreWithRatioResult {
@@ -97,6 +98,7 @@ impl ScoreWithRatioResult {
     }
 
     #[tracing::instrument(level = "trace", skip_all, target = "search::hybrid")]
+    #[allow(clippy::too_many_arguments)]
     fn merge(
         mut vector_results: Self,
         mut keyword_results: Self,
@@ -105,6 +107,7 @@ impl ScoreWithRatioResult {
         distinct: Option<&str>,
         index: &Index,
         rtxn: &RoTxn<'_>,
+        fields_ids_map: &FieldsIdsMap,
     ) -> Result<(SearchResult, u32)> {
         // Pinned documents carry ScoreDetails::Pin, which is a placement directive, not a score.
         // We extract them before the score-based merge, merge organic results normally, then
@@ -146,7 +149,7 @@ impl ScoreWithRatioResult {
             vector_results.document_scores.len() + keyword_results.document_scores.len(),
         );
 
-        let distinct_fid = distinct_fid(distinct, index, rtxn)?;
+        let distinct_fid = distinct_fid(distinct, index, rtxn, fields_ids_map)?;
         // Seed excluded_documents with pinned docids so they don't appear as organic results
         // (they'll be re-injected at their target positions after the merge).
         let mut excluded_documents = pinned_doc_ids.clone();
@@ -356,6 +359,7 @@ impl Search<'_> {
             search.distinct.as_deref(),
             search.index,
             search.rtxn,
+            search.fields_ids_map.as_ref(),
         )?;
         assert!(merge_results.documents_ids.len() <= self.limit);
         Ok((merge_results, Some(semantic_hit_count)))

--- a/crates/milli/src/search/hybrid.rs
+++ b/crates/milli/src/search/hybrid.rs
@@ -278,6 +278,7 @@ impl Search<'_> {
             max_total_hits: self.max_total_hits,
             rtxn: self.rtxn,
             index: self.index,
+            fields_ids_map: self.fields_ids_map,
             index_uid: self.index_uid,
             before_search: self.before_search,
             semantic: self.semantic.clone(),

--- a/crates/milli/src/search/hybrid.rs
+++ b/crates/milli/src/search/hybrid.rs
@@ -281,7 +281,7 @@ impl Search<'_> {
             max_total_hits: self.max_total_hits,
             rtxn: self.rtxn,
             index: self.index,
-            fields_ids_map: self.fields_ids_map.clone(),
+            fields_ids_map: self.fields_ids_map,
             index_uid: self.index_uid,
             before_search: self.before_search,
             semantic: self.semantic.clone(),
@@ -359,7 +359,7 @@ impl Search<'_> {
             search.distinct.as_deref(),
             search.index,
             search.rtxn,
-            search.fields_ids_map.as_ref(),
+            search.fields_ids_map,
         )?;
         assert!(merge_results.documents_ids.len() <= self.limit);
         Ok((merge_results, Some(semantic_hit_count)))

--- a/crates/milli/src/search/mod.rs
+++ b/crates/milli/src/search/mod.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::fmt;
 use std::sync::Arc;
 
@@ -73,7 +74,7 @@ pub struct Search<'a> {
     max_total_hits: Option<usize>,
     rtxn: &'a heed::RoTxn<'a>,
     index: &'a Index,
-    fields_ids_map: &'a FieldsIdsMap,
+    fields_ids_map: Cow<'a, FieldsIdsMap>,
     index_uid: &'a str,
     before_search: OffsetDateTime,
     semantic: Option<SemanticSearch>,
@@ -89,7 +90,7 @@ impl<'a> Search<'a> {
     pub fn new(
         rtxn: &'a heed::RoTxn<'a>,
         index: &'a Index,
-        fields_ids_map: &'a FieldsIdsMap,
+        fields_ids_map: Cow<'a, FieldsIdsMap>,
         index_uid: &'a str,
         before_search: OffsetDateTime,
         progress: &'a Progress,
@@ -260,7 +261,7 @@ impl<'a> Search<'a> {
             let ctx = SearchContext::new(
                 self.index,
                 self.rtxn,
-                self.fields_ids_map,
+                self.fields_ids_map.as_ref(),
                 self.index_uid,
                 self.before_search,
             )?;
@@ -274,7 +275,7 @@ impl<'a> Search<'a> {
         let mut ctx = SearchContext::new(
             self.index,
             self.rtxn,
-            self.fields_ids_map,
+            self.fields_ids_map.as_ref(),
             self.index_uid,
             self.before_search,
         )?;

--- a/crates/milli/src/search/mod.rs
+++ b/crates/milli/src/search/mod.rs
@@ -397,26 +397,27 @@ impl<'a> Search<'a> {
 
         let mut ignored = RoaringBitmap::new();
 
-        let query_graph_terms = if let Some(query) = self.query.as_deref() {
-            let _step = self.progress.update_progress_scoped(SearchStep::TokenizeQuery);
+        let query_graph_terms =
+            if let Some(query) = self.query.as_deref().filter(|q| !q.trim().is_empty()) {
+                let _step = self.progress.update_progress_scoped(SearchStep::TokenizeQuery);
 
-            let ExtractedTokens { query_terms, graph, negative_words, negative_phrases } =
-                extract_tokens(ctx, query, Some(self.words_limit), self.locales.as_ref())?;
+                let ExtractedTokens { query_terms, graph, negative_words, negative_phrases } =
+                    extract_tokens(ctx, query, Some(self.words_limit), self.locales.as_ref())?;
 
-            used_negative_operator = !negative_words.is_empty() || !negative_phrases.is_empty();
+                used_negative_operator = !negative_words.is_empty() || !negative_phrases.is_empty();
 
-            ignored |= resolve_negative_words(ctx, Some(&*universe), &negative_words)?;
-            ignored |= resolve_negative_phrases(ctx, &negative_phrases)?;
+                ignored |= resolve_negative_words(ctx, Some(&*universe), &negative_words)?;
+                ignored |= resolve_negative_phrases(ctx, &negative_phrases)?;
 
-            if query_terms.is_empty() {
-                // Do a placeholder search instead
-                None
+                if query_terms.is_empty() {
+                    // Do a placeholder search instead
+                    None
+                } else {
+                    Some((graph, query_terms))
+                }
             } else {
-                Some((graph, query_terms))
-            }
-        } else {
-            None
-        };
+                None
+            };
 
         let pins = self
             .dynamic_search_rules

--- a/crates/milli/src/search/mod.rs
+++ b/crates/milli/src/search/mod.rs
@@ -25,7 +25,7 @@ use crate::search::new::{
 use crate::vector::{Embedder, Embedding};
 use crate::{
     execute_search, filtered_universe, AscDesc, Deadline, DefaultSearchLogger, DocumentId, Error,
-    Index, Position, Result, SearchContext, SearchStep, UserError,
+    FieldsIdsMap, Index, Position, Result, SearchContext, SearchStep, UserError,
 };
 
 // Building these factories is not free.
@@ -73,6 +73,7 @@ pub struct Search<'a> {
     max_total_hits: Option<usize>,
     rtxn: &'a heed::RoTxn<'a>,
     index: &'a Index,
+    fields_ids_map: &'a FieldsIdsMap,
     index_uid: &'a str,
     before_search: OffsetDateTime,
     semantic: Option<SemanticSearch>,
@@ -88,6 +89,7 @@ impl<'a> Search<'a> {
     pub fn new(
         rtxn: &'a heed::RoTxn<'a>,
         index: &'a Index,
+        fields_ids_map: &'a FieldsIdsMap,
         index_uid: &'a str,
         before_search: OffsetDateTime,
         progress: &'a Progress,
@@ -109,6 +111,7 @@ impl<'a> Search<'a> {
             words_limit: 10,
             rtxn,
             index,
+            fields_ids_map,
             index_uid,
             before_search,
             semantic: None,
@@ -254,8 +257,13 @@ impl<'a> Search<'a> {
         };
 
         if has_vector {
-            let ctx =
-                SearchContext::new(self.index, self.rtxn, self.index_uid, self.before_search)?;
+            let ctx = SearchContext::new(
+                self.index,
+                self.rtxn,
+                self.fields_ids_map,
+                self.index_uid,
+                self.before_search,
+            )?;
             filtered_universe(ctx.index, ctx.txn, &self.filter, self.candidates, self.progress)
         } else {
             Ok(self.execute()?.candidates)
@@ -263,8 +271,13 @@ impl<'a> Search<'a> {
     }
 
     pub fn execute(&self) -> Result<SearchResult> {
-        let mut ctx =
-            SearchContext::new(self.index, self.rtxn, self.index_uid, self.before_search)?;
+        let mut ctx = SearchContext::new(
+            self.index,
+            self.rtxn,
+            self.fields_ids_map,
+            self.index_uid,
+            self.before_search,
+        )?;
 
         if let Some(searchable_attributes) = self.searchable_attributes {
             ctx.attributes_to_search_on(searchable_attributes)?;
@@ -457,6 +470,7 @@ impl fmt::Debug for Search<'_> {
             max_total_hits,
             rtxn: _,
             index: _,
+            fields_ids_map: _,
             index_uid: _,
             before_search: _,
             semantic,

--- a/crates/milli/src/search/mod.rs
+++ b/crates/milli/src/search/mod.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::fmt;
 use std::sync::Arc;
 
@@ -74,7 +73,7 @@ pub struct Search<'a> {
     max_total_hits: Option<usize>,
     rtxn: &'a heed::RoTxn<'a>,
     index: &'a Index,
-    fields_ids_map: Cow<'a, FieldsIdsMap>,
+    fields_ids_map: &'a FieldsIdsMap,
     index_uid: &'a str,
     before_search: OffsetDateTime,
     semantic: Option<SemanticSearch>,
@@ -90,7 +89,7 @@ impl<'a> Search<'a> {
     pub fn new(
         rtxn: &'a heed::RoTxn<'a>,
         index: &'a Index,
-        fields_ids_map: Cow<'a, FieldsIdsMap>,
+        fields_ids_map: &'a FieldsIdsMap,
         index_uid: &'a str,
         before_search: OffsetDateTime,
         progress: &'a Progress,
@@ -261,14 +260,14 @@ impl<'a> Search<'a> {
             let ctx = SearchContext::new(
                 self.index,
                 self.rtxn,
-                self.fields_ids_map.as_ref(),
+                self.fields_ids_map,
                 self.index_uid,
                 self.before_search,
             )?;
             filtered_universe(
                 ctx.index,
                 ctx.txn,
-                self.fields_ids_map.as_ref(),
+                self.fields_ids_map,
                 &self.filter,
                 self.candidates,
                 self.progress,
@@ -282,7 +281,7 @@ impl<'a> Search<'a> {
         let mut ctx = SearchContext::new(
             self.index,
             self.rtxn,
-            self.fields_ids_map.as_ref(),
+            self.fields_ids_map,
             self.index_uid,
             self.before_search,
         )?;
@@ -322,7 +321,7 @@ impl<'a> Search<'a> {
         let mut universe = filtered_universe(
             ctx.index,
             ctx.txn,
-            self.fields_ids_map.as_ref(),
+            self.fields_ids_map,
             &self.filter,
             self.candidates,
             self.progress,

--- a/crates/milli/src/search/mod.rs
+++ b/crates/milli/src/search/mod.rs
@@ -265,7 +265,14 @@ impl<'a> Search<'a> {
                 self.index_uid,
                 self.before_search,
             )?;
-            filtered_universe(ctx.index, ctx.txn, &self.filter, self.candidates, self.progress)
+            filtered_universe(
+                ctx.index,
+                ctx.txn,
+                self.fields_ids_map.as_ref(),
+                &self.filter,
+                self.candidates,
+                self.progress,
+            )
         } else {
             Ok(self.execute()?.candidates)
         }
@@ -312,8 +319,14 @@ impl<'a> Search<'a> {
             }
         }
 
-        let mut universe =
-            filtered_universe(ctx.index, ctx.txn, &self.filter, self.candidates, self.progress)?;
+        let mut universe = filtered_universe(
+            ctx.index,
+            ctx.txn,
+            self.fields_ids_map.as_ref(),
+            &self.filter,
+            self.candidates,
+            self.progress,
+        )?;
 
         let (query_terms, pins, used_negative_operator) =
             self.build_located_query_terms(&mut ctx, &mut universe)?;

--- a/crates/milli/src/search/new/bucket_sort.rs
+++ b/crates/milli/src/search/new/bucket_sort.rs
@@ -40,7 +40,7 @@ pub fn bucket_sort<'ctx, Q: RankingRuleQueryTrait>(
     logger.ranking_rules(&ranking_rules);
     logger.initial_universe(universe);
 
-    let distinct_fid = distinct_fid(distinct, ctx.index, ctx.txn)?;
+    let distinct_fid = distinct_fid(distinct, ctx.index, ctx.txn, ctx.fields_ids_map)?;
 
     // When pins are present we need the organic prefix up to the end of the
     // requested page. Injecting the surviving pins into that prefix and slicing

--- a/crates/milli/src/search/new/db_cache.rs
+++ b/crates/milli/src/search/new/db_cache.rs
@@ -382,7 +382,7 @@ impl<'ctx> SearchContext<'ctx> {
                         .map_err(heed::Error::Decoding)?
                 } else {
                     // Compute the distance at the attribute level and store it in the cache.
-                    let fids = self.index.searchable_fields_ids(self.txn)?;
+                    let fids = self.index.searchable_fields_ids(self.txn, self.fields_ids_map)?;
                     let mut docids = RoaringBitmap::new();
                     for fid in fids {
                         // for each field, intersect left word bitmap and right word bitmap,
@@ -472,7 +472,7 @@ impl<'ctx> SearchContext<'ctx> {
             let prefix_docids = match proximity_precision {
                 ProximityPrecision::ByAttribute => {
                     // Compute the distance at the attribute level and store it in the cache.
-                    let fids = self.index.searchable_fields_ids(self.txn)?;
+                    let fids = self.index.searchable_fields_ids(self.txn, self.fields_ids_map)?;
                     let mut prefix_docids = RoaringBitmap::new();
                     // for each field, intersect left word bitmap and right word bitmap,
                     // then merge the result in a global bitmap before storing it in the cache.

--- a/crates/milli/src/search/new/distinct.rs
+++ b/crates/milli/src/search/new/distinct.rs
@@ -9,7 +9,7 @@ use crate::heed_codec::facet::{
     FacetGroupKey, FacetGroupKeyCodec, FacetGroupValueCodec, FieldDocIdFacetCodec,
 };
 use crate::heed_codec::BytesRefCodec;
-use crate::{FieldId, Index, Result, SearchContext};
+use crate::{FieldId, FieldsIdsMap, Index, Result, SearchContext};
 
 pub struct DistinctOutput {
     pub remaining: RoaringBitmap,
@@ -126,6 +126,7 @@ pub fn distinct_fid(
     query_distinct_field: Option<&str>,
     index: &Index,
     rtxn: &RoTxn<'_>,
+    fields_ids_map: &FieldsIdsMap,
 ) -> Result<Option<FieldId>> {
     let distinct_field = match query_distinct_field {
         Some(distinct) => Some(distinct),
@@ -133,6 +134,6 @@ pub fn distinct_fid(
     };
 
     let distinct_fid =
-        if let Some(field) = distinct_field { index.fields_ids_map(rtxn)?.id(field) } else { None };
+        if let Some(field) = distinct_field { fields_ids_map.id(field) } else { None };
     Ok(distinct_fid)
 }

--- a/crates/milli/src/search/new/exact_attribute.rs
+++ b/crates/milli/src/search/new/exact_attribute.rs
@@ -191,7 +191,7 @@ impl State {
             return Ok(State::Empty(query_graph.clone()));
         }
 
-        let searchable_fields_ids = ctx.index.searchable_fields_ids(ctx.txn)?;
+        let searchable_fields_ids = ctx.index.searchable_fields_ids(ctx.txn, ctx.fields_ids_map)?;
 
         let mut candidates_per_attribute = Vec::with_capacity(searchable_fields_ids.len());
         // then check that there exists at least one attribute that has all of the terms

--- a/crates/milli/src/search/new/geo_sort.rs
+++ b/crates/milli/src/search/new/geo_sort.rs
@@ -98,11 +98,14 @@ impl<'ctx, Q: RankingRuleQueryTrait> RankingRule<'ctx, Q> for GeoSort<Q> {
             return Ok(());
         }
 
-        let fid_map = ctx.index.fields_ids_map(ctx.txn)?;
-        let lat =
-            fid_map.id(RESERVED_GEO_LAT_FIELD_NAME).expect("geo candidates but no fid for lat");
-        let lng =
-            fid_map.id(RESERVED_GEO_LNG_FIELD_NAME).expect("geo candidates but no fid for lng");
+        let lat = ctx
+            .fields_ids_map
+            .id(RESERVED_GEO_LAT_FIELD_NAME)
+            .expect("geo candidates but no fid for lat");
+        let lng = ctx
+            .fields_ids_map
+            .id(RESERVED_GEO_LNG_FIELD_NAME)
+            .expect("geo candidates but no fid for lng");
         self.field_ids = Some([lat, lng]);
         self.fill_buffer(ctx, &geo_candidates)?;
         Ok(())

--- a/crates/milli/src/search/new/matches/matching_words.rs
+++ b/crates/milli/src/search/new/matches/matching_words.rs
@@ -259,9 +259,15 @@ pub(crate) mod tests {
     fn matching_words() {
         let temp_index = temp_index_with_documents();
         let rtxn = temp_index.read_txn().unwrap();
-        let mut ctx =
-            SearchContext::new(&temp_index, &rtxn, "test", time::OffsetDateTime::now_utc())
-                .unwrap();
+        let fields_ids_map = temp_index.fields_ids_map(&rtxn).unwrap();
+        let mut ctx = SearchContext::new(
+            &temp_index,
+            &rtxn,
+            &fields_ids_map,
+            "test",
+            time::OffsetDateTime::now_utc(),
+        )
+        .unwrap();
         let mut builder = TokenizerBuilder::default();
         let tokenizer = builder.build();
         let tokens = tokenizer.tokenize("split this world");

--- a/crates/milli/src/search/new/matches/mod_test.rs
+++ b/crates/milli/src/search/new/matches/mod_test.rs
@@ -27,7 +27,9 @@ impl<'a> MatcherBuilder<'a> {
             time::OffsetDateTime::now_utc(),
         )
         .unwrap();
-        let mut universe = filtered_universe(ctx.index, ctx.txn, &None, None, &progress).unwrap();
+        let mut universe =
+            filtered_universe(ctx.index, ctx.txn, ctx.fields_ids_map, &None, None, &progress)
+                .unwrap();
 
         search.query(query);
 

--- a/crates/milli/src/search/new/matches/mod_test.rs
+++ b/crates/milli/src/search/new/matches/mod_test.rs
@@ -10,10 +10,23 @@ impl<'a> MatcherBuilder<'a> {
     fn new_test(rtxn: &'a heed::RoTxn<'a>, index: &'a TempIndex, query: &str) -> Self {
         let progress = Progress::default();
 
-        let mut search =
-            crate::Search::new(rtxn, index, "test", time::OffsetDateTime::now_utc(), &progress);
-        let mut ctx =
-            SearchContext::new(index, rtxn, "test", time::OffsetDateTime::now_utc()).unwrap();
+        let fields_ids_map = index.fields_ids_map(rtxn).unwrap();
+        let mut search = crate::Search::new(
+            rtxn,
+            index,
+            &fields_ids_map,
+            "test",
+            time::OffsetDateTime::now_utc(),
+            &progress,
+        );
+        let mut ctx = SearchContext::new(
+            index,
+            rtxn,
+            &fields_ids_map,
+            "test",
+            time::OffsetDateTime::now_utc(),
+        )
+        .unwrap();
         let mut universe = filtered_universe(ctx.index, ctx.txn, &None, None, &progress).unwrap();
 
         search.query(query);

--- a/crates/milli/src/search/new/matches/mod_test.rs
+++ b/crates/milli/src/search/new/matches/mod_test.rs
@@ -14,7 +14,7 @@ impl<'a> MatcherBuilder<'a> {
         let mut search = crate::Search::new(
             rtxn,
             index,
-            &fields_ids_map,
+            Cow::Borrowed(&fields_ids_map),
             "test",
             time::OffsetDateTime::now_utc(),
             &progress,

--- a/crates/milli/src/search/new/matches/mod_test.rs
+++ b/crates/milli/src/search/new/matches/mod_test.rs
@@ -14,7 +14,7 @@ impl<'a> MatcherBuilder<'a> {
         let mut search = crate::Search::new(
             rtxn,
             index,
-            Cow::Borrowed(&fields_ids_map),
+            &fields_ids_map,
             "test",
             time::OffsetDateTime::now_utc(),
             &progress,

--- a/crates/milli/src/search/new/mod.rs
+++ b/crates/milli/src/search/new/mod.rs
@@ -63,8 +63,8 @@ use crate::search::new::distinct::apply_distinct_rule;
 use crate::search::steps::SearchStep;
 use crate::vector::Embedder;
 use crate::{
-    AscDesc, Deadline, DocumentId, FieldId, Index, Member, PinDoc, Result, TermsMatchingStrategy,
-    UserError, Weight,
+    AscDesc, Deadline, DocumentId, FieldId, FieldsIdsMap, Index, Member, PinDoc, Result,
+    TermsMatchingStrategy, UserError, Weight,
 };
 
 /// Cache for synonyms to avoid repeated database access
@@ -77,6 +77,7 @@ pub struct SynonymCache {
 pub struct SearchContext<'ctx> {
     pub index: &'ctx Index,
     pub txn: &'ctx RoTxn<'ctx>,
+    pub fields_ids_map: &'ctx FieldsIdsMap,
     pub index_uid: &'ctx str,
     pub before_search: OffsetDateTime,
     pub db_cache: DatabaseCache<'ctx>,
@@ -94,11 +95,12 @@ impl<'ctx> SearchContext<'ctx> {
     pub fn new(
         index: &'ctx Index,
         txn: &'ctx RoTxn<'ctx>,
+        fields_ids_map: &'ctx FieldsIdsMap,
         index_uid: &'ctx str,
         before_search: OffsetDateTime,
     ) -> Result<Self> {
-        let searchable_fids = index.searchable_fields_and_weights(txn)?;
-        let exact_attributes_ids = index.exact_attributes_ids(txn)?;
+        let searchable_fids = index.searchable_fields_and_weights(txn, fields_ids_map)?;
+        let exact_attributes_ids = index.exact_attributes_ids(txn, fields_ids_map)?;
 
         let mut exact = Vec::new();
         let mut tolerant = Vec::new();
@@ -115,6 +117,7 @@ impl<'ctx> SearchContext<'ctx> {
         Ok(Self {
             index,
             txn,
+            fields_ids_map,
             index_uid,
             before_search,
             db_cache: <_>::default(),
@@ -138,8 +141,10 @@ impl<'ctx> SearchContext<'ctx> {
         attributes_to_search_on: &'ctx [String],
     ) -> Result<()> {
         let user_defined_searchable = self.index.user_defined_searchable_fields(self.txn)?;
-        let searchable_fields_weights = self.index.searchable_fields_and_weights(self.txn)?;
-        let exact_attributes_ids = self.index.exact_attributes_ids(self.txn)?;
+        let searchable_fields_weights =
+            self.index.searchable_fields_and_weights(self.txn, self.fields_ids_map)?;
+        let exact_attributes_ids =
+            self.index.exact_attributes_ids(self.txn, self.fields_ids_map)?;
 
         let mut universal_wildcard = false;
 
@@ -836,7 +841,6 @@ pub fn execute_search(
     };
 
     let BucketSortOutput { docids, scores, mut all_candidates, degraded } = bucket_sort_output;
-    let fields_ids_map = ctx.index.fields_ids_map(ctx.txn)?;
 
     // The candidates is the universe unless the exhaustive number of hits
     // is requested and a distinct attribute is set.
@@ -847,7 +851,7 @@ pub fn execute_search(
         };
 
         if let Some(f) = distinct_field {
-            if let Some(distinct_fid) = fields_ids_map.id(f) {
+            if let Some(distinct_fid) = ctx.fields_ids_map.id(f) {
                 all_candidates = apply_distinct_rule(ctx, distinct_fid, &all_candidates)?.remaining;
             }
         }
@@ -904,7 +908,7 @@ pub fn extract_tokens(
             // If no locales are specified, we use the locales specified in the localized attributes rules
             let localized_attributes_rules = ctx.index.localized_attributes_rules(ctx.txn)?;
             let fields_ids_map = ctx.index.fields_ids_map(ctx.txn)?;
-            let searchable_fields = ctx.index.searchable_fields_ids(ctx.txn)?;
+            let searchable_fields = ctx.index.searchable_fields_ids(ctx.txn, ctx.fields_ids_map)?;
 
             let localized_fields = match &ctx.restricted_fids {
                 // if AttributeToSearchOn is set, use the restricted list of ids

--- a/crates/milli/src/search/new/mod.rs
+++ b/crates/milli/src/search/new/mod.rs
@@ -389,14 +389,26 @@ fn get_ranking_rules_for_placeholder_search<'ctx>(
                     continue;
                 }
                 sorted_fields.insert(field_name.clone());
-                ranking_rules.push(Box::new(Sort::new(ctx.index, ctx.txn, field_name, true)?));
+                ranking_rules.push(Box::new(Sort::new(
+                    ctx.index,
+                    ctx.txn,
+                    ctx.fields_ids_map,
+                    field_name,
+                    true,
+                )?));
             }
             crate::Criterion::Desc(field_name) => {
                 if sorted_fields.contains(&field_name) {
                     continue;
                 }
                 sorted_fields.insert(field_name.clone());
-                ranking_rules.push(Box::new(Sort::new(ctx.index, ctx.txn, field_name, false)?));
+                ranking_rules.push(Box::new(Sort::new(
+                    ctx.index,
+                    ctx.txn,
+                    ctx.fields_ids_map,
+                    field_name,
+                    false,
+                )?));
             }
         }
     }
@@ -467,14 +479,26 @@ fn get_ranking_rules_for_vector<'ctx>(
                     continue;
                 }
                 sorted_fields.insert(field_name.clone());
-                ranking_rules.push(Box::new(Sort::new(ctx.index, ctx.txn, field_name, true)?));
+                ranking_rules.push(Box::new(Sort::new(
+                    ctx.index,
+                    ctx.txn,
+                    ctx.fields_ids_map,
+                    field_name,
+                    true,
+                )?));
             }
             crate::Criterion::Desc(field_name) => {
                 if sorted_fields.contains(&field_name) {
                     continue;
                 }
                 sorted_fields.insert(field_name.clone());
-                ranking_rules.push(Box::new(Sort::new(ctx.index, ctx.txn, field_name, false)?));
+                ranking_rules.push(Box::new(Sort::new(
+                    ctx.index,
+                    ctx.txn,
+                    ctx.fields_ids_map,
+                    field_name,
+                    false,
+                )?));
             }
         }
     }
@@ -598,14 +622,26 @@ fn get_ranking_rules_for_query_graph_search<'ctx>(
                     continue;
                 }
                 sorted_fields.insert(field_name.clone());
-                ranking_rules.push(Box::new(Sort::new(ctx.index, ctx.txn, field_name, true)?));
+                ranking_rules.push(Box::new(Sort::new(
+                    ctx.index,
+                    ctx.txn,
+                    ctx.fields_ids_map,
+                    field_name,
+                    true,
+                )?));
             }
             crate::Criterion::Desc(field_name) => {
                 if sorted_fields.contains(&field_name) {
                     continue;
                 }
                 sorted_fields.insert(field_name.clone());
-                ranking_rules.push(Box::new(Sort::new(ctx.index, ctx.txn, field_name, false)?));
+                ranking_rules.push(Box::new(Sort::new(
+                    ctx.index,
+                    ctx.txn,
+                    ctx.fields_ids_map,
+                    field_name,
+                    false,
+                )?));
             }
         }
     }
@@ -629,14 +665,26 @@ fn resolve_sort_criteria<'ctx, Query: RankingRuleQueryTrait>(
                     continue;
                 }
                 sorted_fields.insert(field_name.clone());
-                ranking_rules.push(Box::new(Sort::new(ctx.index, ctx.txn, field_name, true)?));
+                ranking_rules.push(Box::new(Sort::new(
+                    ctx.index,
+                    ctx.txn,
+                    ctx.fields_ids_map,
+                    field_name,
+                    true,
+                )?));
             }
             AscDesc::Desc(Member::Field(field_name)) => {
                 if sorted_fields.contains(&field_name) {
                     continue;
                 }
                 sorted_fields.insert(field_name.clone());
-                ranking_rules.push(Box::new(Sort::new(ctx.index, ctx.txn, field_name, false)?));
+                ranking_rules.push(Box::new(Sort::new(
+                    ctx.index,
+                    ctx.txn,
+                    ctx.fields_ids_map,
+                    field_name,
+                    false,
+                )?));
             }
             AscDesc::Asc(Member::Geo(point)) => {
                 if *geo_sorted {
@@ -671,6 +719,7 @@ fn resolve_sort_criteria<'ctx, Query: RankingRuleQueryTrait>(
 pub fn filtered_universe(
     index: &Index,
     txn: &RoTxn<'_>,
+    fields_ids_map: &FieldsIdsMap,
     filters: &Option<IndexFilter>,
     candidates: Option<&RoaringBitmap>,
     progress: &Progress,
@@ -680,11 +729,11 @@ pub fn filtered_universe(
         (None, Some(candidates)) => candidates.clone(),
         (Some(filters), None) => {
             let _step = progress.update_progress_scoped(SearchStep::EvaluateFilter);
-            filters.evaluate(txn, index)?
+            filters.evaluate(txn, index, fields_ids_map)?
         }
         (Some(filters), Some(candidates)) => {
             let _step = progress.update_progress_scoped(SearchStep::EvaluateFilter);
-            let mut filtered = filters.evaluate(txn, index)?;
+            let mut filtered = filters.evaluate(txn, index, fields_ids_map)?;
             filtered &= candidates;
             filtered
         }
@@ -907,7 +956,6 @@ pub fn extract_tokens(
         None => {
             // If no locales are specified, we use the locales specified in the localized attributes rules
             let localized_attributes_rules = ctx.index.localized_attributes_rules(ctx.txn)?;
-            let fields_ids_map = ctx.index.fields_ids_map(ctx.txn)?;
             let searchable_fields = ctx.index.searchable_fields_ids(ctx.txn, ctx.fields_ids_map)?;
 
             let localized_fields = match &ctx.restricted_fids {
@@ -919,12 +967,12 @@ pub fn extract_tokens(
                         .chain(restricted_fids.tolerant.iter())
                         .map(|(fid, _)| *fid);
 
-                    LocalizedFieldIds::new(&localized_attributes_rules, &fields_ids_map, iter)
+                    LocalizedFieldIds::new(&localized_attributes_rules, ctx.fields_ids_map, iter)
                 }
                 // Otherwise use the full list of ids coming from the index searchable fields
                 None => LocalizedFieldIds::new(
                     &localized_attributes_rules,
-                    &fields_ids_map,
+                    ctx.fields_ids_map,
                     searchable_fields.into_iter(),
                 ),
             };

--- a/crates/milli/src/search/new/query_term/parse_query.rs
+++ b/crates/milli/src/search/new/query_term/parse_query.rs
@@ -389,7 +389,14 @@ mod tests {
         let tokens = tokenizer.tokenize(".");
         let index = temp_index_with_documents();
         let rtxn = index.read_txn()?;
-        let mut ctx = SearchContext::new(&index, &rtxn, "test", time::OffsetDateTime::now_utc())?;
+        let fields_ids_map = index.fields_ids_map(&rtxn)?;
+        let mut ctx = SearchContext::new(
+            &index,
+            &rtxn,
+            &fields_ids_map,
+            "test",
+            time::OffsetDateTime::now_utc(),
+        )?;
         // panics with `attempt to add with overflow` before <https://github.com/meilisearch/meilisearch/issues/3785>
         let ExtractedTokens { query_terms, .. } =
             located_query_terms_from_tokens(&mut ctx, &tokenizer, tokens, None)?;
@@ -402,7 +409,14 @@ mod tests {
     fn test_unicode_typo_tolerance_fixed() -> Result<()> {
         let temp_index = temp_index_with_documents();
         let rtxn = temp_index.read_txn()?;
-        let ctx = SearchContext::new(&temp_index, &rtxn, "test", time::OffsetDateTime::now_utc())?;
+        let fields_ids_map = temp_index.fields_ids_map(&rtxn)?;
+        let ctx = SearchContext::new(
+            &temp_index,
+            &rtxn,
+            &fields_ids_map,
+            "test",
+            time::OffsetDateTime::now_utc(),
+        )?;
 
         let nbr_typos = number_of_typos_allowed(&ctx)?;
 
@@ -431,7 +445,14 @@ mod tests {
     fn test_various_unicode_scripts() -> Result<()> {
         let temp_index = temp_index_with_documents();
         let rtxn = temp_index.read_txn()?;
-        let ctx = SearchContext::new(&temp_index, &rtxn, "test", time::OffsetDateTime::now_utc())?;
+        let fields_ids_map = temp_index.fields_ids_map(&rtxn)?;
+        let ctx = SearchContext::new(
+            &temp_index,
+            &rtxn,
+            &fields_ids_map,
+            "test",
+            time::OffsetDateTime::now_utc(),
+        )?;
 
         let nbr_typos = number_of_typos_allowed(&ctx)?;
 

--- a/crates/milli/src/search/new/ranking_rule_graph/fid/mod.rs
+++ b/crates/milli/src/search/new/ranking_rule_graph/fid/mod.rs
@@ -75,7 +75,7 @@ impl RankingRuleGraphTrait for FidGraph {
             all_fields.extend(fields);
         }
 
-        let weights_map = ctx.index.fieldids_weights_map(ctx.txn)?;
+        let weights_map = ctx.index.fieldids_weights_map(ctx.txn, ctx.fields_ids_map)?;
 
         let mut edges = vec![];
         for fid in all_fields.iter().copied() {

--- a/crates/milli/src/search/new/sort.rs
+++ b/crates/milli/src/search/new/sort.rs
@@ -8,7 +8,7 @@ use crate::heed_codec::{BytesRefCodec, StrRefCodec};
 use crate::score_details::{self, ScoreDetails};
 use crate::search::facet::{ascending_facet_sort, descending_facet_sort};
 use crate::search::new::ranking_rules::RankingRuleId;
-use crate::{Deadline, FieldId, Index, Result};
+use crate::{Deadline, FieldId, FieldsIdsMap, Index, Result};
 
 pub trait RankingRuleOutputIter<'ctx, Query> {
     fn next_bucket(&mut self) -> Result<Option<RankingRuleOutput<Query>>>;
@@ -58,10 +58,10 @@ impl<'ctx, Query> Sort<'ctx, Query> {
     pub fn new(
         index: &Index,
         rtxn: &'ctx heed::RoTxn<'ctx>,
+        fields_ids_map: &'ctx FieldsIdsMap,
         field_name: String,
         is_ascending: bool,
     ) -> Result<Self> {
-        let fields_ids_map = index.fields_ids_map(rtxn)?;
         let field_id = fields_ids_map.id(&field_name);
         let must_redact = Self::must_redact(index, rtxn, &field_name)?;
 

--- a/crates/milli/src/search/new/tests/attribute_fid.rs
+++ b/crates/milli/src/search/new/tests/attribute_fid.rs
@@ -118,8 +118,9 @@ fn test_attribute_fid_simple() {
     let index = create_index();
 
     let txn = index.read_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
 
-    let mut s = index.search(&txn);
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.query("the quick brown fox jumps over the lazy dog");
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
@@ -146,8 +147,9 @@ fn test_attribute_fid_ngrams() {
     "###);
 
     let txn = index.read_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
 
-    let mut s = index.search(&txn);
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.query("the quick brown fox jumps over the lazy dog");
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);

--- a/crates/milli/src/search/new/tests/cutoff.rs
+++ b/crates/milli/src/search/new/tests/cutoff.rs
@@ -62,8 +62,9 @@ fn create_index() -> TempIndex {
 fn basic_degraded_search() {
     let index = create_index();
     let rtxn = index.read_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
 
-    let mut search = index.search(&rtxn);
+    let mut search = index.search(&rtxn, &fields_ids_map);
     search.query("hello puppy kefir");
     search.limit(3);
     search.deadline(Deadline::from_budget(Duration::from_millis(0)));
@@ -76,8 +77,9 @@ fn basic_degraded_search() {
 fn degraded_search_cannot_skip_filter() {
     let index = create_index();
     let rtxn = index.read_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
 
-    let mut search = index.search(&rtxn);
+    let mut search = index.search(&rtxn, &fields_ids_map);
     search.query("hello puppy kefir");
     search.limit(100);
     search.deadline(Deadline::from_budget(Duration::from_millis(0)));
@@ -97,8 +99,9 @@ fn degraded_search_cannot_skip_filter() {
 fn degraded_search_and_score_details() {
     let index = create_index();
     let rtxn = index.read_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
 
-    let mut search = index.search(&rtxn);
+    let mut search = index.search(&rtxn, &fields_ids_map);
     search.query("hello puppy kefir");
     search.limit(4);
     search.scoring_strategy(ScoringStrategy::Detailed);
@@ -562,7 +565,8 @@ fn degraded_search_and_score_details_vector() {
         .unwrap();
 
     let rtxn = index.read_txn().unwrap();
-    let mut search = index.search(&rtxn);
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
+    let mut search = index.search(&rtxn, &fields_ids_map);
 
     let embedder = Arc::new(
         Embedder::new(

--- a/crates/milli/src/search/new/tests/distinct.rs
+++ b/crates/milli/src/search/new/tests/distinct.rs
@@ -246,7 +246,8 @@ fn test_distinct_placeholder_no_ranking_rules() {
 
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.distinct(S("letter"));
     let SearchResult { documents_ids, .. } = s.execute().unwrap();
     insta::assert_snapshot!(format!("{documents_ids:?}"), @"[0, 2, 5, 8, 9, 15, 18, 20, 21, 24, 25, 26]");
@@ -274,8 +275,9 @@ fn test_distinct_at_search_placeholder_no_ranking_rules() {
     let index = create_index();
 
     let txn = index.read_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
 
-    let s = index.search(&txn);
+    let s = index.search(&txn, &fields_ids_map);
     let SearchResult { documents_ids, .. } = s.execute().unwrap();
     insta::assert_snapshot!(format!("{documents_ids:?}"), @"[0, 2, 5, 8, 9, 15, 18, 20, 21, 24, 25, 26]");
     let distinct_values = verify_distinct(&index, &txn, None, &documents_ids);
@@ -308,7 +310,8 @@ fn test_distinct_placeholder_sort() {
 
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.sort_criteria(vec![AscDesc::Desc(Member::Field(S("rank1")))]);
 
     let SearchResult { documents_ids, .. } = s.execute().unwrap();
@@ -348,7 +351,7 @@ fn test_distinct_placeholder_sort() {
     ]
     "###);
 
-    let mut s = index.search(&txn);
+    let mut s = index.search(&txn, &fields_ids_map);
     s.sort_criteria(vec![AscDesc::Desc(Member::Field(S("letter")))]);
 
     let SearchResult { documents_ids, .. } = s.execute().unwrap();
@@ -388,7 +391,7 @@ fn test_distinct_placeholder_sort() {
     ]
     "###);
 
-    let mut s = index.search(&txn);
+    let mut s = index.search(&txn, &fields_ids_map);
     s.sort_criteria(vec![
         AscDesc::Desc(Member::Field(S("letter"))),
         AscDesc::Desc(Member::Field(S("rank1"))),
@@ -443,7 +446,8 @@ fn test_distinct_words() {
 
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::Last);
     s.query("the quick brown fox jumps over the lazy dog");
 
@@ -496,7 +500,8 @@ fn test_distinct_sort_words() {
 
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::Last);
     s.query("the quick brown fox jumps over the lazy dog");
     s.sort_criteria(vec![AscDesc::Desc(Member::Field(S("letter")))]);
@@ -569,7 +574,8 @@ fn test_distinct_all_candidates() {
 
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::Last);
     s.sort_criteria(vec![AscDesc::Desc(Member::Field(S("rank1")))]);
     s.exhaustive_number_hits(true);
@@ -592,7 +598,8 @@ fn test_distinct_typo() {
 
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.query("the quick brown fox jumps over the lazy dog");
     s.terms_matching_strategy(TermsMatchingStrategy::Last);
 

--- a/crates/milli/src/search/new/tests/exactness.rs
+++ b/crates/milli/src/search/new/tests/exactness.rs
@@ -471,7 +471,8 @@ fn test_exactness_simple_ordered() {
 
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::Last);
     s.query("the quick brown fox jumps over the lazy dog");
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
@@ -503,7 +504,8 @@ fn test_exactness_simple_reversed() {
 
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::Last);
     s.query("the quick brown fox jumps over the lazy dog");
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
@@ -526,7 +528,7 @@ fn test_exactness_simple_reversed() {
     ]
     "###);
 
-    let mut s = index.search(&txn);
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::Last);
     s.query("the quick brown fox jumps over the lazy dog");
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
@@ -556,7 +558,8 @@ fn test_exactness_simple_random() {
 
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::Last);
     s.query("the quick brown fox jumps over the lazy dog");
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
@@ -585,7 +588,8 @@ fn test_exactness_attribute_starts_with_simple() {
 
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::Last);
     s.query("this balcony");
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
@@ -611,7 +615,8 @@ fn test_exactness_attribute_starts_with_phrase() {
 
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::Last);
     s.query("\"overlooking the sea\" is a beautiful balcony");
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
@@ -631,7 +636,7 @@ fn test_exactness_attribute_starts_with_phrase() {
     ]
     "###);
 
-    let mut s = index.search(&txn);
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::Last);
     s.query("overlooking the sea is a beautiful balcony");
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
@@ -660,7 +665,8 @@ fn test_exactness_all_candidates_with_typo() {
 
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::Last);
     s.query("overlocking the sea is a beautiful balcony");
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
@@ -696,7 +702,8 @@ fn test_exactness_after_words() {
 
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::Last);
     s.query("the quick brown fox jumps over the lazy dog");
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
@@ -744,7 +751,8 @@ fn test_words_after_exactness() {
 
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::Last);
     s.query("the quick brown fox jumps over the lazy dog");
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
@@ -792,7 +800,8 @@ fn test_proximity_after_exactness() {
 
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::Last);
     s.query("the quick brown fox jumps over the lazy dog");
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
@@ -829,7 +838,8 @@ fn test_proximity_after_exactness() {
 
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::Last);
     s.query("the quick brown fox jumps over the lazy dog");
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
@@ -862,7 +872,8 @@ fn test_exactness_followed_by_typo_prefer_no_typo_prefix() {
 
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::Last);
     s.query("quick brown fox extra");
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
@@ -897,7 +908,8 @@ fn test_typo_followed_by_exactness() {
 
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::Last);
     s.query("extraordinarily quick brown fox");
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);

--- a/crates/milli/src/search/new/tests/geo_sort.rs
+++ b/crates/milli/src/search/new/tests/geo_sort.rs
@@ -81,8 +81,9 @@ fn test_geo_sort() {
         .unwrap();
 
     let rtxn = index.read_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
 
-    let mut s = index.search(&rtxn);
+    let mut s = index.search(&rtxn, &fields_ids_map);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
 
     s.sort_criteria(vec![AscDesc::Asc(Member::Geo([0., 0.]))]);
@@ -117,8 +118,9 @@ fn test_geo_sort_with_following_ranking_rules() {
         .unwrap();
 
     let rtxn = index.read_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
 
-    let mut s = index.search(&rtxn);
+    let mut s = index.search(&rtxn, &fields_ids_map);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
     s.sort_criteria(vec![
         AscDesc::Asc(Member::Geo([0., 0.])),
@@ -158,8 +160,9 @@ fn test_geo_sort_reached_max_bucket_size() {
         .unwrap();
 
     let rtxn = index.read_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
 
-    let mut s = index.search(&rtxn);
+    let mut s = index.search(&rtxn, &fields_ids_map);
     s.geo_max_bucket_size(2);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
     s.sort_criteria(vec![
@@ -218,8 +221,9 @@ fn test_geo_sort_around_the_edge_of_the_flat_earth() {
         .unwrap();
 
     let rtxn = index.read_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
 
-    let mut s = index.search(&rtxn);
+    let mut s = index.search(&rtxn, &fields_ids_map);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
 
     // --- asc
@@ -294,8 +298,9 @@ fn geo_sort_mixed_with_words() {
         .unwrap();
 
     let rtxn = index.read_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
 
-    let mut s = index.search(&rtxn);
+    let mut s = index.search(&rtxn, &fields_ids_map);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
     s.sort_criteria(vec![AscDesc::Asc(Member::Geo([0., 0.]))]);
 
@@ -405,8 +410,9 @@ fn geo_sort_without_any_geo_faceted_documents() {
         .unwrap();
 
     let rtxn = index.read_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
 
-    let mut s = index.search(&rtxn);
+    let mut s = index.search(&rtxn, &fields_ids_map);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
     s.sort_criteria(vec![AscDesc::Asc(Member::Geo([0., 0.]))]);
 

--- a/crates/milli/src/search/new/tests/language.rs
+++ b/crates/milli/src/search/new/tests/language.rs
@@ -14,7 +14,9 @@ fn test_kanji_language_detection() {
         .unwrap();
 
     let txn = index.write_txn().unwrap();
-    let mut search = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+
+    let mut search = index.search(&txn, &fields_ids_map);
 
     search.query("東京");
     let SearchResult { documents_ids, .. } = search.execute().unwrap();

--- a/crates/milli/src/search/new/tests/ngram_split_words.rs
+++ b/crates/milli/src/search/new/tests/ngram_split_words.rs
@@ -78,7 +78,8 @@ fn test_2gram_simple() {
 
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
     s.query("sun flower");
@@ -109,7 +110,8 @@ fn test_3gram_simple() {
 
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.query("sun flower s are");
     let SearchResult { documents_ids, .. } = s.execute().unwrap();
@@ -129,7 +131,8 @@ fn test_2gram_typo() {
     let index = create_index();
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.query("sun flawer");
     let SearchResult { documents_ids, .. } = s.execute().unwrap();
@@ -159,7 +162,8 @@ fn test_no_disable_ngrams() {
 
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.query("sun flower ");
     let SearchResult { documents_ids, .. } = s.execute().unwrap();
@@ -185,7 +189,8 @@ fn test_2gram_prefix() {
 
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.query("sun flow");
     let SearchResult { documents_ids, .. } = s.execute().unwrap();
@@ -214,7 +219,8 @@ fn test_3gram_prefix() {
 
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.query("su nf l");
     let SearchResult { documents_ids, .. } = s.execute().unwrap();
@@ -237,7 +243,8 @@ fn test_split_words() {
     let index = create_index();
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.query("sunflower ");
     let SearchResult { documents_ids, .. } = s.execute().unwrap();
@@ -266,7 +273,8 @@ fn test_disable_split_words() {
 
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.query("sunflower ");
     let SearchResult { documents_ids, .. } = s.execute().unwrap();
@@ -286,7 +294,8 @@ fn test_2gram_split_words() {
     let index = create_index();
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.query("sunf lower");
     let SearchResult { documents_ids, .. } = s.execute().unwrap();
@@ -310,7 +319,8 @@ fn test_3gram_no_split_words() {
     let index = create_index();
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.query("sunf lo wer");
     let SearchResult { documents_ids, .. } = s.execute().unwrap();
@@ -333,7 +343,8 @@ fn test_3gram_no_typos() {
     let index = create_index();
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.query("sunf la wer");
     let SearchResult { documents_ids, .. } = s.execute().unwrap();
@@ -352,7 +363,8 @@ fn test_no_ngram_phrases() {
     let index = create_index();
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.query("\"sun\" flower");
     let SearchResult { documents_ids, .. } = s.execute().unwrap();
@@ -366,7 +378,7 @@ fn test_no_ngram_phrases() {
     ]
     "###);
 
-    let mut s = index.search(&txn);
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.query("\"sun\" \"flower\"");
     let SearchResult { documents_ids, .. } = s.execute().unwrap();
@@ -385,7 +397,8 @@ fn test_short_split_words() {
     let index = create_index();
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.query("xyz");
     let SearchResult { documents_ids, .. } = s.execute().unwrap();
@@ -412,7 +425,8 @@ fn test_split_words_never_disabled() {
 
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.query("the sunflower is tall");
     let SearchResult { documents_ids, .. } = s.execute().unwrap();

--- a/crates/milli/src/search/new/tests/proximity.rs
+++ b/crates/milli/src/search/new/tests/proximity.rs
@@ -268,7 +268,8 @@ fn test_proximity_simple() {
     let index = create_simple_index();
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.query("the quick brown fox jumps over the lazy dog");
     let SearchResult { documents_ids, .. } = s.execute().unwrap();
@@ -295,7 +296,8 @@ fn test_proximity_split_word() {
     let index = create_edge_cases_index();
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
     s.query("sunflower wilting");
@@ -315,7 +317,7 @@ fn test_proximity_split_word() {
     ]
     "###);
 
-    let mut s = index.search(&txn);
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
     s.query("\"sun flower\" wilting");
@@ -342,7 +344,8 @@ fn test_proximity_split_word() {
         .unwrap();
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
     s.query("xyz wilting");
@@ -365,7 +368,8 @@ fn test_proximity_prefix_db() {
     let index = create_edge_cases_index();
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
     s.query("best s");
@@ -390,7 +394,7 @@ fn test_proximity_prefix_db() {
     "###);
 
     // Difference when using the `su` prefix, which is not in the prefix DB
-    let mut s = index.search(&txn);
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
     s.query("best su");
@@ -417,7 +421,7 @@ fn test_proximity_prefix_db() {
     // **proximity** prefix DB. In that case, its sprximity score will always be
     // the maximum. This happens for prefixes that are larger than 2 bytes.
 
-    let mut s = index.search(&txn);
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
     s.query("best win");
@@ -441,7 +445,7 @@ fn test_proximity_prefix_db() {
 
     // Now using `wint`, which is not in the prefix DB:
 
-    let mut s = index.search(&txn);
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
     s.query("best wint");
@@ -465,7 +469,7 @@ fn test_proximity_prefix_db() {
 
     // and using `wi` which is in the prefix DB and proximity prefix DB
 
-    let mut s = index.search(&txn);
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
     s.query("best wi");

--- a/crates/milli/src/search/new/tests/proximity_typo.rs
+++ b/crates/milli/src/search/new/tests/proximity_typo.rs
@@ -57,7 +57,8 @@ fn test_trap_basic() {
     let index = create_index();
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.query("summer holiday");
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);

--- a/crates/milli/src/search/new/tests/sort.rs
+++ b/crates/milli/src/search/new/tests/sort.rs
@@ -183,7 +183,8 @@ fn test_sort() {
     let index = create_index();
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::Last);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
     s.sort_criteria(vec![AscDesc::Desc(Member::Field(S("letter")))]);
@@ -218,7 +219,7 @@ fn test_sort() {
     ]
     "###);
 
-    let mut s = index.search(&txn);
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::Last);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
     s.sort_criteria(vec![AscDesc::Desc(Member::Field(S("rank")))]);
@@ -253,7 +254,7 @@ fn test_sort() {
     ]
     "###);
 
-    let mut s = index.search(&txn);
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::Last);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
     s.sort_criteria(vec![AscDesc::Asc(Member::Field(S("vague")))]);
@@ -288,7 +289,7 @@ fn test_sort() {
     ]
     "###);
 
-    let mut s = index.search(&txn);
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::Last);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
     s.sort_criteria(vec![AscDesc::Desc(Member::Field(S("vague")))]);
@@ -337,7 +338,8 @@ fn test_redacted() {
 
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::Last);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
     s.sort_criteria(vec![

--- a/crates/milli/src/search/new/tests/stop_words.rs
+++ b/crates/milli/src/search/new/tests/stop_words.rs
@@ -79,7 +79,8 @@ fn test_ignore_stop_words() {
     let txn = index.read_txn().unwrap();
 
     // `the` is treated as a prefix here, so it's not ignored
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.query("xyz to the");
     s.terms_matching_strategy(TermsMatchingStrategy::Last);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
@@ -132,7 +133,7 @@ fn test_ignore_stop_words() {
     "###);
 
     // `xyz` is treated as a prefix here, so it's not ignored
-    let mut s = index.search(&txn);
+    let mut s = index.search(&txn, &fields_ids_map);
     s.query("to the xyz");
     s.terms_matching_strategy(TermsMatchingStrategy::Last);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
@@ -185,7 +186,7 @@ fn test_ignore_stop_words() {
     "###);
 
     // `xyz` is not treated as a prefix anymore because of the trailing space, so it's ignored
-    let mut s = index.search(&txn);
+    let mut s = index.search(&txn, &fields_ids_map);
     s.query("to the xyz ");
     s.terms_matching_strategy(TermsMatchingStrategy::Last);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
@@ -237,7 +238,7 @@ fn test_ignore_stop_words() {
     ]
     "###);
 
-    let mut s = index.search(&txn);
+    let mut s = index.search(&txn, &fields_ids_map);
     s.query("to the dragon xyz");
     s.terms_matching_strategy(TermsMatchingStrategy::Last);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
@@ -296,7 +297,8 @@ fn test_stop_words_in_phrase() {
 
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.query("\"how to train your dragon\"");
     s.terms_matching_strategy(TermsMatchingStrategy::Last);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
@@ -389,7 +391,7 @@ fn test_stop_words_in_phrase() {
     ]
     "###);
 
-    let mut s = index.search(&txn);
+    let mut s = index.search(&txn, &fields_ids_map);
     s.query("how \"to\" train \"the");
     s.terms_matching_strategy(TermsMatchingStrategy::Last);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
@@ -441,7 +443,7 @@ fn test_stop_words_in_phrase() {
     ]
     "###);
 
-    let mut s = index.search(&txn);
+    let mut s = index.search(&txn, &fields_ids_map);
     s.query("how \"to\" train \"The dragon");
     s.terms_matching_strategy(TermsMatchingStrategy::Last);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
@@ -449,7 +451,7 @@ fn test_stop_words_in_phrase() {
     insta::assert_snapshot!(format!("{documents_ids:?}"), @"[3, 6, 5]");
     insta::assert_snapshot!(format!("{document_scores:#?}"));
 
-    let mut s = index.search(&txn);
+    let mut s = index.search(&txn, &fields_ids_map);
     s.query("\"to\"");
     s.terms_matching_strategy(TermsMatchingStrategy::Last);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);

--- a/crates/milli/src/search/new/tests/typo.rs
+++ b/crates/milli/src/search/new/tests/typo.rs
@@ -157,7 +157,8 @@ fn test_no_typo() {
 
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.query("the quick brown fox jumps over the lazy dog");
     let SearchResult { documents_ids, document_scores, .. } = s.execute().unwrap();
@@ -175,6 +176,7 @@ fn test_no_typo() {
 fn test_default_typo() {
     let index = create_index();
     let txn = index.read_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
 
     let ot = index.min_word_len_one_typo(&txn).unwrap();
     let tt = index.min_word_len_two_typos(&txn).unwrap();
@@ -182,7 +184,7 @@ fn test_default_typo() {
     insta::assert_debug_snapshot!(tt, @"9");
 
     // 0 typo
-    let mut s = index.search(&txn);
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.query("the quick brown fox jumps over the lazy dog");
     let SearchResult { documents_ids, document_scores, .. } = s.execute().unwrap();
@@ -202,7 +204,7 @@ fn test_default_typo() {
     "###);
 
     // 1 typo on one word, replaced letter
-    let mut s = index.search(&txn);
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.query("the quack brown fox jumps over the lazy dog");
     let SearchResult { documents_ids, document_scores, .. } = s.execute().unwrap();
@@ -216,7 +218,7 @@ fn test_default_typo() {
     "###);
 
     // 1 typo on one word, missing letter, extra letter
-    let mut s = index.search(&txn);
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.query("the quicest brownest fox jummps over the laziest dog");
     let SearchResult { documents_ids, document_scores, .. } = s.execute().unwrap();
@@ -235,7 +237,8 @@ fn test_phrase_no_typo_allowed() {
     let index = create_index();
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.query("the \"quick brewn\" fox jumps over the lazy dog");
     let SearchResult { documents_ids, document_scores, .. } = s.execute().unwrap();
@@ -258,6 +261,7 @@ fn test_typo_exact_word() {
         .unwrap();
 
     let txn = index.read_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
 
     let ot = index.min_word_len_one_typo(&txn).unwrap();
     let tt = index.min_word_len_two_typos(&txn).unwrap();
@@ -265,7 +269,7 @@ fn test_typo_exact_word() {
     insta::assert_debug_snapshot!(tt, @"9");
 
     // don't match quivk
-    let mut s = index.search(&txn);
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.query("the quick brown fox jumps over the lazy dog");
     let SearchResult { documents_ids, document_scores, .. } = s.execute().unwrap();
@@ -279,7 +283,7 @@ fn test_typo_exact_word() {
     "###);
 
     // Don't match quick
-    let mut s = index.search(&txn);
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.query("the quack brown fox jumps over the lazy dog");
     let SearchResult { documents_ids, document_scores, .. } = s.execute().unwrap();
@@ -287,7 +291,7 @@ fn test_typo_exact_word() {
     insta::assert_snapshot!(format!("{document_scores:?}"), @"[]");
 
     // words not in exact_words (quicest, jummps) have normal typo handling
-    let mut s = index.search(&txn);
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.query("the quicest brownest fox jummps over the laziest dog");
     let SearchResult { documents_ids, document_scores, .. } = s.execute().unwrap();
@@ -301,7 +305,7 @@ fn test_typo_exact_word() {
     "###);
 
     // exact words do not disable prefix (sunflowering OK, but no sunflowar)
-    let mut s = index.search(&txn);
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
     s.query("network interconnection sunflower");
@@ -333,6 +337,7 @@ fn test_typo_exact_attribute() {
         .unwrap();
 
     let txn = index.read_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
 
     let ot = index.min_word_len_one_typo(&txn).unwrap();
     let tt = index.min_word_len_two_typos(&txn).unwrap();
@@ -340,7 +345,7 @@ fn test_typo_exact_attribute() {
     insta::assert_debug_snapshot!(tt, @"9");
 
     // Exact match returns both exact attributes and tolerant ones.
-    let mut s = index.search(&txn);
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
     s.query("the quick brown fox jumps over the lazy dog");
@@ -365,7 +370,7 @@ fn test_typo_exact_attribute() {
     "###);
 
     // 1 typo only returns the tolerant attribute
-    let mut s = index.search(&txn);
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
     s.query("the quidk brown fox jumps over the lazy dog");
@@ -386,7 +391,7 @@ fn test_typo_exact_attribute() {
     "###);
 
     // combine with exact words
-    let mut s = index.search(&txn);
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
     s.query("the quivk brown fox jumps over the lazy dog");
@@ -414,7 +419,7 @@ fn test_typo_exact_attribute() {
     "###);
 
     // No result in tolerant attribute
-    let mut s = index.search(&txn);
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
     s.query("the quicest brownest fox jummps over the laziest dog");
@@ -428,7 +433,8 @@ fn test_ngram_typos() {
     let index = create_index();
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
     s.query("the extra lagant fox skyrocketed over the languorous dog");
@@ -442,7 +448,7 @@ fn test_ngram_typos() {
     ]
     "###);
 
-    let mut s = index.search(&txn);
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
     s.query("the ex tra lagant fox skyrocketed over the languorous dog");
@@ -463,7 +469,8 @@ fn test_typo_ranking_rule_not_preceded_by_words_ranking_rule() {
 
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::Last);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
     s.query("the quick brown fox jumps over the lazy dog");
@@ -499,7 +506,7 @@ fn test_typo_ranking_rule_not_preceded_by_words_ranking_rule() {
         })
         .unwrap();
 
-    let mut s = index.search(&txn);
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::Last);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
     s.query("the quick brown fox jumps over the lazy dog");
@@ -515,9 +522,10 @@ fn test_typo_bucketing() {
     let index = create_index();
 
     let txn = index.read_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
 
     // First do the search with just the Words ranking rule
-    let mut s = index.search(&txn);
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
     s.query("network interconnection sunflower");
@@ -545,7 +553,8 @@ fn test_typo_bucketing() {
         .unwrap();
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
     s.query("network interconnection sunflower");
@@ -564,7 +573,7 @@ fn test_typo_bucketing() {
     ]
     "###);
 
-    let mut s = index.search(&txn);
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
     s.query("network interconnection sun flower");
@@ -600,7 +609,8 @@ fn test_typo_synonyms() {
         .unwrap();
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
     s.query("the quick brown fox jumps over the lackadaisical dog");
@@ -616,7 +626,7 @@ fn test_typo_synonyms() {
     ]
     "###);
 
-    let mut s = index.search(&txn);
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
     s.query("the fast brownish fox jumps over the lackadaisical dog");

--- a/crates/milli/src/search/new/tests/typo_proximity.rs
+++ b/crates/milli/src/search/new/tests/typo_proximity.rs
@@ -87,7 +87,8 @@ fn test_trap_basic_and_complex1() {
     let index = create_index();
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.query("beautiful summer");
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
@@ -110,7 +111,8 @@ fn test_trap_complex2() {
     let index = create_index();
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.query("delicious sweet dessert");
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);

--- a/crates/milli/src/search/new/tests/word_position.rs
+++ b/crates/milli/src/search/new/tests/word_position.rs
@@ -134,7 +134,8 @@ fn test_attribute_position_simple() {
 
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.query("quick brown");
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
@@ -150,7 +151,8 @@ fn test_attribute_position_repeated() {
 
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.query("a a a a a");
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
@@ -167,7 +169,8 @@ fn test_attribute_position_different_fields() {
 
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.query("quick brown");
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
@@ -184,7 +187,8 @@ fn test_attribute_position_ngrams() {
 
     let txn = index.read_txn().unwrap();
 
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.query("quick brown");
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);

--- a/crates/milli/src/search/new/tests/words_tms.rs
+++ b/crates/milli/src/search/new/tests/words_tms.rs
@@ -131,7 +131,8 @@ fn test_words_tms_last_simple() {
     let index = create_index();
 
     let txn = index.read_txn().unwrap();
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.query("the quick brown fox jumps over the lazy dog");
     s.terms_matching_strategy(TermsMatchingStrategy::Last);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
@@ -166,7 +167,7 @@ fn test_words_tms_last_simple() {
     ]
     "###);
 
-    let mut s = index.search(&txn);
+    let mut s = index.search(&txn, &fields_ids_map);
     s.query("extravagant the quick brown fox jumps over the lazy dog");
     s.terms_matching_strategy(TermsMatchingStrategy::Last);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
@@ -180,7 +181,8 @@ fn test_words_tms_last_phrase() {
     let index = create_index();
 
     let txn = index.read_txn().unwrap();
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.query("\"the quick brown fox\" jumps over the lazy dog");
     s.terms_matching_strategy(TermsMatchingStrategy::Last);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
@@ -205,7 +207,7 @@ fn test_words_tms_last_phrase() {
     ]
     "###);
 
-    let mut s = index.search(&txn);
+    let mut s = index.search(&txn, &fields_ids_map);
     s.query("\"the quick brown fox\" jumps over the \"lazy\" dog");
     s.terms_matching_strategy(TermsMatchingStrategy::Last);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
@@ -227,7 +229,7 @@ fn test_words_tms_last_phrase() {
     ]
     "###);
 
-    let mut s = index.search(&txn);
+    let mut s = index.search(&txn, &fields_ids_map);
     s.query("\"the quick brown fox jumps over the lazy dog\"");
     s.terms_matching_strategy(TermsMatchingStrategy::Last);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
@@ -243,7 +245,7 @@ fn test_words_tms_last_phrase() {
     ]
     "###);
 
-    let mut s = index.search(&txn);
+    let mut s = index.search(&txn, &fields_ids_map);
     s.query("\"the quick brown fox jumps over the lazy dog");
     s.terms_matching_strategy(TermsMatchingStrategy::Last);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
@@ -270,7 +272,8 @@ fn test_words_proximity_tms_last_simple() {
         .unwrap();
 
     let txn = index.read_txn().unwrap();
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.query("the quick brown fox jumps over the lazy dog");
     s.terms_matching_strategy(TermsMatchingStrategy::Last);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
@@ -305,7 +308,7 @@ fn test_words_proximity_tms_last_simple() {
     ]
     "###);
 
-    let mut s = index.search(&txn);
+    let mut s = index.search(&txn, &fields_ids_map);
     s.query("the brown quick fox jumps over the lazy dog");
     s.terms_matching_strategy(TermsMatchingStrategy::Last);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
@@ -351,7 +354,8 @@ fn test_words_proximity_tms_last_phrase() {
         .unwrap();
 
     let txn = index.read_txn().unwrap();
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.query("the \"quick brown\" fox jumps over the lazy dog");
     s.terms_matching_strategy(TermsMatchingStrategy::Last);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
@@ -382,7 +386,7 @@ fn test_words_proximity_tms_last_phrase() {
     ]
     "###);
 
-    let mut s = index.search(&txn);
+    let mut s = index.search(&txn, &fields_ids_map);
     s.query("the \"quick brown\" \"fox jumps\" over the lazy dog");
     s.terms_matching_strategy(TermsMatchingStrategy::Last);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
@@ -421,7 +425,8 @@ fn test_words_tms_all() {
         .unwrap();
 
     let txn = index.read_txn().unwrap();
-    let mut s = index.search(&txn);
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+    let mut s = index.search(&txn, &fields_ids_map);
     s.query("the quick brown fox jumps over the lazy dog");
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
@@ -447,7 +452,7 @@ fn test_words_tms_all() {
     ]
     "###);
 
-    let mut s = index.search(&txn);
+    let mut s = index.search(&txn, &fields_ids_map);
     s.query("extravagant");
     s.terms_matching_strategy(TermsMatchingStrategy::All);
     s.scoring_strategy(crate::score_details::ScoringStrategy::Detailed);
@@ -472,7 +477,8 @@ fn test_words_tms_attribute_rank_word_position_order_keeps_hits() {
     let hit_count = |criteria: Vec<Criterion>| -> usize {
         index.update_settings(|s| s.set_criteria(criteria.clone())).unwrap();
         let txn = index.read_txn().unwrap();
-        let mut s = index.search(&txn);
+        let fields_ids_map = index.fields_ids_map(&txn).unwrap();
+        let mut s = index.search(&txn, &fields_ids_map);
         s.query("the quick brown fox jumps over the lazy dog");
         s.terms_matching_strategy(TermsMatchingStrategy::Last);
         s.limit(100);

--- a/crates/milli/src/search/similar.rs
+++ b/crates/milli/src/search/similar.rs
@@ -6,7 +6,7 @@ use crate::progress::Progress;
 use crate::score_details::{self, ScoreDetails};
 use crate::search::facet::IndexFilter;
 use crate::vector::{Embedder, VectorStore};
-use crate::{filtered_universe, DocumentId, Index, Result, SearchResult};
+use crate::{filtered_universe, DocumentId, FieldsIdsMap, Index, Result, SearchResult};
 
 pub struct Similar<'a> {
     id: DocumentId,
@@ -15,6 +15,7 @@ pub struct Similar<'a> {
     offset: usize,
     limit: usize,
     rtxn: &'a heed::RoTxn<'a>,
+    fields_ids_map: &'a FieldsIdsMap,
     index: &'a Index,
     embedder_name: String,
     embedder: Arc<Embedder>,
@@ -31,6 +32,7 @@ impl<'a> Similar<'a> {
         limit: usize,
         index: &'a Index,
         rtxn: &'a heed::RoTxn<'a>,
+        fields_ids_map: &'a FieldsIdsMap,
         embedder_name: String,
         embedder: Arc<Embedder>,
         quantized: bool,
@@ -41,8 +43,9 @@ impl<'a> Similar<'a> {
             filter: None,
             offset,
             limit,
-            rtxn,
             index,
+            rtxn,
+            fields_ids_map,
             embedder_name,
             embedder,
             ranking_score_threshold: None,
@@ -62,8 +65,14 @@ impl<'a> Similar<'a> {
     }
 
     pub fn execute(&self) -> Result<SearchResult> {
-        let mut universe =
-            filtered_universe(self.index, self.rtxn, &self.filter, None, self.progress)?;
+        let mut universe = filtered_universe(
+            self.index,
+            self.rtxn,
+            self.fields_ids_map,
+            &self.filter,
+            None,
+            self.progress,
+        )?;
 
         // we never want to receive the docid
         universe.remove(self.id);

--- a/crates/milli/src/search/steps.rs
+++ b/crates/milli/src/search/steps.rs
@@ -2,6 +2,7 @@ use crate::make_enum_progress;
 
 make_enum_progress! {
     pub enum SearchStep {
+        LoadFieldIdsMap,
         TokenizeQuery,
         EmbedQuery,
         EvaluateFilter,

--- a/crates/milli/src/snapshot_tests.rs
+++ b/crates/milli/src/snapshot_tests.rs
@@ -311,7 +311,8 @@ pub fn snap_fields_ids_map(index: &Index) -> String {
 }
 pub fn snap_fieldids_weights_map(index: &Index) -> String {
     let rtxn = index.read_txn().unwrap();
-    let weights_map = index.fieldids_weights_map(&rtxn).unwrap();
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
+    let weights_map = index.fieldids_weights_map(&rtxn, &fields_ids_map).unwrap();
 
     let mut snap = String::new();
     writeln!(&mut snap, "fid weight").unwrap();
@@ -325,7 +326,8 @@ pub fn snap_fieldids_weights_map(index: &Index) -> String {
 }
 pub fn snap_searchable_fields(index: &Index) -> String {
     let rtxn = index.read_txn().unwrap();
-    let searchable_fields = index.searchable_fields(&rtxn).unwrap();
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
+    let searchable_fields = index.searchable_fields(&rtxn, &fields_ids_map).unwrap();
     format!("{searchable_fields:?}")
 }
 pub fn snap_geo_faceted_documents_ids(index: &Index) -> String {
@@ -375,6 +377,7 @@ pub fn snap_words_prefixes_fst(index: &Index) -> String {
 pub fn snap_settings(index: &Index) -> String {
     let mut snap = String::new();
     let rtxn = index.read_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
 
     let mut builder = TokenizerBuilder::new();
     let stop_words = index.stop_words(&rtxn).unwrap();
@@ -425,7 +428,11 @@ pub fn snap_settings(index: &Index) -> String {
     write_setting_to_snap!(exact_attributes);
     write_setting_to_snap!(max_values_per_facet);
     write_setting_to_snap!(pagination_max_total_hits);
-    write_setting_to_snap!(searchable_fields);
+
+    // searchable_fields
+    let searchable_fields = index.searchable_fields(&rtxn, &fields_ids_map).unwrap();
+    writeln!(&mut snap, "{}: {:?}", stringify!(searchable_fields), searchable_fields).unwrap();
+
     write_setting_to_snap!(user_defined_searchable_fields);
 
     snap

--- a/crates/milli/src/test_index.rs
+++ b/crates/milli/src/test_index.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::HashSet;
 use std::ops::Deref;
 
@@ -23,13 +24,12 @@ use crate::update::{
 use crate::vector::settings::{EmbedderSource, EmbeddingSettings};
 use crate::vector::RuntimeEmbedders;
 use crate::{
-    db_snap, obkv_to_json, CreateOrOpen, FieldsIdsMap, Filter, FilterableAttributesRule, Index,
+    db_snap, obkv_to_json, CreateOrOpen, Filter, FilterableAttributesRule, Index,
     MustStopProcessing, Search, SearchResult,
 };
 
 pub(crate) struct TempIndex {
     pub inner: Index,
-    pub fields_ids_map: FieldsIdsMap,
     pub indexer_config: IndexerConfig,
     pub index_documents_config: IndexDocumentsConfig,
     pub progress: Progress,
@@ -57,12 +57,7 @@ impl TempIndex {
         let index_documents_config = IndexDocumentsConfig::default();
         let progress = Progress::default();
 
-        let fields_ids_map = {
-            let rtxn = inner.read_txn().unwrap();
-            inner.fields_ids_map(&rtxn).unwrap()
-        };
-
-        Self { inner, fields_ids_map, indexer_config, index_documents_config, progress, _tempdir }
+        Self { inner, indexer_config, index_documents_config, progress, _tempdir }
     }
     /// Creates a temporary index, with a default `4096 * 2000` size. This should be enough for
     /// most tests.
@@ -251,10 +246,11 @@ impl TempIndex {
     }
 
     pub fn search<'a>(&'a self, rtxn: &'a heed::RoTxn<'a>) -> Search<'a> {
+        let fields_ids_map = self.inner.fields_ids_map(rtxn).unwrap();
         self.inner.search(
             rtxn,
             "test",
-            &self.fields_ids_map,
+            Cow::Owned(fields_ids_map),
             time::OffsetDateTime::now_utc(),
             &self.progress,
         )

--- a/crates/milli/src/test_index.rs
+++ b/crates/milli/src/test_index.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::collections::HashSet;
 use std::ops::Deref;
 
@@ -24,7 +23,7 @@ use crate::update::{
 use crate::vector::settings::{EmbedderSource, EmbeddingSettings};
 use crate::vector::RuntimeEmbedders;
 use crate::{
-    db_snap, obkv_to_json, CreateOrOpen, Filter, FilterableAttributesRule, Index,
+    db_snap, obkv_to_json, CreateOrOpen, FieldsIdsMap, Filter, FilterableAttributesRule, Index,
     MustStopProcessing, Search, SearchResult,
 };
 
@@ -245,12 +244,15 @@ impl TempIndex {
         self.delete_documents(vec![external_document_id.to_string()])
     }
 
-    pub fn search<'a>(&'a self, rtxn: &'a heed::RoTxn<'a>) -> Search<'a> {
-        let fields_ids_map = self.inner.fields_ids_map(rtxn).unwrap();
+    pub fn search<'a>(
+        &'a self,
+        rtxn: &'a heed::RoTxn<'a>,
+        fields_ids_map: &'a FieldsIdsMap,
+    ) -> Search<'a> {
         self.inner.search(
             rtxn,
             "test",
-            Cow::Owned(fields_ids_map),
+            fields_ids_map,
             time::OffsetDateTime::now_utc(),
             &self.progress,
         )
@@ -502,7 +504,8 @@ fn test_basic_geo_bounding_box() {
 
     // ensure we get the right real searchable fields + user defined searchable fields
     let rtxn = index.read_txn().unwrap();
-    let mut search = index.search(&rtxn);
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
+    let mut search = index.search(&rtxn, &fields_ids_map);
 
     // exact match a document
     let search_result = search
@@ -631,19 +634,20 @@ fn test_contains() {
         .unwrap();
 
     let rtxn = index.read_txn().unwrap();
-    let mut search = index.search(&rtxn);
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
+    let mut search = index.search(&rtxn, &fields_ids_map);
     let search_result = search
         .filter(Some(IndexFilter::from(Filter::from_str("doggo CONTAINS kefir").unwrap().unwrap())))
         .execute()
         .unwrap();
     insta::assert_debug_snapshot!(search_result.candidates, @"RoaringBitmap<[0, 1]>");
-    let mut search = index.search(&rtxn);
+    let mut search = index.search(&rtxn, &fields_ids_map);
     let search_result = search
         .filter(Some(IndexFilter::from(Filter::from_str("doggo CONTAINS KEF").unwrap().unwrap())))
         .execute()
         .unwrap();
     insta::assert_debug_snapshot!(search_result.candidates, @"RoaringBitmap<[0, 1, 2]>");
-    let mut search = index.search(&rtxn);
+    let mut search = index.search(&rtxn, &fields_ids_map);
     let search_result = search
         .filter(Some(IndexFilter::from(
             Filter::from_str("doggo NOT CONTAINS fir").unwrap().unwrap(),
@@ -1166,7 +1170,8 @@ fn bug_3021_fourth() {
         "###);
 
     let rtxn = index.read_txn().unwrap();
-    let search = index.search(&rtxn);
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
+    let search = index.search(&rtxn, &fields_ids_map);
     let SearchResult {
         matching_words: _,
         candidates: _,
@@ -1334,7 +1339,8 @@ fn attribute_weights_after_swapping_searchable_attributes() {
         .unwrap();
 
     let rtxn = index.read_txn().unwrap();
-    let mut search = index.search(&rtxn);
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
+    let mut search = index.search(&rtxn, &fields_ids_map);
     let results = search.query("kefir").execute().unwrap();
 
     // We should find kefir the dog first
@@ -1352,7 +1358,8 @@ fn attribute_weights_after_swapping_searchable_attributes() {
         .unwrap();
 
     let rtxn = index.read_txn().unwrap();
-    let mut search = index.search(&rtxn);
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
+    let mut search = index.search(&rtxn, &fields_ids_map);
     let results = search.query("kefir").execute().unwrap();
 
     // We should find tamo first
@@ -1386,7 +1393,8 @@ fn vectors_are_never_indexed_as_searchable_or_filterable() {
         "###);
 
     let rtxn = index.read_txn().unwrap();
-    let mut search = index.search(&rtxn);
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
+    let mut search = index.search(&rtxn, &fields_ids_map);
     let results = search.query("2345").execute().unwrap();
     assert!(results.candidates.is_empty());
     drop(rtxn);
@@ -1411,11 +1419,12 @@ fn vectors_are_never_indexed_as_searchable_or_filterable() {
         "###);
 
     let rtxn = index.read_txn().unwrap();
-    let mut search = index.search(&rtxn);
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
+    let mut search = index.search(&rtxn, &fields_ids_map);
     let results = search.query("2345").execute().unwrap();
     assert!(results.candidates.is_empty());
 
-    let mut search = index.search(&rtxn);
+    let mut search = index.search(&rtxn, &fields_ids_map);
     let results = dbg!(search
         .filter(Some(IndexFilter::from(
             Filter::from_str("_vectors.doggo = 6789").unwrap().unwrap()
@@ -1445,11 +1454,12 @@ fn vectors_are_never_indexed_as_searchable_or_filterable() {
         "###);
 
     let rtxn = index.read_txn().unwrap();
-    let mut search = index.search(&rtxn);
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
+    let mut search = index.search(&rtxn, &fields_ids_map);
     let results = search.query("2345").execute().unwrap();
     assert!(results.candidates.is_empty());
 
-    let mut search = index.search(&rtxn);
+    let mut search = index.search(&rtxn, &fields_ids_map);
     let results = search
         .filter(Some(IndexFilter::from(
             Filter::from_str("_vectors.doggo = 6789").unwrap().unwrap(),

--- a/crates/milli/src/test_index.rs
+++ b/crates/milli/src/test_index.rs
@@ -23,12 +23,13 @@ use crate::update::{
 use crate::vector::settings::{EmbedderSource, EmbeddingSettings};
 use crate::vector::RuntimeEmbedders;
 use crate::{
-    db_snap, obkv_to_json, CreateOrOpen, Filter, FilterableAttributesRule, Index,
+    db_snap, obkv_to_json, CreateOrOpen, FieldsIdsMap, Filter, FilterableAttributesRule, Index,
     MustStopProcessing, Search, SearchResult,
 };
 
 pub(crate) struct TempIndex {
     pub inner: Index,
+    pub fields_ids_map: FieldsIdsMap,
     pub indexer_config: IndexerConfig,
     pub index_documents_config: IndexDocumentsConfig,
     pub progress: Progress,
@@ -56,7 +57,12 @@ impl TempIndex {
         let index_documents_config = IndexDocumentsConfig::default();
         let progress = Progress::default();
 
-        Self { inner, indexer_config, index_documents_config, progress, _tempdir }
+        let fields_ids_map = {
+            let rtxn = inner.read_txn().unwrap();
+            inner.fields_ids_map(&rtxn).unwrap()
+        };
+
+        Self { inner, fields_ids_map, indexer_config, index_documents_config, progress, _tempdir }
     }
     /// Creates a temporary index, with a default `4096 * 2000` size. This should be enough for
     /// most tests.
@@ -245,7 +251,13 @@ impl TempIndex {
     }
 
     pub fn search<'a>(&'a self, rtxn: &'a heed::RoTxn<'a>) -> Search<'a> {
-        self.inner.search(rtxn, "test", time::OffsetDateTime::now_utc(), &self.progress)
+        self.inner.search(
+            rtxn,
+            "test",
+            &self.fields_ids_map,
+            time::OffsetDateTime::now_utc(),
+            &self.progress,
+        )
     }
 }
 
@@ -424,8 +436,9 @@ fn add_documents_and_set_searchable_fields() {
 
     // ensure we get the right real searchable fields + user defined searchable fields
     let rtxn = index.read_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
 
-    let real = index.searchable_fields(&rtxn).unwrap();
+    let real = index.searchable_fields(&rtxn, &fields_ids_map).unwrap();
     assert_eq!(real, &["doggo", "name", "doggo.name", "doggo.age"]);
 
     let user_defined = index.user_defined_searchable_fields(&rtxn).unwrap().unwrap();
@@ -444,8 +457,9 @@ fn set_searchable_fields_and_add_documents() {
 
     // ensure we get the right real searchable fields + user defined searchable fields
     let rtxn = index.read_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
 
-    let real = index.searchable_fields(&rtxn).unwrap();
+    let real = index.searchable_fields(&rtxn, &fields_ids_map).unwrap();
     assert!(real.is_empty());
     let user_defined = index.user_defined_searchable_fields(&rtxn).unwrap().unwrap();
     assert_eq!(user_defined, &["doggo", "name"]);
@@ -460,8 +474,9 @@ fn set_searchable_fields_and_add_documents() {
 
     // ensure we get the right real searchable fields + user defined searchable fields
     let rtxn = index.read_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
 
-    let real = index.searchable_fields(&rtxn).unwrap();
+    let real = index.searchable_fields(&rtxn, &fields_ids_map).unwrap();
     assert_eq!(real, &["doggo", "name", "doggo.name", "doggo.age"]);
 
     let user_defined = index.user_defined_searchable_fields(&rtxn).unwrap().unwrap();

--- a/crates/milli/src/update/index_documents/mod_test.rs
+++ b/crates/milli/src/update/index_documents/mod_test.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 
 use big_s::S;
@@ -608,7 +609,7 @@ fn index_documents_with_nested_primary_key() {
     let mut search = crate::Search::new(
         &rtxn,
         &index,
-        &fields_ids_map,
+        Cow::Borrowed(&fields_ids_map),
         "test",
         OffsetDateTime::now_utc(),
         &progress,
@@ -726,7 +727,7 @@ fn test_facets_generation() {
         let mut search = crate::Search::new(
             &rtxn,
             &index,
-            &fields_ids_map,
+            Cow::Borrowed(&fields_ids_map),
             "test",
             OffsetDateTime::now_utc(),
             &progress,
@@ -772,7 +773,7 @@ fn test_facets_generation() {
     let mut search = crate::Search::new(
         &rtxn,
         &index,
-        &fields_ids_map,
+        Cow::Borrowed(&fields_ids_map),
         "test",
         OffsetDateTime::now_utc(),
         &progress,
@@ -2901,7 +2902,7 @@ fn delete_words_exact_attributes() {
     let mut s = crate::Search::new(
         &txn,
         &index,
-        &fields_ids_map,
+        Cow::Borrowed(&fields_ids_map),
         "test",
         OffsetDateTime::now_utc(),
         &progress,

--- a/crates/milli/src/update/index_documents/mod_test.rs
+++ b/crates/milli/src/update/index_documents/mod_test.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::collections::BTreeMap;
 
 use big_s::S;
@@ -171,17 +170,18 @@ fn complex_documents() {
 
     // Check that there is 1 documents now.
     let rtxn = index.read_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
 
     // Search for a sub object value
-    let result = index.search(&rtxn).query(r#""value2""#).execute().unwrap();
+    let result = index.search(&rtxn, &fields_ids_map).query(r#""value2""#).execute().unwrap();
     assert_eq!(result.documents_ids, vec![0]);
 
     // Search for a sub array value
-    let result = index.search(&rtxn).query(r#""fine""#).execute().unwrap();
+    let result = index.search(&rtxn, &fields_ids_map).query(r#""fine""#).execute().unwrap();
     assert_eq!(result.documents_ids, vec![1]);
 
     // Search for a sub array sub object key
-    let result = index.search(&rtxn).query(r#""amazing""#).execute().unwrap();
+    let result = index.search(&rtxn, &fields_ids_map).query(r#""amazing""#).execute().unwrap();
     assert_eq!(result.documents_ids, vec![2]);
 
     drop(rtxn);
@@ -491,9 +491,10 @@ fn index_documents_with_nested_fields() {
         .unwrap();
 
     let rtxn = index.read_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
 
     // testing the simple query search
-    let mut search = index.search(&rtxn);
+    let mut search = index.search(&rtxn, &fields_ids_map);
     search.query("document");
     search.terms_matching_strategy(TermsMatchingStrategy::default());
     // all documents should be returned
@@ -534,7 +535,7 @@ fn index_documents_with_nested_fields() {
     assert!(documents_ids.is_empty()); // nested is not searchable
 
     // testing the filters
-    let mut search = index.search(&rtxn);
+    let mut search = index.search(&rtxn, &fields_ids_map);
 
     let filter = crate::Filter::from_str(r#"title = "The first document""#).unwrap().unwrap();
     search.filter(Some(IndexFilter::from(filter)));
@@ -609,7 +610,7 @@ fn index_documents_with_nested_primary_key() {
     let mut search = crate::Search::new(
         &rtxn,
         &index,
-        Cow::Borrowed(&fields_ids_map),
+        &fields_ids_map,
         "test",
         OffsetDateTime::now_utc(),
         &progress,
@@ -727,7 +728,7 @@ fn test_facets_generation() {
         let mut search = crate::Search::new(
             &rtxn,
             &index,
-            Cow::Borrowed(&fields_ids_map),
+            &fields_ids_map,
             "test",
             OffsetDateTime::now_utc(),
             &progress,
@@ -773,7 +774,7 @@ fn test_facets_generation() {
     let mut search = crate::Search::new(
         &rtxn,
         &index,
-        Cow::Borrowed(&fields_ids_map),
+        &fields_ids_map,
         "test",
         OffsetDateTime::now_utc(),
         &progress,
@@ -2103,6 +2104,7 @@ fn test_multiple_vectors() {
            .unwrap();
 
     let rtxn = index.read_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
     let embedders = index.embedding_configs();
     let mut embedding_configs = embedders.embedding_configs(&rtxn).unwrap();
     let IndexEmbeddingConfig { name: embedder_name, config: embedder, fragments } =
@@ -2128,7 +2130,7 @@ fn test_multiple_vectors() {
         .unwrap(),
     );
     let res = index
-        .search(&rtxn)
+        .search(&rtxn, &fields_ids_map)
         .semantic(embedder_name, embedder, false, Some([0.0, 1.0, 2.0].to_vec()), None)
         .execute()
         .unwrap();
@@ -2351,7 +2353,8 @@ fn reproduce_the_bug() {
 
     // Ensuring all the returned IDs actually exists
     let rtxn = index.read_txn().unwrap();
-    let res = index.search(&rtxn).execute().unwrap();
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
+    let res = index.search(&rtxn, &fields_ids_map).execute().unwrap();
     index.documents(&rtxn, res.documents_ids).unwrap();
 }
 
@@ -2493,9 +2496,14 @@ fn filtered_placeholder_search_should_not_return_deleted_documents() {
     wtxn.commit().unwrap();
 
     let rtxn = index.read_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
     // Placeholder search with filter
     let filter = Filter::from_str("label = sign").unwrap().unwrap();
-    let results = index.search(&rtxn).filter(Some(IndexFilter::from(filter))).execute().unwrap();
+    let results = index
+        .search(&rtxn, &fields_ids_map)
+        .filter(Some(IndexFilter::from(filter)))
+        .execute()
+        .unwrap();
     assert!(results.documents_ids.is_empty());
 
     db_snap!(index, word_docids);
@@ -2551,8 +2559,9 @@ fn placeholder_search_should_not_return_deleted_documents() {
 
     // Placeholder search
     let rtxn = index.static_read_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
 
-    let results = index.search(&rtxn).execute().unwrap();
+    let results = index.search(&rtxn, &fields_ids_map).execute().unwrap();
     assert!(!results.documents_ids.is_empty());
     for id in results.documents_ids.iter() {
         assert!(
@@ -2609,7 +2618,8 @@ fn search_should_not_return_deleted_documents() {
 
     // search for abstract
     let rtxn = index.read_txn().unwrap();
-    let results = index.search(&rtxn).query("abstract").execute().unwrap();
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
+    let results = index.search(&rtxn, &fields_ids_map).query("abstract").execute().unwrap();
     assert!(!results.documents_ids.is_empty());
     for id in results.documents_ids.iter() {
         assert!(
@@ -2662,12 +2672,17 @@ fn geo_filtered_placeholder_search_should_not_return_deleted_documents() {
     wtxn.commit().unwrap();
 
     let mut wtxn = index.write_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&wtxn).unwrap();
     let external_ids_to_delete = ["5", "6", "7", "12", "17", "19"];
     let deleted_internal_ids = delete_documents(&mut wtxn, &index, &external_ids_to_delete);
 
     // Placeholder search with geo filter
     let filter = Filter::from_str("_geoRadius(50.6924, 3.1763, 20000)").unwrap().unwrap();
-    let results = index.search(&wtxn).filter(Some(IndexFilter::from(filter))).execute().unwrap();
+    let results = index
+        .search(&wtxn, &fields_ids_map)
+        .filter(Some(IndexFilter::from(filter)))
+        .execute()
+        .unwrap();
     assert!(!results.documents_ids.is_empty());
     for id in results.documents_ids.iter() {
         assert!(
@@ -2902,7 +2917,7 @@ fn delete_words_exact_attributes() {
     let mut s = crate::Search::new(
         &txn,
         &index,
-        Cow::Borrowed(&fields_ids_map),
+        &fields_ids_map,
         "test",
         OffsetDateTime::now_utc(),
         &progress,

--- a/crates/milli/src/update/index_documents/mod_test.rs
+++ b/crates/milli/src/update/index_documents/mod_test.rs
@@ -602,10 +602,17 @@ fn index_documents_with_nested_primary_key() {
         .unwrap();
 
     let rtxn = index.read_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
 
     // testing the simple query search
-    let mut search =
-        crate::Search::new(&rtxn, &index, "test", OffsetDateTime::now_utc(), &progress);
+    let mut search = crate::Search::new(
+        &rtxn,
+        &index,
+        &fields_ids_map,
+        "test",
+        OffsetDateTime::now_utc(),
+        &progress,
+    );
     search.query("document");
     search.terms_matching_strategy(TermsMatchingStrategy::default());
     // all documents should be returned
@@ -713,10 +720,17 @@ fn test_facets_generation() {
     "###);
 
     let rtxn = index.read_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
 
     for (s, i) in [("zeroth", 0), ("first", 1), ("second", 2), ("third", 3)] {
-        let mut search =
-            crate::Search::new(&rtxn, &index, "test", OffsetDateTime::now_utc(), &progress);
+        let mut search = crate::Search::new(
+            &rtxn,
+            &index,
+            &fields_ids_map,
+            "test",
+            OffsetDateTime::now_utc(),
+            &progress,
+        );
         let filter = format!(r#""dog.race.bernese mountain" = {s}"#);
         let filter = crate::Filter::from_str(&filter).unwrap().unwrap();
         search.filter(Some(IndexFilter::from(filter)));
@@ -755,8 +769,14 @@ fn test_facets_generation() {
 
     let rtxn = index.read_txn().unwrap();
 
-    let mut search =
-        crate::Search::new(&rtxn, &index, "test", OffsetDateTime::now_utc(), &progress);
+    let mut search = crate::Search::new(
+        &rtxn,
+        &index,
+        &fields_ids_map,
+        "test",
+        OffsetDateTime::now_utc(),
+        &progress,
+    );
     search.sort_criteria(vec![crate::AscDesc::Asc(crate::Member::Field(S(
         "dog.race.bernese mountain",
     )))]);
@@ -2874,10 +2894,18 @@ fn delete_words_exact_attributes() {
 
     insta::assert_snapshot!(format!("{deleted_internal_ids:?}"), @"[1]");
     let txn = index.read_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
     let words = index.words_fst(&txn).unwrap().into_stream().into_strs().unwrap();
     insta::assert_snapshot!(format!("{words:?}"), @r###"["hello"]"###);
 
-    let mut s = crate::Search::new(&txn, &index, "test", OffsetDateTime::now_utc(), &progress);
+    let mut s = crate::Search::new(
+        &txn,
+        &index,
+        &fields_ids_map,
+        "test",
+        OffsetDateTime::now_utc(),
+        &progress,
+    );
     s.query("hello");
     let crate::SearchResult { documents_ids, .. } = s.execute().unwrap();
     insta::assert_snapshot!(format!("{documents_ids:?}"), @"[0]");

--- a/crates/milli/src/update/index_documents/typed_chunk.rs
+++ b/crates/milli/src/update/index_documents/typed_chunk.rs
@@ -650,6 +650,7 @@ pub(crate) fn write_typed_chunk_into_index(
             let _entered = span.enter();
 
             let embedders = index.embedding_configs();
+            let fields_ids_map = index.fields_ids_map(wtxn)?;
             let backend = index.get_vector_store(wtxn)?.unwrap_or_default();
 
             let mut remove_vectors_builder = MergerBuilder::new(KeepFirst);
@@ -733,7 +734,7 @@ pub(crate) fn write_typed_chunk_into_index(
 
                 if embeddings.embedding_count() > usize::from(u8::MAX) {
                     let external_docid = if let Ok(Some(Ok(index))) = index
-                        .external_id_of(wtxn, std::iter::once(docid))
+                        .external_id_of(wtxn, &fields_ids_map, std::iter::once(docid))
                         .map(|it| it.into_iter().next())
                     {
                         index

--- a/crates/milli/src/update/settings.rs
+++ b/crates/milli/src/update/settings.rs
@@ -2007,7 +2007,7 @@ impl InnerIndexSettings {
         let allowed_separators = index.allowed_separators(rtxn)?;
         let dictionary = index.dictionary(rtxn)?;
         let mut fields_ids_map = index.fields_ids_map(rtxn)?;
-        let exact_attributes = index.exact_attributes_ids(rtxn)?;
+        let exact_attributes = index.exact_attributes_ids(rtxn, &fields_ids_map)?;
         let proximity_precision = index.proximity_precision(rtxn)?.unwrap_or_default();
         let runtime_embedders = match runtime_embedders {
             Some(embedding_configs) => embedding_configs,

--- a/crates/milli/src/update/test_settings.rs
+++ b/crates/milli/src/update/test_settings.rs
@@ -43,18 +43,18 @@ fn set_and_reset_searchable_fields() {
 
     // Check that the searchable field is correctly set to "name" only.
     let rtxn = index.read_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
     // When we search for something that is not in
     // the searchable fields it must not return any document.
-    let result = index.search(&rtxn).query("23").execute().unwrap();
+    let result = index.search(&rtxn, &fields_ids_map).query("23").execute().unwrap();
     assert_eq!(result.documents_ids, Vec::<u32>::new());
 
     // When we search for something that is in the searchable fields
     // we must find the appropriate document.
-    let result = index.search(&rtxn).query(r#""kevin""#).execute().unwrap();
+    let result = index.search(&rtxn, &fields_ids_map).query(r#""kevin""#).execute().unwrap();
     let documents = index.documents(&rtxn, result.documents_ids).unwrap();
-    let fid_map = index.fields_ids_map(&rtxn).unwrap();
     assert_eq!(documents.len(), 1);
-    assert_eq!(documents[0].1.get(fid_map.id("name").unwrap()), Some(&br#""kevin""#[..]));
+    assert_eq!(documents[0].1.get(fields_ids_map.id("name").unwrap()), Some(&br#""kevin""#[..]));
     drop(rtxn);
 
     // We change the searchable fields to be the "name" field only.
@@ -79,16 +79,16 @@ fn set_and_reset_searchable_fields() {
 
     // Check that the searchable field have been reset and documents are found now.
     let rtxn = index.read_txn().unwrap();
-    let fid_map = index.fields_ids_map(&rtxn).unwrap();
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
     let user_defined_searchable_fields = index.user_defined_searchable_fields(&rtxn).unwrap();
     snapshot!(format!("{user_defined_searchable_fields:?}"), @"None");
     // the searchable fields should contain all the fields
-    let searchable_fields = index.searchable_fields(&rtxn, &fid_map).unwrap();
+    let searchable_fields = index.searchable_fields(&rtxn, &fields_ids_map).unwrap();
     snapshot!(format!("{searchable_fields:?}"), @r###"["id", "name", "age"]"###);
-    let result = index.search(&rtxn).query("23").execute().unwrap();
+    let result = index.search(&rtxn, &fields_ids_map).query("23").execute().unwrap();
     assert_eq!(result.documents_ids.len(), 1);
     let documents = index.documents(&rtxn, result.documents_ids).unwrap();
-    assert_eq!(documents[0].1.get(fid_map.id("name").unwrap()), Some(&br#""kevin""#[..]));
+    assert_eq!(documents[0].1.get(fields_ids_map.id("name").unwrap()), Some(&br#""kevin""#[..]));
 }
 
 #[test]
@@ -343,11 +343,13 @@ fn set_asc_desc_field() {
 
     // Run an empty query just to ensure that the search results are ordered.
     let rtxn = index.read_txn().unwrap();
-    let SearchResult { documents_ids, .. } = index.search(&rtxn).execute().unwrap();
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
+    let SearchResult { documents_ids, .. } =
+        index.search(&rtxn, &fields_ids_map).execute().unwrap();
     let documents = index.documents(&rtxn, documents_ids).unwrap();
 
     // Fetch the documents "age" field in the ordre in which the documents appear.
-    let age_field_id = index.fields_ids_map(&rtxn).unwrap().id("age").unwrap();
+    let age_field_id = fields_ids_map.id("age").unwrap();
     let iter = documents.into_iter().map(|(_, doc)| {
         let bytes = doc.get(age_field_id).unwrap();
         let string = std::str::from_utf8(bytes).unwrap();
@@ -385,7 +387,9 @@ fn set_distinct_field() {
 
     // Run an empty query just to ensure that the search results are ordered.
     let rtxn = index.read_txn().unwrap();
-    let SearchResult { documents_ids, .. } = index.search(&rtxn).execute().unwrap();
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
+    let SearchResult { documents_ids, .. } =
+        index.search(&rtxn, &fields_ids_map).execute().unwrap();
 
     // There must be at least one document with a 34 as the age.
     assert_eq!(documents_ids.len(), 3);
@@ -419,7 +423,9 @@ fn set_nested_distinct_field() {
 
     // Run an empty query just to ensure that the search results are ordered.
     let rtxn = index.read_txn().unwrap();
-    let SearchResult { documents_ids, .. } = index.search(&rtxn).execute().unwrap();
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
+    let SearchResult { documents_ids, .. } =
+        index.search(&rtxn, &fields_ids_map).execute().unwrap();
 
     // There must be at least one document with a 34 as the age.
     assert_eq!(documents_ids.len(), 3);
@@ -476,6 +482,7 @@ fn set_and_reset_stop_words() {
 
     // Ensure stop_words are effectively stored
     let rtxn = index.read_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
     let stop_words = index.stop_words(&rtxn).unwrap();
     assert!(stop_words.is_some()); // at this point the index should return something
 
@@ -485,16 +492,16 @@ fn set_and_reset_stop_words() {
 
     // when we search for something that is a non prefix stop_words it should be ignored
     // thus we should get a placeholder search (all the results = 3)
-    let result = index.search(&rtxn).query("the ").execute().unwrap();
+    let result = index.search(&rtxn, &fields_ids_map).query("the ").execute().unwrap();
     assert_eq!(result.documents_ids.len(), 3);
-    let result = index.search(&rtxn).query("i ").execute().unwrap();
+    let result = index.search(&rtxn, &fields_ids_map).query("i ").execute().unwrap();
     assert_eq!(result.documents_ids.len(), 3);
-    let result = index.search(&rtxn).query("are ").execute().unwrap();
+    let result = index.search(&rtxn, &fields_ids_map).query("are ").execute().unwrap();
     assert_eq!(result.documents_ids.len(), 3);
 
-    let result = index.search(&rtxn).query("dog").execute().unwrap();
+    let result = index.search(&rtxn, &fields_ids_map).query("dog").execute().unwrap();
     assert_eq!(result.documents_ids.len(), 2); // we have two maxims talking about doggos
-    let result = index.search(&rtxn).query("benoît").execute().unwrap();
+    let result = index.search(&rtxn, &fields_ids_map).query("benoît").execute().unwrap();
     assert_eq!(result.documents_ids.len(), 1); // there is one benoit in our data
 
     // now we'll reset the stop_words and ensure it's None
@@ -505,21 +512,22 @@ fn set_and_reset_stop_words() {
         .unwrap();
 
     let rtxn = index.read_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
     let stop_words = index.stop_words(&rtxn).unwrap();
     assert!(stop_words.is_none());
 
     // now we can search for the stop words
-    let result = index.search(&rtxn).query("the").execute().unwrap();
+    let result = index.search(&rtxn, &fields_ids_map).query("the").execute().unwrap();
     assert_eq!(result.documents_ids.len(), 2);
-    let result = index.search(&rtxn).query("i").execute().unwrap();
+    let result = index.search(&rtxn, &fields_ids_map).query("i").execute().unwrap();
     assert_eq!(result.documents_ids.len(), 1);
-    let result = index.search(&rtxn).query("are").execute().unwrap();
+    let result = index.search(&rtxn, &fields_ids_map).query("are").execute().unwrap();
     assert_eq!(result.documents_ids.len(), 2);
 
     // the rest of the search is still not impacted
-    let result = index.search(&rtxn).query("dog").execute().unwrap();
+    let result = index.search(&rtxn, &fields_ids_map).query("dog").execute().unwrap();
     assert_eq!(result.documents_ids.len(), 2); // we have two maxims talking about doggos
-    let result = index.search(&rtxn).query("benoît").execute().unwrap();
+    let result = index.search(&rtxn, &fields_ids_map).query("benoît").execute().unwrap();
     assert_eq!(result.documents_ids.len(), 1); // there is one benoit in our data
 }
 
@@ -556,15 +564,16 @@ fn set_and_reset_synonyms() {
 
     // Ensure synonyms are effectively stored
     let rtxn = index.read_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
     let synonyms = index.synonyms.iter(&rtxn).unwrap();
     assert_eq!(synonyms.count(), 3); // at this point the index should return something
 
     // Check that we can use synonyms
-    let result = index.search(&rtxn).query("blini").execute().unwrap();
+    let result = index.search(&rtxn, &fields_ids_map).query("blini").execute().unwrap();
     assert_eq!(result.documents_ids.len(), 1);
-    let result = index.search(&rtxn).query("super like").execute().unwrap();
+    let result = index.search(&rtxn, &fields_ids_map).query("super like").execute().unwrap();
     assert_eq!(result.documents_ids.len(), 1);
-    let result = index.search(&rtxn).query("puppies").execute().unwrap();
+    let result = index.search(&rtxn, &fields_ids_map).query("puppies").execute().unwrap();
     assert_eq!(result.documents_ids.len(), 2);
 
     // Reset the synonyms
@@ -580,11 +589,11 @@ fn set_and_reset_synonyms() {
     assert!(synonyms.next().is_none());
 
     // Check that synonyms are no longer work
-    let result = index.search(&rtxn).query("blini").execute().unwrap();
+    let result = index.search(&rtxn, &fields_ids_map).query("blini").execute().unwrap();
     assert!(result.documents_ids.is_empty());
-    let result = index.search(&rtxn).query("super like").execute().unwrap();
+    let result = index.search(&rtxn, &fields_ids_map).query("super like").execute().unwrap();
     assert!(result.documents_ids.is_empty());
-    let result = index.search(&rtxn).query("puppies").execute().unwrap();
+    let result = index.search(&rtxn, &fields_ids_map).query("puppies").execute().unwrap();
     assert!(result.documents_ids.is_empty());
 }
 
@@ -618,11 +627,12 @@ fn thai_synonyms() {
 
     // Ensure synonyms are effectively stored
     let rtxn = index.read_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
     let synonyms = index.synonyms.iter(&rtxn).unwrap();
     assert_eq!(synonyms.count(), 1); // at this point the index should return something
 
     // Check that we can use synonyms
-    let result = index.search(&rtxn).query("japanese").execute().unwrap();
+    let result = index.search(&rtxn, &fields_ids_map).query("japanese").execute().unwrap();
     assert_eq!(result.documents_ids.len(), 2);
 }
 
@@ -780,7 +790,9 @@ fn setting_impact_relevancy() {
     ])).unwrap();
 
     let rtxn = index.read_txn().unwrap();
-    let SearchResult { documents_ids, .. } = index.search(&rtxn).query("S").execute().unwrap();
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
+    let SearchResult { documents_ids, .. } =
+        index.search(&rtxn, &fields_ids_map).query("S").execute().unwrap();
     let first_id = documents_ids[0];
     let documents = index.documents(&rtxn, documents_ids).unwrap();
     let (_, content) = documents.iter().find(|(id, _)| *id == first_id).unwrap();

--- a/crates/milli/src/update/test_settings.rs
+++ b/crates/milli/src/update/test_settings.rs
@@ -83,7 +83,7 @@ fn set_and_reset_searchable_fields() {
     let user_defined_searchable_fields = index.user_defined_searchable_fields(&rtxn).unwrap();
     snapshot!(format!("{user_defined_searchable_fields:?}"), @"None");
     // the searchable fields should contain all the fields
-    let searchable_fields = index.searchable_fields(&rtxn).unwrap();
+    let searchable_fields = index.searchable_fields(&rtxn, &fid_map).unwrap();
     snapshot!(format!("{searchable_fields:?}"), @r###"["id", "name", "age"]"###);
     let result = index.search(&rtxn).query("23").execute().unwrap();
     assert_eq!(result.documents_ids.len(), 1);

--- a/crates/milli/src/update/test_settings.rs
+++ b/crates/milli/src/update/test_settings.rs
@@ -677,8 +677,9 @@ fn setting_not_filterable_cant_filter() {
         .unwrap();
 
     let rtxn = index.read_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
     let filter = Filter::from_str("toto = 32").unwrap().unwrap();
-    let _ = IndexFilter::from(filter).evaluate(&rtxn, &index).unwrap_err();
+    let _ = IndexFilter::from(filter).evaluate(&rtxn, &index, &fields_ids_map).unwrap_err();
 }
 
 #[test]

--- a/crates/milli/tests/search/distinct.rs
+++ b/crates/milli/tests/search/distinct.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::HashSet;
 
 use big_s::S;
@@ -38,7 +39,7 @@ macro_rules! test_distinct {
             let mut search = Search::new(
                 &rtxn,
                 &index,
-                &fields_ids_map,
+                Cow::Borrowed(&fields_ids_map),
                 "test",
                 time::OffsetDateTime::now_utc(),
                 &progress,

--- a/crates/milli/tests/search/distinct.rs
+++ b/crates/milli/tests/search/distinct.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::collections::HashSet;
 
 use big_s::S;
@@ -39,7 +38,7 @@ macro_rules! test_distinct {
             let mut search = Search::new(
                 &rtxn,
                 &index,
-                Cow::Borrowed(&fields_ids_map),
+                &fields_ids_map,
                 "test",
                 time::OffsetDateTime::now_utc(),
                 &progress,

--- a/crates/milli/tests/search/distinct.rs
+++ b/crates/milli/tests/search/distinct.rs
@@ -32,10 +32,17 @@ macro_rules! test_distinct {
             wtxn.commit().unwrap();
 
             let rtxn = index.read_txn().unwrap();
+            let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
 
             let progress = Progress::default();
-            let mut search =
-                Search::new(&rtxn, &index, "test", time::OffsetDateTime::now_utc(), &progress);
+            let mut search = Search::new(
+                &rtxn,
+                &index,
+                &fields_ids_map,
+                "test",
+                time::OffsetDateTime::now_utc(),
+                &progress,
+            );
             search.query(search::TEST_QUERY);
             search.limit($limit);
             search.offset($offset);

--- a/crates/milli/tests/search/facet_distribution.rs
+++ b/crates/milli/tests/search/facet_distribution.rs
@@ -96,12 +96,13 @@ fn test_facet_distribution_with_no_facet_values() {
     wtxn.commit().unwrap();
 
     let rtxn = index.read_txn().unwrap();
-    let mut distrib = FacetDistribution::new(&rtxn, &index);
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
+    let mut distrib = FacetDistribution::new(&rtxn, &index, &fields_ids_map);
     distrib.facets(vec![("genres", OrderBy::default())]);
     let result = distrib.execute().unwrap();
     assert_eq!(result["genres"].len(), 0);
 
-    let mut distrib = FacetDistribution::new(&rtxn, &index);
+    let mut distrib = FacetDistribution::new(&rtxn, &index, &fields_ids_map);
     distrib.facets(vec![("tags", OrderBy::default())]);
     let result = distrib.execute().unwrap();
     assert_eq!(result["tags"].len(), 2);

--- a/crates/milli/tests/search/filters.rs
+++ b/crates/milli/tests/search/filters.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use either::{Either, Left, Right};
 use filter_parser::{FilterCondition, IndexFilterCondition};
 use milli::progress::Progress;
@@ -57,7 +55,7 @@ macro_rules! test_filter {
             let mut search = Search::new(
                 &rtxn,
                 &index,
-                Cow::Borrowed(&fields_ids_map),
+                &fields_ids_map,
                 "test",
                 time::OffsetDateTime::now_utc(),
                 &progress,

--- a/crates/milli/tests/search/filters.rs
+++ b/crates/milli/tests/search/filters.rs
@@ -46,13 +46,20 @@ macro_rules! test_filter {
             let criteria = vec![Words, Typo, Proximity, Attribute, Exactness];
             let index = search::setup_search_index_with_criteria(&criteria);
             let rtxn = index.read_txn().unwrap();
+            let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
 
             let filter_conditions =
                 Filter::from_array::<Vec<Either<Vec<&str>, &str>>, _>($filter).unwrap().unwrap();
 
             let progress = Progress::default();
-            let mut search =
-                Search::new(&rtxn, &index, "test", time::OffsetDateTime::now_utc(), &progress);
+            let mut search = Search::new(
+                &rtxn,
+                &index,
+                &fields_ids_map,
+                "test",
+                time::OffsetDateTime::now_utc(),
+                &progress,
+            );
             search.query(search::TEST_QUERY);
             search.limit(EXTERNAL_DOCUMENTS_IDS.len());
 

--- a/crates/milli/tests/search/filters.rs
+++ b/crates/milli/tests/search/filters.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use either::{Either, Left, Right};
 use filter_parser::{FilterCondition, IndexFilterCondition};
 use milli::progress::Progress;
@@ -55,7 +57,7 @@ macro_rules! test_filter {
             let mut search = Search::new(
                 &rtxn,
                 &index,
-                &fields_ids_map,
+                Cow::Borrowed(&fields_ids_map),
                 "test",
                 time::OffsetDateTime::now_utc(),
                 &progress,

--- a/crates/milli/tests/search/phrase_search.rs
+++ b/crates/milli/tests/search/phrase_search.rs
@@ -32,9 +32,17 @@ fn test_phrase_search_with_stop_words_given_criteria(criteria: &[Criterion]) {
 
     // Phrase search containing stop words
     let txn = index.read_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
 
     let progress = Progress::default();
-    let mut search = Search::new(&txn, &index, "test", time::OffsetDateTime::now_utc(), &progress);
+    let mut search = Search::new(
+        &txn,
+        &index,
+        &fields_ids_map,
+        "test",
+        time::OffsetDateTime::now_utc(),
+        &progress,
+    );
     search.query("\"the use of force\"");
     search.limit(10);
     search.terms_matching_strategy(TermsMatchingStrategy::All);

--- a/crates/milli/tests/search/phrase_search.rs
+++ b/crates/milli/tests/search/phrase_search.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use http_client::policy::IpPolicy;
 use milli::progress::Progress;
 use milli::update::{IndexerConfig, Settings};
@@ -38,7 +40,7 @@ fn test_phrase_search_with_stop_words_given_criteria(criteria: &[Criterion]) {
     let mut search = Search::new(
         &txn,
         &index,
-        &fields_ids_map,
+        Cow::Borrowed(&fields_ids_map),
         "test",
         time::OffsetDateTime::now_utc(),
         &progress,

--- a/crates/milli/tests/search/phrase_search.rs
+++ b/crates/milli/tests/search/phrase_search.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use http_client::policy::IpPolicy;
 use milli::progress::Progress;
 use milli::update::{IndexerConfig, Settings};
@@ -40,7 +38,7 @@ fn test_phrase_search_with_stop_words_given_criteria(criteria: &[Criterion]) {
     let mut search = Search::new(
         &txn,
         &index,
-        Cow::Borrowed(&fields_ids_map),
+        &fields_ids_map,
         "test",
         time::OffsetDateTime::now_utc(),
         &progress,

--- a/crates/milli/tests/search/query_criteria.rs
+++ b/crates/milli/tests/search/query_criteria.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::cmp::Reverse;
 
 use big_s::S;
@@ -36,7 +37,7 @@ macro_rules! test_criterion {
             let mut search = Search::new(
                 &rtxn,
                 &index,
-                &fields_ids_map,
+                Cow::Borrowed(&fields_ids_map),
                 "test",
                 time::OffsetDateTime::now_utc(),
                 &progress,
@@ -267,7 +268,7 @@ fn criteria_mixup() {
         let mut search = Search::new(
             &rtxn,
             &index,
-            &fields_ids_map,
+            Cow::Borrowed(&fields_ids_map),
             "test",
             time::OffsetDateTime::now_utc(),
             &progress,
@@ -418,7 +419,7 @@ fn criteria_ascdesc() {
         let mut search = Search::new(
             &rtxn,
             &index,
-            &fields_ids_map,
+            Cow::Borrowed(&fields_ids_map),
             "test",
             time::OffsetDateTime::now_utc(),
             &progress,

--- a/crates/milli/tests/search/query_criteria.rs
+++ b/crates/milli/tests/search/query_criteria.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::cmp::Reverse;
 
 use big_s::S;
@@ -37,7 +36,7 @@ macro_rules! test_criterion {
             let mut search = Search::new(
                 &rtxn,
                 &index,
-                Cow::Borrowed(&fields_ids_map),
+                &fields_ids_map,
                 "test",
                 time::OffsetDateTime::now_utc(),
                 &progress,
@@ -268,7 +267,7 @@ fn criteria_mixup() {
         let mut search = Search::new(
             &rtxn,
             &index,
-            Cow::Borrowed(&fields_ids_map),
+            &fields_ids_map,
             "test",
             time::OffsetDateTime::now_utc(),
             &progress,
@@ -419,7 +418,7 @@ fn criteria_ascdesc() {
         let mut search = Search::new(
             &rtxn,
             &index,
-            Cow::Borrowed(&fields_ids_map),
+            &fields_ids_map,
             "test",
             time::OffsetDateTime::now_utc(),
             &progress,

--- a/crates/milli/tests/search/query_criteria.rs
+++ b/crates/milli/tests/search/query_criteria.rs
@@ -30,10 +30,17 @@ macro_rules! test_criterion {
             let criteria = $criteria;
             let index = search::setup_search_index_with_criteria(&criteria);
             let rtxn = index.read_txn().unwrap();
+            let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
 
             let progress = Progress::default();
-            let mut search =
-                Search::new(&rtxn, &index, "test", time::OffsetDateTime::now_utc(), &progress);
+            let mut search = Search::new(
+                &rtxn,
+                &index,
+                &fields_ids_map,
+                "test",
+                time::OffsetDateTime::now_utc(),
+                &progress,
+            );
             search.query(search::TEST_QUERY);
             search.limit(EXTERNAL_DOCUMENTS_IDS.len());
             search.terms_matching_strategy($optional_word);
@@ -254,10 +261,17 @@ fn criteria_mixup() {
         wtxn.commit().unwrap();
 
         let rtxn = index.read_txn().unwrap();
+        let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
 
         let progress = Progress::default();
-        let mut search =
-            Search::new(&rtxn, &index, "test", time::OffsetDateTime::now_utc(), &progress);
+        let mut search = Search::new(
+            &rtxn,
+            &index,
+            &fields_ids_map,
+            "test",
+            time::OffsetDateTime::now_utc(),
+            &progress,
+        );
         search.query(search::TEST_QUERY);
         search.limit(EXTERNAL_DOCUMENTS_IDS.len());
         search.terms_matching_strategy(ALLOW_OPTIONAL_WORDS);
@@ -398,10 +412,17 @@ fn criteria_ascdesc() {
         wtxn.commit().unwrap();
 
         let rtxn = index.read_txn().unwrap();
+        let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
 
         let progress = Progress::default();
-        let mut search =
-            Search::new(&rtxn, &index, "test", time::OffsetDateTime::now_utc(), &progress);
+        let mut search = Search::new(
+            &rtxn,
+            &index,
+            &fields_ids_map,
+            "test",
+            time::OffsetDateTime::now_utc(),
+            &progress,
+        );
         search.limit(ASC_DESC_CANDIDATES_THRESHOLD + 1);
 
         let SearchResult { documents_ids, .. } = search.execute().unwrap();

--- a/crates/milli/tests/search/sort.rs
+++ b/crates/milli/tests/search/sort.rs
@@ -11,10 +11,17 @@ fn sort_ranking_rule_missing() {
     // sortables: `tag` and `asc_desc_rank`
     let index = search::setup_search_index_with_criteria(&criteria);
     let rtxn = index.read_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&rtxn).unwrap();
 
     let progress = Progress::default();
-    let mut search =
-        Search::new(&rtxn, &index, "index_uid", time::OffsetDateTime::now_utc(), &progress);
+    let mut search = Search::new(
+        &rtxn,
+        &index,
+        &fields_ids_map,
+        "index_uid",
+        time::OffsetDateTime::now_utc(),
+        &progress,
+    );
     search.query(search::TEST_QUERY);
     search.limit(EXTERNAL_DOCUMENTS_IDS.len());
 

--- a/crates/milli/tests/search/sort.rs
+++ b/crates/milli/tests/search/sort.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use big_s::S;
 use milli::progress::Progress;
 use milli::Criterion::{Attribute, Exactness, Proximity, Typo, Words};
@@ -17,7 +19,7 @@ fn sort_ranking_rule_missing() {
     let mut search = Search::new(
         &rtxn,
         &index,
-        &fields_ids_map,
+        Cow::Borrowed(&fields_ids_map),
         "index_uid",
         time::OffsetDateTime::now_utc(),
         &progress,

--- a/crates/milli/tests/search/sort.rs
+++ b/crates/milli/tests/search/sort.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use big_s::S;
 use milli::progress::Progress;
 use milli::Criterion::{Attribute, Exactness, Proximity, Typo, Words};
@@ -19,7 +17,7 @@ fn sort_ranking_rule_missing() {
     let mut search = Search::new(
         &rtxn,
         &index,
-        Cow::Borrowed(&fields_ids_map),
+        &fields_ids_map,
         "index_uid",
         time::OffsetDateTime::now_utc(),
         &progress,

--- a/crates/milli/tests/search/typo_tolerance.rs
+++ b/crates/milli/tests/search/typo_tolerance.rs
@@ -23,10 +23,17 @@ fn test_typo_tolerance_one_typo() {
     // basic typo search with default typo settings
     {
         let txn = index.read_txn().unwrap();
+        let fields_ids_map = index.fields_ids_map(&txn).unwrap();
 
         let progress = Progress::default();
-        let mut search =
-            Search::new(&txn, &index, "test", time::OffsetDateTime::now_utc(), &progress);
+        let mut search = Search::new(
+            &txn,
+            &index,
+            &fields_ids_map,
+            "test",
+            time::OffsetDateTime::now_utc(),
+            &progress,
+        );
         search.query("zeal");
         search.limit(10);
 
@@ -36,8 +43,14 @@ fn test_typo_tolerance_one_typo() {
         assert_eq!(result.documents_ids.len(), 1);
 
         let progress = Progress::default();
-        let mut search =
-            Search::new(&txn, &index, "test", time::OffsetDateTime::now_utc(), &progress);
+        let mut search = Search::new(
+            &txn,
+            &index,
+            &fields_ids_map,
+            "test",
+            time::OffsetDateTime::now_utc(),
+            &progress,
+        );
         search.query("zean");
         search.limit(10);
 
@@ -48,6 +61,7 @@ fn test_typo_tolerance_one_typo() {
     }
 
     let mut txn = index.write_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
 
     let config = IndexerConfig::default();
     let mut builder = Settings::new(&mut txn, &index, &config);
@@ -64,7 +78,14 @@ fn test_typo_tolerance_one_typo() {
 
     // typo is now supported for 4 letters words
     let progress = Progress::default();
-    let mut search = Search::new(&txn, &index, "test", time::OffsetDateTime::now_utc(), &progress);
+    let mut search = Search::new(
+        &txn,
+        &index,
+        &fields_ids_map,
+        "test",
+        time::OffsetDateTime::now_utc(),
+        &progress,
+    );
     search.query("zean");
     search.limit(10);
 
@@ -82,10 +103,17 @@ fn test_typo_tolerance_two_typo() {
     // basic typo search with default typo settings
     {
         let txn = index.read_txn().unwrap();
+        let fields_ids_map = index.fields_ids_map(&txn).unwrap();
 
         let progress = Progress::default();
-        let mut search =
-            Search::new(&txn, &index, "test", time::OffsetDateTime::now_utc(), &progress);
+        let mut search = Search::new(
+            &txn,
+            &index,
+            &fields_ids_map,
+            "test",
+            time::OffsetDateTime::now_utc(),
+            &progress,
+        );
         search.query("zealand");
         search.limit(10);
 
@@ -95,8 +123,14 @@ fn test_typo_tolerance_two_typo() {
         assert_eq!(result.documents_ids.len(), 1);
 
         let progress = Progress::default();
-        let mut search =
-            Search::new(&txn, &index, "test", time::OffsetDateTime::now_utc(), &progress);
+        let mut search = Search::new(
+            &txn,
+            &index,
+            &fields_ids_map,
+            "test",
+            time::OffsetDateTime::now_utc(),
+            &progress,
+        );
         search.query("zealemd");
         search.limit(10);
 
@@ -107,6 +141,7 @@ fn test_typo_tolerance_two_typo() {
     }
 
     let mut txn = index.write_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
 
     let config = IndexerConfig::default();
     let mut builder = Settings::new(&mut txn, &index, &config);
@@ -123,7 +158,14 @@ fn test_typo_tolerance_two_typo() {
 
     // typo is now supported for 4 letters words
     let progress = Progress::default();
-    let mut search = Search::new(&txn, &index, "test", time::OffsetDateTime::now_utc(), &progress);
+    let mut search = Search::new(
+        &txn,
+        &index,
+        &fields_ids_map,
+        "test",
+        time::OffsetDateTime::now_utc(),
+        &progress,
+    );
     search.query("zealemd");
     search.limit(10);
 
@@ -193,10 +235,17 @@ fn test_typo_disabled_on_word() {
     // basic typo search with default typo settings
     {
         let txn = index.read_txn().unwrap();
+        let fields_ids_map = index.fields_ids_map(&txn).unwrap();
 
         let progress = Progress::default();
-        let mut search =
-            Search::new(&txn, &index, "test", time::OffsetDateTime::now_utc(), &progress);
+        let mut search = Search::new(
+            &txn,
+            &index,
+            &fields_ids_map,
+            "test",
+            time::OffsetDateTime::now_utc(),
+            &progress,
+        );
         search.query("zealand");
         search.limit(10);
 
@@ -207,6 +256,7 @@ fn test_typo_disabled_on_word() {
     }
 
     let mut txn = index.write_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
 
     let config = IndexerConfig::default();
     let mut builder = Settings::new(&mut txn, &index, &config);
@@ -225,7 +275,14 @@ fn test_typo_disabled_on_word() {
         .unwrap();
 
     let progress = Progress::default();
-    let mut search = Search::new(&txn, &index, "test", time::OffsetDateTime::now_utc(), &progress);
+    let mut search = Search::new(
+        &txn,
+        &index,
+        &fields_ids_map,
+        "test",
+        time::OffsetDateTime::now_utc(),
+        &progress,
+    );
     search.query("zealand");
     search.limit(10);
 
@@ -243,10 +300,17 @@ fn test_disable_typo_on_attribute() {
     // basic typo search with default typo settings
     {
         let txn = index.read_txn().unwrap();
+        let fields_ids_map = index.fields_ids_map(&txn).unwrap();
 
         let progress = Progress::default();
-        let mut search =
-            Search::new(&txn, &index, "test", time::OffsetDateTime::now_utc(), &progress);
+        let mut search = Search::new(
+            &txn,
+            &index,
+            &fields_ids_map,
+            "test",
+            time::OffsetDateTime::now_utc(),
+            &progress,
+        );
         // typo in `antebel(l)um`
         search.query("antebelum");
         search.limit(10);
@@ -258,6 +322,7 @@ fn test_disable_typo_on_attribute() {
     }
 
     let mut txn = index.write_txn().unwrap();
+    let fields_ids_map = index.fields_ids_map(&txn).unwrap();
 
     let config = IndexerConfig::default();
     let mut builder = Settings::new(&mut txn, &index, &config);
@@ -274,7 +339,14 @@ fn test_disable_typo_on_attribute() {
         .unwrap();
 
     let progress = Progress::default();
-    let mut search = Search::new(&txn, &index, "test", time::OffsetDateTime::now_utc(), &progress);
+    let mut search = Search::new(
+        &txn,
+        &index,
+        &fields_ids_map,
+        "test",
+        time::OffsetDateTime::now_utc(),
+        &progress,
+    );
     search.query("antebelum");
     search.limit(10);
 

--- a/crates/milli/tests/search/typo_tolerance.rs
+++ b/crates/milli/tests/search/typo_tolerance.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::BTreeSet;
 
 use bumpalo::Bump;
@@ -29,7 +30,7 @@ fn test_typo_tolerance_one_typo() {
         let mut search = Search::new(
             &txn,
             &index,
-            &fields_ids_map,
+            Cow::Borrowed(&fields_ids_map),
             "test",
             time::OffsetDateTime::now_utc(),
             &progress,
@@ -46,7 +47,7 @@ fn test_typo_tolerance_one_typo() {
         let mut search = Search::new(
             &txn,
             &index,
-            &fields_ids_map,
+            Cow::Borrowed(&fields_ids_map),
             "test",
             time::OffsetDateTime::now_utc(),
             &progress,
@@ -81,7 +82,7 @@ fn test_typo_tolerance_one_typo() {
     let mut search = Search::new(
         &txn,
         &index,
-        &fields_ids_map,
+        Cow::Borrowed(&fields_ids_map),
         "test",
         time::OffsetDateTime::now_utc(),
         &progress,
@@ -109,7 +110,7 @@ fn test_typo_tolerance_two_typo() {
         let mut search = Search::new(
             &txn,
             &index,
-            &fields_ids_map,
+            Cow::Borrowed(&fields_ids_map),
             "test",
             time::OffsetDateTime::now_utc(),
             &progress,
@@ -126,7 +127,7 @@ fn test_typo_tolerance_two_typo() {
         let mut search = Search::new(
             &txn,
             &index,
-            &fields_ids_map,
+            Cow::Borrowed(&fields_ids_map),
             "test",
             time::OffsetDateTime::now_utc(),
             &progress,
@@ -161,7 +162,7 @@ fn test_typo_tolerance_two_typo() {
     let mut search = Search::new(
         &txn,
         &index,
-        &fields_ids_map,
+        Cow::Borrowed(&fields_ids_map),
         "test",
         time::OffsetDateTime::now_utc(),
         &progress,
@@ -241,7 +242,7 @@ fn test_typo_disabled_on_word() {
         let mut search = Search::new(
             &txn,
             &index,
-            &fields_ids_map,
+            Cow::Borrowed(&fields_ids_map),
             "test",
             time::OffsetDateTime::now_utc(),
             &progress,
@@ -278,7 +279,7 @@ fn test_typo_disabled_on_word() {
     let mut search = Search::new(
         &txn,
         &index,
-        &fields_ids_map,
+        Cow::Borrowed(&fields_ids_map),
         "test",
         time::OffsetDateTime::now_utc(),
         &progress,
@@ -306,7 +307,7 @@ fn test_disable_typo_on_attribute() {
         let mut search = Search::new(
             &txn,
             &index,
-            &fields_ids_map,
+            Cow::Borrowed(&fields_ids_map),
             "test",
             time::OffsetDateTime::now_utc(),
             &progress,
@@ -342,7 +343,7 @@ fn test_disable_typo_on_attribute() {
     let mut search = Search::new(
         &txn,
         &index,
-        &fields_ids_map,
+        Cow::Borrowed(&fields_ids_map),
         "test",
         time::OffsetDateTime::now_utc(),
         &progress,

--- a/crates/milli/tests/search/typo_tolerance.rs
+++ b/crates/milli/tests/search/typo_tolerance.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::collections::BTreeSet;
 
 use bumpalo::Bump;
@@ -30,7 +29,7 @@ fn test_typo_tolerance_one_typo() {
         let mut search = Search::new(
             &txn,
             &index,
-            Cow::Borrowed(&fields_ids_map),
+            &fields_ids_map,
             "test",
             time::OffsetDateTime::now_utc(),
             &progress,
@@ -47,7 +46,7 @@ fn test_typo_tolerance_one_typo() {
         let mut search = Search::new(
             &txn,
             &index,
-            Cow::Borrowed(&fields_ids_map),
+            &fields_ids_map,
             "test",
             time::OffsetDateTime::now_utc(),
             &progress,
@@ -82,7 +81,7 @@ fn test_typo_tolerance_one_typo() {
     let mut search = Search::new(
         &txn,
         &index,
-        Cow::Borrowed(&fields_ids_map),
+        &fields_ids_map,
         "test",
         time::OffsetDateTime::now_utc(),
         &progress,
@@ -110,7 +109,7 @@ fn test_typo_tolerance_two_typo() {
         let mut search = Search::new(
             &txn,
             &index,
-            Cow::Borrowed(&fields_ids_map),
+            &fields_ids_map,
             "test",
             time::OffsetDateTime::now_utc(),
             &progress,
@@ -127,7 +126,7 @@ fn test_typo_tolerance_two_typo() {
         let mut search = Search::new(
             &txn,
             &index,
-            Cow::Borrowed(&fields_ids_map),
+            &fields_ids_map,
             "test",
             time::OffsetDateTime::now_utc(),
             &progress,
@@ -162,7 +161,7 @@ fn test_typo_tolerance_two_typo() {
     let mut search = Search::new(
         &txn,
         &index,
-        Cow::Borrowed(&fields_ids_map),
+        &fields_ids_map,
         "test",
         time::OffsetDateTime::now_utc(),
         &progress,
@@ -242,7 +241,7 @@ fn test_typo_disabled_on_word() {
         let mut search = Search::new(
             &txn,
             &index,
-            Cow::Borrowed(&fields_ids_map),
+            &fields_ids_map,
             "test",
             time::OffsetDateTime::now_utc(),
             &progress,
@@ -279,7 +278,7 @@ fn test_typo_disabled_on_word() {
     let mut search = Search::new(
         &txn,
         &index,
-        Cow::Borrowed(&fields_ids_map),
+        &fields_ids_map,
         "test",
         time::OffsetDateTime::now_utc(),
         &progress,
@@ -307,7 +306,7 @@ fn test_disable_typo_on_attribute() {
         let mut search = Search::new(
             &txn,
             &index,
-            Cow::Borrowed(&fields_ids_map),
+            &fields_ids_map,
             "test",
             time::OffsetDateTime::now_utc(),
             &progress,
@@ -343,7 +342,7 @@ fn test_disable_typo_on_attribute() {
     let mut search = Search::new(
         &txn,
         &index,
-        Cow::Borrowed(&fields_ids_map),
+        &fields_ids_map,
         "test",
         time::OffsetDateTime::now_utc(),
         &progress,


### PR DESCRIPTION
This PR improves Meilisearch search speed by ensuring we avoid doing unnecessary work internally. We drastically reduced the number of times we retrieve data from disk to a single time across the whole search pipeline.

- [x] Fix the performance difference between `q: ""` and `q: null`, i.e., -55% on placeholder search requests.
- [x] Drastically reduce the number of fields ids map deserializations, i.e., -62% on placeholder search requests.
- [x] Log the time it takes to deserialize the fields ids map in the progress, i.e., `showPerformanceDetails`.

## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respects the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)