### PR TITLE
Add file and line number to log output

### DIFF
--- a/crates/meilisearch/src/main.rs
+++ b/crates/meilisearch/src/main.rs
@@ -37,7 +37,10 @@ fn default_log_route_layer() -> LogRouteType {
 fn default_log_stderr_layer(opt: &Opt) -> LogStderrType {
     let layer = tracing_subscriber::fmt::layer()
         .with_writer(|| LineWriter::new(std::io::stderr()))
-        .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE);
+        .with_ansi(false)
+        .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE)
+        .with_file(true)
+        .with_line_number(true);
 
     let layer = match opt.experimental_logs_mode {
         LogMode::Human => Box::new(layer)

--- a/crates/meilisearch/src/routes/logs.rs
+++ b/crates/meilisearch/src/routes/logs.rs
@@ -199,7 +199,10 @@ fn make_layer<
 
             let fmt_layer = tracing_subscriber::fmt::layer()
                 .with_writer(move || LogWriter { sender: sender.clone() })
-                .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE);
+                .with_ansi(false)
+                .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE)
+                .with_file(true)
+                .with_line_number(true);
 
             let stream = byte_stream(receiver, guard);
             (Box::new(fmt_layer) as Box<dyn Layer<S> + Send + Sync>, Box::pin(stream))
@@ -210,7 +213,9 @@ fn make_layer<
             let fmt_layer = tracing_subscriber::fmt::layer()
                 .with_writer(move || LogWriter { sender: sender.clone() })
                 .json()
-                .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE);
+                .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE)
+                .with_file(true)
+                .with_line_number(true);
 
             let stream = byte_stream(receiver, guard);
             (Box::new(fmt_layer) as Box<dyn Layer<S> + Send + Sync>, Box::pin(stream))


### PR DESCRIPTION
## Related issue

Fixes #6607 

## Generative AI tools

- [ ] This PR does not use generative AI tooling
- [x] This PR uses generative AI tooling and respect the [related policies](https://github.com/meilisearch/meilisearch/blob/main/CONTRIBUTING.md#use-of-generative-ai-tools)
    - Muse Spark (opencode/muse-spark-1.2-contributor-free) via OpenCode — used for codebase search, diff review.


## Requirements

⚠️ Ensure the following requirements before merging ⚠️
- [ ] Automated tests have been added.
- [x] If some tests cannot be automated, manual rigorous tests should be applied.
  - `cargo run -p meilisearch -- --experimental-enable-logs-route`
  - Tested `POST /logs/stream human` and `POST /indexes/t/documents`.
  - Verified the logs contain the expected `file:line` output.
- [ ] ⚠️ If there is any change in the DB:
    - [ ] Test that any impacted DB still works as expected after using `--upgrade-db` on a DB created with the last released Meilisearch
    - [ ] Test that during the upgrade, **search is still available** (artificially make the upgrade longer if needed)
    - [ ] Set the `db change` label.
- [ ] If necessary, the feature have been tested in the Cloud production environment (with [prototypes](./documentation/prototypes.md)) and the Cloud UI is ready.
- [ ] If necessary, the [documentation](https://github.com/meilisearch/documentation) related to the implemented feature in the PR is ready.
- [ ] If necessary, the [integrations](https://github.com/meilisearch/integration-guides) related to the implemented feature in the PR are ready.
