### PR TITLE
Clamp map_size to page size when removing tasks during snapshot creation

### DIFF
--- a/crates/index-scheduler/src/scheduler/process_snapshot_creation.rs
+++ b/crates/index-scheduler/src/scheduler/process_snapshot_creation.rs
@@ -11,7 +11,7 @@ use meilisearch_types::{compression, VERSION_FILE_NAME};
 use crate::heed::EnvOpenOptions;
 use crate::processing::{AtomicUpdateFileStep, SnapshotCreationProgress};
 use crate::queue::TaskQueue;
-use crate::{Error, IndexScheduler, Result};
+use crate::{clamp_to_page_size, Error, IndexScheduler, Result};
 
 pub(crate) const UPDATE_FILES_DIR_NAME: &str = "update_files";
 
@@ -25,7 +25,14 @@ unsafe fn remove_tasks(
 ) -> Result<()> {
     let env_options = EnvOpenOptions::new();
     let mut env_options = env_options.read_txn_without_tls();
-    let env = env_options.max_dbs(TaskQueue::nb_db()).map_size(index_base_map_size).open(dst)?;
+    // heed rejects a map_size that isn't a multiple of the system page size
+    // (see clamp_to_page_size's other call sites) — on platforms with a
+    // larger page size than the one index_base_map_size was chosen for
+    // (e.g. Windows), an unclamped value here makes snapshot creation fail.
+    let env = env_options
+        .max_dbs(TaskQueue::nb_db())
+        .map_size(clamp_to_page_size(index_base_map_size))
+        .open(dst)?;
     let mut wtxn = env.write_txn()?;
     let task_queue = TaskQueue::new(&env, &mut wtxn)?;
 


### PR DESCRIPTION
## Fixes #6051

Snapshot creation fails on Windows with:

```
Batch failed map size (1310824018739) must be a multiple of the system page size (4096)
```

`remove_tasks` (called from `process_snapshots_to_disk` while snapshotting the index scheduler) opens its LMDB env with the raw `index_base_map_size`:

https://github.com/meilisearch/meilisearch/blob/be181e1/crates/index-scheduler/src/scheduler/process_snapshot_creation.rs#L28

Every other `map_size(...)` call site in this crate goes through `clamp_to_page_size` first (`lib.rs:468`, `lib.rs:451`, `index_map.rs:317`) specifically because heed rejects a map size that isn't a multiple of the system page size. This one call site was missed, so snapshot creation fails whenever `index_base_map_size` isn't already page-aligned by coincidence — which is what the reported value (1310824018739, not a multiple of 4096) shows happening.

## Fix

Wrap the value in `clamp_to_page_size(...)` at this call site, matching the existing pattern used everywhere else `map_size` is set.

## Testing

- `cargo check -p index-scheduler`: clean.
- `cargo clippy -p index-scheduler --no-deps`: clean.
- `cargo fmt --check -p index-scheduler`: clean.
- `cargo test -p meilisearch --test integration snapshot::`: all 3 existing snapshot tests pass (`perform_snapshot`, `perform_on_demand_snapshot`, `snapshotception_issue_4653`), confirming no regression on platforms where `index_base_map_size` already happens to be page-aligned.

I don't have a Windows machine to reproduce the original error directly, but the fix applies the exact same, already-proven pattern used at every other `map_size` call site in this file/crate, and the root cause (a missing `clamp_to_page_size` call, identified in the issue itself down to the line) is unambiguous.