### PR TITLE
Simplify Rust install and update Rust to v1.98.1

### DIFF
--- a/.github/templates/dependency-issue.md
+++ b/.github/templates/dependency-issue.md
@@ -13,7 +13,6 @@ This issue is about updating Meilisearch dependencies:
     - [ ] Finally, [Meilisearch](https://github.com/meilisearch/MeiliSearch)
   - [ ] If new Rust versions have been released, update the minimal Rust version in use at Meilisearch:
     - [ ] in this [GitHub Action file](https://github.com/meilisearch/meilisearch/blob/main/.github/workflows/test-suite.yml), by changing the `toolchain` field of the `rustfmt` job to the latest available nightly (of the day before or the current day).
-    - [ ] in every [GitHub Action files](https://github.com/meilisearch/meilisearch/blob/main/.github/workflows), by changing all the `dtolnay/rust-toolchain@` references to use the latest stable version.
     - [ ] in this [`rust-toolchain.toml`](https://github.com/meilisearch/meilisearch/blob/main/rust-toolchain.toml), by changing the `channel` field to the latest stable version.
     - [ ] in the [Dockerfile](https://github.com/meilisearch/meilisearch/blob/main/Dockerfile), by changing the base image to `rust:<target_rust_version>-alpine<alpine_version>`. Check that the image exists on [Dockerhub](https://hub.docker.com/_/rust/tags?page=1&name=alpine). Also, build and run the image to check everything still works!
 

--- a/.github/workflows/bench-manual.yml
+++ b/.github/workflows/bench-manual.yml
@@ -18,10 +18,6 @@ jobs:
     timeout-minutes: 180 # 3h
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-      - uses: dtolnay/rust-toolchain@38ae5351029910ad7674ccfad89c37cbd636f3c4 # 1.91.1
-        with:
-          toolchain: 1.91.1
-          profile: minimal
 
       - name: Run benchmarks - workload ${WORKLOAD_NAME} - branch ${{ github.ref }} - commit ${{ github.sha }}
         run: |

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -68,10 +68,6 @@ jobs:
           fetch-depth: 0 # fetch full history to be able to get main commit sha
           ref: ${{ steps.permission.outputs.head_sha }}
 
-      - uses: dtolnay/rust-toolchain@38ae5351029910ad7674ccfad89c37cbd636f3c4 # 1.91.1
-        with:
-          toolchain: 1.91.1
-
       - name: Run benchmarks on PR ${{ github.event.issue.id }}
         env:
           BENCH_ARGS: ${{ steps.command.outputs.command-arguments }}

--- a/.github/workflows/bench-push-indexing.yml
+++ b/.github/workflows/bench-push-indexing.yml
@@ -12,9 +12,6 @@ jobs:
     timeout-minutes: 180 # 3h
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-      - uses: dtolnay/rust-toolchain@38ae5351029910ad7674ccfad89c37cbd636f3c4 # 1.91.1
-        with:
-          toolchain: 1.91.1
 
       # Run benchmarks
       - name: Run benchmarks - Dataset ${BENCH_NAME} - Branch main - Commit ${{ github.sha }}

--- a/.github/workflows/check-openapi-file.yml
+++ b/.github/workflows/check-openapi-file.yml
@@ -22,11 +22,6 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@38ae5351029910ad7674ccfad89c37cbd636f3c4 # 1.91.1
-        with:
-          toolchain: 1.91.1
-
       - name: Cache dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 

--- a/.github/workflows/flaky-tests.yml
+++ b/.github/workflows/flaky-tests.yml
@@ -23,9 +23,6 @@ jobs:
         run: |
           apt-get update && apt-get install -y curl
           apt-get install build-essential -y
-      - uses: dtolnay/rust-toolchain@38ae5351029910ad7674ccfad89c37cbd636f3c4 # 1.91.1
-        with:
-          toolchain: 1.91.1
       - name: Install cargo-flaky
         run: cargo install cargo-flaky
       - name: Run cargo flaky in the dumps

--- a/.github/workflows/fuzzer-indexing.yml
+++ b/.github/workflows/fuzzer-indexing.yml
@@ -12,9 +12,6 @@ jobs:
     timeout-minutes: 4320 # 72h
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-      - uses: dtolnay/rust-toolchain@38ae5351029910ad7674ccfad89c37cbd636f3c4 # 1.91.1
-        with:
-          toolchain: 1.91.1
 
       # Run benchmarks
       - name: Run the fuzzer

--- a/.github/workflows/publish-apt-brew-pkg.yml
+++ b/.github/workflows/publish-apt-brew-pkg.yml
@@ -31,9 +31,6 @@ jobs:
           sudo rm -rf "/usr/share/dotnet" || true
           sudo rm -rf "/usr/local/lib/android" || true
           sudo rm -rf "/usr/local/share/boost" || true
-      - uses: dtolnay/rust-toolchain@38ae5351029910ad7674ccfad89c37cbd636f3c4 # 1.91.1
-        with:
-          toolchain: 1.91.1
       - name: Install cargo-deb
         run: cargo install cargo-deb
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6

--- a/.github/workflows/publish-release-assets.yml
+++ b/.github/workflows/publish-release-assets.yml
@@ -87,9 +87,6 @@ jobs:
     needs: check-version
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-      - uses: dtolnay/rust-toolchain@38ae5351029910ad7674ccfad89c37cbd636f3c4 # 1.91.1
-        with:
-          toolchain: 1.91.1
       - name: Install cross
         if: matrix.use_cross
         run: cargo install cross --locked
@@ -115,10 +112,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
-        with:
-          toolchain: stable
       - name: Generate OpenAPI file
         run: |
           cd crates/openapi-generator

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -33,10 +33,6 @@ jobs:
           sudo rm -rf "/usr/local/share/boost" || true
       - name: check free space after
         run: df -h
-      - name: Setup test with Rust stable
-        uses: dtolnay/rust-toolchain@38ae5351029910ad7674ccfad89c37cbd636f3c4 # 1.91.1
-        with:
-          toolchain: 1.91.1
       - name: Cache dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
@@ -59,9 +55,6 @@ jobs:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: Cache dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-      - uses: dtolnay/rust-toolchain@38ae5351029910ad7674ccfad89c37cbd636f3c4 # 1.91.1
-        with:
-          toolchain: 1.91.1
       - name: Run cargo build without any default features
         run: cargo build --locked --no-default-features --all
       - name: Run cargo test
@@ -80,9 +73,6 @@ jobs:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: Cache dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-      - uses: dtolnay/rust-toolchain@38ae5351029910ad7674ccfad89c37cbd636f3c4 # 1.91.1
-        with:
-          toolchain: 1.91.1
       - name: Run cargo build without any default features
         run: cargo build --locked --no-default-features --all
       - name: Run cargo test
@@ -100,9 +90,6 @@ jobs:
           sudo rm -rf "/usr/share/dotnet" || true
           sudo rm -rf "/usr/local/lib/android" || true
           sudo rm -rf "/usr/local/share/boost" || true
-      - uses: dtolnay/rust-toolchain@38ae5351029910ad7674ccfad89c37cbd636f3c4 # 1.91.1
-        with:
-          toolchain: 1.91.1
       - name: Run cargo build with almost all features
         run: |
           cargo build --workspace --locked --features "$(cargo xtask list-features --exclude-feature cuda,test-ollama)"
@@ -162,10 +149,6 @@ jobs:
           sudo rm -rf "/usr/local/share/boost" || true
       - name: check free space after
         run: df -h
-      - name: Setup test with Rust stable
-        uses: dtolnay/rust-toolchain@38ae5351029910ad7674ccfad89c37cbd636f3c4 # 1.91.1
-        with:
-          toolchain: 1.91.1
       - name: Cache dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Run cargo test
@@ -183,9 +166,6 @@ jobs:
           sudo rm -rf "/usr/share/dotnet" || true
           sudo rm -rf "/usr/local/lib/android" || true
           sudo rm -rf "/usr/local/share/boost" || true
-      - uses: dtolnay/rust-toolchain@38ae5351029910ad7674ccfad89c37cbd636f3c4 # 1.91.1
-        with:
-          toolchain: 1.91.1
       - name: Run cargo tree without default features and check lindera is not present
         run: |
           if cargo tree -f '{p} {f}' -e normal --no-default-features | grep -qz lindera; then
@@ -207,9 +187,6 @@ jobs:
           sudo rm -rf "/usr/share/dotnet" || true
           sudo rm -rf "/usr/local/lib/android" || true
           sudo rm -rf "/usr/local/share/boost" || true
-      - uses: dtolnay/rust-toolchain@38ae5351029910ad7674ccfad89c37cbd636f3c4 # 1.91.1
-        with:
-          toolchain: 1.91.1
       - name: Cache dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Build
@@ -229,10 +206,6 @@ jobs:
           sudo rm -rf "/usr/share/dotnet" || true
           sudo rm -rf "/usr/local/lib/android" || true
           sudo rm -rf "/usr/local/share/boost" || true
-      - uses: dtolnay/rust-toolchain@38ae5351029910ad7674ccfad89c37cbd636f3c4 # 1.91.1
-        with:
-          toolchain: 1.91.1
-          components: clippy
       - name: Cache dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Run cargo clippy
@@ -249,10 +222,6 @@ jobs:
           sudo rm -rf "/usr/share/dotnet" || true
           sudo rm -rf "/usr/local/lib/android" || true
           sudo rm -rf "/usr/local/share/boost" || true
-      - uses: dtolnay/rust-toolchain@38ae5351029910ad7674ccfad89c37cbd636f3c4 # 1.91.1
-        with:
-          toolchain: 1.91.1
-          components: rustfmt
       - name: Cache dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Run cargo fmt
@@ -271,9 +240,6 @@ jobs:
           sudo rm -rf "/usr/share/dotnet" || true
           sudo rm -rf "/usr/local/lib/android" || true
           sudo rm -rf "/usr/local/share/boost" || true
-      - uses: dtolnay/rust-toolchain@38ae5351029910ad7674ccfad89c37cbd636f3c4 # 1.91.1
-        with:
-          toolchain: 1.91.1
       - name: Cache dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Run declarative tests

--- a/.github/workflows/update-cargo-toml-version.yml
+++ b/.github/workflows/update-cargo-toml-version.yml
@@ -23,9 +23,6 @@ jobs:
           sudo rm -rf "/usr/share/dotnet" || true
           sudo rm -rf "/usr/local/lib/android" || true
           sudo rm -rf "/usr/local/share/boost" || true
-      - uses: dtolnay/rust-toolchain@38ae5351029910ad7674ccfad89c37cbd636f3c4 # 1.91.1
-        with:
-          toolchain: 1.91.1
       - name: Install sd
         run: cargo install sd
       - name: Update Cargo.toml file

--- a/crates/index-scheduler/src/insta_snapshot.rs
+++ b/crates/index-scheduler/src/insta_snapshot.rs
@@ -248,7 +248,7 @@ pub fn snapshot_task(task: &Task) -> String {
         snap.push_str(&format!("error: {error:?}, "));
     }
     if let Some(details) = details {
-        snap.push_str(&format!("details: {}, ", &snapshot_details(details)));
+        snap.push_str(&format!("details: {}, ", snapshot_details(details)));
     }
     snap.push_str(&format!("kind: {kind:?}"));
     if let Some(network) = network {

--- a/crates/index-scheduler/src/scheduler/autobatcher.rs
+++ b/crates/index-scheduler/src/scheduler/autobatcher.rs
@@ -397,7 +397,7 @@ impl BatchKind {
             // we can autobatch different kind of document operations and mix replacements with updates
             (
                 BatchKind::DocumentOperation { allow_index_creation, primary_key: _, mut operation_ids },
-                K::DocumentImport { primary_key: _, .. },
+                K::DocumentImport { .. },
             ) => {
                 operation_ids.push(id);
                 Continue(BatchKind::DocumentOperation {

--- a/crates/meilisearch-types/src/tasks/network.rs
+++ b/crates/meilisearch-types/src/tasks/network.rs
@@ -435,7 +435,7 @@ impl NetworkTopologyChange {
                         ImportState::Ongoing { import_index_state: left_import, total_indexes: left_total_indexes },
                         ImportState::Ongoing { import_index_state: right_import, total_indexes: right_total_indexes },
                     ) => {
-                        let import_index_state = left_import.into_iter().merge_join_by(right_import.into_iter(), |(k,_), (x, _)|k.cmp(x)).map(|eob|
+                        let import_index_state = left_import.into_iter().merge_join_by(right_import, |(k,_), (x, _)|k.cmp(x)).map(|eob|
                             match eob {
                                 EitherOrBoth::Both((name, left), (_, right)) => {
                                     let newer = merge_import_index_state(left, right);

--- a/crates/meilisearch/src/documents_retrieval/preprocessing.rs
+++ b/crates/meilisearch/src/documents_retrieval/preprocessing.rs
@@ -145,7 +145,7 @@ async fn preprocess_filters_allowing_foreign_keys<Q: PreprocessableQuery>(
     Ok((
         queries
             .into_iter()
-            .zip(filters.into_iter())
+            .zip(filters)
             .map(|(query, filter)| PreprocessedQuery { query, filter })
             .collect(),
         remote_errors,
@@ -255,7 +255,7 @@ async fn local_process_foreign_filters(
             .iter()
             .fold(roaring::RoaringBitmap::new(), |bitmap, docids| bitmap | docids);
         if docids_to_fetch.len() > MAX_FOREIGN_FILTER_DOCIDS {
-            return Err(milli::Error::UserError(milli::UserError::InvalidFilter(
+            Err(milli::Error::UserError(milli::UserError::InvalidFilter(
                 format!("Foreign filter is retrieving too many documents, foreign filters can't retrieve more than {MAX_FOREIGN_FILTER_DOCIDS} documents per index"),
             )))?;
         }
@@ -269,7 +269,7 @@ async fn local_process_foreign_filters(
         }
 
         // Build the In filter for each filter
-        for (filter_index, docids) in filter_indices.iter().zip(filters_internal_docids.into_iter())
+        for (filter_index, docids) in filter_indices.iter().zip(filters_internal_docids)
         {
             let inner: Result<Vec<_>, _> = foreign_index.external_id_of(&foreign_rtxn, &fields_ids_map, docids)?.into_iter().map(|id| id.map(|id| id.into())).collect();
 
@@ -421,7 +421,7 @@ async fn filters_into_index_filters(
     };
 
     // build the index filters replacing the foreign filters with a IN filter containing the retrieved external docids
-    let mut in_iter = foreign_filters.into_iter().zip(foreign_filters_external_docids.into_iter());
+    let mut in_iter = foreign_filters.into_iter().zip(foreign_filters_external_docids);
     filters
         .into_iter()
         .map(|(_index_uid, filter)| {

--- a/crates/meilisearch/src/routes/indexes/documents.rs
+++ b/crates/meilisearch/src/routes/indexes/documents.rs
@@ -2301,7 +2301,7 @@ fn retrieve_documents<S: AsRef<str>>(
                 index,
                 rtxn,
                 fields_ids_map,
-                documents.into_iter(),
+                documents,
                 retrieve_vectors,
                 attributes_to_retrieve,
                 extra_attributes_to_retrieve,

--- a/crates/meilisearch/src/routes/metrics.rs
+++ b/crates/meilisearch/src/routes/metrics.rs
@@ -160,8 +160,8 @@ pub async fn get_metrics(
         crate::routes::indexes::Size::Human(_) => 0,
     };
 
-    crate::metrics::MEILISEARCH_DB_SIZE_BYTES.set(database_size as i64);
-    crate::metrics::MEILISEARCH_USED_DB_SIZE_BYTES.set(used_database_size as i64);
+    crate::metrics::MEILISEARCH_DB_SIZE_BYTES.set(database_size);
+    crate::metrics::MEILISEARCH_USED_DB_SIZE_BYTES.set(used_database_size);
     crate::metrics::MEILISEARCH_INDEX_COUNT.set(response.indexes.len() as i64);
 
     crate::metrics::MEILISEARCH_SEARCH_QUEUE_SIZE.set(search_queue.capacity() as i64);

--- a/crates/meilisearch/src/routes/network/mod.rs
+++ b/crates/meilisearch/src/routes/network/mod.rs
@@ -381,9 +381,8 @@ fn merge_networks(
     let mut merged_shards = match new_shards {
         Setting::Set(new_shards) => {
             let mut merged_shards = BTreeMap::new();
-            for either_or_both in old_shards
-                .into_iter()
-                .merge_join_by(new_shards.into_iter(), |left, right| left.0.cmp(&right.0))
+            for either_or_both in
+                old_shards.into_iter().merge_join_by(new_shards, |left, right| left.0.cmp(&right.0))
             {
                 match either_or_both {
                     EitherOrBoth::Both((name, old_shard), (_, Some(new_shard))) => {
@@ -409,7 +408,7 @@ fn merge_networks(
             let mut merged_remotes = BTreeMap::new();
             for either_or_both in old_remotes
                 .into_iter()
-                .merge_join_by(new_remotes.into_iter(), |left, right| left.0.cmp(&right.0))
+                .merge_join_by(new_remotes, |left, right| left.0.cmp(&right.0))
             {
                 match either_or_both {
                     EitherOrBoth::Both((key, old), (_, Some(new))) => {

--- a/crates/meilisearch/src/search/federated/perform.rs
+++ b/crates/meilisearch/src/search/federated/perform.rs
@@ -291,7 +291,7 @@ pub async fn perform_federated_search(
                     return None;
                 }
 
-                distinct_values.extend(facet_values.into_iter());
+                distinct_values.extend(facet_values);
             }
             Some(hit)
         })
@@ -1612,7 +1612,7 @@ impl SearchByIndex {
             let prev_documents_ids = std::mem::take(&mut result_by_query.documents_ids);
             let prev_scores = std::mem::take(&mut result_by_query.document_scores);
 
-            for (doc_id, score) in prev_documents_ids.into_iter().zip(prev_scores.into_iter()) {
+            for (doc_id, score) in prev_documents_ids.into_iter().zip(prev_scores) {
                 if let Some(ScoreDetails::Pin { position, precedence }) = score.first() {
                     let mut hit = result_by_query
                         .hit_maker

--- a/crates/meilisearch/tests/auth/api_keys.rs
+++ b/crates/meilisearch/tests/auth/api_keys.rs
@@ -415,7 +415,7 @@ async fn error_add_api_key_invalid_parameters_actions() {
         "expiresAt": "2050-11-13T00:00:00Z"
     });
     let (response, code) = server.add_api_key(content).await;
-    assert_eq!(400, code, "{:?}", &response);
+    assert_eq!(400, code, "{:?}", response);
 
     meili_snap::snapshot!(code, @"400 Bad Request");
     meili_snap::snapshot!(meili_snap::json_string!(response, { ".createdAt" => "[ignored]", ".updatedAt" => "[ignored]" }), @r###"

--- a/crates/meilisearch/tests/auth/authorization.rs
+++ b/crates/meilisearch/tests/auth/authorization.rs
@@ -174,7 +174,7 @@ async fn error_access_expired_key() {
     });
 
     let (response, code) = server.add_api_key(content).await;
-    assert_eq!(201, code, "{:?}", &response);
+    assert_eq!(201, code, "{:?}", response);
     assert!(response["key"].is_string());
 
     let key = response["key"].as_str().unwrap();
@@ -188,7 +188,7 @@ async fn error_access_expired_key() {
         response["message"] = serde_json::json!(null);
 
         assert_eq!(response, INVALID_RESPONSE.clone(), "on route: {:?} - {:?}", method, route);
-        assert_eq!(403, code, "{:?}", &response);
+        assert_eq!(403, code, "{:?}", response);
     }
 }
 
@@ -204,7 +204,7 @@ async fn error_access_unauthorized_index() {
     });
 
     let (response, code) = server.add_api_key(content).await;
-    assert_eq!(201, code, "{:?}", &response);
+    assert_eq!(201, code, "{:?}", response);
     assert!(response["key"].is_string());
 
     let key = response["key"].as_str().unwrap();
@@ -219,7 +219,7 @@ async fn error_access_unauthorized_index() {
         response["message"] = serde_json::json!(null);
 
         assert_eq!(response, INVALID_RESPONSE.clone(), "on route: {:?} - {:?}", method, route);
-        assert_eq!(403, code, "{:?}", &response);
+        assert_eq!(403, code, "{:?}", response);
     }
 }
 
@@ -241,7 +241,7 @@ async fn error_access_unauthorized_action() {
         });
 
         let (response, code) = server.add_api_key(content).await;
-        assert_eq!(201, code, "{:?}", &response);
+        assert_eq!(201, code, "{:?}", response);
         assert!(response["key"].is_string());
 
         let key = response["key"].as_str().unwrap();
@@ -250,7 +250,7 @@ async fn error_access_unauthorized_action() {
         response["message"] = serde_json::json!(null);
 
         assert_eq!(response, INVALID_RESPONSE.clone(), "on route: {:?} - {:?}", method, route);
-        assert_eq!(403, code, "{:?}", &response);
+        assert_eq!(403, code, "{:?}", response);
     }
 }
 
@@ -285,7 +285,7 @@ async fn access_authorized_restricted_index() {
         });
 
         let (response, code) = server.add_api_key(content).await;
-        assert_eq!(201, code, "{:?}", &response);
+        assert_eq!(201, code, "{:?}", response);
 
         assert!(response["key"].is_string());
 
@@ -307,7 +307,7 @@ async fn access_authorized_restricted_index() {
 
             if matches!(key_policy, IndexScopePolicy::Allow) {
                 // adding an API key is possible for this action
-                assert_eq!(201, code, "{:?}", &response);
+                assert_eq!(201, code, "{:?}", response);
                 assert!(response["key"].is_string());
 
                 let key = response["key"].as_str().unwrap();
@@ -369,7 +369,7 @@ async fn access_authorized_restricted_index() {
                 }
             } else {
                 // cannot add key for this action
-                assert_eq!(400, code, "{:?}", &response);
+                assert_eq!(400, code, "{:?}", response);
 
                 // test all_actions key
                 server.use_api_key(&all_actions_key);
@@ -410,7 +410,7 @@ async fn unauthorized_partial_actions() {
     // create index `products`
     let index = server.index("products");
     let (response, code) = index.create(Some("id")).await;
-    assert_eq!(202, code, "{:?}", &response);
+    assert_eq!(202, code, "{:?}", response);
     let task_id = response["taskUid"].as_u64().unwrap();
     server.wait_task(task_id).await.succeeded();
 
@@ -438,7 +438,7 @@ async fn unauthorized_partial_actions() {
                     });
 
                     let (response, code) = server.add_api_key(content).await;
-                    assert_eq!(201, code, "{:?}", &response);
+                    assert_eq!(201, code, "{:?}", response);
                     assert!(response["key"].is_string());
 
                     let key = response["key"].as_str().unwrap();
@@ -455,7 +455,7 @@ async fn unauthorized_partial_actions() {
                         route,
                         actions
                     );
-                    assert_eq!(code, 403, "{:?}", &response);
+                    assert_eq!(code, 403, "{:?}", response);
                 }
             }
         }
@@ -478,7 +478,7 @@ async fn access_authorized_no_index_restriction() {
             });
 
             let (response, code) = server.add_api_key(content).await;
-            assert_eq!(201, code, "{:?}", &response);
+            assert_eq!(201, code, "{:?}", response);
             assert!(response["key"].is_string());
 
             let key = response["key"].as_str().unwrap();
@@ -511,11 +511,11 @@ async fn access_authorized_stats_restricted_index() {
     // create index `test`
     let index = server.index("test");
     let (response, code) = index.create(Some("id")).await;
-    assert_eq!(202, code, "{:?}", &response);
+    assert_eq!(202, code, "{:?}", response);
     // create index `products`
     let index = server.index("products");
     let (response, code) = index.create(Some("product_id")).await;
-    assert_eq!(202, code, "{:?}", &response);
+    assert_eq!(202, code, "{:?}", response);
     let task_id = response["taskUid"].as_u64().unwrap();
     server.wait_task(task_id).await;
 
@@ -526,7 +526,7 @@ async fn access_authorized_stats_restricted_index() {
         "expiresAt": (OffsetDateTime::now_utc() + Duration::hours(1)).format(&Rfc3339).unwrap(),
     });
     let (response, code) = server.add_api_key(content).await;
-    assert_eq!(201, code, "{:?}", &response);
+    assert_eq!(201, code, "{:?}", response);
     assert!(response["key"].is_string());
 
     // use created key.
@@ -534,7 +534,7 @@ async fn access_authorized_stats_restricted_index() {
     server.use_api_key(key);
 
     let (response, code) = server.stats().await;
-    assert_eq!(200, code, "{:?}", &response);
+    assert_eq!(200, code, "{:?}", response);
 
     // key should have access on `products` index.
     assert!(response["indexes"].get("products").is_some());
@@ -551,11 +551,11 @@ async fn access_authorized_stats_no_index_restriction() {
     // create index `test`
     let index = server.index("test");
     let (response, code) = index.create(Some("id")).await;
-    assert_eq!(202, code, "{:?}", &response);
+    assert_eq!(202, code, "{:?}", response);
     // create index `products`
     let index = server.index("products");
     let (response, code) = index.create(Some("product_id")).await;
-    assert_eq!(202, code, "{:?}", &response);
+    assert_eq!(202, code, "{:?}", response);
     let task_id = response["taskUid"].as_u64().unwrap();
     server.wait_task(task_id).await;
 
@@ -566,7 +566,7 @@ async fn access_authorized_stats_no_index_restriction() {
         "expiresAt": (OffsetDateTime::now_utc() + Duration::hours(1)).format(&Rfc3339).unwrap(),
     });
     let (response, code) = server.add_api_key(content).await;
-    assert_eq!(201, code, "{:?}", &response);
+    assert_eq!(201, code, "{:?}", response);
     assert!(response["key"].is_string());
 
     // use created key.
@@ -574,7 +574,7 @@ async fn access_authorized_stats_no_index_restriction() {
     server.use_api_key(key);
 
     let (response, code) = server.stats().await;
-    assert_eq!(200, code, "{:?}", &response);
+    assert_eq!(200, code, "{:?}", response);
 
     // key should have access on `products` index.
     assert!(response["indexes"].get("products").is_some());
@@ -591,11 +591,11 @@ async fn list_authorized_indexes_restricted_index() {
     // create index `test`
     let index = server.index("test");
     let (response, code) = index.create(Some("id")).await;
-    assert_eq!(202, code, "{:?}", &response);
+    assert_eq!(202, code, "{:?}", response);
     // create index `products`
     let index = server.index("products");
     let (response, code) = index.create(Some("product_id")).await;
-    assert_eq!(202, code, "{:?}", &response);
+    assert_eq!(202, code, "{:?}", response);
     let task_id = response["taskUid"].as_u64().unwrap();
     server.wait_task(task_id).await;
 
@@ -606,7 +606,7 @@ async fn list_authorized_indexes_restricted_index() {
         "expiresAt": (OffsetDateTime::now_utc() + Duration::hours(1)).format(&Rfc3339).unwrap(),
     });
     let (response, code) = server.add_api_key(content).await;
-    assert_eq!(201, code, "{:?}", &response);
+    assert_eq!(201, code, "{:?}", response);
     assert!(response["key"].is_string());
 
     // use created key.
@@ -614,7 +614,7 @@ async fn list_authorized_indexes_restricted_index() {
     server.use_api_key(key);
 
     let (response, code) = server.list_indexes(None, None).await;
-    assert_eq!(200, code, "{:?}", &response);
+    assert_eq!(200, code, "{:?}", response);
 
     let response = response["results"].as_array().unwrap();
     // key should have access on `products` index.
@@ -632,11 +632,11 @@ async fn list_authorized_indexes_no_index_restriction() {
     // create index `test`
     let index = server.index("test");
     let (response, code) = index.create(Some("id")).await;
-    assert_eq!(202, code, "{:?}", &response);
+    assert_eq!(202, code, "{:?}", response);
     // create index `products`
     let index = server.index("products");
     let (response, code) = index.create(Some("product_id")).await;
-    assert_eq!(202, code, "{:?}", &response);
+    assert_eq!(202, code, "{:?}", response);
     let task_id = response["taskUid"].as_u64().unwrap();
     server.wait_task(task_id).await;
 
@@ -647,7 +647,7 @@ async fn list_authorized_indexes_no_index_restriction() {
         "expiresAt": (OffsetDateTime::now_utc() + Duration::hours(1)).format(&Rfc3339).unwrap(),
     });
     let (response, code) = server.add_api_key(content).await;
-    assert_eq!(201, code, "{:?}", &response);
+    assert_eq!(201, code, "{:?}", response);
     assert!(response["key"].is_string());
 
     // use created key.
@@ -655,7 +655,7 @@ async fn list_authorized_indexes_no_index_restriction() {
     server.use_api_key(key);
 
     let (response, code) = server.list_indexes(None, None).await;
-    assert_eq!(200, code, "{:?}", &response);
+    assert_eq!(200, code, "{:?}", response);
 
     let response = response["results"].as_array().unwrap();
     // key should have access on `products` index.
@@ -673,12 +673,12 @@ async fn access_authorized_index_patterns() {
     // create products_1 index
     let index_1 = server.index("products_1");
     let (response, code) = index_1.create(Some("id")).await;
-    assert_eq!(202, code, "{:?}", &response);
+    assert_eq!(202, code, "{:?}", response);
 
     // create products index
     let index_ = server.index("products");
     let (response, code) = index_.create(Some("id")).await;
-    assert_eq!(202, code, "{:?}", &response);
+    assert_eq!(202, code, "{:?}", response);
 
     // create key with all document access on indices with product_* pattern.
     let content = json!({
@@ -689,7 +689,7 @@ async fn access_authorized_index_patterns() {
 
     // Register the key
     let (response, code) = server.add_api_key(content).await;
-    assert_eq!(201, code, "{:?}", &response);
+    assert_eq!(201, code, "{:?}", response);
     assert!(response["key"].is_string());
 
     // use created key.
@@ -711,12 +711,12 @@ async fn access_authorized_index_patterns() {
 
     // Adding document to products_1 index. Should succeed with 202
     let (response, code) = index_1.add_documents(documents.clone(), None).await;
-    assert_eq!(202, code, "{:?}", &response);
+    assert_eq!(202, code, "{:?}", response);
     let task_id = response["taskUid"].as_u64().unwrap();
 
     // Adding document to products index. Should Fail with 403 -- invalid_api_key
     let (response, code) = index_.add_documents(documents, None).await;
-    assert_eq!(403, code, "{:?}", &response);
+    assert_eq!(403, code, "{:?}", response);
 
     server.use_api_key(MASTER_KEY);
 
@@ -726,7 +726,7 @@ async fn access_authorized_index_patterns() {
     server.wait_task(task_id).await;
 
     let (response, code) = index_1.get_task(task_id).await;
-    assert_eq!(200, code, "{:?}", &response);
+    assert_eq!(200, code, "{:?}", response);
     assert_eq!(response["status"], "succeeded");
 }
 
@@ -738,17 +738,17 @@ async fn raise_error_non_authorized_index_patterns() {
     // create products_1 index
     let product_1_index = server.index("products_1");
     let (response, code) = product_1_index.create(Some("id")).await;
-    assert_eq!(202, code, "{:?}", &response);
+    assert_eq!(202, code, "{:?}", response);
 
     // create products_2 index
     let product_2_index = server.index("products_2");
     let (response, code) = product_2_index.create(Some("id")).await;
-    assert_eq!(202, code, "{:?}", &response);
+    assert_eq!(202, code, "{:?}", response);
 
     // create test index
     let test_index = server.index("test");
     let (response, code) = test_index.create(Some("id")).await;
-    assert_eq!(202, code, "{:?}", &response);
+    assert_eq!(202, code, "{:?}", response);
 
     // create key with all document access on indices with product_* pattern.
     let content = json!({
@@ -759,7 +759,7 @@ async fn raise_error_non_authorized_index_patterns() {
 
     // Register the key
     let (response, code) = server.add_api_key(content).await;
-    assert_eq!(201, code, "{:?}", &response);
+    assert_eq!(201, code, "{:?}", response);
     assert!(response["key"].is_string());
 
     // use created key.
@@ -783,17 +783,17 @@ async fn raise_error_non_authorized_index_patterns() {
 
     // Adding document to products_1 index. Should succeed with 202
     let (response, code) = product_1_index.add_documents(documents.clone(), None).await;
-    assert_eq!(202, code, "{:?}", &response);
+    assert_eq!(202, code, "{:?}", response);
     let task1_id = response["taskUid"].as_u64().unwrap();
 
     // Adding document to products_2 index. Should succeed with 202
     let (response, code) = product_2_index.add_documents(documents.clone(), None).await;
-    assert_eq!(202, code, "{:?}", &response);
+    assert_eq!(202, code, "{:?}", response);
     let task2_id = response["taskUid"].as_u64().unwrap();
 
     // Adding a document to test index. Should Fail with 403 -- invalid_api_key
     let (response, code) = test_index.add_documents(documents, None).await;
-    assert_eq!(403, code, "{:?}", &response);
+    assert_eq!(403, code, "{:?}", response);
 
     server.use_api_key(MASTER_KEY);
 
@@ -806,11 +806,11 @@ async fn raise_error_non_authorized_index_patterns() {
     server.wait_task(task2_id).await;
 
     let (response, code) = product_1_index.get_task(task1_id).await;
-    assert_eq!(200, code, "{:?}", &response);
+    assert_eq!(200, code, "{:?}", response);
     assert_eq!(response["status"], "succeeded");
 
     let (response, code) = product_1_index.get_task(task2_id).await;
-    assert_eq!(200, code, "{:?}", &response);
+    assert_eq!(200, code, "{:?}", response);
     assert_eq!(response["status"], "succeeded");
 }
 
@@ -829,24 +829,24 @@ async fn pattern_indexes() {
 
     // Generate and use the api key
     let (response, code) = server.add_api_key(content).await;
-    assert_eq!(201, code, "{:?}", &response);
+    assert_eq!(201, code, "{:?}", response);
     let key = response["key"].as_str().expect("Key is not string");
     server.use_api_key(key);
 
     // Create Index products_1 using generated api key
     let products_1 = server.index("products_1");
     let (response, code) = products_1.create(Some("id")).await;
-    assert_eq!(202, code, "{:?}", &response);
+    assert_eq!(202, code, "{:?}", response);
 
     // Fail to create products_* using generated api key
     let products_1 = server.index("products_*");
     let (response, code) = products_1.create(Some("id")).await;
-    assert_eq!(400, code, "{:?}", &response);
+    assert_eq!(400, code, "{:?}", response);
 
     // Fail to create test_1 using generated api key
     let products_1 = server.index("test_1");
     let (response, code) = products_1.create(Some("id")).await;
-    assert_eq!(403, code, "{:?}", &response);
+    assert_eq!(403, code, "{:?}", response);
 }
 
 #[actix_rt::test]
@@ -857,11 +857,11 @@ async fn list_authorized_tasks_restricted_index() {
     // create index `test`
     let index = server.index("test");
     let (response, code) = index.create(Some("id")).await;
-    assert_eq!(202, code, "{:?}", &response);
+    assert_eq!(202, code, "{:?}", response);
     // create index `products`
     let index = server.index("products");
     let (response, code) = index.create(Some("product_id")).await;
-    assert_eq!(202, code, "{:?}", &response);
+    assert_eq!(202, code, "{:?}", response);
     let task_id = response["taskUid"].as_u64().unwrap();
     server.wait_task(task_id).await;
 
@@ -872,7 +872,7 @@ async fn list_authorized_tasks_restricted_index() {
         "expiresAt": (OffsetDateTime::now_utc() + Duration::hours(1)).format(&Rfc3339).unwrap(),
     });
     let (response, code) = server.add_api_key(content).await;
-    assert_eq!(201, code, "{:?}", &response);
+    assert_eq!(201, code, "{:?}", response);
     assert!(response["key"].is_string());
 
     // use created key.
@@ -880,7 +880,7 @@ async fn list_authorized_tasks_restricted_index() {
     server.use_api_key(key);
 
     let (response, code) = server.service.get("/tasks").await;
-    assert_eq!(200, code, "{:?}", &response);
+    assert_eq!(200, code, "{:?}", response);
     let response = response["results"].as_array().unwrap();
     // key should have access on `products` index.
     assert!(response.iter().any(|task| task["indexUid"] == "products"));
@@ -897,11 +897,11 @@ async fn list_authorized_tasks_no_index_restriction() {
     // create index `test`
     let index = server.index("test");
     let (response, code) = index.create(Some("id")).await;
-    assert_eq!(202, code, "{:?}", &response);
+    assert_eq!(202, code, "{:?}", response);
     // create index `products`
     let index = server.index("products");
     let (response, code) = index.create(Some("product_id")).await;
-    assert_eq!(202, code, "{:?}", &response);
+    assert_eq!(202, code, "{:?}", response);
     let task_id = response["taskUid"].as_u64().unwrap();
     server.wait_task(task_id).await;
 
@@ -912,7 +912,7 @@ async fn list_authorized_tasks_no_index_restriction() {
         "expiresAt": (OffsetDateTime::now_utc() + Duration::hours(1)).format(&Rfc3339).unwrap(),
     });
     let (response, code) = server.add_api_key(content).await;
-    assert_eq!(201, code, "{:?}", &response);
+    assert_eq!(201, code, "{:?}", response);
     assert!(response["key"].is_string());
 
     // use created key.
@@ -920,7 +920,7 @@ async fn list_authorized_tasks_no_index_restriction() {
     server.use_api_key(key);
 
     let (response, code) = server.service.get("/tasks").await;
-    assert_eq!(200, code, "{:?}", &response);
+    assert_eq!(200, code, "{:?}", response);
 
     let response = response["results"].as_array().unwrap();
     // key should have access on `products` index.
@@ -939,8 +939,8 @@ async fn error_creating_index_without_action() {
     let create_index_actions = AUTHORIZATIONS
         .get(&("POST", "/indexes", IndexScopePolicy::Allow))
         .unwrap()
-        .iter()
-        .flat_map(|(s, _)| s.iter())
+        .keys()
+        .flat_map(|s| s.iter())
         .cloned()
         .collect::<HashSet<_>>();
     let content = json!({
@@ -950,7 +950,7 @@ async fn error_creating_index_without_action() {
         "expiresAt": "2050-11-13T00:00:00Z"
     });
     let (response, code) = server.add_api_key(content).await;
-    assert_eq!(201, code, "{:?}", &response);
+    assert_eq!(201, code, "{:?}", response);
     assert!(response["key"].is_string());
 
     // use created key.
@@ -974,7 +974,7 @@ async fn error_creating_index_without_action() {
     ]);
 
     let (response, code) = index.add_documents(documents, None).await;
-    assert_eq!(202, code, "{:?}", &response);
+    assert_eq!(202, code, "{:?}", response);
     let task_id = response["taskUid"].as_u64().unwrap();
 
     let response = server.wait_task(task_id).await;
@@ -985,7 +985,7 @@ async fn error_creating_index_without_action() {
     let settings = json!({ "distinctAttribute": "test"});
 
     let (response, code) = index.update_settings(settings).await;
-    assert_eq!(202, code, "{:?}", &response);
+    assert_eq!(202, code, "{:?}", response);
     let task_id = response["taskUid"].as_u64().unwrap();
 
     let response = server.wait_task(task_id).await;
@@ -995,7 +995,7 @@ async fn error_creating_index_without_action() {
 
     // try to create a index via add specialized settings route
     let (response, code) = index.update_distinct_attribute(json!("test")).await;
-    assert_eq!(202, code, "{:?}", &response);
+    assert_eq!(202, code, "{:?}", response);
     let task_id = response["taskUid"].as_u64().unwrap();
 
     let response = server.wait_task(task_id).await;
@@ -1030,7 +1030,7 @@ async fn lazy_create_index() {
     for content in contents {
         server.use_api_key(MASTER_KEY);
         let (response, code) = server.add_api_key(content).await;
-        assert_eq!(201, code, "{:?}", &response);
+        assert_eq!(201, code, "{:?}", response);
         assert!(response["key"].is_string());
 
         // use created key.
@@ -1047,13 +1047,13 @@ async fn lazy_create_index() {
         ]);
 
         let (response, code) = index.add_documents(documents, None).await;
-        assert_eq!(202, code, "{:?}", &response);
+        assert_eq!(202, code, "{:?}", response);
         let task_id = response["taskUid"].as_u64().unwrap();
 
         server.wait_task(task_id).await;
 
         let (response, code) = index.get_task(task_id).await;
-        assert_eq!(200, code, "{:?}", &response);
+        assert_eq!(200, code, "{:?}", response);
         assert_eq!(response["status"], "succeeded");
 
         // try to create a index via add settings route
@@ -1061,25 +1061,25 @@ async fn lazy_create_index() {
         let settings = json!({ "distinctAttribute": "test"});
 
         let (response, code) = index.update_settings(settings).await;
-        assert_eq!(202, code, "{:?}", &response);
+        assert_eq!(202, code, "{:?}", response);
         let task_id = response["taskUid"].as_u64().unwrap();
 
         server.wait_task(task_id).await;
 
         let (response, code) = index.get_task(task_id).await;
-        assert_eq!(200, code, "{:?}", &response);
+        assert_eq!(200, code, "{:?}", response);
         assert_eq!(response["status"], "succeeded");
 
         // try to create a index via add specialized settings route
         let index = server.index("test2");
         let (response, code) = index.update_distinct_attribute(json!("test")).await;
-        assert_eq!(202, code, "{:?}", &response);
+        assert_eq!(202, code, "{:?}", response);
         let task_id = response["taskUid"].as_u64().unwrap();
 
         server.wait_task(task_id).await;
 
         let (response, code) = index.get_task(task_id).await;
-        assert_eq!(200, code, "{:?}", &response);
+        assert_eq!(200, code, "{:?}", response);
         assert_eq!(response["status"], "succeeded");
     }
 }
@@ -1110,7 +1110,7 @@ async fn lazy_create_index_from_pattern() {
     for content in contents {
         server.use_api_key(MASTER_KEY);
         let (response, code) = server.add_api_key(content).await;
-        assert_eq!(201, code, "{:?}", &response);
+        assert_eq!(201, code, "{:?}", response);
         assert!(response["key"].is_string());
 
         // use created key.
@@ -1128,31 +1128,31 @@ async fn lazy_create_index_from_pattern() {
         ]);
 
         let (response, code) = index.add_documents(documents.clone(), None).await;
-        assert_eq!(202, code, "{:?}", &response);
+        assert_eq!(202, code, "{:?}", response);
         let task_id = response["taskUid"].as_u64().unwrap();
 
         server.wait_task(task_id).await;
 
         let (response, code) = index.get_task(task_id).await;
-        assert_eq!(200, code, "{:?}", &response);
+        assert_eq!(200, code, "{:?}", response);
         assert_eq!(response["status"], "succeeded");
 
         // Fail to create test index
         let (response, code) = test.add_documents(documents, None).await;
-        assert_eq!(403, code, "{:?}", &response);
+        assert_eq!(403, code, "{:?}", response);
 
         // try to create a index via add settings route
         let index = server.index("products_2");
         let settings = json!({ "distinctAttribute": "test"});
 
         let (response, code) = index.update_settings(settings).await;
-        assert_eq!(202, code, "{:?}", &response);
+        assert_eq!(202, code, "{:?}", response);
         let task_id = response["taskUid"].as_u64().unwrap();
 
         server.wait_task(task_id).await;
 
         let (response, code) = index.get_task(task_id).await;
-        assert_eq!(200, code, "{:?}", &response);
+        assert_eq!(200, code, "{:?}", response);
         assert_eq!(response["status"], "succeeded");
 
         // Fail to create test index
@@ -1161,18 +1161,18 @@ async fn lazy_create_index_from_pattern() {
         let settings = json!({ "distinctAttribute": "test"});
 
         let (response, code) = index.update_settings(settings).await;
-        assert_eq!(403, code, "{:?}", &response);
+        assert_eq!(403, code, "{:?}", response);
 
         // try to create a index via add specialized settings route
         let index = server.index("products_3");
         let (response, code) = index.update_distinct_attribute(json!("test")).await;
-        assert_eq!(202, code, "{:?}", &response);
+        assert_eq!(202, code, "{:?}", response);
         let task_id = response["taskUid"].as_u64().unwrap();
 
         server.wait_task(task_id).await;
 
         let (response, code) = index.get_task(task_id).await;
-        assert_eq!(200, code, "{:?}", &response);
+        assert_eq!(200, code, "{:?}", response);
         assert_eq!(response["status"], "succeeded");
 
         // Fail to create test index
@@ -1180,7 +1180,7 @@ async fn lazy_create_index_from_pattern() {
         let settings = json!({ "distinctAttribute": "test"});
 
         let (response, code) = index.update_settings(settings).await;
-        assert_eq!(403, code, "{:?}", &response);
+        assert_eq!(403, code, "{:?}", response);
     }
 }
 
@@ -1197,7 +1197,7 @@ async fn error_creating_index_without_index() {
     });
 
     let (response, code) = server.add_api_key(content).await;
-    assert_eq!(201, code, "{:?}", &response);
+    assert_eq!(201, code, "{:?}", response);
     assert!(response["key"].is_string());
 
     // use created key.
@@ -1214,23 +1214,23 @@ async fn error_creating_index_without_index() {
     ]);
 
     let (response, code) = index.add_documents(documents, None).await;
-    assert_eq!(403, code, "{:?}", &response);
+    assert_eq!(403, code, "{:?}", response);
 
     // try to create a index via add settings route
     let index = server.index("test1");
     let settings = json!({ "distinctAttribute": "test"});
     let (response, code) = index.update_settings(settings).await;
-    assert_eq!(403, code, "{:?}", &response);
+    assert_eq!(403, code, "{:?}", response);
 
     // try to create a index via add specialized settings route
     let index = server.index("test2");
     let (response, code) = index.update_distinct_attribute(json!("test")).await;
-    assert_eq!(403, code, "{:?}", &response);
+    assert_eq!(403, code, "{:?}", response);
 
     // try to create a index via create index route
     let index = server.index("test3");
     let (response, code) = index.create(None).await;
-    assert_eq!(403, code, "{:?}", &response);
+    assert_eq!(403, code, "{:?}", response);
 
     // try to create a index via add documents route
     let index = server.index("products");
@@ -1242,21 +1242,21 @@ async fn error_creating_index_without_index() {
     ]);
 
     let (response, code) = index.add_documents(documents, None).await;
-    assert_eq!(403, code, "{:?}", &response);
+    assert_eq!(403, code, "{:?}", response);
 
     // try to create a index via add settings route
     let index = server.index("products");
     let settings = json!({ "distinctAttribute": "test"});
     let (response, code) = index.update_settings(settings).await;
-    assert_eq!(403, code, "{:?}", &response);
+    assert_eq!(403, code, "{:?}", response);
 
     // try to create a index via add specialized settings route
     let index = server.index("products");
     let (response, code) = index.update_distinct_attribute(json!("test")).await;
-    assert_eq!(403, code, "{:?}", &response);
+    assert_eq!(403, code, "{:?}", response);
 
     // try to create a index via create index route
     let index = server.index("products");
     let (response, code) = index.create(None).await;
-    assert_eq!(403, code, "{:?}", &response);
+    assert_eq!(403, code, "{:?}", response);
 }

--- a/crates/meilisearch/tests/auth/tenant_token.rs
+++ b/crates/meilisearch/tests/auth/tenant_token.rs
@@ -468,7 +468,7 @@ async fn error_access_forbidden_routes() {
     server.use_api_key(&web_token);
 
     for ((method, route, _), actions) in AUTHORIZATIONS.iter() {
-        let actions = actions.iter().flat_map(|(s, _)| s.iter()).copied().collect::<HashSet<_>>();
+        let actions = actions.keys().flat_map(|s| s.iter()).copied().collect::<HashSet<_>>();
         if !actions.contains("search") {
             let (mut response, code) = server.dummy_request(method, route).await;
             response["message"] = serde_json::json!(null);

--- a/crates/meilisearch/tests/documents/add_documents.rs
+++ b/crates/meilisearch/tests/documents/add_documents.rs
@@ -2945,7 +2945,7 @@ async fn batch_several_documents_addition() {
     let (response, _code) = index.filtered_tasks(&[], &["failed"], &[]).await;
 
     // Check if only the 6th task failed
-    println!("{}", &response);
+    println!("{}", response);
     assert_eq!(response["results"].as_array().unwrap().len(), 5);
 
     // Check if there are exactly 120 documents (150 - 30) in the index;

--- a/crates/meilisearch/tests/search/filters.rs
+++ b/crates/meilisearch/tests/search/filters.rs
@@ -1209,7 +1209,7 @@ async fn vector_filter_regenerate() {
 
     let (value, _code) = index
         .search_post(json!({
-            "filter": format!("_vectors.rest.regenerate EXISTS"),
+            "filter": "_vectors.rest.regenerate EXISTS".to_string(),
             "attributesToRetrieve": ["name"]
         }))
         .await;

--- a/crates/milli/src/dynamic_search_rules.rs
+++ b/crates/milli/src/dynamic_search_rules.rs
@@ -390,8 +390,7 @@ impl<'a> DynamicSearchRulesView<'a> {
                     k => {
                         for word_rules in words_rules.iter().combinations(k.into()) {
                             verifying_constraints_rules |= roaring::MultiOps::intersection(
-                                std::iter::once(&constraint_count_rules)
-                                    .chain(word_rules.into_iter()),
+                                std::iter::once(&constraint_count_rules).chain(word_rules),
                             );
                             if fuel.consume_word_combination().is_break() {
                                 break;
@@ -508,7 +507,7 @@ impl<'a> DynamicSearchRulesView<'a> {
                         break;
                     }
                     verifying_constraints_rules |= roaring::MultiOps::intersection(
-                        std::iter::once(&constraint_count_rules).chain(combination.into_iter()),
+                        std::iter::once(&constraint_count_rules).chain(combination),
                     );
                 }
             }

--- a/crates/milli/src/search/facet/filter/index_filter.rs
+++ b/crates/milli/src/search/facet/filter/index_filter.rs
@@ -76,7 +76,7 @@ impl IndexFilter {
             }
 
             // If the field is not filterable, return an error
-            return Err(fid.to_external_error(FilterError::AttributeNotFilterable {
+            Err(fid.to_external_error(FilterError::AttributeNotFilterable {
                 attribute,
                 filterable_patterns: filtered_matching_patterns(
                     &filterable_attributes_rules,
@@ -482,17 +482,17 @@ impl IndexFilter {
                 let base_point: [f64; 2] =
                     [point[0].parse_finite_float()?, point[1].parse_finite_float()?];
                 if !(-90.0..=90.0).contains(&base_point[0]) {
-                    return Err(point[0].to_external_error(BadGeoError::Lat(base_point[0])))?;
+                    Err(point[0].to_external_error(BadGeoError::Lat(base_point[0])))?;
                 }
                 if !(-180.0..=180.0).contains(&base_point[1]) {
-                    return Err(point[1].to_external_error(BadGeoError::Lng(base_point[1])))?;
+                    Err(point[1].to_external_error(BadGeoError::Lng(base_point[1])))?;
                 }
                 let radius = radius.parse_finite_float()?;
                 let mut resolution = 125;
                 if let Some(res_token) = res_token {
                     resolution = res_token.parse_finite_float()? as usize;
                     if !(3..=1000).contains(&resolution) {
-                        return Err(
+                        Err(
                             res_token.to_external_error(BadGeoError::InvalidResolution(resolution))
                         )?;
                     }
@@ -554,27 +554,19 @@ impl IndexFilter {
                     bottom_left_point[1].parse_finite_float()?,
                 ];
                 if !(-90.0..=90.0).contains(&top_right[0]) {
-                    return Err(
-                        top_right_point[0].to_external_error(BadGeoError::Lat(top_right[0]))
-                    )?;
+                    Err(top_right_point[0].to_external_error(BadGeoError::Lat(top_right[0])))?;
                 }
                 if !(-180.0..=180.0).contains(&top_right[1]) {
-                    return Err(
-                        top_right_point[1].to_external_error(BadGeoError::Lng(top_right[1]))
-                    )?;
+                    Err(top_right_point[1].to_external_error(BadGeoError::Lng(top_right[1])))?;
                 }
                 if !(-90.0..=90.0).contains(&bottom_left[0]) {
-                    return Err(
-                        bottom_left_point[0].to_external_error(BadGeoError::Lat(bottom_left[0]))
-                    )?;
+                    Err(bottom_left_point[0].to_external_error(BadGeoError::Lat(bottom_left[0])))?;
                 }
                 if !(-180.0..=180.0).contains(&bottom_left[1]) {
-                    return Err(
-                        bottom_left_point[1].to_external_error(BadGeoError::Lng(bottom_left[1]))
-                    )?;
+                    Err(bottom_left_point[1].to_external_error(BadGeoError::Lng(bottom_left[1])))?;
                 }
                 if top_right[0] < bottom_left[0] {
-                    return Err(bottom_left_point[1].to_external_error(
+                    Err(bottom_left_point[1].to_external_error(
                         BadGeoError::BoundingBoxTopIsBelowBottom(top_right[0], bottom_left[0]),
                     ))?;
                 }
@@ -712,15 +704,13 @@ impl IndexFilter {
             }
             IndexFilterCondition::GeoPolygon { points } => {
                 if !index.is_geojson_filtering_enabled(rtxn)? {
-                    return Err(points[0][0].to_external_error(
-                        FilterError::AttributeNotFilterable {
-                            attribute: RESERVED_GEOJSON_FIELD_NAME,
-                            filterable_patterns: filtered_matching_patterns(
-                                filterable_attribute_rules,
-                                &|features| features.is_filterable(),
-                            ),
-                        },
-                    ))?;
+                    Err(points[0][0].to_external_error(FilterError::AttributeNotFilterable {
+                        attribute: RESERVED_GEOJSON_FIELD_NAME,
+                        filterable_patterns: filtered_matching_patterns(
+                            filterable_attribute_rules,
+                            &|features| features.is_filterable(),
+                        ),
+                    }))?;
                 }
 
                 let mut coords = Vec::new();
@@ -728,10 +718,10 @@ impl IndexFilter {
                     let lat = lat_token.parse_finite_float()?;
                     let lng = lng_token.parse_finite_float()?;
                     if !(-90.0..=90.0).contains(&lat) {
-                        return Err(lat_token.to_external_error(BadGeoError::Lat(lat)))?;
+                        Err(lat_token.to_external_error(BadGeoError::Lat(lat)))?;
                     }
                     if !(-180.0..=180.0).contains(&lng) {
-                        return Err(lng_token.to_external_error(BadGeoError::Lng(lng)))?;
+                        Err(lng_token.to_external_error(BadGeoError::Lng(lng)))?;
                     }
                     coords.push(geo_types::Coord { x: lng, y: lat });
                 }

--- a/crates/milli/src/search/new/mod.rs
+++ b/crates/milli/src/search/new/mod.rs
@@ -543,11 +543,11 @@ fn get_ranking_rules_for_query_graph_search<'ctx>(
             | crate::Criterion::AttributeRank
             | crate::Criterion::WordPosition
             | crate::Criterion::Proximity
-            | crate::Criterion::Exactness => {
-                if !words {
-                    ranking_rules.push(Box::new(Words::new(terms_matching_strategy)));
-                    words = true;
-                }
+            | crate::Criterion::Exactness
+                if !words =>
+            {
+                ranking_rules.push(Box::new(Words::new(terms_matching_strategy)));
+                words = true;
             }
             _ => {}
         }

--- a/crates/milli/src/search/new/ranking_rule_graph/dead_ends_cache.rs
+++ b/crates/milli/src/search/new/ranking_rule_graph/dead_ends_cache.rs
@@ -57,10 +57,9 @@ impl<T> DeadEndsCache<T> {
     ) -> Option<SmallBitmap<T>> {
         let mut cursor = self;
         for c in prefix {
-            if let Some(next) = cursor.advance(c) {
+            {
+                let next = cursor.advance(c)?;
                 cursor = next;
-            } else {
-                return None;
             }
         }
         Some(cursor.forbidden.clone())

--- a/crates/milli/src/update/index_documents/transform.rs
+++ b/crates/milli/src/update/index_documents/transform.rs
@@ -225,7 +225,7 @@ impl<'a, 'i> Transform<'a, 'i> {
             // Insertion in a obkv need to be done with keys ordered. For now they are ordered
             // according to the document addition key order, so we sort it according to the
             // fieldids map keys order.
-            field_buffer_cache.sort_unstable_by(|(f1, _), (f2, _)| f1.cmp(f2));
+            field_buffer_cache.sort_unstable_by_key(|(f1, _)| *f1);
 
             // Build the new obkv document.
             let mut writer = KvWriter::new(&mut obkv_buffer);
@@ -920,8 +920,8 @@ impl<'a, 'i> Transform<'a, 'i> {
                     &settings_diff,
                     injected_vectors,
                     old_vectors_fid,
-                    Some(&mut original_obkv_buffer).filter(|_| original_sorter.is_some()),
-                    Some(&mut flattened_obkv_buffer).filter(|_| flattened_sorter.is_some()),
+                    original_sorter.is_some().then_some(&mut original_obkv_buffer),
+                    flattened_sorter.is_some().then_some(&mut flattened_obkv_buffer),
                 )?;
 
                 if let Some(original_sorter) = original_sorter.as_mut() {

--- a/crates/milli/src/update/settings.rs
+++ b/crates/milli/src/update/settings.rs
@@ -604,7 +604,7 @@ impl<'a, 't, 'i> Settings<'a, 't, 'i> {
 
                 // since we can't compare a BTreeSet with an FST we are going to convert the
                 // BTreeSet to an FST and then compare bytes per bytes the two FSTs.
-                let fst = fst::Set::from_iter(stop_words.into_iter())?;
+                let fst = fst::Set::from_iter(stop_words)?;
 
                 // Does the new FST differ from the previous one?
                 if current
@@ -1133,9 +1133,8 @@ impl<'a, 't, 'i> Settings<'a, 't, 'i> {
             .collect();
         let mut updated_configs = BTreeMap::new();
         let mut embedder_actions = BTreeMap::new();
-        for joined in old_configs
-            .into_iter()
-            .merge_join_by(configs.into_iter(), |(left, _), (right, _)| left.cmp(right))
+        for joined in
+            old_configs.into_iter().merge_join_by(configs, |(left, _), (right, _)| left.cmp(right))
         {
             match joined {
                 // updated config

--- a/crates/milli/src/vector/json_template/mod.rs
+++ b/crates/milli/src/vector/json_template/mod.rs
@@ -62,12 +62,12 @@ impl Error {
     /// Produces an error message when the error happened at rendering time.
     pub fn rendering_error(&self, root: &str) -> String {
         if self.path.is_empty() {
-            format!("error while rendering template: {}", &self.template_error)
+            format!("error while rendering template: {}", self.template_error)
         } else {
             format!(
                 "in `{}`, error while rendering template: {}",
                 path_with_root(root, self.path.iter()),
-                &self.template_error
+                self.template_error
             )
         }
     }
@@ -75,12 +75,12 @@ impl Error {
     /// Produces an error message when the error happened at parsing time.
     pub fn parsing_error(&self, root: &str) -> String {
         if self.path.is_empty() {
-            format!("error while parsing template: {}", &self.template_error)
+            format!("error while parsing template: {}", self.template_error)
         } else {
             format!(
                 "in `{}`, error while parsing template: {}",
                 path_with_root(root, self.path.iter()),
-                &self.template_error
+                self.template_error
             )
         }
     }

--- a/crates/milli/tests/search/query_criteria.rs
+++ b/crates/milli/tests/search/query_criteria.rs
@@ -244,7 +244,7 @@ fn criteria_mixup() {
 
     let config = IndexerConfig::default();
     for criteria in criteria_mix {
-        eprintln!("Testing with criteria order: {:?}", &criteria);
+        eprintln!("Testing with criteria order: {:?}", criteria);
         //update criteria
         let mut wtxn = index.write_txn().unwrap();
         let mut builder = Settings::new(&mut wtxn, &index, &config);
@@ -395,7 +395,7 @@ fn criteria_ascdesc() {
     let documents = index.all_documents(&rtxn).unwrap().map(|doc| doc.unwrap()).collect::<Vec<_>>();
 
     for criterion in [Asc(S("name")), Desc(S("name")), Asc(S("age")), Desc(S("age"))] {
-        eprintln!("Testing with criterion: {:?}", &criterion);
+        eprintln!("Testing with criterion: {:?}", criterion);
 
         let mut wtxn = index.write_txn().unwrap();
         let mut builder = Settings::new(&mut wtxn, &index, &config);

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "1.91.1"
-components = ["clippy"]
+components = ["clippy", "rustfmt"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.98.0"
+channel = "1.98.1"
 components = ["clippy", "rustfmt"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.91.1"
+channel = "1.98.0"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Simplify CI by removing dtolnay's GH action. This means that changing the Rust version now solely happens in a single place: the `rust-toolchain.toml` file.

This is particularly useful now that we're using SHA1 rather than tags to specify the version of an action.

## Why does this work?

Apparently, the GH runners ship with `rustup`. Any `cargo` invocation made in the repo's directory will download the toolchain specified in `rust-toolchain.toml`. I just had to explicitly specify the `rustfmt` component in the `components` list, otherwise it was not getting installed.

## What about the future incompatibility lint?

The future incompatibility lint is triggered by a dependency of charabia. charabia 0.10.0 fixes the issue. #6602  handles the upgrade of charabia

## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respect the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - *list of used tools and what they were used for*
