### PR TITLE
Skip the settings when nothing changes

### DIFF
--- a/crates/milli/src/update/new/indexer/mod.rs
+++ b/crates/milli/src/update/new/indexer/mod.rs
@@ -20,8 +20,8 @@ use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterato
 pub use settings_changes::settings_change_extract;
 pub use update_by_function::UpdateByFunction;
 pub use word_delta::WordDelta;
-pub use write::ChannelCongestion;
-use write::{build_vectors, update_index, write_to_db};
+use write::{build_vectors, write_to_db};
+pub use write::{update_index, ChannelCongestion};
 
 use super::channel::*;
 use super::steps::IndexingStep;

--- a/crates/milli/src/update/new/indexer/write.rs
+++ b/crates/milli/src/update/new/indexer/write.rs
@@ -170,7 +170,7 @@ pub fn build_vectors(
 }
 
 #[allow(clippy::too_many_arguments)]
-pub(super) fn update_index(
+pub fn update_index(
     index: &Index,
     wtxn: &mut RwTxn<'_>,
     new_fields_ids_map: FieldIdMapWithMetadata,

--- a/crates/milli/src/update/settings.rs
+++ b/crates/milli/src/update/settings.rs
@@ -33,7 +33,7 @@ use crate::progress::{EmbedderStats, Progress};
 use crate::prompt::{default_max_bytes, default_template_text, Prompt, PromptData};
 use crate::proximity::ProximityPrecision;
 use crate::update::index_documents::IndexDocumentsMethod;
-use crate::update::new::indexer::reindex;
+use crate::update::new::indexer::{reindex, update_index};
 use crate::update::new::steps::SettingsIndexerStep;
 use crate::update::{IndexDocuments, UpdateIndexingStep};
 use crate::vector::db::{FragmentConfigs, IndexEmbeddingConfig};
@@ -1631,6 +1631,16 @@ impl<'a, 't, 'i> Settings<'a, 't, 'i> {
             )
             .map(Some)
         } else {
+            update_index(
+                self.index,
+                self.wtxn,
+                inner_settings_diff.new.fields_ids_map.clone(),
+                None,
+                inner_settings_diff.new_embedders().clone(),
+                ip_policy,
+                self.index.field_distribution(self.wtxn)?,
+                self.index.documents_ids(self.wtxn)?,
+            )?;
             Ok(None)
         }
     }

--- a/crates/milli/src/update/settings.rs
+++ b/crates/milli/src/update/settings.rs
@@ -1615,7 +1615,9 @@ impl<'a, 't, 'i> Settings<'a, 't, 'i> {
             settings_update_only,
         );
 
-        if self.index.number_of_documents(self.wtxn)? > 0 {
+        if self.index.number_of_documents(self.wtxn)? > 0
+            && inner_settings_diff.any_reindexing_needed()
+        {
             reindex(
                 self.wtxn,
                 self.index,


### PR DESCRIPTION
Small regression with the new settings indexer that made the engine compute and reindex a bunch of internal data structures even when nothing changes in the settings.

## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respects the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)