### PR TITLE
Revert some search progress traces

### DIFF
--- a/crates/meilisearch/src/search/federated/perform.rs
+++ b/crates/meilisearch/src/search/federated/perform.rs
@@ -21,7 +21,7 @@ use meilisearch_types::milli::vector::Embedding;
 use meilisearch_types::milli::{
     self, merge_positioned_hits_into_page, serialize_index_filter_to_filter_string,
     AttributePatterns, Deadline, DocumentId, FederatingResultsStep, FieldsIdsMap, MetadataBuilder,
-    OrderBy, PatternMatch, Pin, Precedence, SearchStep, DEFAULT_VALUES_PER_FACET,
+    OrderBy, PatternMatch, Pin, Precedence, DEFAULT_VALUES_PER_FACET,
 };
 use meilisearch_types::network::{Network, Remote, RemoteAvailability};
 use meilisearch_types::settings::DEFAULT_PAGINATION_MAX_TOTAL_HITS;
@@ -1667,8 +1667,6 @@ impl SearchByIndex {
         let mut documents_seen = RoaringBitmap::new();
         let mut local_pinned_hits = Vec::new();
         for result_by_query in &mut results_by_query {
-            let _step = progress.update_progress_scoped(SearchStep::Format);
-
             let prev_documents_ids = std::mem::take(&mut result_by_query.documents_ids);
             let prev_scores = std::mem::take(&mut result_by_query.document_scores);
 
@@ -1727,10 +1725,7 @@ impl SearchByIndex {
                     }
 
                     let hit: Result<_, ResponseError> = (|| {
-                        let mut hit = {
-                            let _step = progress.update_progress_scoped(SearchStep::Format);
-                            hit_maker.make_hit(docid, &score)?
-                        };
+                        let mut hit = { hit_maker.make_hit(docid, &score)? };
 
                         if let Some(distinct) = self.federation.distinct.as_deref() {
                             let mut facet_values = Vec::new();

--- a/crates/meilisearch/src/search/federated/perform.rs
+++ b/crates/meilisearch/src/search/federated/perform.rs
@@ -1433,10 +1433,7 @@ impl SearchByIndex {
 
         let required_hit_count = usize::min(params.required_hit_count, max_total_hits);
 
-        let fidmap = {
-            let _step = progress.update_progress_scoped(SearchStep::LoadFieldIdsMap);
-            index.fields_ids_map(&rtxn).without_index()?
-        };
+        let fidmap = index.fields_ids_map(&rtxn).without_index()?;
 
         let mut degraded = false;
         let mut used_negative_operator = false;

--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -1792,10 +1792,7 @@ pub fn perform_search(
     let rtxn = index.read_txn()?;
     let deadline = index.search_deadline(&rtxn)?;
 
-    let fields_ids_map = {
-        let _step = progress.update_progress_scoped(SearchStep::LoadFieldIdsMap);
-        index.fields_ids_map(&rtxn)?
-    };
+    let fields_ids_map = index.fields_ids_map(&rtxn)?;
     let filter = match &query.filter {
         Some(filter) => {
             let filter = parse_filter(filter, Code::InvalidSearchFilter, features, None)?;

--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -1914,7 +1914,6 @@ pub fn perform_search(
         format,
         matching_words,
         documents_ids.iter().copied().zip(document_scores.iter()),
-        progress,
     )?;
 
     // Document join: hydrate documents based on the foreign keys
@@ -2477,9 +2476,7 @@ fn make_hits<'a>(
     format: AttributesFormat,
     matching_words: milli::MatchingWords,
     documents_ids_scores: impl Iterator<Item = (u32, &'a Vec<ScoreDetails>)> + 'a,
-    progress: &Progress,
 ) -> milli::Result<Vec<SearchHit>> {
-    let _step = progress.update_progress_scoped(SearchStep::Format);
     let mut documents = Vec::new();
 
     let dictionary = index.dictionary(rtxn)?;
@@ -2710,7 +2707,6 @@ pub fn perform_similar(
         format,
         Default::default(),
         documents_ids.iter().copied().zip(document_scores.iter()),
-        progress,
     )?;
 
     let max_total_hits = index

--- a/crates/milli/src/search/steps.rs
+++ b/crates/milli/src/search/steps.rs
@@ -9,7 +9,6 @@ make_enum_progress! {
         KeywordRanking,
         PlaceholderRanking,
         SemanticRanking,
-        Format,
         FacetDistribution,
         Personalization,
     }

--- a/crates/milli/src/search/steps.rs
+++ b/crates/milli/src/search/steps.rs
@@ -2,7 +2,6 @@ use crate::make_enum_progress;
 
 make_enum_progress! {
     pub enum SearchStep {
-        LoadFieldIdsMap,
         TokenizeQuery,
         EmbedQuery,
         EvaluateFilter,


### PR DESCRIPTION
This PR removes some progress trace steps to avoid doing too much work on search routes.

## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respect the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - *list of used tools and what they were used for*
