### PR TITLE
fix(search_queue): prune cancelled waiters to prevent spurious TooManySearchRequests

### DIFF
--- a/crates/meilisearch/src/search_queue.rs
+++ b/crates/meilisearch/src/search_queue.rs
@@ -107,6 +107,12 @@ impl SearchQueue {
         self.searches_waiting_to_be_processed.load(Ordering::Relaxed)
     }
 
+    /// Remove closed senders from the queue.
+    /// A sender is closed when its receiver has been dropped (e.g., request cancelled).
+    fn prune_closed_senders(queue: &mut Vec<oneshot::Sender<Permit>>) {
+        queue.retain(|sender| !sender.is_closed());
+    }
+
     /// This function is the main loop, it's in charge on scheduling which search request should execute first and
     /// how many should executes at the same time.
     ///
@@ -130,6 +136,8 @@ impl SearchQueue {
                 biased;
                 _ = search_finished.recv() => {
                     searches_running = searches_running.saturating_sub(1);
+                    // Prune closed senders before selecting the next waiter
+                    Self::prune_closed_senders(&mut queue);
                     if !queue.is_empty() {
                         // Can't panic: the queue wasn't empty thus the range isn't empty.
                         let remove = rng.gen_range(0..queue.len());
@@ -146,6 +154,9 @@ impl SearchQueue {
                         None => continue,
                     };
 
+                    // Prune closed senders before making capacity decisions
+                    Self::prune_closed_senders(&mut queue);
+
                     if searches_running < usize::from(parallelism) && queue.is_empty() {
                         searches_running += 1;
                         // if the search requests die, it's not a hard error on our side
@@ -159,6 +170,7 @@ impl SearchQueue {
                         continue;
 
                     } else if queue.len() >= capacity {
+                        // Can't panic: queue.len() >= capacity > 0, so range is not empty.
                         let remove = rng.gen_range(0..queue.len());
                         let thing = queue.swap_remove(remove); // this will drop the channel and notify the search that it won't be processed
                         drop(thing);
@@ -166,6 +178,9 @@ impl SearchQueue {
                     queue.push(search_request);
                 },
             }
+
+            // Prune closed senders before publishing metrics
+            Self::prune_closed_senders(&mut queue);
 
             metric_searches_running.store(searches_running, Ordering::Relaxed);
             metric_searches_waiting.store(queue.len(), Ordering::Relaxed);

--- a/crates/meilisearch/tests/search/search_queue.rs
+++ b/crates/meilisearch/tests/search/search_queue.rs
@@ -219,3 +219,59 @@ async fn works_with_capacity_of_zero() {
         .expect("I should get a permit straight away")
         .unwrap();
 }
+
+#[actix_rt::test]
+async fn cancelled_permit_waiter_removed_from_search_queue() {
+    let queue = Arc::new(SearchQueue::new(1, NonZeroUsize::new(1).unwrap()));
+
+    // Saturate the only running-search slot so the next request must wait.
+    let active_permit = queue
+        .try_get_search_permit()
+        .await
+        .expect("the first request should receive a permit");
+    assert_eq!(queue.searches_waiting(), 0);
+
+    let waiting_queue = Arc::clone(&queue);
+    let waiting_task = tokio::spawn(async move {
+        waiting_queue.try_get_search_permit().await
+    });
+
+    // Wait until the scheduler has accepted the waiter and published the queue length.
+    tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            if queue.searches_waiting() == 1 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("the waiter should be accepted by the scheduler");
+    assert!(
+        !waiting_task.is_finished(),
+        "the accepted waiter should still be awaiting its permit"
+    );
+
+    // The request future is cancelled while it awaits the permit.
+    // This drops its receiver, but the scheduler already owns the sender.
+    waiting_task.abort();
+    let cancellation = waiting_task
+        .await
+        .expect_err("aborting the waiter should cancel its task");
+    assert!(cancellation.is_cancelled());
+
+    // With the fix, the cancelled waiter's sender should be pruned from the queue.
+    // searches_waiting should return to 0.
+    tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            if queue.searches_waiting() == 0 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("the cancelled waiter should be removed from the queue");
+
+    drop(active_permit);
+}


### PR DESCRIPTION
Fixes #6508

## Summary
When a search request is cancelled while waiting for a permit, its oneshot receiver is dropped but the scheduler retains the sender in its queue. This caused stale waiters to be counted in queue.len().

## Changes
- Added prune_closed_senders helper in crates/meilisearch/src/search_queue.rs
- Called before selecting next waiter, before capacity checks, and before publishing metrics
- Added test cancelled_permit_waiter_removed_from_search_queue

## Testing
- New test verifies cancelled waiter no longer occupies queue slot
- Existing tests should still pass