### PR TITLE
Make the health route checks blocking

### DIFF
--- a/crates/meilisearch/src/routes/mod.rs
+++ b/crates/meilisearch/src/routes/mod.rs
@@ -599,9 +599,15 @@ pub async fn get_health(
             .json(HealthResponse { status: HealthStatus::MustRestart }));
     }
 
-    search_queue.health().unwrap();
-    index_scheduler.health().unwrap();
-    auth_controller.health().unwrap();
+    tokio::task::spawn_blocking(move || {
+        search_queue.health()?;
+        index_scheduler.health()?;
+        auth_controller.health()?;
+        Ok::<(), ResponseError>(())
+    })
+    .await
+    .unwrap()
+    .unwrap();
 
     Ok(HttpResponse::Ok().json(HealthResponse::default()))
 }


### PR DESCRIPTION
This PR makes sure the health route is not impacting the actix's workers pool too much by marking the blocking part of the health route as is.

## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respect the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)