### PR TITLE
Fix duplicate pins in federated search

### DIFF
--- a/crates/meilisearch/src/search/federated/perform.rs
+++ b/crates/meilisearch/src/search/federated/perform.rs
@@ -21,7 +21,7 @@ use meilisearch_types::milli::vector::Embedding;
 use meilisearch_types::milli::{
     self, merge_positioned_hits_into_page, serialize_index_filter_to_filter_string,
     AttributePatterns, Deadline, DocumentId, FederatingResultsStep, FieldsIdsMap, MetadataBuilder,
-    OrderBy, PatternMatch, SearchStep, DEFAULT_VALUES_PER_FACET,
+    OrderBy, PatternMatch, Pin, Precedence, SearchStep, DEFAULT_VALUES_PER_FACET,
 };
 use meilisearch_types::network::{Network, Remote, RemoteAvailability};
 use meilisearch_types::settings::DEFAULT_PAGINATION_MAX_TOTAL_HITS;
@@ -47,7 +47,8 @@ use crate::error::MeilisearchHttpError;
 use crate::personalization::PersonalizationService;
 use crate::routes::indexes::search::search_kind;
 use crate::search::federated::types::{
-    FEDERATION_EXTRA_DOCUMENT, INDEX_UID, QUERIES_POSITION, WEIGHTED_RANKING_SCORE,
+    FEDERATION_EXTRA_DOCUMENT, INDEX_UID, PINNED_PRECEDENCE, QUERIES_POSITION,
+    WEIGHTED_RANKING_SCORE,
 };
 use crate::search::hydration::{FederatedHydrationFormatter, HydrationContext};
 use crate::search::{
@@ -304,15 +305,20 @@ pub async fn perform_federated_search(
     for result_by_index in &mut results_by_index {
         let prev_hits = std::mem::take(&mut result_by_index.hits);
         for hit in prev_hits {
-            if let Some(ScoreDetails::Pin { position }) = hit.score.first() {
-                pins.push((*position, hit.query_index, hit.hit));
+            if let Some(ScoreDetails::Pin { position, precedence }) = hit.score.first() {
+                pins.push(GlobalPin {
+                    position: *position,
+                    precedence: *precedence,
+                    query_index: hit.query_index,
+                    hit: hit.hit,
+                });
             } else {
                 result_by_index.hits.push(hit);
             }
         }
     }
     extract_remote_pin_hits(&mut remote_results, &mut pins);
-    pins.sort_by_key(|&(pos, _, _)| pos);
+    Pin::sort(&mut pins);
 
     // store remote rejected hits to fixup the facet distributions
     // ideally could fixup in the iterator,
@@ -400,7 +406,13 @@ pub async fn perform_federated_search(
         }
     }
 
-    merged_hits = merge_pinned_hits_into_page(pins, skip, take, merged_hits);
+    merged_hits = merge_pinned_hits_into_page(
+        pins.len(),
+        pins.into_iter().map(|pin| (pin.position, pin.query_index, pin.hit)),
+        skip,
+        take,
+        merged_hits,
+    );
 
     // 3.3.1. hydrate documents based on the hydration points
     progress.update_progress(FederatingResultsStep::HydrateDocuments);
@@ -502,6 +514,53 @@ pub async fn perform_federated_search(
         },
         deadline,
     ))
+}
+
+struct GlobalPin {
+    position: u32,
+    precedence: Option<u64>,
+    query_index: usize,
+    hit: SearchHit,
+}
+
+impl Pin for GlobalPin {
+    type Id = SearchHit;
+
+    fn position(&self) -> u32 {
+        self.position
+    }
+
+    fn precedence(&self) -> Precedence {
+        Precedence(self.precedence)
+    }
+
+    fn id(&self) -> Self::Id {
+        self.hit.clone()
+    }
+}
+
+struct LocalPin {
+    position: u32,
+    precedence: Precedence,
+    query_index: usize,
+    hit: SearchHitByIndex,
+    doc_id: DocumentId,
+}
+
+impl Pin for LocalPin {
+    type Id = DocumentId;
+
+    fn id(&self) -> Self::Id {
+        self.doc_id
+    }
+
+    fn position(&self) -> u32 {
+        self.position
+    }
+
+    fn precedence(&self) -> Precedence {
+        self.precedence
+    }
 }
 
 struct QueryByIndex {
@@ -778,12 +837,14 @@ fn iter_remote_hits(
 }
 
 fn merge_pinned_hits_into_page<T>(
-    pins: Vec<(u32, usize, T)>,
+    pin_count: usize,
+    pins: impl IntoIterator<Item = (u32, usize, T)>,
     skip: usize,
     take: usize,
     organic_hits: Vec<(usize, T)>,
 ) -> Vec<(usize, T)> {
     merge_positioned_hits_into_page(
+        pin_count,
         pins,
         skip,
         take,
@@ -795,17 +856,18 @@ fn merge_pinned_hits_into_page<T>(
 
 fn extract_remote_pin_hits(
     remote_results: &mut [FederatedSearchResult],
-    pins: &mut Vec<(u32, usize, SearchHit)>,
+    pins: &mut Vec<GlobalPin>,
 ) {
     fn parse_pin_pos_and_query_idx(
         federation: &mut serde_json::Map<String, serde_json::Value>,
-    ) -> Option<(u32, usize)> {
+    ) -> Option<(u32, Option<u64>, usize)> {
         let pin_pos: u32 = federation.remove(PINNED_POSITION)?.as_u64()?.try_into().ok()?;
+        let pin_precedence: Option<u64> = federation.remove(PINNED_PRECEDENCE)?.as_u64();
         let _ = federation.remove(WEIGHTED_SCORE_VALUES);
         let _ = federation.remove(FEDERATION_EXTRA_DOCUMENT);
         let query_idx: usize = federation.get(QUERIES_POSITION)?.as_u64()?.try_into().ok()?;
 
-        Some((pin_pos, query_idx))
+        Some((pin_pos, pin_precedence, query_idx))
     }
 
     for remote_result in remote_results {
@@ -817,8 +879,8 @@ fn extract_remote_pin_hits(
                 .and_then(|federation| federation.as_object_mut())
                 .and_then(parse_pin_pos_and_query_idx);
 
-            if let Some((position, query_index)) = pair {
-                pins.push((position, query_index, hit));
+            if let Some((position, precedence, query_index)) = pair {
+                pins.push(GlobalPin { position, precedence, query_index, hit });
             } else {
                 remote_result.hits.push(hit);
             }
@@ -861,8 +923,9 @@ fn build_federation_hit(
             serde_json::Value::Object(std::mem::take(extra_document)),
         );
 
-        if let Some(ScoreDetails::Pin { position }) = score.first() {
+        if let Some(ScoreDetails::Pin { position, precedence }) = score.first() {
             federation.insert(PINNED_POSITION.to_string(), serde_json::json!(position));
+            federation.insert(PINNED_PRECEDENCE.to_string(), serde_json::json!(precedence));
         }
     }
 
@@ -1611,7 +1674,7 @@ impl SearchByIndex {
             let prev_scores = std::mem::take(&mut result_by_query.document_scores);
 
             for (doc_id, score) in prev_documents_ids.into_iter().zip(prev_scores.into_iter()) {
-                if let Some(ScoreDetails::Pin { position }) = score.first() {
+                if let Some(ScoreDetails::Pin { position, precedence }) = score.first() {
                     let mut hit = result_by_query
                         .hit_maker
                         .make_hit(doc_id, &score, progress)
@@ -1626,16 +1689,18 @@ impl SearchByIndex {
                     );
 
                     hit.document.insert(FEDERATION_HIT.to_string(), _federation);
-                    local_pinned_hits.push((
-                        *position,
-                        result_by_query.query_index,
-                        SearchHitByIndex {
+                    local_pinned_hits.push(LocalPin {
+                        position: *position,
+                        precedence: Precedence(*precedence),
+                        query_index: result_by_query.query_index,
+                        hit: SearchHitByIndex {
                             hit,
                             score,
                             weight: result_by_query.weight,
                             query_index: result_by_query.query_index,
                         },
-                    ));
+                        doc_id,
+                    });
                 } else {
                     result_by_query.documents_ids.push(doc_id);
                     result_by_query.document_scores.push(score);
@@ -1643,7 +1708,7 @@ impl SearchByIndex {
             }
         }
 
-        local_pinned_hits.sort_by_key(|&(pos, _, _)| pos);
+        Pin::dedup_and_sort(&mut local_pinned_hits);
 
         // A set of the seen values for the facet.
         // Whenever we consider a document, we check that its value for the distinct fid has not already been seen.
@@ -1699,11 +1764,16 @@ impl SearchByIndex {
             .take(required_hit_count)
             .map_ok(|hit| (hit.query_index, hit))
             .collect::<Result<Vec<_>, (ResponseError, Option<usize>)>>()?;
-        let merged_result =
-            merge_pinned_hits_into_page(local_pinned_hits, 0, required_hit_count, organic_hits)
-                .into_iter()
-                .map(|(_, hit)| hit)
-                .collect();
+        let merged_result = merge_pinned_hits_into_page(
+            local_pinned_hits.len(),
+            local_pinned_hits.into_iter().map(|pin| (pin.position, pin.query_index, pin.hit)),
+            0,
+            required_hit_count,
+            organic_hits,
+        )
+        .into_iter()
+        .map(|(_, hit)| hit)
+        .collect();
         let estimated_total_hits = candidates.len() as usize;
         let facets = facet_patterns_by_index
             .map(|facets_by_index| {

--- a/crates/meilisearch/src/search/federated/types.rs
+++ b/crates/meilisearch/src/search/federated/types.rs
@@ -33,6 +33,7 @@ pub const QUERIES_POSITION: &str = "queriesPosition";
 pub const WEIGHTED_RANKING_SCORE: &str = "weightedRankingScore";
 pub const WEIGHTED_SCORE_VALUES: &str = "weightedScoreValues";
 pub const PINNED_POSITION: &str = "pinnedPosition";
+pub const PINNED_PRECEDENCE: &str = "pinnedPrecedence";
 pub const FEDERATION_REMOTE: &str = "remote";
 pub const FEDERATION_EXTRA_DOCUMENT: &str = "extra_document";
 

--- a/crates/meilisearch/tests/dynamic_search_rules/mod.rs
+++ b/crates/meilisearch/tests/dynamic_search_rules/mod.rs
@@ -1952,7 +1952,8 @@ async fn filter_conditions() {
         "_rankingScoreDetails": {
           "pin": {
             "order": 0,
-            "position": 0
+            "position": 0,
+            "precedence": null
           }
         }
       },
@@ -2019,7 +2020,8 @@ async fn filter_conditions() {
         "_rankingScoreDetails": {
           "pin": {
             "order": 0,
-            "position": 0
+            "position": 0,
+            "precedence": null
           }
         }
       },
@@ -2086,7 +2088,8 @@ async fn filter_conditions() {
         "_rankingScoreDetails": {
           "pin": {
             "order": 0,
-            "position": 0
+            "position": 0,
+            "precedence": null
           }
         }
       },
@@ -2223,7 +2226,8 @@ async fn filter_conditions() {
         "_rankingScoreDetails": {
           "pin": {
             "order": 0,
-            "position": 0
+            "position": 0,
+            "precedence": null
           }
         }
       },
@@ -2331,7 +2335,8 @@ async fn filter_conditions() {
         "_rankingScoreDetails": {
           "pin": {
             "order": 0,
-            "position": 1
+            "position": 1,
+            "precedence": null
           }
         }
       }
@@ -2756,7 +2761,8 @@ async fn search_applies_precedenceless_rules() {
         "_rankingScoreDetails": {
           "pin": {
             "order": 0,
-            "position": 0
+            "position": 0,
+            "precedence": 10
           }
         }
       },
@@ -2766,7 +2772,8 @@ async fn search_applies_precedenceless_rules() {
         "_rankingScoreDetails": {
           "pin": {
             "order": 0,
-            "position": 1
+            "position": 1,
+            "precedence": null
           }
         }
       }

--- a/crates/meilisearch/tests/dynamic_search_rules/mod.rs
+++ b/crates/meilisearch/tests/dynamic_search_rules/mod.rs
@@ -2780,3 +2780,329 @@ async fn search_applies_precedenceless_rules() {
     ]
     "###);
 }
+
+#[actix_web::test]
+async fn multi_search_deduplicates_pins() {
+    let server = dynamic_search_rules_server().await;
+    let index = server.index("movies");
+
+    let (task, code) = index
+        .add_documents(
+            json!([
+                { "id": "organic-match", "title": "Batman Returns" },
+                { "id": "pinned-query-miss", "title": "The Matrix" },
+                { "id": "filtered-pin", "title": "Batman Returns" }
+            ]),
+            None,
+        )
+        .await;
+    snapshot!(code, @"202 Accepted");
+    server.wait_task(task.uid()).await.succeeded();
+
+    let (task, code) = server
+        .create_dynamic_search_rule(
+            "pin-invoked-twice-in-multi-search",
+            json!({
+                "active": true,
+                "conditions": {
+                    "query": {
+                        "words": "returns"
+                    }
+                },
+                "actions": [
+                    {
+                        "selector": { "id": "pinned-query-miss" },
+                        "action": { "type": "pin", "position": 0 }
+                    },
+                    {
+                        "selector": { "id": "filtered-pin" },
+                        "action": { "type": "pin", "position": 1 }
+                    }
+                ]
+            }),
+        )
+        .await;
+    snapshot!(code, @"202 Accepted");
+    server.wait_task(task.uid()).await.succeeded();
+
+    let (value, code) = server
+        .multi_search(json!({
+          "federation": {},
+          "queries": [
+            // 2 identical queries, both trigger the DSR
+           { "q": "Batman Returns", "indexUid": "movies", "showRankingScoreDetails": true },
+           { "q": "Batman Returns", "indexUid": "movies", "showRankingScoreDetails": true }
+          ]
+        }))
+        .await;
+    snapshot!(code, @"200 OK");
+    // docs are pinned only once
+    snapshot!(json_string!(value, { ".requestUid" => "[uuid]", ".processingTimeMs" => "[duration]" }), @r###"
+    {
+      "hits": [
+        {
+          "id": "pinned-query-miss",
+          "title": "The Matrix",
+          "_federation": {
+            "indexUid": "movies",
+            "queriesPosition": 0,
+            "weightedRankingScore": 1.0
+          },
+          "_rankingScoreDetails": {
+            "pin": {
+              "order": 0,
+              "position": 0,
+              "precedence": null
+            }
+          }
+        },
+        {
+          "id": "filtered-pin",
+          "title": "Batman Returns",
+          "_federation": {
+            "indexUid": "movies",
+            "queriesPosition": 0,
+            "weightedRankingScore": 1.0
+          },
+          "_rankingScoreDetails": {
+            "pin": {
+              "order": 0,
+              "position": 1,
+              "precedence": null
+            }
+          }
+        },
+        {
+          "id": "organic-match",
+          "title": "Batman Returns",
+          "_federation": {
+            "indexUid": "movies",
+            "queriesPosition": 0,
+            "weightedRankingScore": 1.0
+          },
+          "_rankingScoreDetails": {
+            "words": {
+              "order": 0,
+              "matchingWords": 2,
+              "maxMatchingWords": 2,
+              "score": 1.0
+            },
+            "typo": {
+              "order": 1,
+              "typoCount": 0,
+              "maxTypoCount": 2,
+              "score": 1.0
+            },
+            "proximity": {
+              "order": 2,
+              "score": 1.0
+            },
+            "attributeRank": {
+              "order": 3,
+              "score": 1.0
+            },
+            "wordPosition": {
+              "order": 4,
+              "score": 1.0
+            },
+            "exactness": {
+              "order": 5,
+              "matchType": "exactMatch",
+              "score": 1.0
+            }
+          }
+        }
+      ],
+      "processingTimeMs": "[duration]",
+      "limit": 20,
+      "offset": 0,
+      "estimatedTotalHits": 3,
+      "requestUid": "[uuid]"
+    }
+    "###);
+}
+
+#[actix_web::test]
+async fn multi_search_lower_precedence_pin_wins() {
+    let server = dynamic_search_rules_server().await;
+    let index = server.index("movies");
+
+    let (task, code) = index
+        .add_documents(
+            json!([
+                { "id": "organic-match", "title": "Batman Returns" },
+                { "id": "pinned-twice", "title": "The Matrix" },
+                { "id": "filtered-pin", "title": "Batman Returns" }
+            ]),
+            None,
+        )
+        .await;
+    snapshot!(code, @"202 Accepted");
+    server.wait_task(task.uid()).await.succeeded();
+
+    let (task, code) = server
+        .create_dynamic_search_rule(
+            "pin-for-query-0",
+            json!({
+                "precedence": 42,
+                "active": true,
+                "conditions": {
+                    "query": {
+                        "words": "returns"
+                    }
+                },
+                "actions": [
+                    {
+                        "selector": { "id": "pinned-twice" },
+                        "action": { "type": "pin", "position": 0 }
+                    }
+                ]
+            }),
+        )
+        .await;
+    snapshot!(code, @"202 Accepted");
+    server.wait_task(task.uid()).await.succeeded();
+
+    let (task, code) = server
+        .create_dynamic_search_rule(
+            "pin-for-query-1",
+            json!({
+                "precedence": 0,
+                "active": true,
+                "conditions": {
+                    "query": {
+                        "words": "batman"
+                    }
+                },
+                "actions": [
+                    {
+                        "selector": { "id": "pinned-twice" },
+                        "action": { "type": "pin", "position": 1 }
+                    }
+                ]
+            }),
+        )
+        .await;
+    snapshot!(code, @"202 Accepted");
+    server.wait_task(task.uid()).await.succeeded();
+
+    let (value, code) = server
+        .multi_search(json!({
+          "federation": {},
+          "queries": [
+            // each query triggers one DSR, each DSR wants to pin the same document in different locations
+           { "q": "Returns", "indexUid": "movies", "showRankingScoreDetails": true },
+           { "q": "Batman", "indexUid": "movies", "showRankingScoreDetails": true }
+          ]
+        }))
+        .await;
+    snapshot!(code, @"200 OK");
+    // doc is only pinned once at the location (1) decided by the rule with earliest precedence
+    snapshot!(json_string!(value, { ".requestUid" => "[uuid]", ".processingTimeMs" => "[duration]" }), @r###"
+    {
+      "hits": [
+        {
+          "id": "organic-match",
+          "title": "Batman Returns",
+          "_federation": {
+            "indexUid": "movies",
+            "queriesPosition": 1,
+            "weightedRankingScore": 0.9848484848484848
+          },
+          "_rankingScoreDetails": {
+            "words": {
+              "order": 0,
+              "matchingWords": 1,
+              "maxMatchingWords": 1,
+              "score": 1.0
+            },
+            "typo": {
+              "order": 1,
+              "typoCount": 0,
+              "maxTypoCount": 1,
+              "score": 1.0
+            },
+            "proximity": {
+              "order": 2,
+              "score": 1.0
+            },
+            "attributeRank": {
+              "order": 3,
+              "score": 1.0
+            },
+            "wordPosition": {
+              "order": 4,
+              "score": 1.0
+            },
+            "exactness": {
+              "order": 5,
+              "matchType": "matchesStart",
+              "score": 0.6666666666666666
+            }
+          }
+        },
+        {
+          "id": "pinned-twice",
+          "title": "The Matrix",
+          "_federation": {
+            "indexUid": "movies",
+            "queriesPosition": 1,
+            "weightedRankingScore": 1.0
+          },
+          "_rankingScoreDetails": {
+            "pin": {
+              "order": 0,
+              "position": 1,
+              "precedence": 0
+            }
+          }
+        },
+        {
+          "id": "filtered-pin",
+          "title": "Batman Returns",
+          "_federation": {
+            "indexUid": "movies",
+            "queriesPosition": 1,
+            "weightedRankingScore": 0.9848484848484848
+          },
+          "_rankingScoreDetails": {
+            "words": {
+              "order": 0,
+              "matchingWords": 1,
+              "maxMatchingWords": 1,
+              "score": 1.0
+            },
+            "typo": {
+              "order": 1,
+              "typoCount": 0,
+              "maxTypoCount": 1,
+              "score": 1.0
+            },
+            "proximity": {
+              "order": 2,
+              "score": 1.0
+            },
+            "attributeRank": {
+              "order": 3,
+              "score": 1.0
+            },
+            "wordPosition": {
+              "order": 4,
+              "score": 1.0
+            },
+            "exactness": {
+              "order": 5,
+              "matchType": "matchesStart",
+              "score": 0.6666666666666666
+            }
+          }
+        }
+      ],
+      "processingTimeMs": "[duration]",
+      "limit": 20,
+      "offset": 0,
+      "estimatedTotalHits": 3,
+      "requestUid": "[uuid]"
+    }
+    "###);
+}

--- a/crates/milli/src/dynamic_search_rules.rs
+++ b/crates/milli/src/dynamic_search_rules.rs
@@ -17,6 +17,7 @@ use crate::search::facet::ascending_facet_sort;
 use crate::search::facet::facet_range_search::find_docids_of_facet_within_bounds;
 use crate::search::facet::value_bounds::{evaluate_equal, to_str_bounds, ValueBounds};
 use crate::search::new::LocatedQueryTerm;
+use crate::search::{Pin, Precedence};
 use crate::update::new::document::DocumentFromDb;
 use crate::{
     AscDesc, DocumentId, FieldId, FieldsIdsMap, Index, IndexFilter, PinDoc, Result, SearchContext,
@@ -80,18 +81,17 @@ impl<'a> DynamicSearchRulesView<'a> {
         let active_rules =
             self.active_rules_for_query(query_terms, filter, search_context, fuel)?;
 
-        self.find_pins(self.rule_ids_sorted_by_precedence(active_rules)?, search_context, fuel)
-            .filter(
-                |pin| {
-                    if let Ok(pin) = pin.as_ref() {
-                        universe.remove(pin.doc_id)
-                    } else {
-                        true
-                    }
-                },
-            )
+        let pins: Result<Vec<PinDoc>> = self
+            .find_pins(self.rule_ids_sorted_by_precedence(active_rules)?, search_context, fuel)
+            .filter(|pin| if let Ok(pin) = pin.as_ref() { universe.remove(pin.id) } else { true })
             .take(fuel.max_pin_actions())
-            .collect()
+            .collect();
+
+        let mut pins = pins?;
+
+        Pin::dedup_and_sort(&mut pins);
+
+        Ok(pins)
     }
 
     pub fn rules_from_rule_ids<I>(
@@ -192,10 +192,26 @@ impl<'a> DynamicSearchRulesView<'a> {
                 let Some(actions) = rule.field(fields::ACTIONS)? else {
                     return Ok(None);
                 };
+
+                let precedence: Result<Option<u64>, _> = match rule.field(fields::PRECEDENCE)? {
+                    Some(precedence) => serde_json::from_str(precedence.get()),
+                    None => Ok(None),
+                };
+
+                let precedence = match precedence {
+                    Ok(precedence) => precedence,
+                    Err(err) => {
+                        tracing::warn!(
+                        "could not deserialize actions of rule with internal id `{rule_id}`: {err}"
+                    );
+                        return Ok(None);
+                    }
+                };
+
                 let actions: Result<Vec<RuleAction>, serde_json::Error> =
                     serde_json::from_str(actions.get());
                 match actions {
-                    Ok(actions) => Ok(Some(actions.into_iter())),
+                    Ok(actions) => Ok(Some(actions.into_iter().zip(std::iter::repeat(precedence)))),
                     Err(err) => {
                         tracing::warn!(
                         "could not deserialize actions of rule with internal id `{rule_id}`: {err}"
@@ -206,7 +222,8 @@ impl<'a> DynamicSearchRulesView<'a> {
             })
             .filter_map(|x| x.transpose())
             .flatten_ok()
-            .filter_map_ok(|action| {
+            .filter_map_ok(|(action, precedence)| {
+                let precedence = Precedence(precedence);
                 let doc_id = action.active_document(search_context).transpose()?;
 
                 let doc_id = match doc_id {
@@ -215,7 +232,7 @@ impl<'a> DynamicSearchRulesView<'a> {
                 };
                 match action.action {
                     DynamicSearchRuleAction::Pin { position } => {
-                        Some(Ok(PinDoc { pos: position, doc_id }))
+                        Some(Ok(PinDoc { position, precedence, id: doc_id }))
                     }
                 }
             })

--- a/crates/milli/src/lib.rs
+++ b/crates/milli/src/lib.rs
@@ -97,8 +97,9 @@ pub use self::search::similar::Similar;
 pub use self::search::steps::{FederatingResultsStep, SearchStep, TotalProcessingTimeStep};
 pub use self::search::{
     merge_positioned_hits_into_page, serialize_index_filter_to_filter_string, FacetDistribution,
-    Filter, FormatOptions, IndexFilter, MatchBounds, MatcherBuilder, MatchingWords, OrderBy,
-    PinDoc, Search, SearchResult, SemanticSearch, TermsMatchingStrategy, DEFAULT_VALUES_PER_FACET,
+    Filter, FormatOptions, IndexFilter, MatchBounds, MatcherBuilder, MatchingWords, OrderBy, Pin,
+    PinDoc, Precedence, Search, SearchResult, SemanticSearch, TermsMatchingStrategy,
+    DEFAULT_VALUES_PER_FACET,
 };
 pub use self::update::{
     ChannelCongestion, FragmentDiff, InnerIndexSettings, InnerIndexSettingsDiff, SettingsDelta,

--- a/crates/milli/src/score_details.rs
+++ b/crates/milli/src/score_details.rs
@@ -3,7 +3,8 @@ use std::cmp::Ordering;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
-use crate::{criterion::AttributeState, distance_between_two_points};
+use crate::criterion::AttributeState;
+use crate::distance_between_two_points;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum ScoreDetails {
@@ -28,6 +29,7 @@ pub enum ScoreDetails {
     /// handle pinned documents appropriately.
     Pin {
         position: u32,
+        precedence: Option<u64>,
     },
 }
 
@@ -405,10 +407,11 @@ impl ScoreDetails {
                         .insert("skipped".to_string(), serde_json::json!({ "order": order }));
                     order += 1;
                 }
-                ScoreDetails::Pin { position } => {
+                ScoreDetails::Pin { position, precedence } => {
                     let pin_details = serde_json::json!({
                         "order": order,
                         "position": position,
+                        "precedence": precedence,
                     });
                     details_map.insert("pin".into(), pin_details);
                     order += 1;

--- a/crates/milli/src/search/hybrid.rs
+++ b/crates/milli/src/search/hybrid.rs
@@ -10,8 +10,8 @@ use crate::search::steps::SearchStep;
 use crate::search::SemanticSearch;
 use crate::vector::{Embedding, SearchQuery};
 use crate::{
-    merge_positioned_hits_into_page, FieldsIdsMap, Index, MatchingWords, PinDoc, Result, Search,
-    SearchResult,
+    merge_positioned_hits_into_page, FieldsIdsMap, Index, MatchingWords, PinDoc, Precedence,
+    Result, Search, SearchResult,
 };
 
 struct ScoreWithRatioResult {
@@ -117,9 +117,13 @@ impl ScoreWithRatioResult {
 
         for results in [&mut keyword_results.document_scores, &mut vector_results.document_scores] {
             results.retain(|(doc_id, (scores, _))| {
-                if let Some(ScoreDetails::Pin { position }) = scores.first() {
+                if let Some(ScoreDetails::Pin { position, precedence }) = scores.first() {
                     if pinned_doc_ids.insert(*doc_id) {
-                        pins.push(PinDoc { pos: *position, doc_id: *doc_id });
+                        pins.push(PinDoc {
+                            position: *position,
+                            precedence: Precedence(*precedence),
+                            id: *doc_id,
+                        });
                     }
                     false
                 } else {
@@ -127,7 +131,7 @@ impl ScoreWithRatioResult {
                 }
             });
         }
-        pins.sort_by_key(|pin| pin.pos);
+        pins.sort_by_key(|pin| pin.position);
 
         // When pins are present we need the organic prefix up to the end of the
         // requested page, then we merge pins into that prefix before slicing the
@@ -248,12 +252,18 @@ fn merge_pins_into_page(
 
     let organic_hits = documents_ids.into_iter().zip(document_scores).collect();
     let merged_hits = merge_positioned_hits_into_page(
-        pins.to_vec(),
+        pins.len(),
+        pins,
         from,
         length,
         organic_hits,
-        |pin| pin.pos,
-        |pin| (pin.doc_id, vec![ScoreDetails::Pin { position: pin.pos }]),
+        |pin| pin.position,
+        |pin| {
+            (
+                pin.id,
+                vec![ScoreDetails::Pin { position: pin.position, precedence: pin.precedence.0 }],
+            )
+        },
     );
 
     merged_hits.into_iter().unzip()

--- a/crates/milli/src/search/mod.rs
+++ b/crates/milli/src/search/mod.rs
@@ -51,8 +51,79 @@ pub struct SemanticSearch {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PinDoc {
-    pub pos: Position,
-    pub doc_id: DocumentId,
+    pub position: Position,
+    pub precedence: Precedence,
+    pub id: DocumentId,
+}
+
+impl Pin for PinDoc {
+    type Id = DocumentId;
+
+    fn id(&self) -> Self::Id {
+        self.id
+    }
+
+    fn position(&self) -> u32 {
+        self.position
+    }
+
+    fn precedence(&self) -> Precedence {
+        self.precedence
+    }
+}
+
+pub trait Pin {
+    type Id;
+    fn id(&self) -> Self::Id;
+
+    fn position(&self) -> u32;
+    fn precedence(&self) -> Precedence;
+
+    fn sort(pins: &mut Vec<Self>)
+    where
+        Self: Sized,
+    {
+        pins.sort_unstable_by_key(|item| (item.position(), item.precedence()));
+    }
+
+    fn dedup(pins: &mut Vec<Self>)
+    where
+        Self: Sized,
+        Self::Id: PartialEq + PartialOrd + Ord,
+    {
+        pins.sort_unstable_by_key(|item| (item.id(), item.precedence(), item.position()));
+        pins.dedup_by_key(|item| item.id());
+    }
+
+    fn dedup_and_sort(pins: &mut Vec<Self>)
+    where
+        Self: Sized,
+        Self::Id: PartialEq + PartialOrd + Ord,
+    {
+        Self::dedup(pins);
+        Self::sort(pins);
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Precedence(pub Option<u64>);
+
+impl PartialOrd for Precedence {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Precedence {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        use std::cmp::Ordering::*;
+        match (self.0, other.0) {
+            (None, None) => Equal,
+            (None, Some(_)) => Greater,
+            (Some(_), None) => Less,
+            (Some(left), Some(right)) => left.cmp(&right),
+        }
+    }
 }
 
 pub struct Search<'a> {

--- a/crates/milli/src/search/mod.rs
+++ b/crates/milli/src/search/mod.rs
@@ -648,7 +648,8 @@ pub fn build_dfa(word: &str, typos: u8, is_prefix: bool) -> DFA {
 }
 
 pub fn merge_positioned_hits_into_page<P, T, FPos, FMap>(
-    pins: Vec<P>,
+    pin_count: usize,
+    pins: impl IntoIterator<Item = P>,
     skip: usize,
     take: usize,
     organic_hits: Vec<T>,
@@ -659,12 +660,12 @@ where
     FPos: Fn(&P) -> Position,
     FMap: FnMut(P) -> T,
 {
-    if pins.is_empty() {
+    if pin_count == 0 {
         return organic_hits;
     }
 
     let page_end = skip.saturating_add(take);
-    let capacity = take.min(organic_hits.len().saturating_add(pins.len()));
+    let capacity = take.min(organic_hits.len().saturating_add(pin_count));
     let mut merged_hits = Vec::with_capacity(capacity);
     let mut organic_hits = organic_hits.into_iter();
     let mut pins = pins.into_iter().peekable();

--- a/crates/milli/src/search/mod.rs
+++ b/crates/milli/src/search/mod.rs
@@ -115,7 +115,7 @@ impl PartialOrd for Precedence {
 }
 
 /// Overrides the natural order of Option such that None is considered greater than Some rather than Less
-/// 
+///
 /// When both options are Some, use the regular order.
 impl Ord for Precedence {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {

--- a/crates/milli/src/search/mod.rs
+++ b/crates/milli/src/search/mod.rs
@@ -114,6 +114,9 @@ impl PartialOrd for Precedence {
     }
 }
 
+/// Overrides the natural order of Option such that None is considered greater than Some rather than Less
+/// 
+/// When both options are Some, use the regular order.
 impl Ord for Precedence {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         use std::cmp::Ordering::*;

--- a/crates/milli/src/search/new/bucket_sort.rs
+++ b/crates/milli/src/search/new/bucket_sort.rs
@@ -359,17 +359,23 @@ fn inject_pins(
     let BucketSortOutput { docids, scores, mut all_candidates, degraded } = output;
 
     for pin in &pins {
-        all_candidates.insert(pin.doc_id);
+        all_candidates.insert(pin.id);
     }
 
     let organic_hits = docids.into_iter().zip(scores).collect();
     let merged_hits = merge_positioned_hits_into_page(
+        pins.len(),
         pins,
         from,
         length,
         organic_hits,
-        |pin| pin.pos,
-        |pin| (pin.doc_id, vec![ScoreDetails::Pin { position: pin.pos }]),
+        |pin| pin.position,
+        |pin| {
+            (
+                pin.id,
+                vec![ScoreDetails::Pin { position: pin.position, precedence: pin.precedence.0 }],
+            )
+        },
     );
     let (merged_docids, merged_scores): (Vec<_>, Vec<_>) = merged_hits.into_iter().unzip();
 


### PR DESCRIPTION
## Related issue

Fixes #6540 

## API change

- Add `precedence` to `ScoreDetails::Pin` in ranking score details

## Implementation

- Introduce a trait to factor the behavior of deduplicating and sorting pins
- Use the trait to correctly deduplicate pins in federated search
- Fix existing tests
- Add tests:
    1. Checking that pins are no longer duplicated (checked that pins would be duplicated on main)
    2. Checking that the pin belonging to the rule with the earliest precedence wins

## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respect the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - *list of used tools and what they were used for*