### PR TITLE
docs: fix mailto typo, dead TOC anchor and grammar

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -3,7 +3,7 @@
 Currently this repository hosts two kinds of benchmarks:
 
 1. The older "milli benchmarks", that use [criterion](https://github.com/bheisler/criterion.rs) and live in the "benchmarks" directory.
-2. The newer "bench" that are workload-based and so split between the [`workloads`](./workloads/) directory and the [`xtask::bench`](./xtask/src/bench/) module.
+2. The newer "bench" that are workload-based and so split between the [`workloads`](./workloads/) directory and the [`xtask::bench`](./crates/xtask/src/bench/) module.
 
 This document describes the newer "bench" benchmarks. For more details on the "milli benchmarks", see [benchmarks/README.md](./benchmarks/README.md).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ If Meilisearch does not offer optimized support for your language, please consid
 - [How to Contribute](#how-to-contribute)
 - [Development Workflow](#development-workflow)
 - [Git Guidelines](#git-guidelines)
-- [Release Process (for internal team only)](#release-process-for-internal-team-only)
+- [Release Process (for internal team only)](#publish-process-for-internal-team-only)
 
 ## Use of generative AI tools
 
@@ -238,7 +238,7 @@ This project uses GitHub Merge Queues that helps us manage pull requests merging
 Before merging a PR, the maintainer should ensure the following requirements are met
 - Automated tests have been added.
 - If some tests cannot be automated, manual rigorous tests should be applied.
-- ⚠️ If there is an change in the DB: it's mandatory to manually test the `--upgrade-db` on a DB of the previous Meilisearch minor version (e.g. v1.13 for the v1.14 release).
+- ⚠️ If there is a change in the DB: it's mandatory to manually test the `--upgrade-db` on a DB of the previous Meilisearch minor version (e.g. v1.13 for the v1.14 release).
 - If necessary, the feature have been tested in the Cloud production environment (with [prototypes](./documentation/prototypes.md)) and the Cloud UI is ready.
 - If necessary, the [documentation](https://github.com/meilisearch/documentation) related to the implemented feature in the PR is ready.
 - If necessary, the [integrations](https://github.com/meilisearch/integration-guides) related to the implemented feature in the PR are ready.

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Meilisearch is available in two editions:
 - Not allowed in production without a commercial agreement with Meilisearch.
   - You may use, modify, and distribute the Licensed Work for non-production purposes only, such as testing, development, or evaluation.
 
-Want access to Enterprise features? → Contact us at [sales@meilisearch.com](maito:sales@meilisearch.com).
+Want access to Enterprise features? → Contact us at [sales@meilisearch.com](mailto:sales@meilisearch.com).
 
 ### 📦 External crates
 


### PR DESCRIPTION
Three small docs fixes:

1. `README.md`: the Enterprise contact link used `maito:` instead of `mailto:`, so it did nothing on click.
2. `CONTRIBUTING.md`: the Release Process TOC entry pointed at `#release-process-for-internal-team-only`, but the heading is `## Publish Process (for internal team only)` → `#publish-process-for-internal-team-only`.
3. Same file: "If there is **an** change in the DB" → "**a** change".

Generated with AI assistance; all claims verified against the current tree per CONTRIBUTING's disclosure note.