### PR TITLE
Add test to export chat settings in dumps

### DIFF
--- a/crates/dump/src/lib.rs
+++ b/crates/dump/src/lib.rs
@@ -273,7 +273,9 @@ pub(crate) mod test {
     use maplit::{btreemap, btreeset};
     use meilisearch_types::batches::{Batch, BatchEnqueuedAt, BatchStats};
     use meilisearch_types::facet_values_sort::FacetValuesSort;
-    use meilisearch_types::features::RuntimeTogglableFeatures;
+    use meilisearch_types::features::{
+        ChatCompletionSettings, ChatCompletionSource, RuntimeTogglableFeatures,
+    };
     use meilisearch_types::index_uid_pattern::IndexUidPattern;
     use meilisearch_types::keys::{Action, Key};
     use meilisearch_types::milli::update::Setting;
@@ -554,6 +556,13 @@ pub(crate) mod test {
         let network = create_test_network();
         dump.create_network(network).unwrap();
 
+        // ========== chat completions settings
+        let chat_settings = create_test_chat_settings();
+        let mut chat_writer = dump.create_chat_completions_settings().unwrap();
+        for (name, settings) in &chat_settings {
+            chat_writer.push_settings(name, settings).unwrap();
+        }
+
         (dump, batch_queue)
     }
 
@@ -581,6 +590,37 @@ pub(crate) mod test {
             version: Default::default(),
             shards: maplit::btreemap! {"shard".to_string() => Shard { remotes: maplit::btreeset!["other".to_string()]} },
         }
+    }
+
+    fn create_test_chat_settings() -> Vec<(String, ChatCompletionSettings)> {
+        vec![
+            (
+                "default".to_string(),
+                ChatCompletionSettings {
+                    source: ChatCompletionSource::OpenAi,
+                    org_id: Some("org-test".to_string()),
+                    project_id: None,
+                    api_version: None,
+                    deployment_id: None,
+                    base_url: Some("https://api.openai.com/v1/".to_string()),
+                    api_key: Some("sk-test-key-12345678".to_string()),
+                    prompts: Default::default(),
+                },
+            ),
+            (
+                "custom".to_string(),
+                ChatCompletionSettings {
+                    source: ChatCompletionSource::Mistral,
+                    org_id: None,
+                    project_id: None,
+                    api_version: None,
+                    deployment_id: None,
+                    base_url: Some("https://api.mistral.ai/v1/".to_string()),
+                    api_key: Some("mistral-key-abcdefgh".to_string()),
+                    prompts: Default::default(),
+                },
+            ),
+        ]
     }
 
     #[test]
@@ -638,5 +678,16 @@ pub(crate) mod test {
         expected.leader = None;
         expected.local = None;
         assert_eq!(&expected, dump.network().unwrap().unwrap());
+
+        // ==== checking the chat completions settings
+        let mut expected_chat = create_test_chat_settings();
+        expected_chat.sort_by(|a, b| a.0.cmp(&b.0));
+        let mut chat_settings = dump
+            .chat_completions_settings()
+            .unwrap()
+            .map(|entry| entry.unwrap())
+            .collect::<Vec<_>>();
+        chat_settings.sort_by(|a, b| a.0.cmp(&b.0));
+        assert_eq!(chat_settings, expected_chat);
     }
 }

--- a/crates/dump/src/writer.rs
+++ b/crates/dump/src/writer.rs
@@ -350,6 +350,9 @@ pub(crate) mod test {
         .
         ├---- batches/
         │    └---- queue.jsonl
+        ├---- chat-completions-settings/
+        │    ├---- custom.json
+        │    └---- default.json
         ├---- indexes/
         │    └---- doggos/
         │    │    ├---- documents.jsonl


### PR DESCRIPTION
Fixes #5736

## Problem
Chat completions settings were exportable in dumps (writer `create_chat_completions_settings` + reader `chat_completions_settings`) but had no test coverage. The round-trip test `test_creating_and_read_dump` didn't exercise them, so a regression in dump export/import of chat settings would go unnoticed.

## Change
- Added `create_test_chat_settings` fixture covering two providers (OpenAI and Mistral).
- Wired chat-settings writing into `create_test_dump_writer`.
- Added a read-back assertion in `test_creating_and_read_dump` comparing exported settings to the fixture.
- Updated the directory-hierarchy snapshot in `writer.rs` to reflect the new `chat-completions-settings/` directory.

## Verification
- `cargo test -p dump` — 24/24 pass
- `cargo clippy -p dump --all-targets` — clean