### PR TITLE
Publish Docker images to GitHub Container Registry alongside Docker Hub

### DIFF
--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -1,4 +1,4 @@
-name: Publish images to Docker Hub
+name: Publish images to Docker Hub and GitHub Container Registry
 
 on:
   push:
@@ -28,12 +28,15 @@ jobs:
             runner: ubuntu-24.04-arm
           - edition: community
             registry: getmeili/meilisearch
+            ghcr-registry: ghcr.io/${{ github.repository_owner }}/meilisearch
             feature-flag: ""
           - edition: enterprise
             registry: getmeili/meilisearch-enterprise
+            ghcr-registry: ghcr.io/${{ github.repository_owner }}/meilisearch-enterprise
             feature-flag: "--features enterprise"
 
-    permissions: {}
+    permissions:
+      packages: write # This is needed to push the images to GitHub Container Registry
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
@@ -52,6 +55,13 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker meta
         id: meta
@@ -74,7 +84,10 @@ jobs:
         with:
           platforms: linux/${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          tags: ${{ matrix.registry }}
+          # A single build is pushed by digest to both registries
+          tags: |
+            ${{ matrix.registry }}
+            ${{ matrix.ghcr-registry }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
           build-args: |
             COMMIT_SHA=${{ github.sha }}
@@ -104,13 +117,16 @@ jobs:
         include:
           - edition: community
             registry: getmeili/meilisearch
+            ghcr-registry: ghcr.io/${{ github.repository_owner }}/meilisearch
           - edition: enterprise
             registry: getmeili/meilisearch-enterprise
+            ghcr-registry: ghcr.io/${{ github.repository_owner }}/meilisearch-enterprise
     needs:
       - build
 
     permissions:
       id-token: write # This is needed to use Cosign in keyless mode
+      packages: write # This is needed to push the images to GitHub Container Registry
 
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
@@ -170,6 +186,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
@@ -177,7 +200,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
-          images: ${{ matrix.registry }}
+          images: |
+            ${{ matrix.registry }}
+            ${{ matrix.ghcr-registry }}
           # Prevent `latest` to be updated for each new tag pushed.
           # We need latest and `vX.Y` tags to only be pushed for the stable Meilisearch releases.
           flavor: latest=false
@@ -191,6 +216,9 @@ jobs:
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests
         run: |
+          # The same digests were pushed to both registries by the `build` job,
+          # so the manifest list is tagged (via the Docker meta output) on
+          # Docker Hub and GitHub Container Registry alike.
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ matrix.registry }}@sha256:%s ' *)
 


### PR DESCRIPTION
Fixes #6015

## What does this PR do?

This PR extends the Docker publish workflow (`.github/workflows/publish-docker-images.yml`) so that every Meilisearch image (community and enterprise editions, all tags including `nightly`) is also published to the GitHub Container Registry, in addition to Docker Hub:

- `ghcr.io/meilisearch/meilisearch`
- `ghcr.io/meilisearch/meilisearch-enterprise`

## Motivation

Docker Hub is hard to reach from some networks (rate limits, restricted regions), while `ghcr.io` is often directly pullable. Publishing to GHCR gives users in those environments an official, trusted source for the images — no third-party mirror needed. See #6015.

## How it works

- The `build` job pushes the platform digests to **both registries in a single build step** (`docker/build-push-action` with both image names and `push-by-digest=true`), so there is **no extra build cost**: layers are built once and only uploaded twice.
- The `merge` job runs `docker/metadata-action` with both image names, so the tag list (`vX.Y.Z`, `vX.Y`, `vX`, `latest`, `nightly`) is generated for both registries, and the `imagetools create` manifest step tags both registries at once.
- Cosign signing covers both registries automatically, since it iterates over the tags produced by the metadata step.
- GHCR authentication uses the built-in `GITHUB_TOKEN` with a `packages: write` permission — **no new secrets are required**.
- The GHCR repository name is derived from `github.repository_owner` instead of being hardcoded, which keeps the workflow correct for forks (useful for testing).

## Verification

I tested this end-to-end on my fork ([run](https://github.com/ximing/meilisearch/actions/runs/34303888227), with the Docker Hub parts stripped since forks don't have the `DOCKERHUB_*` secrets):

- The single build step successfully pushed the same digests to two GHCR repositories
- The merge job created the multi-arch (`linux/amd64` + `linux/arm64`) manifest list on both registries with identical digests
- Both registries' tags were signed with Cosign in keyless mode

```
$ docker buildx imagetools inspect ghcr.io/ximing/meilisearch:nightly
Name:      ghcr.io/ximing/meilisearch:nightly
MediaType: application/vnd.oci.image.index.v1+json
Platform:  linux/amd64
Platform:  linux/arm64
```

## Note for maintainers

After the first push, the two packages (`meilisearch`, `meilisearch-enterprise`) will be created as **private** by default. They need to be made public once via the package settings (or org-wide for `ghcr.io/meilisearch/*`) so users can pull them anonymously.