### PR TITLE
Add context for CorruptedTaskQueue error in message

### DIFF
--- a/crates/index-scheduler/src/error.rs
+++ b/crates/index-scheduler/src/error.rs
@@ -170,8 +170,8 @@ pub enum Error {
     // Irrecoverable errors:
     #[error(transparent)]
     CreateBatch(Box<Self>),
-    #[error("Corrupted task queue.")]
-    CorruptedTaskQueue,
+    #[error("Corrupted task queue in {file}: {message}.")]
+    CorruptedTaskQueue { file: &'static str, message: String },
     #[error(transparent)]
     DatabaseUpgrade(Box<Self>),
     #[error(transparent)]
@@ -278,7 +278,7 @@ impl Error {
             | Error::RequiresEnterpriseEdition { .. }
             | Error::Anyhow(_) => true,
             Error::CreateBatch(_)
-            | Error::CorruptedTaskQueue
+            | Error::CorruptedTaskQueue { .. }
             | Error::DatabaseUpgrade(_)
             | Error::UnrecoverableError(_)
             | Error::IndexSchedulerVersionMismatch { .. }
@@ -366,7 +366,7 @@ impl ErrorCode for Error {
 
             // Irrecoverable errors
             Error::Anyhow(_) => Code::Internal,
-            Error::CorruptedTaskQueue => Code::Internal,
+            Error::CorruptedTaskQueue { .. } => Code::Internal,
             Error::CorruptedDump => Code::Internal,
             Error::DatabaseUpgrade(_) => Code::Internal,
             Error::Export(_) => Code::Internal,

--- a/crates/index-scheduler/src/lib.rs
+++ b/crates/index-scheduler/src/lib.rs
@@ -1016,7 +1016,11 @@ impl IndexScheduler {
             &mut network_task.kind
         else {
             tracing::error!("unexpected network kind for network task while registering task");
-            return Err(Error::CorruptedTaskQueue);
+            return Err(Error::CorruptedTaskQueue {
+                file: file!(),
+                message: "Unexpected network kind for network task while registering task"
+                    .to_string(),
+            });
         };
 
         let o = update_fn(network_topology_change)?;
@@ -1079,7 +1083,15 @@ impl IndexScheduler {
                                 .tasks
                                 .get_task(self.rtxn, task_id)
                                 .map_err(io::Error::other)?
-                                .ok_or_else(|| io::Error::other(Error::CorruptedTaskQueue))?;
+                                .ok_or_else(|| {
+                                    io::Error::other(Error::CorruptedTaskQueue {
+                                        file: file!(),
+                                        message: format!(
+                                            "Task content not found for uid `{}` when notifying webhooks",
+                                            task_id
+                                        ),
+                                    })
+                                })?;
 
                             serde_json::to_writer(&mut self.buffer, &TaskView::from_task(&task))?;
                             self.buffer.push(b'\n');

--- a/crates/index-scheduler/src/queue/batches.rs
+++ b/crates/index-scheduler/src/queue/batches.rs
@@ -299,8 +299,12 @@ impl BatchQueue {
                     }
                     Ok(batch)
                 } else {
-                    self.get_batch(rtxn, batch_id)
-                        .and_then(|batch| batch.ok_or(Error::CorruptedTaskQueue))
+                    self.get_batch(rtxn, batch_id).and_then(|batch| {
+                        batch.ok_or_else(|| Error::CorruptedTaskQueue {
+                            file: file!(),
+                            message: format!("Batch content not found for uid `{batch_id}` when getting existing batches"),
+                        })
+                    })
                 }
             })
             .collect::<Result<_>>()

--- a/crates/index-scheduler/src/queue/mod.rs
+++ b/crates/index-scheduler/src/queue/mod.rs
@@ -190,10 +190,12 @@ impl Queue {
         tasks
             .into_iter()
             .map(|task_id| {
-                let mut task = self
-                    .tasks
-                    .get_task(rtxn, task_id)
-                    .and_then(|task| task.ok_or(Error::CorruptedTaskQueue));
+                let mut task = self.tasks.get_task(rtxn, task_id).and_then(|task| {
+                    task.ok_or_else(|| Error::CorruptedTaskQueue {
+                        file: file!(),
+                        message: format!("Task content not found for uid `{}` when getting existing tasks for processing batch", task_id),
+                    })
+                });
                 processing_batch.processing(&mut task);
                 task
             })
@@ -315,8 +317,15 @@ impl Queue {
 
         // it's safe to unwrap here because we checked the len above
         let newest_task_id = to_delete.iter().next_back().unwrap();
-        let last_task_to_delete =
-            self.tasks.get_task(wtxn, newest_task_id)?.ok_or(Error::CorruptedTaskQueue)?;
+        let last_task_to_delete = self.tasks.get_task(wtxn, newest_task_id)?.ok_or_else(|| {
+            Error::CorruptedTaskQueue {
+                file: file!(),
+                message: format!(
+                    "Task content not found for uid `{}` when getting the last task to delete",
+                    newest_task_id
+                ),
+            }
+        })?;
 
         // increase time by one nanosecond so that the enqueuedAt of the last task to delete is also lower than that date.
         let delete_before = last_task_to_delete.enqueued_at + Duration::from_nanos(1);
@@ -326,7 +335,12 @@ impl Queue {
             &KindWithContent::TaskDeletion {
                 query: format!(
                     "?beforeEnqueuedAt={}&statuses=succeeded,failed,canceled",
-                    delete_before.format(&Rfc3339).map_err(|_| Error::CorruptedTaskQueue)?,
+                    delete_before.format(&Rfc3339).map_err(|_| Error::CorruptedTaskQueue {
+                        file: file!(),
+                        message:
+                            "Failed to format beforeEnqueuedAt when registering a task deletion"
+                                .to_string(),
+                    })?,
                 ),
                 tasks: to_delete,
             },

--- a/crates/index-scheduler/src/queue/tasks.rs
+++ b/crates/index-scheduler/src/queue/tasks.rs
@@ -114,7 +114,10 @@ impl TaskQueue {
     ///
     /// - CorruptedTaskQueue: The task doesn't exist in the database
     pub(crate) fn update_task(&self, wtxn: &mut RwTxn, task: &mut Task) -> Result<()> {
-        let old_task = self.get_task(wtxn, task.uid)?.ok_or(Error::CorruptedTaskQueue)?;
+        let old_task = self.get_task(wtxn, task.uid)?.ok_or_else(|| Error::CorruptedTaskQueue {
+            file: file!(),
+            message: format!("Task content not found for uid `{}` when updating task", task.uid),
+        })?;
         // network topology tasks may be processed multiple times.
         let maybe_reprocessing = old_task.status != Status::Enqueued
             || task.kind.as_kind() == Kind::NetworkTopologyChange;
@@ -288,7 +291,15 @@ impl TaskQueue {
         tasks
             .into_iter()
             .map(|task_id| {
-                self.get_task(rtxn, task_id).and_then(|task| task.ok_or(Error::CorruptedTaskQueue))
+                self.get_task(rtxn, task_id).and_then(|task| {
+                    task.ok_or_else(|| Error::CorruptedTaskQueue {
+                        file: file!(),
+                        message: format!(
+                            "Task content not found for uid `{}` when getting existing tasks",
+                            task_id
+                        ),
+                    })
+                })
             })
             .collect::<Result<_>>()
     }

--- a/crates/index-scheduler/src/scheduler/create_batch.rs
+++ b/crates/index-scheduler/src/scheduler/create_batch.rs
@@ -288,8 +288,12 @@ impl IndexScheduler {
                 must_create_index,
             })),
             BatchKind::DocumentEdition { id } => {
-                let mut task =
-                    self.queue.tasks.get_task(rtxn, id)?.ok_or(Error::CorruptedTaskQueue)?;
+                let mut task = self.queue.tasks.get_task(rtxn, id)?.ok_or_else(|| {
+                    Error::CorruptedTaskQueue {
+                        file: file!(),
+                        message: format!("Task content not found for uid `{}` when creating next batch index for document edition", id),
+                    }
+                })?;
                 current_batch.processing(Some(&mut task));
                 match &task.kind {
                     KindWithContent::DocumentEdition { index_uid, .. } => {
@@ -448,8 +452,12 @@ impl IndexScheduler {
                 }))
             }
             BatchKind::IndexCreation { id } => {
-                let mut task =
-                    self.queue.tasks.get_task(rtxn, id)?.ok_or(Error::CorruptedTaskQueue)?;
+                let mut task = self.queue.tasks.get_task(rtxn, id)?.ok_or_else(|| {
+                    Error::CorruptedTaskQueue {
+                        file: file!(),
+                        message: format!("Task content not found for uid `{}` when creating next batch index for index creation", id),
+                    }
+                })?;
                 current_batch.processing(Some(&mut task));
                 let (index_uid, primary_key) = match &task.kind {
                     KindWithContent::IndexCreation { index_uid, primary_key } => {
@@ -460,8 +468,12 @@ impl IndexScheduler {
                 Ok(Some(Batch::IndexCreation { index_uid, primary_key, task }))
             }
             BatchKind::IndexUpdate { id } => {
-                let mut task =
-                    self.queue.tasks.get_task(rtxn, id)?.ok_or(Error::CorruptedTaskQueue)?;
+                let mut task = self.queue.tasks.get_task(rtxn, id)?.ok_or_else(|| {
+                    Error::CorruptedTaskQueue {
+                        file: file!(),
+                        message: format!("Task content not found for uid `{}` when creating next batch index for index update", id),
+                    }
+                })?;
                 current_batch.processing(Some(&mut task));
                 let (primary_key, new_index_uid) = match &task.kind {
                     KindWithContent::IndexUpdate { primary_key, new_index_uid, .. } => {
@@ -481,8 +493,12 @@ impl IndexScheduler {
                 )?,
             })),
             BatchKind::IndexSwap { id } => {
-                let mut task =
-                    self.queue.tasks.get_task(rtxn, id)?.ok_or(Error::CorruptedTaskQueue)?;
+                let mut task = self.queue.tasks.get_task(rtxn, id)?.ok_or_else(|| {
+                    Error::CorruptedTaskQueue {
+                        file: file!(),
+                        message: format!("Task content not found for uid `{}` when creating next batch index for index swap", id),
+                    }
+                })?;
                 current_batch.processing(Some(&mut task));
                 Ok(Some(Batch::IndexSwap { task }))
             }
@@ -538,8 +554,15 @@ impl IndexScheduler {
         // 0. we get the last task to cancel.
         let to_cancel = self.queue.tasks.get_kind(rtxn, Kind::TaskCancelation)? & enqueued;
         if let Some(task_id) = to_cancel.max() {
-            let mut task =
-                self.queue.tasks.get_task(rtxn, task_id)?.ok_or(Error::CorruptedTaskQueue)?;
+            let mut task = self.queue.tasks.get_task(rtxn, task_id)?.ok_or_else(|| {
+                Error::CorruptedTaskQueue {
+                    file: file!(),
+                    message: format!(
+                        "Task content not found for uid `{}` when getting the last task to cancel",
+                        task_id
+                    ),
+                }
+            })?;
             current_batch.processing(Some(&mut task));
             current_batch.reason(BatchStopReason::TaskCannotBeBatched {
                 kind: Kind::TaskCancelation,
@@ -602,8 +625,15 @@ impl IndexScheduler {
         // 4. we get the next task to compact
         let to_compact = self.queue.tasks.get_kind(rtxn, Kind::IndexCompaction)? & enqueued;
         if let Some(task_id) = to_compact.min() {
-            let mut task =
-                self.queue.tasks.get_task(rtxn, task_id)?.ok_or(Error::CorruptedTaskQueue)?;
+            let mut task = self.queue.tasks.get_task(rtxn, task_id)?.ok_or_else(|| {
+                Error::CorruptedTaskQueue {
+                    file: file!(),
+                    message: format!(
+                        "Task content not found for uid `{}` when getting the next compact task",
+                        task_id
+                    ),
+                }
+            })?;
             current_batch.processing(Some(&mut task));
             current_batch.reason(BatchStopReason::TaskCannotBeBatched {
                 kind: Kind::IndexCompaction,
@@ -638,8 +668,15 @@ impl IndexScheduler {
         // 7. we batch the dumps.
         let to_dump = self.queue.tasks.get_kind(rtxn, Kind::DumpCreation)? & enqueued;
         if let Some(to_dump) = to_dump.min() {
-            let mut task =
-                self.queue.tasks.get_task(rtxn, to_dump)?.ok_or(Error::CorruptedTaskQueue)?;
+            let mut task = self.queue.tasks.get_task(rtxn, to_dump)?.ok_or_else(|| {
+                Error::CorruptedTaskQueue {
+                    file: file!(),
+                    message: format!(
+                        "Task content not found for uid `{}` when getting the next dump task",
+                        to_dump
+                    ),
+                }
+            })?;
             current_batch.processing(Some(&mut task));
             current_batch.reason(BatchStopReason::TaskCannotBeBatched {
                 kind: Kind::DumpCreation,
@@ -686,7 +723,15 @@ impl IndexScheduler {
             let Some(task_id) = enqueued_it.next() else {
                 return Ok((None, current_batch));
             };
-            task = self.queue.tasks.get_task(rtxn, task_id)?.ok_or(Error::CorruptedTaskQueue)?;
+            task = self.queue.tasks.get_task(rtxn, task_id)?.ok_or_else(|| {
+                Error::CorruptedTaskQueue {
+                    file: file!(),
+                    message: format!(
+                        "Task content not found for uid `{}` when creating next batch unprioritized",
+                        task_id
+                    ),
+                }
+            })?;
 
             if skip_if(&task) {
                 continue;
@@ -738,11 +783,15 @@ impl IndexScheduler {
                 stop_reason = BatchStopReason::ReachedTaskLimit { task_limit: tasks_limit };
                 break;
             }
-            let task = self
-                .queue
-                .tasks
-                .get_task(rtxn, task_id)
-                .and_then(|task| task.ok_or(Error::CorruptedTaskQueue))?;
+            let task = self.queue.tasks.get_task(rtxn, task_id).and_then(|task| {
+                task.ok_or_else(|| Error::CorruptedTaskQueue {
+                    file: file!(),
+                    message: format!(
+                        "Task content not found for uid `{}` when creating next batch unprioritized",
+                        task_id
+                    ),
+                })
+            })?;
 
             if skip_if(&task) {
                 continue;
@@ -900,7 +949,10 @@ impl IndexScheduler {
             NetworkTopologyState::WaitingForOthers => {
                 let Some(task_network) = &task.network else {
                     tracing::error!("network topology change task has no network");
-                    return Err(Error::CorruptedTaskQueue);
+                    return Err(Error::CorruptedTaskQueue {
+                        file: file!(),
+                        message: "Network topology change task has no network".to_string(),
+                    });
                 };
 
                 let origin;

--- a/crates/index-scheduler/src/scheduler/enterprise_edition/network.rs
+++ b/crates/index-scheduler/src/scheduler/enterprise_edition/network.rs
@@ -42,7 +42,11 @@ impl IndexScheduler {
             &mut network_task.kind
         else {
             tracing::error!("unexpected network kind for network task while processing batch");
-            return Err(Error::CorruptedTaskQueue);
+            return Err(Error::CorruptedTaskQueue {
+                file: file!(),
+                message: "Unexpected network kind for network task while processing batch"
+                    .to_string(),
+            });
         };
 
         progress.update_progress(processing::network::NetworkTopologyState::from(
@@ -82,12 +86,18 @@ impl IndexScheduler {
     ) -> Result<(Vec<Task>, ProcessBatchInfo)> {
         let KindWithContent::NetworkTopologyChange(network_topology_change) = &mut task.kind else {
             tracing::error!("network topology change task has the wrong kind with content");
-            return Err(Error::CorruptedTaskQueue);
+            return Err(Error::CorruptedTaskQueue {
+                file: file!(),
+                message: "Network topology change task has the wrong kind with content".to_string(),
+            });
         };
 
         let Some(task_network) = &task.network else {
             tracing::error!("network topology change task has no network");
-            return Err(Error::CorruptedTaskQueue);
+            return Err(Error::CorruptedTaskQueue {
+                file: file!(),
+                message: "Network topology change task has no network".to_string(),
+            });
         };
 
         let origin;

--- a/crates/index-scheduler/src/scheduler/enterprise_edition/s3.rs
+++ b/crates/index-scheduler/src/scheduler/enterprise_edition/s3.rs
@@ -263,7 +263,12 @@ fn stream_tarball_into_pipe(
             .queue
             .tasks
             .get_task(&rtxn, task_id)?
-            .ok_or(Error::CorruptedTaskQueue)?;
+            .ok_or_else(|| Error::CorruptedTaskQueue {
+                file: file!(),
+                message: format!(
+                    "Task content not found for uid `{task_id}` when streaming the update files for snapshot creation"
+                ),
+            })?;
         if let Some(content_uuid) = task.content_uuid() {
             use std::fs::File;
 

--- a/crates/index-scheduler/src/scheduler/mod.rs
+++ b/crates/index-scheduler/src/scheduler/mod.rs
@@ -389,7 +389,12 @@ impl IndexScheduler {
                         .tasks
                         .get_task(&wtxn, id)
                         .map_err(|e| Error::UnrecoverableError(Box::new(e)))?
-                        .ok_or(Error::CorruptedTaskQueue)?;
+                        .ok_or_else(|| Error::CorruptedTaskQueue {
+                            file: file!(),
+                            message: format!(
+                                "Task content not found for uid `{id}` when updating the tasks for process batch failure"
+                            ),
+                        })?;
                     task.status = Status::Failed;
                     task.error = Some(error.clone());
                     task.details = task.details.map(|d| d.to_failed());
@@ -466,7 +471,12 @@ impl IndexScheduler {
                         .tasks
                         .get_task(&rtxn, id)
                         .map_err(|e| Error::UnrecoverableError(Box::new(e)))?
-                        .ok_or(Error::CorruptedTaskQueue)?;
+                        .ok_or_else(|| Error::CorruptedTaskQueue {
+                            file: file!(),
+                            message: format!(
+                                "Task content not found for uid `{id}` when deleting the persisted task data"
+                            ),
+                        })?;
                     if let Err(e) = self.queue.delete_persisted_task_data(&task) {
                         tracing::error!(
                         "Failure to delete the content files associated with task {}. Error: {e}",

--- a/crates/index-scheduler/src/scheduler/process_batch.rs
+++ b/crates/index-scheduler/src/scheduler/process_batch.rs
@@ -811,7 +811,12 @@ impl IndexScheduler {
 
         for task_id in tasks_to_update {
             let mut task =
-                self.queue.tasks.get_task(wtxn, task_id)?.ok_or(Error::CorruptedTaskQueue)?;
+                self.queue.tasks.get_task(wtxn, task_id)?.ok_or_else(|| Error::CorruptedTaskQueue {
+                    file: file!(),
+                    message: format!(
+                        "Task content not found for uid `{task_id}` when updating the tasks for index swap"
+                    ),
+                })?;
             swap_index_uid_in_task(&mut task, (lhs.uid(), rhs.uid()));
             self.queue.tasks.all_tasks.put(wtxn, &task_id, &task)?;
             atomic.fetch_add(1, Ordering::Relaxed);

--- a/crates/index-scheduler/src/scheduler/process_snapshot_creation.rs
+++ b/crates/index-scheduler/src/scheduler/process_snapshot_creation.rs
@@ -157,8 +157,14 @@ impl IndexScheduler {
         let (atomic, update_file_progress) = AtomicUpdateFileStep::new(enqueued.len() as u32);
         progress.update_progress(update_file_progress);
         for task_id in enqueued {
-            let task =
-                self.queue.tasks.get_task(&rtxn, task_id)?.ok_or(Error::CorruptedTaskQueue)?;
+            let task = self.queue.tasks.get_task(&rtxn, task_id)?.ok_or_else(|| {
+                Error::CorruptedTaskQueue {
+                    file: file!(),
+                    message: format!(
+                        "Task content not found for uid `{task_id}` when copying the update files for snapshot creation"
+                    ),
+                }
+            })?;
             if let Some(content_uuid) = task.content_uuid() {
                 let src = self.queue.file_store.update_path(content_uuid);
                 let dst = update_files_dir.join(content_uuid.to_string());


### PR DESCRIPTION
## Related issue

Fixes https://linear.app/meilisearch/issue/ENGPROD-2780/add-more-context-in-the-corruption-error-messages

The error message when there is a corrupted task queue will now provide more context:
```
"Corrupted task queue in {file}: {message}."
```
