### PR TITLE
docs: fix typo accross -> across

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -141,8 +141,8 @@ They are JSON files with the following structure (comments are not actually supp
   "assets": {
     // name of the asset.
     // Must be unique at the workload level.
-    // For better results, the same asset (same sha256) should have the same name accross workloads.
-    // Having multiple assets with the same name and distinct hashes is supported accross workloads,
+    // For better results, the same asset (same sha256) should have the same name across workloads.
+    // Having multiple assets with the same name and distinct hashes is supported across workloads,
     // but will lead to superfluous downloads.
     //
     // Assets are stored in the `bench/assets/` directory by default.


### PR DESCRIPTION
Corrects the misspelling `accross` -> `across` in `BENCHMARKS.md`.

Documentation only, no behaviour change.