### PR TITLE
Add missing logs in multisearch

### DIFF
--- a/crates/meilisearch/src/documents_retrieval/mod.rs
+++ b/crates/meilisearch/src/documents_retrieval/mod.rs
@@ -227,6 +227,7 @@ impl<T, E: Into<ResponseError>> WithIndex for Result<T, E> {
     }
 }
 
+#[derive(Debug)]
 pub enum DocumentSearchResult {
     Federated(Box<FederatedSearchResult>),
     Multi(Vec<SearchResultWithIndex>),

--- a/crates/meilisearch/src/routes/indexes/search.rs
+++ b/crates/meilisearch/src/routes/indexes/search.rs
@@ -604,9 +604,9 @@ pub async fn search_with_url_query(
         }
         analytics.publish(aggregate, &req);
 
-        let search_result = search_result?;
+        debug!(request_uid = ?request_uid, returns = ?&search_result, progress = ?progress.accumulated_durations(), "Search get");
 
-        debug!(request_uid = ?request_uid, returns = ?search_result, progress = ?progress.accumulated_durations(), "Search get");
+        let search_result = search_result?;
 
         Ok(HttpResponse::Ok().json(search_result))
     } else {
@@ -904,9 +904,9 @@ pub async fn search_with_post(
         }
         analytics.publish(aggregate, &req);
 
-        let search_result = search_result?;
+        debug!(request_uid = ?request_uid, returns = ?&search_result, progress = ?progress.accumulated_durations(), "Search post");
 
-        debug!(request_uid = ?request_uid, returns = ?search_result, progress = ?progress.accumulated_durations(), "Search post");
+        let search_result = search_result?;
 
         Ok(HttpResponse::Ok().json(search_result))
     } else {

--- a/crates/meilisearch/src/routes/multi_search.rs
+++ b/crates/meilisearch/src/routes/multi_search.rs
@@ -41,7 +41,7 @@ use crate::search_queue::SearchQueue;
 pub struct MultiSearchApi;
 
 /// Response containing results from multiple search queries
-#[derive(Serialize, ToSchema)]
+#[derive(Serialize, ToSchema, Debug)]
 pub struct SearchResults {
     /// Array of search results for each query
     results: Vec<SearchResultWithIndex>,
@@ -165,6 +165,11 @@ pub async fn multi_search_with_post(
         let request_uid = Uuid::now_v7();
 
         let federated_search = params.into_inner();
+        debug!(
+            request_uid = ?request_uid,
+            parameters = ?federated_search,
+            "Multi-search"
+        );
 
         let mut multi_aggregate = MultiSearchAggregator::from_federated_search(&federated_search);
 
@@ -194,6 +199,12 @@ pub async fn multi_search_with_post(
 
         permit.drop().await;
         analytics.publish(multi_aggregate, &req);
+        debug!(
+            request_uid = ?request_uid,
+            returns = ?&search_results,
+            progress = ?progress.accumulated_durations(),
+            "Multi-search"
+        );
 
         let search_results = search_results.map_err(|(mut err, query_index)| {
             // Add the query index that failed as context for the error message.


### PR DESCRIPTION
Debug logs were missing when using the new search pipeline. This Pr reintroduces these logs
