### PR TITLE
Remove 100ms penalty on task replication

### DIFF
--- a/crates/index-scheduler/src/lib.rs
+++ b/crates/index-scheduler/src/lib.rs
@@ -35,6 +35,7 @@ mod queue;
 mod scheduler;
 #[cfg(test)]
 mod test_utils;
+pub mod timeouts;
 pub mod upgrade;
 mod utils;
 pub mod uuid_codec;
@@ -364,6 +365,9 @@ impl IndexScheduler {
         let scheduler = Scheduler::new(&options, auth_env);
 
         let web_client = http_client::reqwest::ClientBuilder::new()
+            .prepare(|build| {
+                build.connect_timeout(std::time::Duration::from_secs(*timeouts::CONNECT_SECONDS))
+            })
             .build_with_policies(scheduler.ip_policy.clone(), Default::default())
             .unwrap();
 

--- a/crates/index-scheduler/src/scheduler/enterprise_edition/network.rs
+++ b/crates/index-scheduler/src/scheduler/enterprise_edition/network.rs
@@ -488,9 +488,7 @@ impl IndexScheduler {
         in_name: String,
         origin: &Origin,
     ) -> crate::Result<()> {
-        let client = http_client::reqwest::ClientBuilder::new()
-            .build_with_policies(self.ip_policy().clone(), Default::default())
-            .unwrap();
+        let client = self.web_client();
 
         let body = route::NetworkChange {
             origin: origin.clone(),

--- a/crates/index-scheduler/src/timeouts.rs
+++ b/crates/index-scheduler/src/timeouts.rs
@@ -1,0 +1,22 @@
+use std::sync::LazyLock;
+
+pub static CONNECT_SECONDS: LazyLock<u64> =
+    LazyLock::new(|| fetch_or_default("MEILI_EXPERIMENTAL_PROXY_CONNECT_TIMEOUT_SECONDS", 3));
+
+pub static BACKOFF_SECONDS: LazyLock<u64> =
+    LazyLock::new(|| fetch_or_default("MEILI_EXPERIMENTAL_PROXY_BACKOFF_TIMEOUT_SECONDS", 25));
+
+pub static REQUEST_SECONDS: LazyLock<u64> =
+    LazyLock::new(|| fetch_or_default("MEILI_EXPERIMENTAL_PROXY_REQUEST_TIMEOUT_SECONDS", 30));
+
+fn fetch_or_default(key: &str, default: u64) -> u64 {
+    match std::env::var(key) {
+        Ok(timeout) => timeout.parse().unwrap_or_else(|_| {
+            panic!("`{key}` environment variable is not parseable as an integer: {timeout}")
+        }),
+        Err(std::env::VarError::NotPresent) => default,
+        Err(std::env::VarError::NotUnicode(_)) => {
+            panic!("`{key}` environment variable is not set to a integer")
+        }
+    }
+}

--- a/crates/meilisearch/src/proxy/enterprise_edition.rs
+++ b/crates/meilisearch/src/proxy/enterprise_edition.rs
@@ -26,31 +26,6 @@ use crate::error::MeilisearchHttpError;
 use crate::proxy::{Body, Endpoint, ProxyError, ReqwestErrorWithoutUrl};
 use crate::routes::SummarizedTaskView;
 
-mod timeouts {
-    use std::sync::LazyLock;
-
-    pub static CONNECT_SECONDS: LazyLock<u64> =
-        LazyLock::new(|| fetch_or_default("MEILI_EXPERIMENTAL_PROXY_CONNECT_TIMEOUT_SECONDS", 3));
-
-    pub static BACKOFF_SECONDS: LazyLock<u64> =
-        LazyLock::new(|| fetch_or_default("MEILI_EXPERIMENTAL_PROXY_BACKOFF_TIMEOUT_SECONDS", 25));
-
-    pub static REQUEST_SECONDS: LazyLock<u64> =
-        LazyLock::new(|| fetch_or_default("MEILI_EXPERIMENTAL_PROXY_REQUEST_TIMEOUT_SECONDS", 30));
-
-    fn fetch_or_default(key: &str, default: u64) -> u64 {
-        match std::env::var(key) {
-            Ok(timeout) => timeout.parse().unwrap_or_else(|_| {
-                panic!("`{key}` environment variable is not parseable as an integer: {timeout}")
-            }),
-            Err(std::env::VarError::NotPresent) => default,
-            Err(std::env::VarError::NotUnicode(_)) => {
-                panic!("`{key}` environment variable is not set to a integer")
-            }
-        }
-    }
-}
-
 impl<T, F> Body<T, F>
 where
     T: serde::Serialize,
@@ -253,7 +228,7 @@ where
 
                     let backoff = backoff::ExponentialBackoffBuilder::new()
                         .with_max_elapsed_time(Some(std::time::Duration::from_secs(
-                            *timeouts::BACKOFF_SECONDS,
+                            *index_scheduler::timeouts::BACKOFF_SECONDS,
                         )))
                         .build();
 
@@ -370,7 +345,9 @@ where
     let api_key = remote.write_api_key.clone();
 
     let backoff = backoff::ExponentialBackoffBuilder::new()
-        .with_max_elapsed_time(Some(std::time::Duration::from_secs(*timeouts::BACKOFF_SECONDS)))
+        .with_max_elapsed_time(Some(std::time::Duration::from_secs(
+            *index_scheduler::timeouts::BACKOFF_SECONDS,
+        )))
         .build();
 
     backoff::future::retry(backoff, move || {
@@ -384,8 +361,9 @@ where
 
         async move {
             let request = client.request(method, url).prepare(|request| {
-                let request =
-                    request.timeout(std::time::Duration::from_secs(*timeouts::REQUEST_SECONDS));
+                let request = request.timeout(std::time::Duration::from_secs(
+                    *index_scheduler::timeouts::REQUEST_SECONDS,
+                ));
                 let request = if let Some(body) = body { request.body(body) } else { request };
                 let request = if let Some(api_key) = api_key {
                     request.bearer_auth(api_key)
@@ -473,7 +451,8 @@ async fn try_proxy(
     body: Option<Bytes>,
 ) -> Result<SummarizedTaskView, backoff::Error<ProxyError>> {
     let request = client.request(method, url).prepare(|request| {
-        let request = request.timeout(std::time::Duration::from_secs(*timeouts::REQUEST_SECONDS));
+        let request = request
+            .timeout(std::time::Duration::from_secs(*index_scheduler::timeouts::REQUEST_SECONDS));
         let request = if let Some(body) = body { request.body(body) } else { request };
         let request =
             if let Some(api_key) = api_key { request.bearer_auth(api_key) } else { request };

--- a/crates/meilisearch/src/proxy/enterprise_edition.rs
+++ b/crates/meilisearch/src/proxy/enterprise_edition.rs
@@ -9,7 +9,7 @@ use actix_http::uri::PathAndQuery;
 use actix_web::http::header::CONTENT_TYPE;
 use actix_web::HttpRequest;
 use bytes::Bytes;
-use http_client::reqwest::{ClientBuilder, StatusCode};
+use http_client::reqwest::StatusCode;
 use index_scheduler::{IndexScheduler, ReqwestRequestWrapper};
 use meilisearch_types::error::ResponseError;
 use meilisearch_types::network::{route, Remote};
@@ -189,12 +189,7 @@ where
         };
 
         let mut in_flight_remote_queries = BTreeMap::new();
-        let client = ClientBuilder::new()
-            .prepare(|inner| {
-                inner.connect_timeout(std::time::Duration::from_secs(*timeouts::CONNECT_SECONDS))
-            })
-            .build_with_policies(index_scheduler.ip_policy().clone(), Default::default())
-            .unwrap();
+        let client = index_scheduler.web_client();
 
         let method = req.method();
 
@@ -302,13 +297,13 @@ where
 }
 
 pub async fn send_request<T, F, U>(
+    index_scheduler: &IndexScheduler,
     path_and_query: PathAndQuery,
     method: http_client::reqwest::Method,
     content_type: Option<String>,
     body: Body<T, F>,
     remote_name: &str,
     remote: &Remote,
-    ip_policy: http_client::policy::IpPolicy,
 ) -> Result<U, ProxyError>
 where
     T: serde::Serialize,
@@ -324,12 +319,7 @@ where
 
     let body = body.into_bytes(remote_name, remote).map_err(Box::new)?;
 
-    let client = ClientBuilder::new()
-        .prepare(|inner| {
-            inner.connect_timeout(std::time::Duration::from_secs(*timeouts::CONNECT_SECONDS))
-        })
-        .build_with_policies(ip_policy, Default::default())
-        .unwrap();
+    let client = index_scheduler.web_client();
 
     let url = route::url_from_base_and_route(&remote.url, path_and_query).map_err(|err| {
         Box::new(index_scheduler::Error::InvalidRemoteUrl {

--- a/crates/meilisearch/src/routes/network/enterprise_edition.rs
+++ b/crates/meilisearch/src/routes/network/enterprise_edition.rs
@@ -123,7 +123,6 @@ async fn patch_network_without_origin(
         }
 
         let mut kept_leader = false;
-        let ip_policy = index_scheduler.ip_policy().clone();
 
         futures::stream::iter(
             old_network
@@ -146,18 +145,18 @@ async fn patch_network_without_origin(
                 }),
         )
         .try_for_each_concurrent(Some(40), |(remote_name, remote, allow_unreachable)| {
-            let ip_policy = ip_policy.clone();
+            let index_scheduler = index_scheduler.clone();
             async move {
                 {
                     // 1. check that the experimental feature is enabled
                     let remote_features: RuntimeTogglableFeatures = match proxy::send_request(
+                        &index_scheduler,
                         PathAndQuery::from_static("/experimental-features"),
                         http_client::reqwest::Method::GET,
                         None,
                         Body::none(),
                         remote_name,
                         remote,
-                        ip_policy.clone(),
                     )
                     .await
                     {
@@ -179,13 +178,13 @@ async fn patch_network_without_origin(
 
                     // 2. check whether there are any unfinished network task
                     let network_tasks: AllTasks = match proxy::send_request(
+                        &index_scheduler,
                         PathAndQuery::from_static("/tasks?types=networkTopologyChange&statuses=enqueued,processing&limit=1"),
                         http_client::reqwest::Method::GET,
                         None,
                         Body::none(),
                         remote_name,
                         remote,
-                        ip_policy,
                     )
                     .await
                     {


### PR DESCRIPTION
This PR removes a 100ms penalty on task replication (document addition, settings change, etc) that could block the actix workers.

This is the same improvement as in https://github.com/meilisearch/meilisearch/pull/6229

## Generative AI tools

- [x] This PR does not use generative AI tooling
- [ ] This PR uses generative AI tooling and respect the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - *list of used tools and what they were used for*
