### PR TITLE
Return a named error when the words dictionary exceeds its maximum size

### DIFF
--- a/crates/meilisearch-types/src/error.rs
+++ b/crates/meilisearch-types/src/error.rs
@@ -201,6 +201,7 @@ IndexScopedApiKeyWithGlobalAction              , InvalidRequest       , BAD_REQU
 BadParameter                                   , InvalidRequest       , BAD_REQUEST;
 BadRequest                                     , InvalidRequest       , BAD_REQUEST;
 DatabaseSizeLimitReached                       , Internal             , INTERNAL_SERVER_ERROR;
+WordsDictionarySizeLimitReached                , Internal             , INTERNAL_SERVER_ERROR;
 DocumentNotFound                               , InvalidRequest       , NOT_FOUND;
 DumpAlreadyProcessing                          , InvalidRequest       , CONFLICT;
 DumpNotFound                                   , InvalidRequest       , NOT_FOUND;
@@ -513,6 +514,7 @@ impl ErrorCode for milli::Error {
                 UserError::InvalidStoreFile => Code::InvalidStoreFile,
                 UserError::NoSpaceLeftOnDevice => Code::NoSpaceLeftOnDevice,
                 UserError::MaxDatabaseSizeReached => Code::DatabaseSizeLimitReached,
+                UserError::MaxWordsFstSizeReached { .. } => Code::WordsDictionarySizeLimitReached,
                 UserError::AttributeLimitReached => Code::MaxFieldsLimitExceeded,
                 UserError::InvalidFilter(_)
                 | UserError::InvalidFilterExpression(..)

--- a/crates/milli/src/error.rs
+++ b/crates/milli/src/error.rs
@@ -295,6 +295,8 @@ and can not be more than 511 bytes.", .document_id.to_string()
     InvalidStoreFile,
     #[error("Maximum database size has been reached.")]
     MaxDatabaseSizeReached,
+    #[error("Maximum words dictionary size has been reached: the dictionary would weigh {size} bytes while it cannot exceed {} bytes. This happens when an index contains too many unique words, for example when unique identifiers are indexed as searchable text.", crate::index::MAX_WORDS_FST_SIZE)]
+    MaxWordsFstSizeReached { size: usize },
     #[error("Document doesn't have a `{}` attribute: `{}`.", .primary_key, serde_json::to_string(.document).unwrap())]
     MissingDocumentId { primary_key: String, document: Object },
     #[error("Document have too many matching `{}` attribute: `{}`.", .primary_key, serde_json::to_string(.document).unwrap())]

--- a/crates/milli/src/index.rs
+++ b/crates/milli/src/index.rs
@@ -213,6 +213,17 @@ impl CreateOrOpen {
     }
 }
 
+/// A serialized FST is stored as a single LMDB value, which cannot exceed 2^31 bytes.
+pub const MAX_WORDS_FST_SIZE: usize = 1 << 31;
+
+pub(crate) fn check_words_fst_size(size: usize) -> Result<()> {
+    if size < MAX_WORDS_FST_SIZE {
+        Ok(())
+    } else {
+        Err(UserError::MaxWordsFstSizeReached { size }.into())
+    }
+}
+
 impl Index {
     pub fn new_with_creation_dates<P: AsRef<Path>>(
         mut options: heed::EnvOpenOptions<WithoutTls>,
@@ -1226,12 +1237,11 @@ impl Index {
         &self,
         wtxn: &mut RwTxn<'_>,
         fst: &fst::Set<A>,
-    ) -> heed::Result<()> {
-        self.main.remap_types::<Str, Bytes>().put(
-            wtxn,
-            main_key::WORDS_FST_KEY,
-            fst.as_fst().as_bytes(),
-        )
+    ) -> Result<()> {
+        let bytes = fst.as_fst().as_bytes();
+        check_words_fst_size(bytes.len())?;
+        self.main.remap_types::<Str, Bytes>().put(wtxn, main_key::WORDS_FST_KEY, bytes)?;
+        Ok(())
     }
 
     /// Returns the FST which is the words dictionary of the engine.
@@ -1394,12 +1404,11 @@ impl Index {
         &self,
         wtxn: &mut RwTxn<'_>,
         fst: &fst::Set<A>,
-    ) -> heed::Result<()> {
-        self.main.remap_types::<Str, Bytes>().put(
-            wtxn,
-            main_key::WORDS_PREFIXES_FST_KEY,
-            fst.as_fst().as_bytes(),
-        )
+    ) -> Result<()> {
+        let bytes = fst.as_fst().as_bytes();
+        check_words_fst_size(bytes.len())?;
+        self.main.remap_types::<Str, Bytes>().put(wtxn, main_key::WORDS_PREFIXES_FST_KEY, bytes)?;
+        Ok(())
     }
 
     pub(crate) fn delete_words_prefixes_fst(&self, wtxn: &mut RwTxn<'_>) -> heed::Result<bool> {

--- a/crates/milli/src/test_index.rs
+++ b/crates/milli/src/test_index.rs
@@ -1468,3 +1468,18 @@ fn vectors_are_never_indexed_as_searchable_or_filterable() {
         .unwrap();
     assert!(results.candidates.is_empty());
 }
+
+#[test]
+fn words_fst_size_is_bounded() {
+    use crate::error::UserError;
+    use crate::index::{MAX_WORDS_FST_SIZE, check_words_fst_size};
+
+    assert!(check_words_fst_size(0).is_ok());
+    assert!(check_words_fst_size(MAX_WORDS_FST_SIZE - 1).is_ok());
+
+    let error = check_words_fst_size(MAX_WORDS_FST_SIZE).unwrap_err();
+    assert!(matches!(
+        error,
+        crate::Error::UserError(UserError::MaxWordsFstSizeReached { size }) if size == MAX_WORDS_FST_SIZE
+    ));
+}

--- a/crates/milli/src/update/new/indexer/post_processing/mod.rs
+++ b/crates/milli/src/update/new/indexer/post_processing/mod.rs
@@ -13,6 +13,7 @@ use super::document_changes::IndexingContext;
 use crate::facet::FacetType;
 use crate::heed_codec::facet::{FacetGroupKey, FacetGroupKeyCodec};
 use crate::heed_codec::StrRefCodec;
+use crate::index::check_words_fst_size;
 use crate::index::main_key::{WORDS_FST_KEY, WORDS_PREFIXES_FST_KEY};
 use crate::progress::Progress;
 use crate::update::del_add::DelAdd;
@@ -178,9 +179,11 @@ fn compute_word_fst(
     }
 
     let (word_fst_mmap, prefix_data) = word_fst_builder.build()?;
+    check_words_fst_size(word_fst_mmap.len())?;
     index.main.remap_types::<Str, Bytes>().put(wtxn, WORDS_FST_KEY, &word_fst_mmap)?;
 
     if let Some(PrefixData { prefixes_fst_mmap }) = prefix_data {
+        check_words_fst_size(prefixes_fst_mmap.len())?;
         index.main.remap_types::<Str, Bytes>().put(
             wtxn,
             WORDS_PREFIXES_FST_KEY,
@@ -206,6 +209,7 @@ pub fn recompute_word_fst_from_word_docids_database(
         word_fst_builder.register_word(DelAdd::Addition, word.as_ref())?;
     }
     let (word_fst_mmap, _) = word_fst_builder.build()?;
+    check_words_fst_size(word_fst_mmap.len())?;
     index.main.remap_types::<Str, Bytes>().put(wtxn, WORDS_FST_KEY, &word_fst_mmap)?;
 
     Ok(())


### PR DESCRIPTION
## Related issue

Related to #3784 — it does not close it: the ceiling stays where it is; reaching it becomes a named error instead of an opaque I/O failure.

## Generative AI tools

- [ ] This PR does not use generative AI tooling
- [x] This PR uses generative AI tooling and respect the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - *Claude Code — investigation (the size measurements in #3784), implementation, and the test. I own the contribution and verified every claim against local runs.*

## What does this PR do?

A serialized words FST is stored as a single LMDB value, which cannot exceed 2^31 bytes; past that, indexing dies with `os error 5` — an error opaque enough that reports behind it stayed undiagnosed for years (#3654, likely #5760, measurement in #3784).

- fails the FST write with a new `MaxWordsFstSizeReached` user error (code `words_dictionary_size_limit_reached`) when the words or prefixes FST would exceed the limit;
- guards all three write paths (both indexers and the prefixes FST) through one checked put;
- adds a unit test for the threshold. The error path cannot be integration-tested without building a 2 GiB dictionary, so the check is a pure function tested directly.

## Requirements

⚠️ Ensure the following requirements before merging ⚠️
- [x] Automated tests have been added.
- [ ] If some tests cannot be automated, manual rigorous tests should be applied.
- [ ] ⚠️ If there is any change in the DB: — *no DB change; write-path validation only*
- [ ] If necessary, the feature have been tested in the Cloud production environment…
- [ ] If necessary, the documentation related to the implemented feature in the PR is ready. — *a known-limitations row for this ceiling is prepared for the documentation repo; I will open it alongside*
- [ ] If necessary, the integrations related to the implemented feature in the PR are ready.

