### PR TITLE
fix: add missing tracing instrumentation for facet bulk processing

### DIFF
--- a/crates/milli/src/update/new/indexer/post_processing/facet_bulk.rs
+++ b/crates/milli/src/update/new/indexer/post_processing/facet_bulk.rs
@@ -21,6 +21,7 @@ use crate::{CboRoaringBitmapCodec, FieldId, Index};
 /// The function will generate all the group levels from
 /// the group 1 to the level n until the number of group
 /// is smaller than the minimum required size.
+#[tracing::instrument(level = "trace", skip_all, target = "indexing::post_processing::facet_bulk")]
 pub fn generate_facet_levels(
     index: &Index,
     wtxn: &mut RwTxn,

--- a/crates/milli/src/update/new/indexer/post_processing/mod.rs
+++ b/crates/milli/src/update/new/indexer/post_processing/mod.rs
@@ -329,6 +329,8 @@ fn compute_facet_level_database(
     // We move all bulks at the front and incrementals (others) at the end.
     deltas.sort_by_key(|(_, delta)| if let FacetFieldIdDelta::Bulk = delta { 0 } else { 1 });
 
+    let span = tracing::trace_span!(target: "indexing::post_processing::facet_field_ids", "strings");
+    let _entered = span.enter();
     for (fid, delta) in deltas {
         // skip field ids that should not be facet leveled
         let Some(metadata) = global_fields_ids_map.metadata(fid) else {
@@ -347,6 +349,8 @@ fn compute_facet_level_database(
         match delta {
             FacetFieldIdDelta::Bulk => {
                 progress.update_progress(PostProcessingFacets::StringsBulk);
+                let span = tracing::trace_span!(target: "indexing::post_processing::facet_field_ids", "bulk_string", %fid);
+                let _entered = span.enter();
                 tracing::debug!(%fid, "bulk string facet processing in parallel");
                 generate_facet_levels(index, wtxn, fid, FacetType::String)?
             }
@@ -371,6 +375,8 @@ fn compute_facet_level_database(
     // We move all bulks at the front and incrementals (others) at the end.
     deltas.sort_by_key(|(_, delta)| if let FacetFieldIdDelta::Bulk = delta { 0 } else { 1 });
 
+    let span = tracing::trace_span!(target: "indexing::post_processing::facet_field_ids", "numbers");
+    let _entered = span.enter();
     for (fid, delta) in deltas {
         let span =
             tracing::trace_span!(target: "indexing::post_processing::facet_field_ids", "number");
@@ -378,6 +384,8 @@ fn compute_facet_level_database(
         match delta {
             FacetFieldIdDelta::Bulk => {
                 progress.update_progress(PostProcessingFacets::NumbersBulk);
+                let span = tracing::trace_span!(target: "indexing::post_processing::facet_field_ids", "bulk_number", %fid);
+                let _entered = span.enter();
                 tracing::debug!(%fid, "bulk number facet processing");
                 FacetsUpdateBulk::new_not_updating_level_0(index, vec![fid], FacetType::Number)
                     .execute(wtxn)?


### PR DESCRIPTION
## Summary

Adds tracing spans for `StringsBulk` and `NumbersBulk` operations in facet post-processing, and instruments `generate_facet_levels` with tracing.

## Problem

As reported in #5654, there was a significant discrepancy in timing traces for facet post-processing:

```
"post processing facets > strings incremental": "169.89ms",
"post processing facets > numbers incremental": "957.28ms",
"post processing facets > facet search": "60.29us",
"post processing facets": "7.10s"
```

The sum of traced operations (~1.13s) was much less than the total time (7.10s), leaving ~5.97s unaccounted for.

## Root Cause

The `StringsBulk` and `NumbersBulk` operations were not properly instrumented with tracing spans. While they had `tracing::debug!` log messages, these don't create the timing spans needed for the progress trace.

## Fix

1. Added `#[tracing::instrument]` attribute to `generate_facet_levels` function
2. Added tracing spans around bulk string processing (`bulk_string`)
3. Added tracing spans around bulk number processing (`bulk_number`)
4. Added parent spans for the entire string and number processing sections

This ensures all major operations within facet post-processing are properly instrumented, allowing users to identify performance bottlenecks.

## Testing

- Code compiles successfully with `cargo check -p milli`
- No functional changes, only tracing instrumentation added

Fixes #5654
