### PR TITLE
optimize scan for filters_into_index_filters

### DIFF
--- a/crates/index-scheduler/src/filter.rs
+++ b/crates/index-scheduler/src/filter.rs
@@ -172,8 +172,6 @@ pub fn filters_into_index_filters(
         let foreign_index = index_scheduler.user_index(foreign_index_uid.as_ref())?;
         let foreign_rtxn = foreign_index.read_txn()?;
         let foreign_fields_ids_map = foreign_index.fields_ids_map(&foreign_rtxn).unwrap();
-        let foreign_external_docids = foreign_index.external_documents_ids();
-
         // Gather the internal docids for each filter
         let mut filters_internal_docids = Vec::new();
         for filter_index in filter_indices.iter() {
@@ -207,12 +205,21 @@ pub fn filters_into_index_filters(
                 index_uid: Some(foreign_index_uid.as_ref().to_string()),
             });
         }
-        let mut internal_to_external_docids = HashMap::new();
-        // TODO: optimize DB scan (linear: EXP-1117)
-        for result in foreign_external_docids.iter(&foreign_rtxn)? {
-            let (external, internal) = result?;
-            if docids_to_fetch.contains(internal) {
-                internal_to_external_docids.insert(internal, external.to_string());
+        let mut internal_to_external_docids =
+            HashMap::with_capacity(docids_to_fetch.len() as usize);
+
+        if let Some(pk_name) = foreign_index.primary_key(&foreign_rtxn)? {
+            let fields_ids_map = foreign_index.fields_ids_map(&foreign_rtxn)?;
+            if let Some(pk_id) = fields_ids_map.id(pk_name) {
+                // 2. Point-lookup ONLY the matching internal docids (O(M log N))
+                let docs = foreign_index.documents(&foreign_rtxn, docids_to_fetch.iter()).unwrap();
+                for (internal, doc) in docs {
+                    if let Some(external_val) = doc.get(pk_id) {
+                        if let Ok(external_id) = serde_json::from_slice::<String>(external_val) {
+                            internal_to_external_docids.insert(internal, external_id);
+                        }
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
## Related issue

Fixes #EXP-1117
This PR replaces the $O(N)$ iterator scan in filters_into_index_filters with direct $O(M \log N)$ point lookups via foreign_index.documents(), retrieving only the primary key strings for the target matched documents.

## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respect the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - *list of used tools and what they were used for*

## Requirements

⚠️ Ensure the following requirements before merging ⚠️
- [ ] Automated tests have been added.
- [ ] If some tests cannot be automated, manual rigorous tests should be applied.
- [ ] ⚠️ If there is any change in the DB:
    - [ ] Test that any impacted DB still works as expected after using `--upgrade-db` on a DB created with the last released Meilisearch
    - [ ] Test that during the upgrade, **search is still available** (artificially make the upgrade longer if needed)
    - [ ] Set the `db change` label.
- [ ] If necessary, the feature have been tested in the Cloud production environment (with [prototypes](./documentation/prototypes.md)) and the Cloud UI is ready.
- [ ] If necessary, the [documentation](https://github.com/meilisearch/documentation) related to the implemented feature in the PR is ready.
- [ ] If necessary, the [integrations](https://github.com/meilisearch/integration-guides) related to the implemented feature in the PR are ready.
