### PR TITLE
fix(search_queue): prevent double permit release signal on explicit Permit::drop (#6578)

### DIFF
--- a/crates/meilisearch/src/search_queue.rs
+++ b/crates/meilisearch/src/search_queue.rs
@@ -52,6 +52,7 @@ impl Permit {
     pub async fn drop(self) {
         // if the channel is closed then the whole instance is down
         let _ = self.sender.send(()).await;
+        std::mem::forget(self);
     }
 }
 
@@ -202,5 +203,24 @@ impl SearchQueue {
         } else {
             Ok(())
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_permit_explicit_drop_single_release() {
+        let (sender, mut receiver) = mpsc::channel(10);
+        let permit = Permit { sender };
+        permit.drop().await;
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        let mut count = 0;
+        while receiver.try_recv().is_ok() {
+            count += 1;
+        }
+        assert_eq!(count, 1, "explicit drop must send exactly one release signal");
     }
 }


### PR DESCRIPTION
### Summary
Fixes #6578. Calling Permit::drop(self) sent an explicit release signal on self.sender, after which Rust's Drop implementation (Drop for Permit) fired and spawned a second release signal on a cloned sender. Every explicit permit.drop().await resulted in two capacity releases instead of one, potentially exceeding max_search_queue_capacity.

### Fix
- Call std::mem::forget(self) in Permit::drop(self) to bypass Drop::drop(&mut self) after sending the explicit release signal.
- Add unit test test_permit_explicit_drop_single_release in crates/meilisearch/src/search_queue.rs.