### PR TITLE
fetch meilisearch version

### DIFF
--- a/crates/meilisearch/src/lib.rs
+++ b/crates/meilisearch/src/lib.rs
@@ -576,16 +576,17 @@ fn import_dump(
     let progress = Progress::default();
     let reader = File::open(dump_path)?;
     let mut dump_reader = dump::DumpReader::open(reader)?;
-
     if let Some(date) = dump_reader.date() {
         tracing::info!(
-            version = ?dump_reader.version(), // TODO: get the meilisearch version instead of the dump version
+            version = env!("CARGO_PKG_VERSION"),
+            dump_version = ?dump_reader.version(),
             %date,
             "Importing a dump of meilisearch"
         );
     } else {
         tracing::info!(
-            version = ?dump_reader.version(), // TODO: get the meilisearch version instead of the dump version
+            version = env!("CARGO_PKG_VERSION"),
+            dump_version = ?dump_reader.version(),
             "Importing a dump of meilisearch",
         );
     }


### PR DESCRIPTION
## Related issue

Fixes # TODO
in import_dump there is a TODO to use the Meilisearch version instead of  the dump version

## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respect the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - *list of used tools and what they were used for*

## Requirements

⚠️ Ensure the following requirements before merging ⚠️
- [ ] Automated tests have been added.
- [ ] If some tests cannot be automated, manual rigorous tests should be applied.
- [ ] ⚠️ If there is any change in the DB:
    - [ ] Test that any impacted DB still works as expected after using `--upgrade-db` on a DB created with the last released Meilisearch
    - [ ] Test that during the upgrade, **search is still available** (artificially make the upgrade longer if needed)
    - [ ] Set the `db change` label.
- [ ] If necessary, the feature have been tested in the Cloud production environment (with [prototypes](./documentation/prototypes.md)) and the Cloud UI is ready.
- [ ] If necessary, the [documentation](https://github.com/meilisearch/documentation) related to the implemented feature in the PR is ready.
- [ ] If necessary, the [integrations](https://github.com/meilisearch/integration-guides) related to the implemented feature in the PR are ready.
