### PR TITLE
Speed up the search speed a bit more

### DIFF
--- a/crates/meilisearch/src/search/federated/perform.rs
+++ b/crates/meilisearch/src/search/federated/perform.rs
@@ -1607,6 +1607,8 @@ impl SearchByIndex {
         let mut documents_seen = RoaringBitmap::new();
         let mut local_pinned_hits = Vec::new();
         for result_by_query in &mut results_by_query {
+            let _step = progress.update_progress_scoped(SearchStep::Format);
+
             let prev_documents_ids = std::mem::take(&mut result_by_query.documents_ids);
             let prev_scores = std::mem::take(&mut result_by_query.document_scores);
 
@@ -1614,7 +1616,7 @@ impl SearchByIndex {
                 if let Some(ScoreDetails::Pin { position }) = score.first() {
                     let mut hit = result_by_query
                         .hit_maker
-                        .make_hit(doc_id, &score, progress)
+                        .make_hit(doc_id, &score)
                         .with_index(result_by_query.query_index)?;
                     let _federation = build_federation_hit(
                         params,
@@ -1663,7 +1665,10 @@ impl SearchByIndex {
                     }
 
                     let hit: Result<_, ResponseError> = (|| {
-                        let mut hit = hit_maker.make_hit(docid, &score, progress)?;
+                        let mut hit = {
+                            let _step = progress.update_progress_scoped(SearchStep::Format);
+                            hit_maker.make_hit(docid, &score)?
+                        };
 
                         if let Some(distinct) = self.federation.distinct.as_deref() {
                             let mut facet_values = Vec::new();

--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -1792,8 +1792,10 @@ pub fn perform_search(
     let rtxn = index.read_txn()?;
     let deadline = index.search_deadline(&rtxn)?;
 
-    let fields_ids_map = index.fields_ids_map(&rtxn)?;
-
+    let fields_ids_map = {
+        let _step = progress.update_progress_scoped(SearchStep::LoadFieldIdsMap);
+        index.fields_ids_map(&rtxn)?
+    };
     let filter = match &query.filter {
         Some(filter) => {
             let filter = parse_filter(filter, Code::InvalidSearchFilter, features, None)?;
@@ -2208,9 +2210,7 @@ struct HitMaker<'a> {
     rtxn: &'a RoTxn<'a>,
     fields_ids_map: &'a FieldsIdsMap,
     displayed_ids: BTreeSet<FieldId>,
-    vectors_fid: Option<FieldId>,
     retrieve_vectors: RetrieveVectors,
-    to_retrieve_ids: BTreeSet<FieldId>,
     extra_ids: Vec<String>,
     formatter_builder: MatcherBuilder<'a>,
     formatted_options: BTreeMap<FieldId, FormatOptions>,
@@ -2221,6 +2221,7 @@ struct HitMaker<'a> {
     locales: Option<Vec<Language>>,
     attribute_state: AttributeState,
     localized_attributes: Vec<LocalizedAttributesRule>,
+    attributes_to_retrieve: Vec<&'a str>,
 }
 
 impl<'a> HitMaker<'a> {
@@ -2348,15 +2349,32 @@ impl<'a> HitMaker<'a> {
 
         let localized_attributes = index.localized_attributes_rules(rtxn)?.unwrap_or_default();
 
+        let add_vectors_fid =
+            vectors_fid.filter(|_fid| retrieve_vectors == RetrieveVectors::Retrieve);
+
+        // Select the attributes to retrieve
+        // Note that to_retrieve_ids is already an intersection with the displayed attributes
+        let attributes_to_retrieve = to_retrieve_ids
+            .iter()
+            // skip the vectors_fid if RetrieveVectors::Hide
+            .filter(|fid| match vectors_fid {
+                Some(vectors_fid) => {
+                    !(retrieve_vectors == RetrieveVectors::Hide && **fid == vectors_fid)
+                }
+                None => true,
+            })
+            // need to retrieve the existing `_vectors` field if the `RetrieveVectors::Retrieve`
+            .chain(add_vectors_fid.iter())
+            // Convert the field into their names
+            .map(|&fid| fields_ids_map.name(fid).expect("Missing field name"))
+            .collect();
         Ok(Self {
             index,
             rtxn,
             fields_ids_map,
             displayed_ids,
             extra_ids,
-            vectors_fid,
             retrieve_vectors,
-            to_retrieve_ids,
             formatter_builder,
             formatted_options,
             show_ranking_score: format.show_ranking_score,
@@ -2366,41 +2384,15 @@ impl<'a> HitMaker<'a> {
             locales: format.locales,
             attribute_state,
             localized_attributes,
+            attributes_to_retrieve,
         })
     }
 
-    pub fn make_hit(
-        &self,
-        id: DocumentId,
-        score: &[ScoreDetails],
-        progress: &Progress,
-    ) -> milli::Result<SearchHit> {
-        let _step = progress.update_progress_scoped(SearchStep::Format);
+    pub fn make_hit(&self, id: DocumentId, score: &[ScoreDetails]) -> milli::Result<SearchHit> {
         let obkv = self.index.document(self.rtxn, id)?;
 
-        let add_vectors_fid =
-            self.vectors_fid.filter(|_fid| self.retrieve_vectors == RetrieveVectors::Retrieve);
-
-        // Select the attributes to retrieve
-        // Note that to_retrieve_ids is already an intersection with the displayed attributes
-        let attributes_to_retrieve: Vec<_> = self
-            .to_retrieve_ids
-            .iter()
-            // skip the vectors_fid if RetrieveVectors::Hide
-            .filter(|fid| match self.vectors_fid {
-                Some(vectors_fid) => {
-                    !(self.retrieve_vectors == RetrieveVectors::Hide && **fid == vectors_fid)
-                }
-                None => true,
-            })
-            // need to retrieve the existing `_vectors` field if the `RetrieveVectors::Retrieve`
-            .chain(add_vectors_fid.iter())
-            // Convert the field into their names
-            .map(|&fid| self.fields_ids_map.name(fid).expect("Missing field name"))
-            .collect();
-
         // Generate a document with all the attributes to retrieve
-        let mut document = make_document(obkv, self.fields_ids_map, &attributes_to_retrieve)?;
+        let mut document = make_document(obkv, self.fields_ids_map, &self.attributes_to_retrieve)?;
 
         let extra_document = self
             .extra_ids
@@ -2490,6 +2482,7 @@ fn make_hits<'a>(
     documents_ids_scores: impl Iterator<Item = (u32, &'a Vec<ScoreDetails>)> + 'a,
     progress: &Progress,
 ) -> milli::Result<Vec<SearchHit>> {
+    let _step = progress.update_progress_scoped(SearchStep::Format);
     let mut documents = Vec::new();
 
     let dictionary = index.dictionary(rtxn)?;
@@ -2506,7 +2499,7 @@ fn make_hits<'a>(
     let hit_maker = HitMaker::new(index, rtxn, fields_ids_map, format, formatter_builder)?;
 
     for (id, score) in documents_ids_scores {
-        documents.push(hit_maker.make_hit(id, score, progress)?);
+        documents.push(hit_maker.make_hit(id, score)?);
     }
     Ok(documents)
 }

--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -29,7 +29,7 @@ use meilisearch_types::milli::vector::parsed_vectors::ExplicitVectors;
 use meilisearch_types::milli::vector::Embedder;
 use meilisearch_types::milli::{
     filtered_matching_patterns, filtered_universe, make_document, AttributePatterns,
-    AttributeState, Deadline, Error, FacetValueHit, Filter, IndexFilter, InternalError,
+    AttributeState, Deadline, DocumentId, Error, FacetValueHit, Filter, IndexFilter, InternalError,
     MetadataBuilder, OrderBy, PatternMatch, SearchForFacetValues, SearchStep, UserError,
 };
 use meilisearch_types::network::Network;
@@ -2367,7 +2367,7 @@ impl<'a> HitMaker<'a> {
 
     pub fn make_hit(
         &self,
-        id: u32,
+        id: DocumentId,
         score: &[ScoreDetails],
         progress: &Progress,
     ) -> milli::Result<SearchHit> {

--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -2220,6 +2220,7 @@ struct HitMaker<'a> {
     show_matches_position: bool,
     locales: Option<Vec<Language>>,
     attribute_state: AttributeState,
+    localized_attributes: Vec<LocalizedAttributesRule>,
 }
 
 impl<'a> HitMaker<'a> {
@@ -2345,6 +2346,8 @@ impl<'a> HitMaker<'a> {
 
         let attribute_state = AttributeState::from_criteria(index.criteria(rtxn)?);
 
+        let localized_attributes = index.localized_attributes_rules(rtxn)?.unwrap_or_default();
+
         Ok(Self {
             index,
             rtxn,
@@ -2362,6 +2365,7 @@ impl<'a> HitMaker<'a> {
             sort: format.sort,
             locales: format.locales,
             attribute_state,
+            localized_attributes,
         })
     }
 
@@ -2426,9 +2430,6 @@ impl<'a> HitMaker<'a> {
             document.insert("_vectors".into(), vectors.into());
         }
 
-        let localized_attributes =
-            self.index.localized_attributes_rules(self.rtxn)?.unwrap_or_default();
-
         // If you need to format fields, pay the cost create the document from the displayed fields
         // TODO make the format field use the obkv and only format necessary fields
         let (matches_position, formatted) = if !self.show_matches_position
@@ -2453,7 +2454,7 @@ impl<'a> HitMaker<'a> {
                 self.show_matches_position,
                 &self.displayed_ids,
                 self.locales.as_deref(),
-                &localized_attributes,
+                &self.localized_attributes,
             )?
         };
 


### PR DESCRIPTION
This PR improves search speed slightly by preparing more items before formatting. It also improves the logging of search performances. The search speed goes from 48ms to 35ms in my tests.

## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respects the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)