### PR TITLE
fetch DB name cleanly

### DIFF
--- a/crates/index-scheduler/src/scheduler/process_snapshot_creation.rs
+++ b/crates/index-scheduler/src/scheduler/process_snapshot_creation.rs
@@ -1,4 +1,3 @@
-use std::ffi::OsStr;
 use std::fs;
 use std::sync::atomic::Ordering;
 
@@ -208,11 +207,21 @@ impl IndexScheduler {
 
         // 5. Copy and tarball the flat snapshot
         progress.update_progress(SnapshotCreationProgress::CreateTheTarball);
+
         // 5.1 Find the original name of the database
-        // TODO find a better way to get this path
-        let mut base_path = self.env.path().to_owned();
-        base_path.pop();
-        let db_name = base_path.file_name().and_then(OsStr::to_str).unwrap_or("data.ms");
+        let db_name = self
+            .env
+            .path()
+            .parent()
+            .and_then(|parent| parent.file_name())
+            .and_then(|name| name.to_str())
+            .unwrap_or_else(|| {
+                tracing::warn!(
+                    path = ?self.env.path(),
+                    "Failed to extract database name from environment path, using default 'data.ms'"
+                );
+                "data.ms"
+            });
 
         // 5.2 Tarball the content of the snapshot in a tempfile with a .snapshot extension
         let snapshot_path = self.scheduler.snapshots_path.join(format!("{}.snapshot", db_name));


### PR DESCRIPTION
## Related issue

Fixes # TODO fetch the DB name in a better way

## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respect the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - *list of used tools and what they were used for*

## Requirements

⚠️ Ensure the following requirements before merging ⚠️
- [ ] Automated tests have been added.
- [ ] If some tests cannot be automated, manual rigorous tests should be applied.
- [ ] ⚠️ If there is any change in the DB:
    - [ ] Test that any impacted DB still works as expected after using `--upgrade-db` on a DB created with the last released Meilisearch
    - [ ] Test that during the upgrade, **search is still available** (artificially make the upgrade longer if needed)
    - [ ] Set the `db change` label.
- [ ] If necessary, the feature have been tested in the Cloud production environment (with [prototypes](./documentation/prototypes.md)) and the Cloud UI is ready.
- [ ] If necessary, the [documentation](https://github.com/meilisearch/documentation) related to the implemented feature in the PR is ready.
- [ ] If necessary, the [integrations](https://github.com/meilisearch/integration-guides) related to the implemented feature in the PR are ready.
