### PR TITLE
Make sure legacy attribute patterns works

### DIFF
--- a/crates/milli/src/filterable_attributes_rules.rs
+++ b/crates/milli/src/filterable_attributes_rules.rs
@@ -4,7 +4,9 @@ use deserr::{DeserializeError, Deserr, ValuePointerRef};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
-use crate::attribute_patterns::{match_distinct_field, match_field_legacy, PatternMatch};
+use crate::attribute_patterns::{
+    match_distinct_field, match_field_legacy, match_pattern, PatternMatch,
+};
 use crate::constants::{RESERVED_GEOJSON_FIELD_NAME, RESERVED_GEO_FIELD_NAME};
 use crate::AttributePatterns;
 
@@ -29,13 +31,23 @@ impl FilterableAttributesRule {
         }
     }
 
+    /// Takes two patterns and returns true if one pattern matches another.
     pub fn intersect_patterns(&self, other: &str) -> bool {
         match self {
             // If the rule is a field, match the field against the provided pattern using the legacy behavior
-            FilterableAttributesRule::Field(field) => matches!(
-                match_field_legacy(other, field),
-                PatternMatch::Parent | PatternMatch::Match
-            ),
+            FilterableAttributesRule::Field(field) => {
+                let legacy = matches!(
+                    match_field_legacy(other, field),
+                    PatternMatch::Parent | PatternMatch::Match
+                );
+
+                let new = matches!(
+                    match_pattern(other, field),
+                    PatternMatch::Parent | PatternMatch::Match
+                );
+
+                legacy | new
+            }
             // If the rule is a pattern, match each one of them against the provided pattern using the new behavior
             FilterableAttributesRule::Pattern(patterns) => patterns.intersect_patterns(other),
         }

--- a/crates/milli/src/filterable_attributes_rules.rs
+++ b/crates/milli/src/filterable_attributes_rules.rs
@@ -35,6 +35,8 @@ impl FilterableAttributesRule {
     pub fn intersect_patterns(&self, other: &str) -> bool {
         match self {
             // If the rule is a field, match the field against the provided pattern using the legacy behavior
+            // match using both the legacy and new syntaxes, so that we catch the old prefix based
+            // syntax and the new wildcard behavior, for example in the `facets` field of the search
             FilterableAttributesRule::Field(field) => {
                 let legacy = matches!(
                     match_field_legacy(other, field),
@@ -46,7 +48,7 @@ impl FilterableAttributesRule {
                     PatternMatch::Parent | PatternMatch::Match
                 );
 
-                legacy | new
+                legacy || new
             }
             // If the rule is a pattern, match each one of them against the provided pattern using the new behavior
             FilterableAttributesRule::Pattern(patterns) => patterns.intersect_patterns(other),


### PR DESCRIPTION
This PR fixes a regression introduced in v1.50, where patterns like `"*"` no longer match filterable fields when they were declared using the old filterable syntax (not the `attributesPattern` syntax).

## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respects the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - *list of used tools and what they were used for*