### PR TITLE
Add config for number of HTTP server workers

### DIFF
--- a/crates/meilisearch/src/analytics/segment_analytics.rs
+++ b/crates/meilisearch/src/analytics/segment_analytics.rs
@@ -1,6 +1,7 @@
 use std::any::TypeId;
 use std::collections::{HashMap, HashSet};
 use std::fs;
+use std::num::NonZeroUsize;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -231,6 +232,7 @@ struct Infos {
     ignore_snapshot_if_db_exists: bool,
     http_addr: bool,
     http_payload_size_limit: Byte,
+    http_workers: Option<usize>,
     task_queue_webhook: bool,
     task_webhook_authorization_header: bool,
     log_level: String,
@@ -276,6 +278,7 @@ impl Infos {
             max_index_size: _,
             max_task_db_size: _,
             http_payload_size_limit,
+            http_workers,
             ssl_cert_path,
             ssl_key_path,
             ssl_auth_path,
@@ -374,6 +377,7 @@ impl Infos {
             ignore_snapshot_if_db_exists,
             http_addr: http_addr != default_http_addr(),
             http_payload_size_limit,
+            http_workers: http_workers.map(NonZeroUsize::get),
             experimental_max_number_of_batched_tasks,
             experimental_limit_batched_tasks_total_size:
                 experimental_limit_batched_tasks_total_size.map(|size| size.as_u64()),

--- a/crates/meilisearch/src/main.rs
+++ b/crates/meilisearch/src/main.rs
@@ -189,11 +189,14 @@ async fn run_http(
         analytics,
     };
 
-    let http_server =
+    let mut http_server =
         HttpServer::new(move || create_app(services.clone(), opt.clone(), enable_dashboard))
             // Disable signals allows the server to terminate immediately when a user enter CTRL-C
             .disable_signals()
             .keep_alive(KeepAlive::Os);
+    if let Some(http_workers) = opt_clone.http_workers {
+        http_server = http_server.workers(http_workers.get());
+    }
 
     if let Some(config) = opt_clone.get_ssl_config()? {
         http_server.bind_rustls_0_23(opt_clone.http_addr, config)?.run().await?;

--- a/crates/meilisearch/src/option.rs
+++ b/crates/meilisearch/src/option.rs
@@ -33,6 +33,7 @@ const MEILI_TASK_WEBHOOK_URL: &str = "MEILI_TASK_WEBHOOK_URL";
 const MEILI_TASK_WEBHOOK_AUTHORIZATION_HEADER: &str = "MEILI_TASK_WEBHOOK_AUTHORIZATION_HEADER";
 const MEILI_NO_ANALYTICS: &str = "MEILI_NO_ANALYTICS";
 const MEILI_HTTP_PAYLOAD_SIZE_LIMIT: &str = "MEILI_HTTP_PAYLOAD_SIZE_LIMIT";
+const MEILI_HTTP_WORKERS: &str = "MEILI_HTTP_WORKERS";
 const MEILI_SSL_CERT_PATH: &str = "MEILI_SSL_CERT_PATH";
 const MEILI_SSL_KEY_PATH: &str = "MEILI_SSL_KEY_PATH";
 const MEILI_SSL_AUTH_PATH: &str = "MEILI_SSL_AUTH_PATH";
@@ -269,6 +270,11 @@ pub struct Opt {
     #[clap(long, env = MEILI_HTTP_PAYLOAD_SIZE_LIMIT, default_value_t = default_http_payload_size_limit())]
     #[serde(default = "default_http_payload_size_limit")]
     pub http_payload_size_limit: Byte,
+
+    /// Sets the number of HTTP workers to start, i.e. the number of threads that will handle
+    /// incoming requests. Defaults to the number of logical CPUs if unset.
+    #[clap(long, env = MEILI_HTTP_WORKERS)]
+    pub http_workers: Option<NonZeroUsize>,
 
     /// Sets the server's SSL certificates.
     #[clap(long, env = MEILI_SSL_CERT_PATH, value_parser)]
@@ -586,6 +592,7 @@ impl Opt {
             max_index_size: _,
             max_task_db_size: _,
             http_payload_size_limit,
+            http_workers,
             ssl_cert_path,
             ssl_key_path,
             ssl_auth_path,
@@ -645,6 +652,9 @@ impl Opt {
             MEILI_HTTP_PAYLOAD_SIZE_LIMIT,
             http_payload_size_limit.to_string(),
         );
+        if let Some(http_workers) = http_workers {
+            export_to_env_if_not_present(MEILI_HTTP_WORKERS, http_workers.to_string());
+        }
         if let Some(ssl_cert_path) = ssl_cert_path {
             export_to_env_if_not_present(MEILI_SSL_CERT_PATH, ssl_cert_path);
         }


### PR DESCRIPTION
Previously, there was no way to constrain the number of HTTP workers that are spawned on startup unless you constrained the machine or container environment. This adds a command-line flag and environment variable to configure the number of workers. If unset, continues to default to what actix-web did before, which is use `std::thread::available_parallelism()`

## Generative AI tools

- [x] This PR does not use generative AI tooling

## Changelog

New flag `--http-workers` and environment variable `MEILI_HTTP_WORKERS` takes a non-zero integer to control the number of initial workers to spawn for the http server.
