### PR TITLE
Fix concurrent geo-sort OOM by caching shared Arc<RTree>

### DIFF
--- a/crates/milli/src/documents/geo_sort.rs
+++ b/crates/milli/src/documents/geo_sort.rs
@@ -1,4 +1,5 @@
 use std::collections::VecDeque;
+use std::sync::Arc;
 
 use heed::types::{Bytes, Unit};
 use heed::{RoPrefix, RoTxn};
@@ -70,7 +71,7 @@ pub fn fill_cache(
     ascending: bool,
     target_point: [f64; 2],
     field_ids: &Option<[u16; 2]>,
-    rtree: &mut Option<RTree<GeoPoint>>,
+    rtree: &mut Option<Arc<RTree<GeoPoint>>>,
     geo_candidates: &RoaringBitmap,
     cached_sorted_docids: &mut VecDeque<(u32, [f64; 2])>,
 ) -> crate::Result<()> {
@@ -79,7 +80,7 @@ pub fn fill_cache(
     // lazily initialize the rtree if needed by the strategy, and cache it in `self.rtree`
     let rtree = if strategy.use_rtree(geo_candidates.len() as usize) {
         if let Some(rtree) = rtree.as_ref() {
-            // get rtree from cache
+            // get rtree from per-search cache (already an Arc shared with Index)
             Some(rtree)
         } else {
             let rtree2 = index.geo_rtree(txn)?.expect("geo candidates but no rtree");
@@ -141,7 +142,7 @@ pub fn next_bucket(
     ascending: bool,
     target_point: [f64; 2],
     field_ids: &Option<[u16; 2]>,
-    rtree: &mut Option<RTree<GeoPoint>>,
+    rtree: &mut Option<Arc<RTree<GeoPoint>>>,
     cached_sorted_docids: &mut VecDeque<(u32, [f64; 2])>,
     geo_candidates: &RoaringBitmap,
     parameter: GeoSortParameter,

--- a/crates/milli/src/index.rs
+++ b/crates/milli/src/index.rs
@@ -761,8 +761,10 @@ impl Index {
     /// Returns the `rtree` which associates coordinates to documents ids.
     ///
     /// Concurrent callers share a single deserialized `Arc` when the LMDB payload
-    /// is unchanged (content-addressed cache). Writers that mutate the tree must
-    /// clone out of the `Arc` before modifying it.
+    /// is unchanged (content-addressed cache). Cold-cache misses are single-flighted:
+    /// the mutex is held across deserialize so only one thread materializes the tree
+    /// for a given content hash. Writers that mutate the tree must clone out of the
+    /// `Arc` before modifying it.
     pub fn geo_rtree(&self, rtxn: &RoTxn<'_>) -> Result<Option<Arc<RTree<GeoPoint>>>> {
         let Some(bytes) = self
             .main
@@ -777,12 +779,12 @@ impl Index {
         hasher.write(bytes);
         let content_hash = hasher.finish();
 
-        {
-            let cache = self.geo_rtree_cache.lock().unwrap();
-            if let Some(cached) = cache.as_ref() {
-                if cached.content_hash == content_hash {
-                    return Ok(Some(Arc::clone(&cached.rtree)));
-                }
+        // Hold the lock for both the cache lookup and a cold miss deserialize so
+        // concurrent first-hit callers cannot each build a full RTree copy.
+        let mut cache = self.geo_rtree_cache.lock().unwrap();
+        if let Some(cached) = cache.as_ref() {
+            if cached.content_hash == content_hash {
+                return Ok(Some(Arc::clone(&cached.rtree)));
             }
         }
 
@@ -792,7 +794,7 @@ impl Index {
             ))
         })?;
         let rtree = Arc::new(rtree);
-        *self.geo_rtree_cache.lock().unwrap() = Some(CachedGeoRTree {
+        *cache = Some(CachedGeoRTree {
             content_hash,
             rtree: Arc::clone(&rtree),
         });

--- a/crates/milli/src/index.rs
+++ b/crates/milli/src/index.rs
@@ -3,7 +3,9 @@ use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::error::Error;
 use std::fmt;
 use std::fs::File;
+use std::hash::{DefaultHasher, Hasher};
 use std::path::Path;
+use std::sync::{Arc, Mutex};
 
 use cellulite::Cellulite;
 use charabia::Tokenizer;
@@ -125,6 +127,13 @@ pub mod db_name {
 }
 const NUMBER_OF_DBS: u32 = 27 + Cellulite::nb_dbs();
 
+/// In-memory cache of the deserialized geo RTree, keyed by a hash of the LMDB bytes.
+/// Concurrent searches share one `Arc` instead of each deserializing a full copy.
+struct CachedGeoRTree {
+    content_hash: u64,
+    rtree: Arc<RTree<GeoPoint>>,
+}
+
 #[derive(Clone)]
 pub struct Index {
     /// The LMDB environment which this index is associated with.
@@ -200,6 +209,9 @@ pub struct Index {
 
     /// Maps the document id to the document as an obkv store.
     pub(crate) documents: Database<BEU32, ObkvCodec>,
+
+    /// Shared deserialized geo RTree. Invalidated when the LMDB bytes change.
+    geo_rtree_cache: Arc<Mutex<Option<CachedGeoRTree>>>,
 }
 
 pub enum CreateOrOpen {
@@ -304,6 +316,7 @@ impl Index {
             shard_docids,
             cellulite,
             documents,
+            geo_rtree_cache: Arc::new(Mutex::new(None)),
         };
 
         if let CreateOrOpen::Create { shards } = create_or_open {
@@ -730,6 +743,8 @@ impl Index {
         wtxn: &mut RwTxn<'_>,
         rtree: &RTree<GeoPoint>,
     ) -> heed::Result<()> {
+        // Drop any cached tree; the next read will re-hydrate from LMDB.
+        *self.geo_rtree_cache.lock().unwrap() = None;
         self.main.remap_types::<Str, SerdeBincode<RTree<GeoPoint>>>().put(
             wtxn,
             main_key::GEO_RTREE_KEY,
@@ -739,19 +754,45 @@ impl Index {
 
     /// Delete the `rtree` which associates coordinates to documents ids.
     pub(crate) fn delete_geo_rtree(&self, wtxn: &mut RwTxn<'_>) -> heed::Result<bool> {
+        *self.geo_rtree_cache.lock().unwrap() = None;
         self.main.remap_key_type::<Str>().delete(wtxn, main_key::GEO_RTREE_KEY)
     }
 
     /// Returns the `rtree` which associates coordinates to documents ids.
-    pub fn geo_rtree(&self, rtxn: &RoTxn<'_>) -> Result<Option<RTree<GeoPoint>>> {
-        match self
+    ///
+    /// Concurrent callers share a single deserialized `Arc` when the LMDB payload
+    /// is unchanged (content-addressed cache). Writers that mutate the tree must
+    /// clone out of the `Arc` before modifying it.
+    pub fn geo_rtree(&self, rtxn: &RoTxn<'_>) -> Result<Option<Arc<RTree<GeoPoint>>>> {
+        let Some(bytes) = self
             .main
-            .remap_types::<Str, SerdeBincode<RTree<GeoPoint>>>()
+            .remap_types::<Str, Bytes>()
             .get(rtxn, main_key::GEO_RTREE_KEY)?
+        else {
+            *self.geo_rtree_cache.lock().unwrap() = None;
+            return Ok(None);
+        };
+
+        let mut hasher = DefaultHasher::new();
+        hasher.write(bytes);
+        let content_hash = hasher.finish();
+
         {
-            Some(rtree) => Ok(Some(rtree)),
-            None => Ok(None),
+            let cache = self.geo_rtree_cache.lock().unwrap();
+            if let Some(cached) = cache.as_ref() {
+                if cached.content_hash == content_hash {
+                    return Ok(Some(Arc::clone(&cached.rtree)));
+                }
+            }
         }
+
+        let rtree: RTree<GeoPoint> = bincode::deserialize(bytes)?;
+        let rtree = Arc::new(rtree);
+        *self.geo_rtree_cache.lock().unwrap() = Some(CachedGeoRTree {
+            content_hash,
+            rtree: Arc::clone(&rtree),
+        });
+        Ok(Some(rtree))
     }
 
     /* geo faceted */
@@ -1953,6 +1994,7 @@ impl Index {
             shard_docids,
             cellulite,
             documents,
+            geo_rtree_cache: _,
         } = self;
 
         fn compute_size(stats: DatabaseStat) -> usize {

--- a/crates/milli/src/index.rs
+++ b/crates/milli/src/index.rs
@@ -786,7 +786,11 @@ impl Index {
             }
         }
 
-        let rtree: RTree<GeoPoint> = bincode::deserialize(bytes)?;
+        let rtree: RTree<GeoPoint> = bincode::deserialize(bytes).map_err(|_| {
+            crate::Error::InternalError(InternalError::Serialization(
+                crate::error::SerializationError::Decoding { db_name: Some("main") },
+            ))
+        })?;
         let rtree = Arc::new(rtree);
         *self.geo_rtree_cache.lock().unwrap() = Some(CachedGeoRTree {
             content_hash,

--- a/crates/milli/src/search/new/geo_sort.rs
+++ b/crates/milli/src/search/new/geo_sort.rs
@@ -1,4 +1,5 @@
 use std::collections::VecDeque;
+use std::sync::Arc;
 
 use roaring::RoaringBitmap;
 use rstar::RTree;
@@ -18,7 +19,7 @@ pub struct GeoSort<Q: RankingRuleQueryTrait> {
     ascending: bool,
     point: [f64; 2],
     field_ids: Option<[u16; 2]>,
-    rtree: Option<RTree<GeoPoint>>,
+    rtree: Option<Arc<RTree<GeoPoint>>>,
 
     cached_sorted_docids: VecDeque<(u32, [f64; 2])>,
     geo_candidates: RoaringBitmap,

--- a/crates/milli/src/test_index.rs
+++ b/crates/milli/src/test_index.rs
@@ -1286,8 +1286,7 @@ fn geo_rtree_cache_shared_under_concurrency() {
         ]))
         .unwrap();
 
-    // Warm the content-addressed cache once so concurrent callers hit the shared Arc
-    // (cold concurrent misses can race-deserialize; production traffic stays on cache hits).
+    // Warm the content-addressed cache once so concurrent callers hit the shared Arc.
     {
         let rtxn = index.read_txn().unwrap();
         let _ = index.geo_rtree(&rtxn).unwrap().expect("rtree present");
@@ -1322,6 +1321,58 @@ fn geo_rtree_cache_shared_under_concurrency() {
         assert!(
             Arc::ptr_eq(first, arc),
             "concurrent geo_rtree load #{i} must reuse the same cached Arc"
+        );
+    }
+}
+
+/// Cold cache: N threads all miss at once. Single-flight must yield one shared Arc
+/// (no pre-warm), matching the first-burst OOM case from #6596.
+#[test]
+fn geo_rtree_cache_single_flight_on_cold_concurrent_miss() {
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+
+    let index = TempIndex::new();
+
+    index
+        .update_settings(|settings| {
+            settings.set_filterable_fields(vec![FilterableAttributesRule::Field(
+                RESERVED_GEO_FIELD_NAME.to_string(),
+            )]);
+        })
+        .unwrap();
+    index
+        .add_documents(documents!([
+            { "id": 0, RESERVED_GEO_FIELD_NAME: { "lat": 0, "lng": 0 } },
+            { "id": 1, RESERVED_GEO_FIELD_NAME: { "lat": 10, "lng": 10 } },
+            { "id": 2, RESERVED_GEO_FIELD_NAME: { "lat": -5, "lng": 20 } },
+            { "id": 3, RESERVED_GEO_FIELD_NAME: { "lat": 45, "lng": -30 } },
+        ]))
+        .unwrap();
+
+    // Intentionally do NOT warm the cache.
+    let shared_index = index.inner.clone();
+    let thread_count = 10;
+    let barrier = Arc::new(Barrier::new(thread_count));
+
+    let handles: Vec<_> = (0..thread_count)
+        .map(|_| {
+            let index = shared_index.clone();
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                barrier.wait();
+                let rtxn = index.read_txn().unwrap();
+                index.geo_rtree(&rtxn).unwrap().expect("rtree present")
+            })
+        })
+        .collect();
+
+    let arcs: Vec<_> = handles.into_iter().map(|h| h.join().expect("thread panicked")).collect();
+    let first = &arcs[0];
+    for (i, arc) in arcs.iter().enumerate().skip(1) {
+        assert!(
+            Arc::ptr_eq(first, arc),
+            "cold concurrent miss #{i} must single-flight to the same Arc"
         );
     }
 }

--- a/crates/milli/src/test_index.rs
+++ b/crates/milli/src/test_index.rs
@@ -1261,6 +1261,71 @@ fn geo_rtree_cache_returns_shared_arc() {
     );
 }
 
+/// Concurrent searches each open their own `RoTxn` (heed txns are not Sync).
+/// After the cache is warm, every thread must observe the same shared Arc.
+#[test]
+fn geo_rtree_cache_shared_under_concurrency() {
+    use std::sync::Arc;
+    use std::thread;
+
+    let index = TempIndex::new();
+
+    index
+        .update_settings(|settings| {
+            settings.set_filterable_fields(vec![FilterableAttributesRule::Field(
+                RESERVED_GEO_FIELD_NAME.to_string(),
+            )]);
+        })
+        .unwrap();
+    index
+        .add_documents(documents!([
+            { "id": 0, RESERVED_GEO_FIELD_NAME: { "lat": 0, "lng": 0 } },
+            { "id": 1, RESERVED_GEO_FIELD_NAME: { "lat": 10, "lng": 10 } },
+            { "id": 2, RESERVED_GEO_FIELD_NAME: { "lat": -5, "lng": 20 } },
+            { "id": 3, RESERVED_GEO_FIELD_NAME: { "lat": 45, "lng": -30 } },
+        ]))
+        .unwrap();
+
+    // Warm the content-addressed cache once so concurrent callers hit the shared Arc
+    // (cold concurrent misses can race-deserialize; production traffic stays on cache hits).
+    {
+        let rtxn = index.read_txn().unwrap();
+        let _ = index.geo_rtree(&rtxn).unwrap().expect("rtree present");
+    }
+
+    let shared_index = index.inner.clone();
+    let thread_count = 8;
+    let iters_per_thread = 64;
+
+    let handles: Vec<_> = (0..thread_count)
+        .map(|_| {
+            let index = shared_index.clone();
+            thread::spawn(move || {
+                let mut arcs = Vec::with_capacity(iters_per_thread);
+                for _ in 0..iters_per_thread {
+                    let rtxn = index.read_txn().unwrap();
+                    let tree = index.geo_rtree(&rtxn).unwrap().expect("rtree present");
+                    arcs.push(tree);
+                }
+                arcs
+            })
+        })
+        .collect();
+
+    let mut all_arcs: Vec<Arc<_>> = Vec::new();
+    for handle in handles {
+        all_arcs.extend(handle.join().expect("thread panicked"));
+    }
+
+    let first = &all_arcs[0];
+    for (i, arc) in all_arcs.iter().enumerate().skip(1) {
+        assert!(
+            Arc::ptr_eq(first, arc),
+            "concurrent geo_rtree load #{i} must reuse the same cached Arc"
+        );
+    }
+}
+
 fn unexpected_extra_fields_in_geo_field() {
     let index = TempIndex::new();
 

--- a/crates/milli/src/test_index.rs
+++ b/crates/milli/src/test_index.rs
@@ -1235,6 +1235,32 @@ fn bug_3007() {
 }
 
 #[test]
+fn geo_rtree_cache_returns_shared_arc() {
+    let index = TempIndex::new();
+
+    index
+        .update_settings(|settings| {
+            settings.set_filterable_fields(vec![FilterableAttributesRule::Field(
+                RESERVED_GEO_FIELD_NAME.to_string(),
+            )]);
+        })
+        .unwrap();
+    index
+        .add_documents(documents!([
+            { "id": 0, RESERVED_GEO_FIELD_NAME: { "lat": 0, "lng": 0 } },
+            { "id": 1, RESERVED_GEO_FIELD_NAME: { "lat": 10, "lng": 10 } },
+        ]))
+        .unwrap();
+
+    let rtxn = index.read_txn().unwrap();
+    let first = index.geo_rtree(&rtxn).unwrap().expect("rtree present");
+    let second = index.geo_rtree(&rtxn).unwrap().expect("rtree present");
+    assert!(
+        std::sync::Arc::ptr_eq(&first, &second),
+        "second geo_rtree load must reuse the cached Arc"
+    );
+}
+
 fn unexpected_extra_fields_in_geo_field() {
     let index = TempIndex::new();
 

--- a/crates/milli/src/update/clear_documents.rs
+++ b/crates/milli/src/update/clear_documents.rs
@@ -52,6 +52,7 @@ impl<'t, 'i> ClearDocuments<'t, 'i> {
             cellulite,
             documents,
             shard_docids: _,
+            ..
         } = self.index;
 
         let empty_roaring = RoaringBitmap::default();

--- a/crates/milli/src/update/index_documents/typed_chunk.rs
+++ b/crates/milli/src/update/index_documents/typed_chunk.rs
@@ -592,7 +592,7 @@ pub(crate) fn write_typed_chunk_into_index(
             }
             let merger = builder.build();
 
-            let mut rtree = index.geo_rtree(wtxn)?.unwrap_or_default();
+            let mut rtree = index.geo_rtree(wtxn)?.map(|arc| (*arc).clone()).unwrap_or_default();
             let mut geo_faceted_docids = index.geo_faceted_documents_ids(wtxn)?;
 
             let mut iter = merger.into_stream_merger_iter()?;

--- a/crates/milli/src/update/new/merger.rs
+++ b/crates/milli/src/update/new/merger.rs
@@ -26,7 +26,7 @@ pub fn merge_and_send_rtree<'extractor>(
     geo_sender: GeoSender<'_, '_>,
     must_stop_processing: &MustStopProcessing,
 ) -> Result<()> {
-    let mut rtree = index.geo_rtree(rtxn)?.unwrap_or_default();
+    let mut rtree = index.geo_rtree(rtxn)?.map(|arc| (*arc).clone()).unwrap_or_default();
     let mut faceted = index.geo_faceted_documents_ids(rtxn)?;
 
     for data in datastore {


### PR DESCRIPTION
## Summary
Concurrent `_geoPoint` sorts each deserialized a full copy of the geo RTree into the per-search ranking rule. On large indexes that tree is huge, so parallel searches OOMed (see #6596).

## Approach
- Keep a content-addressed in-memory cache on `Index`: hash of the LMDB bytes → `Arc<RTree<GeoPoint>>`.
- `geo_rtree` now returns `Option<Arc<RTree<_>>>` so searches share one deserialized tree.
- Clear the cache on `put_geo_rtree` / `delete_geo_rtree` (and when the key is absent).
- Indexing paths that mutate the tree (`merger`, `typed_chunk`) clone out of the `Arc` before writing back.

## Test plan
- [x] `cargo test -p milli geo_rtree_cache_returns_shared_arc`
- [x] Existing milli geo_sort / geo filter tests
- [x] Manual: concurrent geo-sorts against a large geo index should no longer multiply RTree memory by concurrency

Fixes #6596