### PR TITLE
Make HitMaker TokenizerBuilder stop-words aware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4370,6 +4370,7 @@ dependencies = [
  "either",
  "file-store",
  "flate2",
+ "fst",
  "futures",
  "futures-util",
  "hex",

--- a/crates/meilisearch/Cargo.toml
+++ b/crates/meilisearch/Cargo.toml
@@ -111,6 +111,7 @@ humantime = { version = "2.3.0", default-features = false }
 cidr = { version = "0.3.2", features = ["serde"] }
 routes = { path = "../routes" }
 bumparaw-collections = "0.1.7"
+fst = "0.4.7"
 
 [dev-dependencies]
 actix-rt = "2.11.0"

--- a/crates/meilisearch/src/search/federated/perform.rs
+++ b/crates/meilisearch/src/search/federated/perform.rs
@@ -1360,6 +1360,7 @@ impl SearchByIndex {
         let separators = index.allowed_separators(&rtxn).without_index()?;
         let separators: Option<Vec<_>> =
             separators.as_ref().map(|x| x.iter().map(String::as_str).collect());
+        let stop_words = index.stop_words(&rtxn).without_index()?;
 
         let max_total_hits = index
             .pagination_max_total_hits(&rtxn)
@@ -1583,7 +1584,11 @@ impl SearchByIndex {
                 degraded |= query_degraded;
                 used_negative_operator |= query_used_negative_operator;
 
-                let tokenizer = HitMaker::tokenizer(dictionary.as_deref(), separators.as_deref());
+                let tokenizer = HitMaker::tokenizer(
+                    dictionary.as_deref(),
+                    separators.as_deref(),
+                    stop_words.as_ref(),
+                );
 
                 let formatter_builder = HitMaker::formatter_builder(matching_words, tokenizer);
 

--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -2242,8 +2242,9 @@ impl<'a> HitMaker<'a> {
     pub fn tokenizer<'b>(
         dictionary: Option<&'b [&'b str]>,
         separators: Option<&'b [&'b str]>,
+        stop_words: Option<&'b fst::Set<&'b [u8]>>,
     ) -> milli::tokenizer::Tokenizer<'b> {
-        let mut tokenizer_builder = TokenizerBuilder::default();
+        let mut tokenizer_builder = TokenizerBuilder::<&[u8]>::new();
         tokenizer_builder.create_char_map(true);
 
         if let Some(separators) = separators {
@@ -2252,6 +2253,10 @@ impl<'a> HitMaker<'a> {
 
         if let Some(dictionary) = dictionary {
             tokenizer_builder.words_dict(dictionary);
+        }
+
+        if let Some(stop_words) = stop_words {
+            tokenizer_builder.stop_words(stop_words);
         }
 
         tokenizer_builder.into_tokenizer()
@@ -2505,8 +2510,10 @@ fn make_hits<'a>(
     let separators = index.allowed_separators(rtxn)?;
     let separators: Option<Vec<_>> =
         separators.as_ref().map(|x| x.iter().map(String::as_str).collect());
+    let stop_words = index.stop_words(rtxn)?;
 
-    let tokenizer = HitMaker::tokenizer(dictionary.as_deref(), separators.as_deref());
+    let tokenizer =
+        HitMaker::tokenizer(dictionary.as_deref(), separators.as_deref(), stop_words.as_ref());
 
     let formatter_builder = HitMaker::formatter_builder(matching_words, tokenizer);
 

--- a/crates/meilisearch/tests/search/mod.rs
+++ b/crates/meilisearch/tests/search/mod.rs
@@ -187,6 +187,113 @@ async fn search_with_stop_word() {
 }
 
 #[actix_rt::test]
+async fn stop_words_not_highlighted() {
+    // related to https://github.com/meilisearch/meilisearch/issues/6594
+    let server = Server::new_shared();
+    let index = server.unique_index();
+
+    let (_, code) = index.update_settings(json!({"stopWords": ["the", "The", "to"]})).await;
+    snapshot!(code, @"202 Accepted");
+
+    let documents = json!([
+        {
+            "id": 1,
+            "title": "to The City",
+        },
+        {
+            "id": 2,
+            "title": "This is Their The City",
+        },
+        {
+            "id": 3,
+            "title": "to the New City",
+        },
+        {
+            "id": 4,
+            "title": "to THE City",
+        }
+    ]);
+    let (task, _code) = index.add_documents(documents, None).await;
+    server.wait_task(task.uid()).await.succeeded();
+
+    // prefix search
+    index
+        .search(json!({"q": "to the", "attributesToHighlight": ["title"], "attributesToRetrieve": ["title"] }), |response, code| {
+            assert_eq!(code, 200, "{response}");
+            snapshot!(json_string!(response["hits"]), @r###"
+            [
+              {
+                "title": "to THE City",
+                "_formatted": {
+                  "title": "to <em>THE</em> City"
+                }
+              },
+              {
+                "title": "This is Their The City",
+                "_formatted": {
+                  "title": "This is <em>The</em>ir The City"
+                }
+              }
+            ]
+            "###);
+        })
+        .await;
+
+    // exact matches "THE". "THE" is not a stop word
+    index
+        // search is case-insensitive, "tHE" or "THE" returns same hits
+        .search(json!({"q": "to tHE ", "attributesToHighlight": ["title"], "attributesToRetrieve": ["title"] }), |response, code| {
+            assert_eq!(code, 200, "{response}");
+            snapshot!(json_string!(response["hits"]), @r###"
+            [
+              {
+                "title": "to THE City",
+                "_formatted": {
+                  "title": "to <em>THE</em> City"
+                }
+              }
+            ]
+            "###);
+        })
+        .await;
+
+    // non-prefix search
+    index
+          .search(json!({"q": "to the ", "attributesToHighlight": ["title"], "attributesToRetrieve": ["title"] }), |response, code| {
+              assert_eq!(code, 200, "{response}");
+              snapshot!(json_string!(response["hits"]), @r###"
+              [
+                {
+                  "title": "to The City",
+                  "_formatted": {
+                    "title": "to The City"
+                  }
+                },
+                {
+                  "title": "This is Their The City",
+                  "_formatted": {
+                    "title": "This is Their The City"
+                  }
+                },
+                {
+                  "title": "to the New City",
+                  "_formatted": {
+                    "title": "to the New City"
+                  }
+                },
+                {
+                  "title": "to THE City",
+                  "_formatted": {
+                    "title": "to THE City"
+                  }
+                }
+              ]
+              "###);
+          })
+          .await;
+}
+
+#[actix_rt::test]
 async fn search_with_typo_settings() {
     // related to https://github.com/meilisearch/meilisearch/issues/5240
     let server = Server::new_shared();

--- a/crates/milli/src/search/new/matches/matching_words.rs
+++ b/crates/milli/src/search/new/matches/matching_words.rs
@@ -78,7 +78,11 @@ impl MatchingWords {
         for located_words in &self.words {
             for word in &located_words.value {
                 let word = self.word_interner.get(*word);
-                // if the word is a prefix we match using starts_with.
+                // if it is a stop-word, don't match
+                if token.is_stopword() {
+                    continue;
+                }
+                // if the word is a prefix, we match using starts_with.
                 if located_words.is_prefix && token.lemma().starts_with(word) {
                     let Some((char_index, c)) =
                         word.char_indices().take(located_words.original_char_count).last()


### PR DESCRIPTION
## Description

Hi. I have been debugging this issue since a few days and finally came up with this PR. Open to suggestions 

This PR fixes the behavior of stop words when prefix searching. The exact issue arises when your document contains different case variants of the stop word you have set.

## Related issue

Fixes #6594 

## What does this PR do?

It makes the `HitMaker` `TokenizerBuilder` stop-words aware i.e. the stop-words of the index are now passed to the tokenizer builder and the `tokenizer` now tokenizes so that the stop words are considered as `StopWord` and not `Word`. This allows `match_unique_words` to skip matching a stop word. I also added a test case for this change

The second change that i have done is reordering the match branches in `match_unique_words` so that exact-match check runs before the prefix-match check. In my opinion this is most natural. I came across this while debugging and i found that "THE" is evaluated as a prefix match rather than an exact match which is wrong. Because of this change, two insta snapshots were effected which i updated. However i am  unsure if this is breaching the scope of this PR. Happy to create a separate PR if that is what you prefer

## Generative AI tools

- [ ] This PR does not use generative AI tooling
- [x] This PR uses generative AI tooling and respect the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - *Claude was used to assist in gathering knowledge of different crates but the code was not written by it*

## Requirements

⚠️ Ensure the following requirements before merging ⚠️
- [x] Automated tests have been added.
- [ ] If some tests cannot be automated, manual rigorous tests should be applied.
- [ ] ⚠️ If there is any change in the DB:
    - [ ] Test that any impacted DB still works as expected after using `--upgrade-db` on a DB created with the last released Meilisearch
    - [ ] Test that during the upgrade, **search is still available** (artificially make the upgrade longer if needed)
    - [ ] Set the `db change` label.
- [ ] If necessary, the feature have been tested in the Cloud production environment (with [prototypes](./documentation/prototypes.md)) and the Cloud UI is ready.
- [ ] If necessary, the [documentation](https://github.com/meilisearch/documentation) related to the implemented feature in the PR is ready.
- [ ] If necessary, the [integrations](https://github.com/meilisearch/integration-guides) related to the implemented feature in the PR are ready.
