### PR TITLE
Constrain phrase search across stop word gaps

### DIFF
--- a/crates/meilisearch/tests/search/mod.rs
+++ b/crates/meilisearch/tests/search/mod.rs
@@ -2360,3 +2360,97 @@ async fn test_skip_on_creation() {
     let (resp, code) = index.get_document(2, None).await;
     assert_eq!(code, 404, "{resp}");
 }
+
+#[actix_rt::test]
+async fn phrase_search_with_many_consecutive_stop_words_still_returns_documents() {
+    // Consecutive stop words can push a word pair beyond the maximum indexed
+    // proximity; such a pair cannot be constrained and must not empty the
+    // results (the words-level intersection still applies).
+    let documents = json!([
+        {"id": 1, "title": "soup as well as of the day"},
+        {"id": 2, "title": "unrelated document"}
+    ]);
+
+    test_settings_documents_indexing_swapping_and_search(
+        &documents,
+        &json!({"stopWords": ["as", "well", "of", "the"]}),
+        &json!({"q": "\"soup as well as of the day\"", "attributesToRetrieve": ["id"]}),
+        |response, code| {
+            assert_eq!(code, 200, "{}", response);
+            snapshot!(json_string!(response["hits"]), @r###"
+            [
+              {
+                "id": 1
+              }
+            ]
+            "###);
+        },
+    )
+    .await;
+}
+
+#[actix_rt::test]
+async fn phrase_search_with_stop_words_is_not_a_bare_word_intersection() {
+    let documents = json!([
+        {"id": 1, "title": "The soup of the day"},
+        {"id": 2, "title": "soup day"},
+        {"id": 3, "title": "the soup and later the day"},
+        {"id": 4, "title": "unrelated document"}
+    ]);
+
+    // A phrase containing stop words must still constrain the real words by
+    // their distance: "the soup of the day" may match words up to the removed
+    // stop words' span apart, but not words scattered further away (doc 3).
+    test_settings_documents_indexing_swapping_and_search(
+        &documents,
+        &json!({"stopWords": ["of", "the"], "rankingRules": ["words", "typo", "proximity", "attribute", "sort", "exactness"]}),
+        &json!({"q": "\"the soup of the day\"", "attributesToRetrieve": ["id", "title"]}),
+        |response, code| {
+            assert_eq!(code, 200, "{}", response);
+            snapshot!(json_string!(response["hits"]), @r###"
+            [
+              {
+                "id": 1,
+                "title": "The soup of the day"
+              },
+              {
+                "id": 2,
+                "title": "soup day"
+              }
+            ]
+            "###);
+        },
+    )
+    .await;
+}
+
+#[actix_rt::test]
+async fn exactness_ranking_resolves_stop_word_phrases() {
+    // The exactness ranking rule resolves phrases through the same
+    // compute_phrase_docids path; isolate it from the other rules so the
+    // ExactTerm::Phrase branch is covered explicitly.
+    let documents = json!([
+        {"id": 1, "title": "The soup of the day"},
+        {"id": 2, "title": "soup day"}
+    ]);
+
+    test_settings_documents_indexing_swapping_and_search(
+        &documents,
+        &json!({"stopWords": ["of", "the"], "rankingRules": ["exactness"]}),
+        &json!({"q": "\"the soup of the day\"", "attributesToRetrieve": ["id"]}),
+        |response, code| {
+            assert_eq!(code, 200, "{}", response);
+            snapshot!(json_string!(response["hits"]), @r###"
+            [
+              {
+                "id": 1
+              },
+              {
+                "id": 2
+              }
+            ]
+            "###);
+        },
+    )
+    .await;
+}

--- a/crates/milli/src/search/new/resolve_query_graph.rs
+++ b/crates/milli/src/search/new/resolve_query_graph.rs
@@ -10,6 +10,7 @@ use super::query_graph::QueryNodeData;
 use super::query_term::{Phrase, QueryTermSubset};
 use super::small_bitmap::SmallBitmap;
 use super::{QueryGraph, SearchContext, Word};
+use crate::proximity::MAX_DISTANCE;
 use crate::search::new::query_term::LocatedQueryTermSubset;
 use crate::Result;
 
@@ -210,22 +211,27 @@ pub fn compute_phrase_docids(
         return Ok(RoaringBitmap::new());
     };
 
-    let winsize = words.len().min(3);
+    // Windows are built over the real words: stop words leave `None` holes,
+    // and a window over the raw sequence may not contain two words to pair.
+    let real_words: Vec<(usize, Interned<String>)> = words
+        .iter()
+        .enumerate()
+        .filter_map(|(index, word)| word.as_ref().map(|word| (index, *word)))
+        .collect();
 
-    for win in words.windows(winsize) {
+    let winsize = real_words.len().clamp(1, 3);
+
+    for win in real_words.windows(winsize) {
         // Get all the documents with the matching distance for each word pairs.
         let mut bitmaps = Vec::with_capacity(winsize.pow(2));
-        for (offset, &s1) in win
-            .iter()
-            .enumerate()
-            .filter_map(|(index, word)| word.as_ref().map(|word| (index, word)))
-        {
-            for (dist, &s2) in win
-                .iter()
-                .skip(offset + 1)
-                .enumerate()
-                .filter_map(|(index, word)| word.as_ref().map(|word| (index, word)))
-            {
+        for (offset, &(position1, s1)) in win.iter().enumerate() {
+            for &(position2, s2) in win.iter().skip(offset + 1) {
+                let dist = position2 - position1 - 1;
+                // Word pairs are only indexed up to MAX_DISTANCE, so a pair
+                // separated by more stop words cannot be constrained.
+                if dist as u32 + 1 >= MAX_DISTANCE {
+                    continue;
+                }
                 if dist == 0 {
                     match ctx.get_db_word_pair_proximity_docids(None, s1, s2, 1)? {
                         Some(m) => bitmaps.push(m),


### PR DESCRIPTION
## Related issue

Fixes #5298

## Generative AI tools

- [ ] This PR does not use generative AI tooling
- [x] This PR uses generative AI tooling and respect the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - *Claude Code — used for the investigation (reproduction, instrumentation of `compute_phrase_docids`, the measurements below), the implementation, and the tests. I own the contribution and verified every claim in this description against local runs.*

## What does this PR do?

With stop words configured, a phrase query degrades into a bare word intersection: with `stopWords: ["of", "the"]`, the phrase `"the soup of the day"` matches a document titled `soup day`.

`compute_phrase_docids` keeps stop words as `None` holes (positions preserved) but builds its proximity windows over the raw sequence, so a window of size 3 never contains two real words once two or more stop words separate them — the phrase gets no proximity constraint at all.

This PR:
- builds the windows over the real words, keeping their raw positions, so pairs are constrained by their true distance — the same "up to the gap" rule the `dist > 0` branch already applies (so `soup day` matching a shorter gap stays, as in #5491's test expectations);
- skips pairs wider than the indexed `MAX_DISTANCE` (unconstrainable; behavior unchanged there, covered by a test);
- adds three integration tests — the bare-intersection one fails on `main`; the other two cover the unconstrainable-pair path and the exactness ranking rule resolving a stop-word phrase.

No indexing change is needed: the index already preserves the gaps (a phrase `"soup day"` does not match `The soup of the day`), so the indexing-time concern from #5491 does not apply here. Median query time is unchanged (5 ms on both trees; 200 runs, 5k documents). I ran the full integration suite on both trees with `--no-default-features`: identical failure sets; I could not run the default-features leg locally, relying on CI for it.

## Requirements

⚠️ Ensure the following requirements before merging ⚠️
- [x] Automated tests have been added.
- [ ] If some tests cannot be automated, manual rigorous tests should be applied.
- [ ] ⚠️ If there is any change in the DB: — *no DB change: the fix is entirely on the search path*
- [ ] If necessary, the feature have been tested in the Cloud production environment…
- [ ] If necessary, the documentation related to the implemented feature in the PR is ready.
- [ ] If necessary, the integrations related to the implemented feature in the PR are ready.

