### PR TITLE
docs: fix more broken links and a missing image

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,6 +17,6 @@ Fixes #...
     - [ ] Test that any impacted DB still works as expected after using `--upgrade-db` on a DB created with the last released Meilisearch
     - [ ] Test that during the upgrade, **search is still available** (artificially make the upgrade longer if needed)
     - [ ] Set the `db change` label.
-- [ ] If necessary, the feature have been tested in the Cloud production environment (with [prototypes](./documentation/prototypes.md)) and the Cloud UI is ready.
+- [ ] If necessary, the feature have been tested in the Cloud production environment (with [prototypes](../documentation/prototypes.md)) and the Cloud UI is ready.
 - [ ] If necessary, the [documentation](https://github.com/meilisearch/documentation) related to the implemented feature in the PR is ready.
 - [ ] If necessary, the [integrations](https://github.com/meilisearch/integration-guides) related to the implemented feature in the PR are ready.

--- a/crates/filter-parser/README.md
+++ b/crates/filter-parser/README.md
@@ -33,4 +33,4 @@ cargo fuzz run parse -- -max_len=500
 ## What to do if you find a bug in the parser
 
 - Write a test at the end of the [`lib.rs`](./src/lib.rs) to ensure it never happens again.
-- Add a file in [the corpus directory](./fuzz/corpus/parse/) with your filter to help the fuzzer find new bugs. Since this directory is going to be heavily polluted by the execution of the fuzzer it's in the gitignore and you'll need to force push your new test.
+- Add a file in [the corpus directory](./fuzz/fuzz/corpus/parse/) with your filter to help the fuzzer find new bugs. Since this directory is going to be heavily polluted by the execution of the fuzzer it's in the gitignore and you'll need to force push your new test.

--- a/documentation/release.md
+++ b/documentation/release.md
@@ -74,7 +74,7 @@ Why? GitHub Merge Queue does not work with branch patterns yet, so we have to ad
 
 ⚠️ If you encounter any merge conflicts, please do NOT fix the git conflicts directly on the `release-vX.Y.Z` branch. It would bring the changes present in `main` into `release-vX.Y.Z`, which would break a potential future patched release.
 
-![GitHub interface showing merge conflicts](../assets/merge-conflicts.png)
+
 
 Instead:
 - Create a new branch originating `release-vX.Y.Z+1`, like `tmp-release-vX.Y.Z+1`


### PR DESCRIPTION
Three more dead references, each verified against the tree:

1. `crates/filter-parser/README.md`: the fuzz corpus directory is at `fuzz/fuzz/corpus/parse/` (cargo-fuzz double-`fuzz` layout), not `fuzz/corpus/parse/`
2. `documentation/release.md`: referenced `../assets/merge-conflicts.png`, which does not exist anywhere in the tree; removed the broken image
3. `.github/pull_request_template.md`: the prototypes link resolved against `.github/`; repointed at the repo-root `documentation/prototypes.md`

Generated with AI assistance; all claims verified per CONTRIBUTING's disclosure note.