### PR TITLE
Upgrade apk packages in Dockerfile to fix known CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 # Compile
 FROM    rust:1.89-alpine3.22 AS compiler
 
-RUN     apk add -q --no-cache build-base openssl-dev
+RUN     apk upgrade -q --no-cache \
+        && apk add -q --no-cache build-base openssl-dev
 
 WORKDIR /
 
@@ -24,7 +25,8 @@ LABEL   org.opencontainers.image.source="https://github.com/meilisearch/meilisea
 ENV     MEILI_HTTP_ADDR 0.0.0.0:7700
 ENV     MEILI_SERVER_PROVIDER docker
 
-RUN     apk add -q --no-cache libgcc tini curl
+RUN     apk upgrade -q --no-cache \
+        && apk add -q --no-cache libgcc tini curl
 
 # add meilisearch and meilitool to the `/bin` so you can run it from anywhere
 # and it's easy to find.


### PR DESCRIPTION
## Related issue

No dedicated issue was open for this specific fix. It's a small, self-contained security hardening change (Dockerfile-only), similar in scope to #4781.

## What does this PR do?

Fixes HIGH/CRITICAL vulnerabilities flagged by Trivy in the published Docker image, without changing the pinned Alpine version.

Both stages of the Dockerfile install packages with `apk add --no-cache`, but that only fetches the latest index for the packages being newly added — it doesn't upgrade packages already baked into the base image layers (`rust:1.89-alpine3.22` and `alpine:3.22`). As a result, `binutils`, `musl`/`musl-utils`, `openssl` (libssl3/libcrypto3), and `zlib` stay pinned to whatever was current when those upstream base images were last published, even though patched versions of all of them are already available in the same `alpine:3.22` apk repository.

This adds `apk upgrade -q --no-cache` before `apk add` in both the `compiler` and final stages, so the build always picks up the latest available packages for the pinned Alpine branch.

### Before (Trivy, HIGH/CRITICAL only)
- `rust:1.89-alpine3.22` (compiler stage): 23 vulnerabilities (21 HIGH, 2 CRITICAL) — binutils (CVE-2025-5244, CVE-2025-5245), openssl (CVE-2026-31789 critical, plus several more), musl (CVE-2026-40200), zlib (CVE-2026-22184).
- Final `alpine:3.22` image: 2 HIGH — libssl3/libcrypto3 (CVE-2026-14456).

### After
- Built and scanned the resulting `meilisearch` image locally with Trivy: **0 vulnerabilities at any severity**.
- Verified `docker build --build-arg EXTRA_ARGS=""` completes successfully and the resulting binary runs (`meilisearch --version`).

### Functional verification

Ran the built image as a real container (`docker run -p ...:7700 -e MEILI_MASTER_KEY=...`) and exercised the HTTP API end-to-end:
- `GET /health` → `{"status":"available"}`
- `GET /version` → 200, reports `1.53.1`
- `POST /indexes` → index created, task enqueued and completed
- `POST /indexes/movies/documents` → 2 documents indexed successfully
- `POST /indexes/movies/search` → correct hit returned for a partial-word query
- `curl` from inside the container against `/health` works (used for container healthchecks)
- Confirmed `tini` is PID 1 and forwards `SIGTERM` correctly: `docker stop` shut the server down cleanly (exit code 143, no hang, no forced kill needed)

No functional regressions observed from the package upgrades.

## Generative AI disclosure

Claude Code was used to research the vulnerabilities (via Trivy), draft the Dockerfile change, and validate it (local Docker build + Trivy re-scan) before opening this PR. No Rust source code was touched or generated; the change is limited to the Dockerfile.

## PR checklist
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
