### PR TITLE
Expose per-index databaseSize and usedDatabaseSize in the stats routes

### DIFF
--- a/crates/meilisearch/src/routes/indexes/mod.rs
+++ b/crates/meilisearch/src/routes/indexes/mod.rs
@@ -572,9 +572,9 @@ pub struct IndexStats {
     /// Number of documents in the index
     pub number_of_documents: u64,
     /// Size of the index' DB, in bytes.
-    pub database_size: Size,
+    pub index_size: Size,
     /// Size of the used pages of the index' DB, in bytes.
-    pub used_database_size: Size,
+    pub used_index_size: Size,
     /// Size of the documents database, in bytes.
     pub raw_document_db_size: Size,
     /// Average size of a document in the documents database.
@@ -638,8 +638,8 @@ impl IndexStats {
         Self {
             number_of_documents: number_of_documents
                 .unwrap_or(documents_database_stats.number_of_entries()),
-            database_size: Size::new(database_size, format),
-            used_database_size: Size::new(used_database_size, format),
+            index_size: Size::new(database_size, format),
+            used_index_size: Size::new(used_database_size, format),
             raw_document_db_size: Size::new(documents_database_stats.total_size(), format),
             avg_document_size: Size::new(documents_database_stats.average_value_size(), format),
             internal_database_sizes: if with_internal_database_sizes {
@@ -668,8 +668,8 @@ impl IndexStats {
         (status = OK, description = "The stats of the index.", body = IndexStats, content_type = "application/json", example = json!(
             {
                 "numberOfDocuments": 10,
-                "databaseSize": 1572864,
-                "usedDatabaseSize": 524288,
+                "indexSize": 1572864,
+                "usedIndexSize": 524288,
                 "rawDocumentDbSize": 10,
                 "avgDocumentSize": 10,
                 "numberOfEmbeddings": 10,

--- a/crates/meilisearch/src/routes/indexes/mod.rs
+++ b/crates/meilisearch/src/routes/indexes/mod.rs
@@ -571,6 +571,10 @@ impl Size {
 pub struct IndexStats {
     /// Number of documents in the index
     pub number_of_documents: u64,
+    /// Size of the index' DB, in bytes.
+    pub database_size: Size,
+    /// Size of the used pages of the index' DB, in bytes.
+    pub used_database_size: Size,
     /// Size of the documents database, in bytes.
     pub raw_document_db_size: Size,
     /// Average size of a document in the documents database.
@@ -619,11 +623,11 @@ impl IndexStats {
                 index_scheduler::InnerIndexStats {
                     documents_database_stats,
                     number_of_documents,
-                    database_size: _,
+                    database_size,
                     internal_database_sizes,
                     number_of_embeddings,
                     number_of_embedded_documents,
-                    used_database_size: _,
+                    used_database_size,
                     primary_key: _,
                     field_distribution,
                     created_at: _,
@@ -634,6 +638,8 @@ impl IndexStats {
         Self {
             number_of_documents: number_of_documents
                 .unwrap_or(documents_database_stats.number_of_entries()),
+            database_size: Size::new(database_size, format),
+            used_database_size: Size::new(used_database_size, format),
             raw_document_db_size: Size::new(documents_database_stats.total_size(), format),
             avg_document_size: Size::new(documents_database_stats.average_value_size(), format),
             internal_database_sizes: if with_internal_database_sizes {
@@ -662,6 +668,8 @@ impl IndexStats {
         (status = OK, description = "The stats of the index.", body = IndexStats, content_type = "application/json", example = json!(
             {
                 "numberOfDocuments": 10,
+                "databaseSize": 1572864,
+                "usedDatabaseSize": 524288,
                 "rawDocumentDbSize": 10,
                 "avgDocumentSize": 10,
                 "numberOfEmbeddings": 10,

--- a/crates/meilisearch/src/routes/mod.rs
+++ b/crates/meilisearch/src/routes/mod.rs
@@ -418,6 +418,8 @@ pub struct Stats {
                 "indexes": {
                     "movies": {
                         "numberOfDocuments": 10,
+                        "databaseSize": 1572864,
+                        "usedDatabaseSize": 524288,
                         "rawDocumentDbSize": 100,
                         "maxDocumentSize": 16,
                         "avgDocumentSize": 10,

--- a/crates/meilisearch/src/routes/mod.rs
+++ b/crates/meilisearch/src/routes/mod.rs
@@ -418,8 +418,8 @@ pub struct Stats {
                 "indexes": {
                     "movies": {
                         "numberOfDocuments": 10,
-                        "databaseSize": 1572864,
-                        "usedDatabaseSize": 524288,
+                        "indexSize": 1572864,
+                        "usedIndexSize": 524288,
                         "rawDocumentDbSize": 100,
                         "maxDocumentSize": 16,
                         "avgDocumentSize": 10,

--- a/crates/meilisearch/tests/documents/delete_documents.rs
+++ b/crates/meilisearch/tests/documents/delete_documents.rs
@@ -152,15 +152,15 @@ async fn delete_document_by_filter() {
 
     let (stats, _) = index.stats().await;
     snapshot!(json_string!(stats, {
-        ".databaseSize" => "[size]",
-        ".usedDatabaseSize" => "[size]",
+        ".indexSize" => "[size]",
+        ".usedIndexSize" => "[size]",
         ".rawDocumentDbSize" => "[size]",
         ".avgDocumentSize" => "[size]",
     }), @r###"
     {
       "numberOfDocuments": 4,
-      "databaseSize": "[size]",
-      "usedDatabaseSize": "[size]",
+      "indexSize": "[size]",
+      "usedIndexSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,
@@ -210,15 +210,15 @@ async fn delete_document_by_filter() {
 
     let (stats, _) = index.stats().await;
     snapshot!(json_string!(stats, {
-        ".databaseSize" => "[size]",
-        ".usedDatabaseSize" => "[size]",
+        ".indexSize" => "[size]",
+        ".usedIndexSize" => "[size]",
         ".rawDocumentDbSize" => "[size]",
         ".avgDocumentSize" => "[size]",
     }), @r###"
     {
       "numberOfDocuments": 2,
-      "databaseSize": "[size]",
-      "usedDatabaseSize": "[size]",
+      "indexSize": "[size]",
+      "usedIndexSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,
@@ -287,15 +287,15 @@ async fn delete_document_by_filter() {
 
     let (stats, _) = index.stats().await;
     snapshot!(json_string!(stats, {
-        ".databaseSize" => "[size]",
-        ".usedDatabaseSize" => "[size]",
+        ".indexSize" => "[size]",
+        ".usedIndexSize" => "[size]",
         ".rawDocumentDbSize" => "[size]",
         ".avgDocumentSize" => "[size]",
     }), @r###"
     {
       "numberOfDocuments": 1,
-      "databaseSize": "[size]",
-      "usedDatabaseSize": "[size]",
+      "indexSize": "[size]",
+      "usedIndexSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,

--- a/crates/meilisearch/tests/documents/delete_documents.rs
+++ b/crates/meilisearch/tests/documents/delete_documents.rs
@@ -152,11 +152,15 @@ async fn delete_document_by_filter() {
 
     let (stats, _) = index.stats().await;
     snapshot!(json_string!(stats, {
+        ".databaseSize" => "[size]",
+        ".usedDatabaseSize" => "[size]",
         ".rawDocumentDbSize" => "[size]",
         ".avgDocumentSize" => "[size]",
     }), @r###"
     {
       "numberOfDocuments": 4,
+      "databaseSize": "[size]",
+      "usedDatabaseSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,
@@ -206,11 +210,15 @@ async fn delete_document_by_filter() {
 
     let (stats, _) = index.stats().await;
     snapshot!(json_string!(stats, {
+        ".databaseSize" => "[size]",
+        ".usedDatabaseSize" => "[size]",
         ".rawDocumentDbSize" => "[size]",
         ".avgDocumentSize" => "[size]",
     }), @r###"
     {
       "numberOfDocuments": 2,
+      "databaseSize": "[size]",
+      "usedDatabaseSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,
@@ -279,11 +287,15 @@ async fn delete_document_by_filter() {
 
     let (stats, _) = index.stats().await;
     snapshot!(json_string!(stats, {
+        ".databaseSize" => "[size]",
+        ".usedDatabaseSize" => "[size]",
         ".rawDocumentDbSize" => "[size]",
         ".avgDocumentSize" => "[size]",
     }), @r###"
     {
       "numberOfDocuments": 1,
+      "databaseSize": "[size]",
+      "usedDatabaseSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,

--- a/crates/meilisearch/tests/dumps/mod.rs
+++ b/crates/meilisearch/tests/dumps/mod.rs
@@ -29,12 +29,16 @@ async fn import_dump_v1_movie_raw() {
     snapshot!(code, @"200 OK");
     snapshot!(
       json_string!(stats, {
+          ".databaseSize" => "[size]",
+          ".usedDatabaseSize" => "[size]",
           ".rawDocumentDbSize" => "[size]",
           ".avgDocumentSize" => "[size]",
       }),
       @r###"
     {
       "numberOfDocuments": 53,
+      "databaseSize": "[size]",
+      "usedDatabaseSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,
@@ -190,12 +194,16 @@ async fn import_dump_v1_movie_with_settings() {
     snapshot!(code, @"200 OK");
     snapshot!(
         json_string!(stats, {
+            ".databaseSize" => "[size]",
+            ".usedDatabaseSize" => "[size]",
             ".rawDocumentDbSize" => "[size]",
             ".avgDocumentSize" => "[size]",
         }),
         @r###"
     {
       "numberOfDocuments": 53,
+      "databaseSize": "[size]",
+      "usedDatabaseSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,
@@ -364,12 +372,16 @@ async fn import_dump_v1_rubygems_with_settings() {
     snapshot!(code, @"200 OK");
     snapshot!(
       json_string!(stats, {
+          ".databaseSize" => "[size]",
+          ".usedDatabaseSize" => "[size]",
           ".rawDocumentDbSize" => "[size]",
           ".avgDocumentSize" => "[size]",
       }),
       @r###"
     {
       "numberOfDocuments": 53,
+      "databaseSize": "[size]",
+      "usedDatabaseSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,
@@ -535,12 +547,16 @@ async fn import_dump_v2_movie_raw() {
     snapshot!(code, @"200 OK");
     snapshot!(
       json_string!(stats, {
+          ".databaseSize" => "[size]",
+          ".usedDatabaseSize" => "[size]",
           ".rawDocumentDbSize" => "[size]",
           ".avgDocumentSize" => "[size]",
       }),
       @r###"
     {
       "numberOfDocuments": 53,
+      "databaseSize": "[size]",
+      "usedDatabaseSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,
@@ -696,12 +712,16 @@ async fn import_dump_v2_movie_with_settings() {
     snapshot!(code, @"200 OK");
     snapshot!(
       json_string!(stats, {
+          ".databaseSize" => "[size]",
+          ".usedDatabaseSize" => "[size]",
           ".rawDocumentDbSize" => "[size]",
           ".avgDocumentSize" => "[size]",
       }),
       @r###"
     {
       "numberOfDocuments": 53,
+      "databaseSize": "[size]",
+      "usedDatabaseSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,
@@ -867,12 +887,16 @@ async fn import_dump_v2_rubygems_with_settings() {
     snapshot!(code, @"200 OK");
     snapshot!(
       json_string!(stats, {
+          ".databaseSize" => "[size]",
+          ".usedDatabaseSize" => "[size]",
           ".rawDocumentDbSize" => "[size]",
           ".avgDocumentSize" => "[size]",
       }),
       @r###"
     {
       "numberOfDocuments": 53,
+      "databaseSize": "[size]",
+      "usedDatabaseSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,
@@ -1035,12 +1059,16 @@ async fn import_dump_v3_movie_raw() {
     snapshot!(code, @"200 OK");
     snapshot!(
       json_string!(stats, {
+          ".databaseSize" => "[size]",
+          ".usedDatabaseSize" => "[size]",
           ".rawDocumentDbSize" => "[size]",
           ".avgDocumentSize" => "[size]",
       }),
       @r###"
     {
       "numberOfDocuments": 53,
+      "databaseSize": "[size]",
+      "usedDatabaseSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,
@@ -1196,12 +1224,16 @@ async fn import_dump_v3_movie_with_settings() {
     snapshot!(code, @"200 OK");
     snapshot!(
       json_string!(stats, {
+          ".databaseSize" => "[size]",
+          ".usedDatabaseSize" => "[size]",
           ".rawDocumentDbSize" => "[size]",
           ".avgDocumentSize" => "[size]",
       }),
       @r###"
     {
       "numberOfDocuments": 53,
+      "databaseSize": "[size]",
+      "usedDatabaseSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,
@@ -1367,12 +1399,16 @@ async fn import_dump_v3_rubygems_with_settings() {
     snapshot!(code, @"200 OK");
     snapshot!(
       json_string!(stats, {
+          ".databaseSize" => "[size]",
+          ".usedDatabaseSize" => "[size]",
           ".rawDocumentDbSize" => "[size]",
           ".avgDocumentSize" => "[size]",
       }),
       @r###"
     {
       "numberOfDocuments": 53,
+      "databaseSize": "[size]",
+      "usedDatabaseSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,
@@ -1535,12 +1571,16 @@ async fn import_dump_v4_movie_raw() {
     snapshot!(code, @"200 OK");
     snapshot!(
       json_string!(stats, {
+          ".databaseSize" => "[size]",
+          ".usedDatabaseSize" => "[size]",
           ".rawDocumentDbSize" => "[size]",
           ".avgDocumentSize" => "[size]",
       }),
       @r###"
     {
       "numberOfDocuments": 53,
+      "databaseSize": "[size]",
+      "usedDatabaseSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,
@@ -1696,12 +1736,16 @@ async fn import_dump_v4_movie_with_settings() {
     snapshot!(code, @"200 OK");
     snapshot!(
       json_string!(stats, {
+          ".databaseSize" => "[size]",
+          ".usedDatabaseSize" => "[size]",
           ".rawDocumentDbSize" => "[size]",
           ".avgDocumentSize" => "[size]",
       }),
       @r###"
     {
       "numberOfDocuments": 53,
+      "databaseSize": "[size]",
+      "usedDatabaseSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,
@@ -1867,12 +1911,16 @@ async fn import_dump_v4_rubygems_with_settings() {
     snapshot!(code, @"200 OK");
     snapshot!(
       json_string!(stats, {
+          ".databaseSize" => "[size]",
+          ".usedDatabaseSize" => "[size]",
           ".rawDocumentDbSize" => "[size]",
           ".avgDocumentSize" => "[size]",
       }),
       @r###"
     {
       "numberOfDocuments": 53,
+      "databaseSize": "[size]",
+      "usedDatabaseSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,
@@ -2043,11 +2091,15 @@ async fn import_dump_v5() {
     let (stats, code) = index1.stats().await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(stats, {
+        ".databaseSize" => "[size]",
+        ".usedDatabaseSize" => "[size]",
         ".rawDocumentDbSize" => "[size]",
         ".avgDocumentSize" => "[size]",
     }), @r###"
     {
       "numberOfDocuments": 10,
+      "databaseSize": "[size]",
+      "usedDatabaseSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,
@@ -2083,12 +2135,16 @@ async fn import_dump_v5() {
     snapshot!(code, @"200 OK");
     snapshot!(
       json_string!(stats, {
+          ".databaseSize" => "[size]",
+          ".usedDatabaseSize" => "[size]",
           ".rawDocumentDbSize" => "[size]",
           ".avgDocumentSize" => "[size]",
       }),
       @r###"
     {
       "numberOfDocuments": 10,
+      "databaseSize": "[size]",
+      "usedDatabaseSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,

--- a/crates/meilisearch/tests/dumps/mod.rs
+++ b/crates/meilisearch/tests/dumps/mod.rs
@@ -29,16 +29,16 @@ async fn import_dump_v1_movie_raw() {
     snapshot!(code, @"200 OK");
     snapshot!(
       json_string!(stats, {
-          ".databaseSize" => "[size]",
-          ".usedDatabaseSize" => "[size]",
+          ".indexSize" => "[size]",
+          ".usedIndexSize" => "[size]",
           ".rawDocumentDbSize" => "[size]",
           ".avgDocumentSize" => "[size]",
       }),
       @r###"
     {
       "numberOfDocuments": 53,
-      "databaseSize": "[size]",
-      "usedDatabaseSize": "[size]",
+      "indexSize": "[size]",
+      "usedIndexSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,
@@ -194,16 +194,16 @@ async fn import_dump_v1_movie_with_settings() {
     snapshot!(code, @"200 OK");
     snapshot!(
         json_string!(stats, {
-            ".databaseSize" => "[size]",
-            ".usedDatabaseSize" => "[size]",
+            ".indexSize" => "[size]",
+            ".usedIndexSize" => "[size]",
             ".rawDocumentDbSize" => "[size]",
             ".avgDocumentSize" => "[size]",
         }),
         @r###"
     {
       "numberOfDocuments": 53,
-      "databaseSize": "[size]",
-      "usedDatabaseSize": "[size]",
+      "indexSize": "[size]",
+      "usedIndexSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,
@@ -372,16 +372,16 @@ async fn import_dump_v1_rubygems_with_settings() {
     snapshot!(code, @"200 OK");
     snapshot!(
       json_string!(stats, {
-          ".databaseSize" => "[size]",
-          ".usedDatabaseSize" => "[size]",
+          ".indexSize" => "[size]",
+          ".usedIndexSize" => "[size]",
           ".rawDocumentDbSize" => "[size]",
           ".avgDocumentSize" => "[size]",
       }),
       @r###"
     {
       "numberOfDocuments": 53,
-      "databaseSize": "[size]",
-      "usedDatabaseSize": "[size]",
+      "indexSize": "[size]",
+      "usedIndexSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,
@@ -547,16 +547,16 @@ async fn import_dump_v2_movie_raw() {
     snapshot!(code, @"200 OK");
     snapshot!(
       json_string!(stats, {
-          ".databaseSize" => "[size]",
-          ".usedDatabaseSize" => "[size]",
+          ".indexSize" => "[size]",
+          ".usedIndexSize" => "[size]",
           ".rawDocumentDbSize" => "[size]",
           ".avgDocumentSize" => "[size]",
       }),
       @r###"
     {
       "numberOfDocuments": 53,
-      "databaseSize": "[size]",
-      "usedDatabaseSize": "[size]",
+      "indexSize": "[size]",
+      "usedIndexSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,
@@ -712,16 +712,16 @@ async fn import_dump_v2_movie_with_settings() {
     snapshot!(code, @"200 OK");
     snapshot!(
       json_string!(stats, {
-          ".databaseSize" => "[size]",
-          ".usedDatabaseSize" => "[size]",
+          ".indexSize" => "[size]",
+          ".usedIndexSize" => "[size]",
           ".rawDocumentDbSize" => "[size]",
           ".avgDocumentSize" => "[size]",
       }),
       @r###"
     {
       "numberOfDocuments": 53,
-      "databaseSize": "[size]",
-      "usedDatabaseSize": "[size]",
+      "indexSize": "[size]",
+      "usedIndexSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,
@@ -887,16 +887,16 @@ async fn import_dump_v2_rubygems_with_settings() {
     snapshot!(code, @"200 OK");
     snapshot!(
       json_string!(stats, {
-          ".databaseSize" => "[size]",
-          ".usedDatabaseSize" => "[size]",
+          ".indexSize" => "[size]",
+          ".usedIndexSize" => "[size]",
           ".rawDocumentDbSize" => "[size]",
           ".avgDocumentSize" => "[size]",
       }),
       @r###"
     {
       "numberOfDocuments": 53,
-      "databaseSize": "[size]",
-      "usedDatabaseSize": "[size]",
+      "indexSize": "[size]",
+      "usedIndexSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,
@@ -1059,16 +1059,16 @@ async fn import_dump_v3_movie_raw() {
     snapshot!(code, @"200 OK");
     snapshot!(
       json_string!(stats, {
-          ".databaseSize" => "[size]",
-          ".usedDatabaseSize" => "[size]",
+          ".indexSize" => "[size]",
+          ".usedIndexSize" => "[size]",
           ".rawDocumentDbSize" => "[size]",
           ".avgDocumentSize" => "[size]",
       }),
       @r###"
     {
       "numberOfDocuments": 53,
-      "databaseSize": "[size]",
-      "usedDatabaseSize": "[size]",
+      "indexSize": "[size]",
+      "usedIndexSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,
@@ -1224,16 +1224,16 @@ async fn import_dump_v3_movie_with_settings() {
     snapshot!(code, @"200 OK");
     snapshot!(
       json_string!(stats, {
-          ".databaseSize" => "[size]",
-          ".usedDatabaseSize" => "[size]",
+          ".indexSize" => "[size]",
+          ".usedIndexSize" => "[size]",
           ".rawDocumentDbSize" => "[size]",
           ".avgDocumentSize" => "[size]",
       }),
       @r###"
     {
       "numberOfDocuments": 53,
-      "databaseSize": "[size]",
-      "usedDatabaseSize": "[size]",
+      "indexSize": "[size]",
+      "usedIndexSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,
@@ -1399,16 +1399,16 @@ async fn import_dump_v3_rubygems_with_settings() {
     snapshot!(code, @"200 OK");
     snapshot!(
       json_string!(stats, {
-          ".databaseSize" => "[size]",
-          ".usedDatabaseSize" => "[size]",
+          ".indexSize" => "[size]",
+          ".usedIndexSize" => "[size]",
           ".rawDocumentDbSize" => "[size]",
           ".avgDocumentSize" => "[size]",
       }),
       @r###"
     {
       "numberOfDocuments": 53,
-      "databaseSize": "[size]",
-      "usedDatabaseSize": "[size]",
+      "indexSize": "[size]",
+      "usedIndexSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,
@@ -1571,16 +1571,16 @@ async fn import_dump_v4_movie_raw() {
     snapshot!(code, @"200 OK");
     snapshot!(
       json_string!(stats, {
-          ".databaseSize" => "[size]",
-          ".usedDatabaseSize" => "[size]",
+          ".indexSize" => "[size]",
+          ".usedIndexSize" => "[size]",
           ".rawDocumentDbSize" => "[size]",
           ".avgDocumentSize" => "[size]",
       }),
       @r###"
     {
       "numberOfDocuments": 53,
-      "databaseSize": "[size]",
-      "usedDatabaseSize": "[size]",
+      "indexSize": "[size]",
+      "usedIndexSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,
@@ -1736,16 +1736,16 @@ async fn import_dump_v4_movie_with_settings() {
     snapshot!(code, @"200 OK");
     snapshot!(
       json_string!(stats, {
-          ".databaseSize" => "[size]",
-          ".usedDatabaseSize" => "[size]",
+          ".indexSize" => "[size]",
+          ".usedIndexSize" => "[size]",
           ".rawDocumentDbSize" => "[size]",
           ".avgDocumentSize" => "[size]",
       }),
       @r###"
     {
       "numberOfDocuments": 53,
-      "databaseSize": "[size]",
-      "usedDatabaseSize": "[size]",
+      "indexSize": "[size]",
+      "usedIndexSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,
@@ -1911,16 +1911,16 @@ async fn import_dump_v4_rubygems_with_settings() {
     snapshot!(code, @"200 OK");
     snapshot!(
       json_string!(stats, {
-          ".databaseSize" => "[size]",
-          ".usedDatabaseSize" => "[size]",
+          ".indexSize" => "[size]",
+          ".usedIndexSize" => "[size]",
           ".rawDocumentDbSize" => "[size]",
           ".avgDocumentSize" => "[size]",
       }),
       @r###"
     {
       "numberOfDocuments": 53,
-      "databaseSize": "[size]",
-      "usedDatabaseSize": "[size]",
+      "indexSize": "[size]",
+      "usedIndexSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,
@@ -2091,15 +2091,15 @@ async fn import_dump_v5() {
     let (stats, code) = index1.stats().await;
     snapshot!(code, @"200 OK");
     snapshot!(json_string!(stats, {
-        ".databaseSize" => "[size]",
-        ".usedDatabaseSize" => "[size]",
+        ".indexSize" => "[size]",
+        ".usedIndexSize" => "[size]",
         ".rawDocumentDbSize" => "[size]",
         ".avgDocumentSize" => "[size]",
     }), @r###"
     {
       "numberOfDocuments": 10,
-      "databaseSize": "[size]",
-      "usedDatabaseSize": "[size]",
+      "indexSize": "[size]",
+      "usedIndexSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,
@@ -2135,16 +2135,16 @@ async fn import_dump_v5() {
     snapshot!(code, @"200 OK");
     snapshot!(
       json_string!(stats, {
-          ".databaseSize" => "[size]",
-          ".usedDatabaseSize" => "[size]",
+          ".indexSize" => "[size]",
+          ".usedIndexSize" => "[size]",
           ".rawDocumentDbSize" => "[size]",
           ".avgDocumentSize" => "[size]",
       }),
       @r###"
     {
       "numberOfDocuments": 10,
-      "databaseSize": "[size]",
-      "usedDatabaseSize": "[size]",
+      "indexSize": "[size]",
+      "usedIndexSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,

--- a/crates/meilisearch/tests/stats/mod.rs
+++ b/crates/meilisearch/tests/stats/mod.rs
@@ -111,15 +111,15 @@ async fn add_remove_embeddings() {
 
     let (stats, _code) = index.stats().await;
     snapshot!(json_string!(stats, {
-        ".databaseSize" => "[size]",
-        ".usedDatabaseSize" => "[size]",
+        ".indexSize" => "[size]",
+        ".usedIndexSize" => "[size]",
         ".rawDocumentDbSize" => "[size]",
         ".avgDocumentSize" => "[size]",
     }), @r###"
     {
       "numberOfDocuments": 2,
-      "databaseSize": "[size]",
-      "usedDatabaseSize": "[size]",
+      "indexSize": "[size]",
+      "usedIndexSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,
@@ -143,15 +143,15 @@ async fn add_remove_embeddings() {
 
     let (stats, _code) = index.stats().await;
     snapshot!(json_string!(stats, {
-        ".databaseSize" => "[size]",
-        ".usedDatabaseSize" => "[size]",
+        ".indexSize" => "[size]",
+        ".usedIndexSize" => "[size]",
         ".rawDocumentDbSize" => "[size]",
         ".avgDocumentSize" => "[size]",
     }), @r###"
     {
       "numberOfDocuments": 2,
-      "databaseSize": "[size]",
-      "usedDatabaseSize": "[size]",
+      "indexSize": "[size]",
+      "usedIndexSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,
@@ -175,15 +175,15 @@ async fn add_remove_embeddings() {
 
     let (stats, _code) = index.stats().await;
     snapshot!(json_string!(stats, {
-        ".databaseSize" => "[size]",
-        ".usedDatabaseSize" => "[size]",
+        ".indexSize" => "[size]",
+        ".usedIndexSize" => "[size]",
         ".rawDocumentDbSize" => "[size]",
         ".avgDocumentSize" => "[size]",
     }), @r###"
     {
       "numberOfDocuments": 2,
-      "databaseSize": "[size]",
-      "usedDatabaseSize": "[size]",
+      "indexSize": "[size]",
+      "usedIndexSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,
@@ -208,15 +208,15 @@ async fn add_remove_embeddings() {
 
     let (stats, _code) = index.stats().await;
     snapshot!(json_string!(stats, {
-        ".databaseSize" => "[size]",
-        ".usedDatabaseSize" => "[size]",
+        ".indexSize" => "[size]",
+        ".usedIndexSize" => "[size]",
         ".rawDocumentDbSize" => "[size]",
         ".avgDocumentSize" => "[size]",
     }), @r###"
     {
       "numberOfDocuments": 2,
-      "databaseSize": "[size]",
-      "usedDatabaseSize": "[size]",
+      "indexSize": "[size]",
+      "usedIndexSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,
@@ -265,15 +265,15 @@ async fn add_remove_embedded_documents() {
 
     let (stats, _code) = index.stats().await;
     snapshot!(json_string!(stats, {
-        ".databaseSize" => "[size]",
-        ".usedDatabaseSize" => "[size]",
+        ".indexSize" => "[size]",
+        ".usedIndexSize" => "[size]",
         ".rawDocumentDbSize" => "[size]",
         ".avgDocumentSize" => "[size]",
     }), @r###"
     {
       "numberOfDocuments": 2,
-      "databaseSize": "[size]",
-      "usedDatabaseSize": "[size]",
+      "indexSize": "[size]",
+      "usedIndexSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,
@@ -293,15 +293,15 @@ async fn add_remove_embedded_documents() {
 
     let (stats, _code) = index.stats().await;
     snapshot!(json_string!(stats, {
-        ".databaseSize" => "[size]",
-        ".usedDatabaseSize" => "[size]",
+        ".indexSize" => "[size]",
+        ".usedIndexSize" => "[size]",
         ".rawDocumentDbSize" => "[size]",
         ".avgDocumentSize" => "[size]",
     }), @r###"
     {
       "numberOfDocuments": 1,
-      "databaseSize": "[size]",
-      "usedDatabaseSize": "[size]",
+      "indexSize": "[size]",
+      "usedIndexSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,
@@ -333,15 +333,15 @@ async fn update_embedder_settings() {
 
     let (stats, _code) = index.stats().await;
     snapshot!(json_string!(stats, {
-        ".databaseSize" => "[size]",
-        ".usedDatabaseSize" => "[size]",
+        ".indexSize" => "[size]",
+        ".usedIndexSize" => "[size]",
         ".rawDocumentDbSize" => "[size]",
         ".avgDocumentSize" => "[size]",
     }), @r###"
     {
       "numberOfDocuments": 2,
-      "databaseSize": "[size]",
-      "usedDatabaseSize": "[size]",
+      "indexSize": "[size]",
+      "usedIndexSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,
@@ -376,15 +376,15 @@ async fn update_embedder_settings() {
 
     let (stats, _code) = index.stats().await;
     snapshot!(json_string!(stats, {
-        ".databaseSize" => "[size]",
-        ".usedDatabaseSize" => "[size]",
+        ".indexSize" => "[size]",
+        ".usedIndexSize" => "[size]",
         ".rawDocumentDbSize" => "[size]",
         ".avgDocumentSize" => "[size]",
     }), @r###"
     {
       "numberOfDocuments": 2,
-      "databaseSize": "[size]",
-      "usedDatabaseSize": "[size]",
+      "indexSize": "[size]",
+      "usedIndexSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,

--- a/crates/meilisearch/tests/stats/mod.rs
+++ b/crates/meilisearch/tests/stats/mod.rs
@@ -111,11 +111,15 @@ async fn add_remove_embeddings() {
 
     let (stats, _code) = index.stats().await;
     snapshot!(json_string!(stats, {
+        ".databaseSize" => "[size]",
+        ".usedDatabaseSize" => "[size]",
         ".rawDocumentDbSize" => "[size]",
         ".avgDocumentSize" => "[size]",
     }), @r###"
     {
       "numberOfDocuments": 2,
+      "databaseSize": "[size]",
+      "usedDatabaseSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,
@@ -139,11 +143,15 @@ async fn add_remove_embeddings() {
 
     let (stats, _code) = index.stats().await;
     snapshot!(json_string!(stats, {
+        ".databaseSize" => "[size]",
+        ".usedDatabaseSize" => "[size]",
         ".rawDocumentDbSize" => "[size]",
         ".avgDocumentSize" => "[size]",
     }), @r###"
     {
       "numberOfDocuments": 2,
+      "databaseSize": "[size]",
+      "usedDatabaseSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,
@@ -167,11 +175,15 @@ async fn add_remove_embeddings() {
 
     let (stats, _code) = index.stats().await;
     snapshot!(json_string!(stats, {
+        ".databaseSize" => "[size]",
+        ".usedDatabaseSize" => "[size]",
         ".rawDocumentDbSize" => "[size]",
         ".avgDocumentSize" => "[size]",
     }), @r###"
     {
       "numberOfDocuments": 2,
+      "databaseSize": "[size]",
+      "usedDatabaseSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,
@@ -196,11 +208,15 @@ async fn add_remove_embeddings() {
 
     let (stats, _code) = index.stats().await;
     snapshot!(json_string!(stats, {
+        ".databaseSize" => "[size]",
+        ".usedDatabaseSize" => "[size]",
         ".rawDocumentDbSize" => "[size]",
         ".avgDocumentSize" => "[size]",
     }), @r###"
     {
       "numberOfDocuments": 2,
+      "databaseSize": "[size]",
+      "usedDatabaseSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,
@@ -249,11 +265,15 @@ async fn add_remove_embedded_documents() {
 
     let (stats, _code) = index.stats().await;
     snapshot!(json_string!(stats, {
+        ".databaseSize" => "[size]",
+        ".usedDatabaseSize" => "[size]",
         ".rawDocumentDbSize" => "[size]",
         ".avgDocumentSize" => "[size]",
     }), @r###"
     {
       "numberOfDocuments": 2,
+      "databaseSize": "[size]",
+      "usedDatabaseSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,
@@ -273,11 +293,15 @@ async fn add_remove_embedded_documents() {
 
     let (stats, _code) = index.stats().await;
     snapshot!(json_string!(stats, {
+        ".databaseSize" => "[size]",
+        ".usedDatabaseSize" => "[size]",
         ".rawDocumentDbSize" => "[size]",
         ".avgDocumentSize" => "[size]",
     }), @r###"
     {
       "numberOfDocuments": 1,
+      "databaseSize": "[size]",
+      "usedDatabaseSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,
@@ -309,11 +333,15 @@ async fn update_embedder_settings() {
 
     let (stats, _code) = index.stats().await;
     snapshot!(json_string!(stats, {
+        ".databaseSize" => "[size]",
+        ".usedDatabaseSize" => "[size]",
         ".rawDocumentDbSize" => "[size]",
         ".avgDocumentSize" => "[size]",
     }), @r###"
     {
       "numberOfDocuments": 2,
+      "databaseSize": "[size]",
+      "usedDatabaseSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,
@@ -348,11 +376,15 @@ async fn update_embedder_settings() {
 
     let (stats, _code) = index.stats().await;
     snapshot!(json_string!(stats, {
+        ".databaseSize" => "[size]",
+        ".usedDatabaseSize" => "[size]",
         ".rawDocumentDbSize" => "[size]",
         ".avgDocumentSize" => "[size]",
     }), @r###"
     {
       "numberOfDocuments": 2,
+      "databaseSize": "[size]",
+      "usedDatabaseSize": "[size]",
       "rawDocumentDbSize": "[size]",
       "avgDocumentSize": "[size]",
       "isIndexing": false,

--- a/crates/meilisearch/tests/upgrade/v1_12/v1_12_0.rs
+++ b/crates/meilisearch/tests/upgrade/v1_12/v1_12_0.rs
@@ -134,8 +134,8 @@ async fn check_the_index_scheduler(server: &Server) {
     assert_json_snapshot!(stats, {
         ".databaseSize" => "[bytes]",
         ".usedDatabaseSize" => "[bytes]",
-        ".indexes.kefir.databaseSize" => "[bytes]",
-        ".indexes.kefir.usedDatabaseSize" => "[bytes]",
+        ".indexes.kefir.indexSize" => "[bytes]",
+        ".indexes.kefir.usedIndexSize" => "[bytes]",
         ".indexes.kefir.rawDocumentDbSize" => "[bytes]",
         ".indexes.kefir.avgDocumentSize" => "[bytes]",
     },
@@ -147,8 +147,8 @@ async fn check_the_index_scheduler(server: &Server) {
       "indexes": {
         "kefir": {
           "numberOfDocuments": 2,
-          "databaseSize": "[bytes]",
-          "usedDatabaseSize": "[bytes]",
+          "indexSize": "[bytes]",
+          "usedIndexSize": "[bytes]",
           "rawDocumentDbSize": "[bytes]",
           "avgDocumentSize": "[bytes]",
           "isIndexing": false,
@@ -224,8 +224,8 @@ async fn check_the_index_scheduler(server: &Server) {
     assert_json_snapshot!(stats, {
         ".databaseSize" => "[bytes]",
         ".usedDatabaseSize" => "[bytes]",
-        ".indexes.kefir.databaseSize" => "[bytes]",
-        ".indexes.kefir.usedDatabaseSize" => "[bytes]",
+        ".indexes.kefir.indexSize" => "[bytes]",
+        ".indexes.kefir.usedIndexSize" => "[bytes]",
         ".indexes.kefir.rawDocumentDbSize" => "[bytes]",
         ".indexes.kefir.avgDocumentSize" => "[bytes]",
     },
@@ -237,8 +237,8 @@ async fn check_the_index_scheduler(server: &Server) {
       "indexes": {
         "kefir": {
           "numberOfDocuments": 2,
-          "databaseSize": "[bytes]",
-          "usedDatabaseSize": "[bytes]",
+          "indexSize": "[bytes]",
+          "usedIndexSize": "[bytes]",
           "rawDocumentDbSize": "[bytes]",
           "avgDocumentSize": "[bytes]",
           "isIndexing": false,
@@ -258,15 +258,15 @@ async fn check_the_index_scheduler(server: &Server) {
     let index = server.index("kefir");
     let (stats, _) = index.stats().await;
     snapshot!(json_string!(stats, {
-        ".databaseSize" => "[bytes]",
-        ".usedDatabaseSize" => "[bytes]",
+        ".indexSize" => "[bytes]",
+        ".usedIndexSize" => "[bytes]",
         ".rawDocumentDbSize" => "[bytes]",
         ".avgDocumentSize" => "[bytes]",
     }), @r###"
     {
       "numberOfDocuments": 2,
-      "databaseSize": "[bytes]",
-      "usedDatabaseSize": "[bytes]",
+      "indexSize": "[bytes]",
+      "usedIndexSize": "[bytes]",
       "rawDocumentDbSize": "[bytes]",
       "avgDocumentSize": "[bytes]",
       "isIndexing": false,

--- a/crates/meilisearch/tests/upgrade/v1_12/v1_12_0.rs
+++ b/crates/meilisearch/tests/upgrade/v1_12/v1_12_0.rs
@@ -134,6 +134,8 @@ async fn check_the_index_scheduler(server: &Server) {
     assert_json_snapshot!(stats, {
         ".databaseSize" => "[bytes]",
         ".usedDatabaseSize" => "[bytes]",
+        ".indexes.kefir.databaseSize" => "[bytes]",
+        ".indexes.kefir.usedDatabaseSize" => "[bytes]",
         ".indexes.kefir.rawDocumentDbSize" => "[bytes]",
         ".indexes.kefir.avgDocumentSize" => "[bytes]",
     },
@@ -145,6 +147,8 @@ async fn check_the_index_scheduler(server: &Server) {
       "indexes": {
         "kefir": {
           "numberOfDocuments": 2,
+          "databaseSize": "[bytes]",
+          "usedDatabaseSize": "[bytes]",
           "rawDocumentDbSize": "[bytes]",
           "avgDocumentSize": "[bytes]",
           "isIndexing": false,
@@ -220,6 +224,8 @@ async fn check_the_index_scheduler(server: &Server) {
     assert_json_snapshot!(stats, {
         ".databaseSize" => "[bytes]",
         ".usedDatabaseSize" => "[bytes]",
+        ".indexes.kefir.databaseSize" => "[bytes]",
+        ".indexes.kefir.usedDatabaseSize" => "[bytes]",
         ".indexes.kefir.rawDocumentDbSize" => "[bytes]",
         ".indexes.kefir.avgDocumentSize" => "[bytes]",
     },
@@ -231,6 +237,8 @@ async fn check_the_index_scheduler(server: &Server) {
       "indexes": {
         "kefir": {
           "numberOfDocuments": 2,
+          "databaseSize": "[bytes]",
+          "usedDatabaseSize": "[bytes]",
           "rawDocumentDbSize": "[bytes]",
           "avgDocumentSize": "[bytes]",
           "isIndexing": false,
@@ -250,11 +258,15 @@ async fn check_the_index_scheduler(server: &Server) {
     let index = server.index("kefir");
     let (stats, _) = index.stats().await;
     snapshot!(json_string!(stats, {
+        ".databaseSize" => "[bytes]",
+        ".usedDatabaseSize" => "[bytes]",
         ".rawDocumentDbSize" => "[bytes]",
         ".avgDocumentSize" => "[bytes]",
     }), @r###"
     {
       "numberOfDocuments": 2,
+      "databaseSize": "[bytes]",
+      "usedDatabaseSize": "[bytes]",
       "rawDocumentDbSize": "[bytes]",
       "avgDocumentSize": "[bytes]",
       "isIndexing": false,

--- a/workloads/tests/movies.json
+++ b/workloads/tests/movies.json
@@ -232,6 +232,7 @@
       "expectedStatus": 200,
       "expectedResponse": {
         "avgDocumentSize": 0,
+        "databaseSize": "[size]",
         "fieldDistribution": {
           "genres": 31944,
           "id": 31944,
@@ -242,7 +243,8 @@
         },
         "isIndexing": false,
         "numberOfDocuments": 31944,
-        "rawDocumentDbSize": 0
+        "rawDocumentDbSize": 0,
+        "usedDatabaseSize": "[size]"
       },
       "synchronous": "DontWait"
     },
@@ -418,6 +420,7 @@
       "expectedStatus": 200,
       "expectedResponse": {
         "avgDocumentSize": "[avgDocSize]",
+        "databaseSize": "[size]",
         "fieldDistribution": {
           "genres": 31944,
           "id": 31944,
@@ -430,7 +433,8 @@
         "numberOfDocuments": 31944,
         "numberOfEmbeddedDocuments": 0,
         "numberOfEmbeddings": 0,
-        "rawDocumentDbSize": "[rawDbSize]"
+        "rawDocumentDbSize": "[rawDbSize]",
+        "usedDatabaseSize": "[size]"
       },
       "synchronous": "DontWait"
     },

--- a/workloads/tests/movies.json
+++ b/workloads/tests/movies.json
@@ -232,7 +232,7 @@
       "expectedStatus": 200,
       "expectedResponse": {
         "avgDocumentSize": 0,
-        "databaseSize": "[size]",
+        "indexSize": "[size]",
         "fieldDistribution": {
           "genres": 31944,
           "id": 31944,
@@ -244,7 +244,7 @@
         "isIndexing": false,
         "numberOfDocuments": 31944,
         "rawDocumentDbSize": 0,
-        "usedDatabaseSize": "[size]"
+        "usedIndexSize": "[size]"
       },
       "synchronous": "DontWait"
     },
@@ -420,7 +420,7 @@
       "expectedStatus": 200,
       "expectedResponse": {
         "avgDocumentSize": "[avgDocSize]",
-        "databaseSize": "[size]",
+        "indexSize": "[size]",
         "fieldDistribution": {
           "genres": 31944,
           "id": 31944,
@@ -434,7 +434,7 @@
         "numberOfEmbeddedDocuments": 0,
         "numberOfEmbeddings": 0,
         "rawDocumentDbSize": "[rawDbSize]",
-        "usedDatabaseSize": "[size]"
+        "usedIndexSize": "[size]"
       },
       "synchronous": "DontWait"
     },


### PR DESCRIPTION
# Pull Request

## Related issue

Fixes meilisearch/meilisearch#6562

## What does this PR do?

* Adds `databaseSize` and `usedDatabaseSize` to the per-index `IndexStats` payload, returned unconditionally by `GET /indexes/{index_uid}/stats` and per index in `GET /stats`
* Values come from the already-cached `index-stats` entry (`index_scheduler::IndexStats`), so no extra computation or index open
* Both fields go through the existing `Size` type, so they honour `sizeFormat=raw|human`
* Updates the OpenAPI examples and the affected snapshot tests

Purely additive, no breaking change.

## Generative AI tools

- [ ] This PR does not use generative AI tooling
- [X] This PR uses generative AI tooling and respects the [related policies](<https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools>)
  - [X] Claude code was used to do most of this PR.

## PR checklist

Please check if your PR fulfills the following requirements:

- [X] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [X] Have you read the contributing guidelines?
- [X] Have you made sure that the title is accurate and descriptive of the changes?