### PR TITLE
fix: return proper NDJSON from get task documents route

### DIFF
--- a/crates/meilisearch/src/routes/tasks.rs
+++ b/crates/meilisearch/src/routes/tasks.rs
@@ -12,7 +12,7 @@ use meilisearch_types::batches::BatchId;
 use meilisearch_types::deserr::query_params::Param;
 use meilisearch_types::deserr::DeserrQueryParamError;
 use meilisearch_types::error::deserr_codes::*;
-use meilisearch_types::error::{InvalidTaskDateError, ResponseError};
+use meilisearch_types::error::{Code, InvalidTaskDateError, ResponseError};
 use meilisearch_types::index_uid::IndexUid;
 use meilisearch_types::star_or::{OptionStarOr, OptionStarOrList};
 use meilisearch_types::task_view::TaskView;
@@ -804,7 +804,22 @@ async fn get_task_documents_file(
                 // disk but it's really (really) complex to do with the current state of async Rust.
                 let mut content = String::new();
                 tfile.read_to_string(&mut content).await?;
-                Ok(HttpResponse::Ok().content_type("application/x-ndjson").body(content))
+
+                // The update file can store the documents as concatenated JSON objects
+                // (when they were added from a JSON array or CSV payload) rather than
+                // newline-delimited JSON. Re-serialize each object followed by a newline
+                // so the response body actually matches the declared `application/x-ndjson`
+                // content type instead of returning invalid NDJSON.
+                let mut ndjson = String::with_capacity(content.len());
+                let mut deserializer = serde_json::Deserializer::from_str(&content);
+                for value in deserializer.into_iter::<serde_json::Value>() {
+                    let value = value
+                        .map_err(|e| ResponseError::from_msg(e.to_string(), Code::Internal))?;
+                    serde_json::to_writer(&mut ndjson, &value)
+                        .map_err(|e| ResponseError::from_msg(e.to_string(), Code::Internal))?;
+                    ndjson.push('\n');
+                }
+                Ok(HttpResponse::Ok().content_type("application/x-ndjson").body(ndjson))
             }
             None => Err(index_scheduler::Error::TaskFileNotFound(task_uid).into()),
         }


### PR DESCRIPTION
### What does this PR do?

Fixes #6379. The `GET /tasks/{uid}/documents` route declared `Content-Type: application/x-ndjson` but the response body was not guaranteed to be valid NDJSON.

When documents were added as a JSON array or CSV, `read_json`/`read_csv` writes each object via `serde_json::to_writer` without a trailing newline, producing concatenated JSON (`{...}{...}{...}`). The route returned this raw file content with `application/x-ndjson` — a mismatch between the declared content type and the actual body.

### Fix

In `get_task_documents_file`, after reading the update file, re-serialize each JSON object followed by a newline character. This ensures the response body is always valid NDJSON regardless of how the documents were originally uploaded. Since `serde_json` is configured with `preserve_order`, the field order in each document is preserved.

### File changed

- `crates/meilisearch/src/routes/tasks.rs`: reformat the stored concatenated JSON as proper NDJSON before returning.