### PR TITLE
Trigger task cleanup before the task DB fills up

### DIFF
--- a/crates/index-scheduler/src/queue/mod.rs
+++ b/crates/index-scheduler/src/queue/mod.rs
@@ -286,10 +286,13 @@ impl Queue {
     }
 
     /// Register a task to cleanup the task queue if needed
-    pub fn cleanup_task_queue(&self, wtxn: &mut RwTxn) -> Result<()> {
+    pub fn cleanup_task_queue(
+        &self,
+        wtxn: &mut RwTxn,
+        task_database_is_almost_full: bool,
+    ) -> Result<()> {
         let nb_tasks = self.tasks.all_task_ids(wtxn)?.len();
-        // if we have less than 1M tasks everything is fine
-        if nb_tasks < self.max_number_of_tasks as u64 {
+        if nb_tasks < self.max_number_of_tasks as u64 && !task_database_is_almost_full {
             return Ok(());
         }
 

--- a/crates/index-scheduler/src/queue/test.rs
+++ b/crates/index-scheduler/src/queue/test.rs
@@ -132,10 +132,11 @@ fn test_auto_deletion_of_tasks() {
 }
 
 #[test]
-fn test_task_queue_is_full() {
+fn test_auto_deletion_when_task_database_is_almost_full() {
     let (index_scheduler, mut handle) = IndexScheduler::test_with_custom_config(vec![], |config| {
         // that's the minimum map size possible
         config.task_db_size = 1048576 * 3;
+        config.max_number_of_tasks = usize::MAX;
         None
     });
 
@@ -143,30 +144,56 @@ fn test_task_queue_is_full() {
         .register(KindWithContent::IndexCreation { index_uid: S("doggo"), primary_key: None })
         .unwrap();
     handle.advance_one_successful_batch();
-    // on average this task takes ~600 bytes
-    loop {
-        let result = index_scheduler
-            .register(KindWithContent::IndexCreation { index_uid: S("doggo"), primary_key: None });
-        if result.is_err() {
-            break;
-        }
+    while index_scheduler.remaining_size_until_task_queue_stop().unwrap() > 0 {
+        index_scheduler
+            .register(KindWithContent::IndexCreation { index_uid: S("doggo"), primary_key: None })
+            .unwrap();
         handle.advance_one_failed_batch();
     }
     index_scheduler.assert_internally_consistent();
 
-    // at this point the task DB shoud have reached its limit and we should not be able to register new tasks
-    let result = index_scheduler
-        .register(KindWithContent::IndexCreation { index_uid: S("doggo"), primary_key: None })
-        .unwrap_err();
-    snapshot!(result, @"Meilisearch cannot receive write operations because the limit of the task database has been reached. Please delete tasks to continue performing write operations.");
-    // we won't be able to test this error in an integration test thus as a best effort test I still ensure the error return the expected error code
-    snapshot!(format!("{:?}", result.error_code()), @"NoSpaceLeftOnDevice");
+    handle.advance_one_successful_batch();
+    let rtxn = index_scheduler.env.read_txn().unwrap();
+    let cleanup_tasks = index_scheduler
+        .queue
+        .tasks
+        .get_existing_tasks(&rtxn, index_scheduler.queue.tasks.all_task_ids(&rtxn).unwrap())
+        .unwrap()
+        .into_iter()
+        .filter(|task| matches!(task.kind, KindWithContent::TaskDeletion { .. }))
+        .count();
+    assert_eq!(cleanup_tasks, 1);
+    drop(rtxn);
 
-    // Even the task deletion and cancelation that don't delete anything should be refused
+    index_scheduler
+        .register(KindWithContent::IndexCreation { index_uid: S("doggo"), primary_key: None })
+        .unwrap();
+}
+
+#[test]
+fn test_task_queue_is_full_without_finished_tasks() {
+    let (index_scheduler, _handle) = IndexScheduler::test_with_custom_config(vec![], |config| {
+        config.task_db_size = 1048576 * 3;
+        None
+    });
+
+    let error = loop {
+        match index_scheduler
+            .register(KindWithContent::IndexCreation { index_uid: S("doggo"), primary_key: None })
+        {
+            Ok(_) => continue,
+            Err(error) => break error,
+        }
+    };
+
+    snapshot!(error, @"Meilisearch cannot receive write operations because the limit of the task database has been reached. Please delete tasks to continue performing write operations.");
+    snapshot!(format!("{:?}", error.error_code()), @"NoSpaceLeftOnDevice");
+
     let result = index_scheduler
         .register(KindWithContent::TaskDeletion { query: S("test"), tasks: RoaringBitmap::new() })
         .unwrap_err();
     snapshot!(result, @"Meilisearch cannot receive write operations because the limit of the task database has been reached. Please delete tasks to continue performing write operations.");
+
     let result = index_scheduler
         .register(KindWithContent::TaskCancelation {
             query: S("test"),
@@ -175,30 +202,7 @@ fn test_task_queue_is_full() {
         .unwrap_err();
     snapshot!(result, @"Meilisearch cannot receive write operations because the limit of the task database has been reached. Please delete tasks to continue performing write operations.");
 
-    // we won't be able to test this error in an integration test thus as a best effort test I still ensure the error return the expected error code
-    snapshot!(format!("{:?}", result.error_code()), @"NoSpaceLeftOnDevice");
-
-    // But a task cancelation that cancel something should work
     index_scheduler
         .register(KindWithContent::TaskCancelation { query: S("test"), tasks: (0..100).collect() })
         .unwrap();
-    handle.advance_one_successful_batch();
-
-    // But we should still be forbidden from enqueuing new tasks
-    let result = index_scheduler
-        .register(KindWithContent::IndexCreation { index_uid: S("doggo"), primary_key: None })
-        .unwrap_err();
-    snapshot!(result, @"Meilisearch cannot receive write operations because the limit of the task database has been reached. Please delete tasks to continue performing write operations.");
-
-    // And a task deletion that delete something should works
-    index_scheduler
-        .register(KindWithContent::TaskDeletion { query: S("test"), tasks: (0..100).collect() })
-        .unwrap();
-    handle.advance_one_successful_batch();
-
-    // Now we should be able to enqueue a few tasks again
-    index_scheduler
-        .register(KindWithContent::IndexCreation { index_uid: S("doggo"), primary_key: None })
-        .unwrap();
-    handle.advance_one_failed_batch();
 }

--- a/crates/index-scheduler/src/scheduler/mod.rs
+++ b/crates/index-scheduler/src/scheduler/mod.rs
@@ -174,8 +174,9 @@ impl IndexScheduler {
 
         let previous_processing_batch = self.processing_tasks.write().unwrap().stop_processing();
 
+        let task_database_is_almost_full = self.remaining_size_until_task_queue_stop()? == 0;
         let mut wtxn = self.env.write_txn()?;
-        self.queue.cleanup_task_queue(&mut wtxn)?;
+        self.queue.cleanup_task_queue(&mut wtxn, task_database_is_almost_full)?;
         wtxn.commit()?;
 
         let rtxn = self.env.read_txn().map_err(Error::HeedTransaction)?;


### PR DESCRIPTION
## Related issue

Follow-up to #3622.

## What does this PR do?

Task cleanup currently starts after the queue reaches one million tasks. The task database can hit its storage threshold before that when tasks are larger, which stops regular writes even when there are finished tasks that could be removed.

This also starts cleanup when the task database reaches the existing write-stop threshold. If there are no finished tasks to delete, the current database-full behavior is preserved.

## Requirements

- [x] Automated tests have been added.
- [ ] If some tests cannot be automated, manual rigorous tests should be applied.
- [ ] If there is any change in the DB:
    - [ ] Test that any impacted DB still works as expected after using `--upgrade-db` on a DB created with the last released Meilisearch
    - [ ] Test that during the upgrade, search is still available
    - [ ] Set the `db change` label.
- [ ] If necessary, the feature has been tested in the Cloud production environment and the Cloud UI is ready.
- [ ] If necessary, the related documentation is ready.
- [ ] If necessary, the related integrations are ready.

## Test

`cargo test -p index-scheduler queue::test::test_ -- --test-threads=1`
